### PR TITLE
Change dn121 model_features from 1024 to 2048

### DIFF
--- a/fastai/conv_learner.py
+++ b/fastai/conv_learner.py
@@ -9,7 +9,7 @@ model_meta = {
     wrn:[8,6], inceptionresnet_2:[-2,9], inception_4:[-1,9],
     dn121:[0,6], dn161:[0,6], dn169:[0,6], dn201:[0,6],
 }
-model_features = {inception_4: 3072, dn121: 1024, dn161: 4416}
+model_features = {inception_4: 3072, dn121: 2048, dn161: 4416}
 
 class ConvnetBuilder():
     """Class representing a convolutional network.


### PR DESCRIPTION
After trying to use dn121 and getting an error when doing precompute = True I tracked it down to this as the issue.  The activation generated is 2048 where the bcolz empty file that is generated is 1024 giving a `ValueError: array trailing dimensions do not match with self` error.  The change I made just makes the initial file 2048 wide instead of 1024.  This fixes the issue, but I'm not 100% if the 1024 is correct and it is actually the model that shouldn't be generating 2048 wide activations.  If that is the case, I need to dig into that side instead.