### PR TITLE
Fix/use `cls` instead of `self` in @classmethod decorated methods

### DIFF
--- a/fastai/column_data.py
+++ b/fastai/column_data.py
@@ -30,14 +30,14 @@ class ColumnarModelData(ModelData):
             DataLoader(val_ds, bs*2, shuffle=False))
 
     @classmethod
-    def from_data_frames(self, path, trn_df, val_df, trn_y, val_y, cat_flds, bs):
-        return self(path, ColumnarDataset.from_data_frame(trn_df, cat_flds, trn_y),
+    def from_data_frames(cls, path, trn_df, val_df, trn_y, val_y, cat_flds, bs):
+        return cls(path, ColumnarDataset.from_data_frame(trn_df, cat_flds, trn_y),
                     ColumnarDataset.from_data_frame(val_df, cat_flds, val_y), bs)
 
     @classmethod
-    def from_data_frame(self, path, val_idxs, df, y, cat_flds, bs):
+    def from_data_frame(cls, path, val_idxs, df, y, cat_flds, bs):
         ((val_df, trn_df), (val_y, trn_y)) = split_by_idx(val_idxs, df, y)
-        return self.from_data_frames(path, trn_df, val_df, trn_y, val_y, cat_flds, bs)
+        return cls.from_data_frames(path, trn_df, val_df, trn_y, val_y, cat_flds, bs)
 
     def get_learner(self, emb_szs, n_cont, emb_drop, out_sz, szs, drops,
                     y_range=None, use_bn=False):
@@ -112,13 +112,13 @@ class CollabFilterDataset(Dataset):
         self.cols = [self.user_col,self.item_col,self.ratings]
 
     @classmethod
-    def from_data_frame(self, path, df, user_name, item_name, rating_name):
-        return self(path, df[user_name], df[item_name], df[rating_name])
+    def from_data_frame(cls, path, df, user_name, item_name, rating_name):
+        return cls(path, df[user_name], df[item_name], df[rating_name])
 
     @classmethod
-    def from_csv(self, path, csv, user_name, item_name, rating_name):
+    def from_csv(cls, path, csv, user_name, item_name, rating_name):
         df = pd.read_csv(os.path.join(path,csv))
-        return self.from_data_frame(path, df, user_name, item_name, rating_name)
+        return cls.from_data_frame(path, df, user_name, item_name, rating_name)
 
     def proc_col(self,col):
         uniq = col.unique()

--- a/fastai/conv_learner.py
+++ b/fastai/conv_learner.py
@@ -86,9 +86,9 @@ class ConvLearner(Learner):
         self.precompute = precompute
 
     @classmethod
-    def pretrained(self, f, data, ps=None, xtra_fc=None, xtra_cut=0, **kwargs):
+    def pretrained(cls, f, data, ps=None, xtra_fc=None, xtra_cut=0, **kwargs):
         models = ConvnetBuilder(f, data.c, data.is_multi, data.is_reg, ps=ps, xtra_fc=xtra_fc, xtra_cut=xtra_cut)
-        return self(data, models, **kwargs)
+        return cls(data, models, **kwargs)
 
     @property
     def model(self): return self.models.fc_model if self.precompute else self.models.model

--- a/fastai/dataset.py
+++ b/fastai/dataset.py
@@ -267,8 +267,8 @@ class ImageClassifierData(ImageData):
     @property
     def is_multi(self): return self.trn_dl.dataset.is_multi
 
-    @classmethod
-    def get_ds(self, fn, trn, val, tfms, test=None, **kwargs):
+    @staticmethod
+    def get_ds(fn, trn, val, tfms, test=None, **kwargs):
         res = [
             fn(trn[0], trn[1], tfms[0], **kwargs), # train
             fn(val[0], val[1], tfms[1], **kwargs), # val

--- a/fastai/dataset.py
+++ b/fastai/dataset.py
@@ -285,19 +285,19 @@ class ImageClassifierData(ImageData):
         return res
 
     @classmethod
-    def from_arrays(self, path, trn, val, bs=64, tfms=(None,None), classes=None, num_workers=4, test=None):
-        datasets = self.get_ds(ArraysIndexDataset, trn, val, tfms, test=test)
-        return self(path, datasets, bs, num_workers, classes=classes)
+    def from_arrays(cls, path, trn, val, bs=64, tfms=(None,None), classes=None, num_workers=4, test=None):
+        datasets = cls.get_ds(ArraysIndexDataset, trn, val, tfms, test=test)
+        return cls(path, datasets, bs, num_workers, classes=classes)
 
     @classmethod
-    def from_paths(self, path, bs=64, tfms=(None,None), trn_name='train', val_name='valid', test_name=None, num_workers=8):
+    def from_paths(cls, path, bs=64, tfms=(None,None), trn_name='train', val_name='valid', test_name=None, num_workers=8):
         trn,val = [folder_source(path, o) for o in (trn_name, val_name)]
         test_fnames = read_dir(path, test_name) if test_name else None
-        datasets = self.get_ds(FilesIndexArrayDataset, trn, val, tfms, path=path, test=test_fnames)
-        return self(path, datasets, bs, num_workers, classes=trn[2])
+        datasets = cls.get_ds(FilesIndexArrayDataset, trn, val, tfms, path=path, test=test_fnames)
+        return cls(path, datasets, bs, num_workers, classes=trn[2])
 
     @classmethod
-    def from_csv(self, path, folder, csv_fname, bs=64, tfms=(None,None),
+    def from_csv(cls, path, folder, csv_fname, bs=64, tfms=(None,None),
                val_idxs=None, suffix='', test_name=None, continuous=False, skip_header=True, num_workers=8):
         fnames,y,classes = csv_source(folder, csv_fname, skip_header, suffix, continuous=continuous)
         ((val_fnames,trn_fnames),(val_y,trn_y)) = split_by_idx(val_idxs, np.array(fnames), y)
@@ -307,9 +307,9 @@ class ImageClassifierData(ImageData):
             f = FilesIndexArrayRegressionDataset
         else:
             f = FilesIndexArrayDataset if len(trn_y.shape)==1 else FilesNhotArrayDataset
-        datasets = self.get_ds(f, (trn_fnames,trn_y), (val_fnames,val_y), tfms,
+        datasets = cls.get_ds(f, (trn_fnames,trn_y), (val_fnames,val_y), tfms,
                                path=path, test=test_fnames)
-        return self(path, datasets, bs, num_workers, classes=classes)
+        return cls(path, datasets, bs, num_workers, classes=classes)
 
 def split_by_idx(idxs, *a):
     mask = np.zeros(len(a[0]),dtype=bool)


### PR DESCRIPTION
- and use `@staticmethod` where the first argument is never really used.

I was trying to follow along the codebase, and the `self` got me quite confused when reading the classmethods. Contributing this, so that other python users don't have to get as confused when codereading.

Not a big deal, once I figured that it worked fine, just that `self` didn't mean anything important in `@classmethod` methods.

Here's a reference that makes this a bit more clear. http://stackabuse.com/pythons-classmethod-and-staticmethod-explained/