### PR TITLE
Fix ConvLearner#summary

### DIFF
--- a/fastai/conv_learner.py
+++ b/fastai/conv_learner.py
@@ -109,6 +109,13 @@ class ConvLearner(Learner):
     def get_layer_groups(self):
         return self.models.get_layer_groups(self.precompute)
 
+    def summary(self):
+        precompute = self.precompute
+        self.precompute = False
+        res = super().summary()
+        self.precompute = precompute
+        return res
+
     def get_activations(self, force=False):
         tmpl = f'_{self.models.name}_{self.data.sz}.bc'
         # TODO: Somehow check that directory names haven't changed (e.g. added test set)


### PR DESCRIPTION
If an instance of ConvLearner is created with precompute=True when we call instance.summary, this produces the following error:

```
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-7-135c0218ac8e> in <module>()
      3 learn = ConvLearner.pretrained(arch, data, precompute=True)
      4 # learn.fit(0.01, 3)
----> 5 learn.summary()

~/workspace/fastai_forked/courses/dl1/fastai/learner.py in summary(self)
     44     def data(self): return self.data_
     45 
---> 46     def summary(self): return model_summary(self.model, [3,self.data.sz,self.data.sz])
     47 
     48     def set_bn_freeze(self, m, do_freeze):

~/workspace/fastai_forked/courses/dl1/fastai/model.py in model_summary(m, input_size)
    152         x = [to_gpu(Variable(torch.rand(1,*in_size))) for in_size in input_size]
    153     else: x = [to_gpu(Variable(torch.rand(1,*input_size)))]
--> 154     m(*x)
    155 
    156     for h in hooks: h.remove()

~/anaconda3/lib/python3.6/site-packages/torch/nn/modules/module.py in __call__(self, *input, **kwargs)
    222         for hook in self._forward_pre_hooks.values():
    223             hook(self, input)
--> 224         result = self.forward(*input, **kwargs)
    225         for hook in self._forward_hooks.values():
    226             hook_result = hook(self, input, result)

~/anaconda3/lib/python3.6/site-packages/torch/nn/modules/container.py in forward(self, input)
     65     def forward(self, input):
     66         for module in self._modules.values():
---> 67             input = module(input)
     68         return input
     69 

~/anaconda3/lib/python3.6/site-packages/torch/nn/modules/module.py in __call__(self, *input, **kwargs)
    222         for hook in self._forward_pre_hooks.values():
    223             hook(self, input)
--> 224         result = self.forward(*input, **kwargs)
    225         for hook in self._forward_hooks.values():
    226             hook_result = hook(self, input, result)

~/anaconda3/lib/python3.6/site-packages/torch/nn/modules/batchnorm.py in forward(self, input)
     35         return F.batch_norm(
     36             input, self.running_mean, self.running_var, self.weight, self.bias,
---> 37             self.training, self.momentum, self.eps)
     38 
     39     def __repr__(self):

~/anaconda3/lib/python3.6/site-packages/torch/nn/functional.py in batch_norm(input, running_mean, running_var, weight, bias, training, momentum, eps)
    637                training=False, momentum=0.1, eps=1e-5):
    638     f = torch._C._functions.BatchNorm(running_mean, running_var, training, momentum, eps, torch.backends.cudnn.enabled)
--> 639     return f(input, weight, bias)
    640 
    641 

RuntimeError: running_mean should contain 3 elements not 1024
```

This error arises because in `Learner#summary` we call `model_summary` with dimensions compatible with a conv layer:
```
def summary(self): return model_summary(self.model, [3,self.data.sz,self.data.sz]) 
```

This is not a great fix as it assumes that the first layer of ConvLearner created with precompute=True will respond to `num_features` and return something meaningful. From a quick glance at pytorch, this might exist only on BatchNorm layers and not necessarily on anything else.

This fix still works for the default case and maybe it is good enough for now or can try to work out something better covering more cases as I continue to learn the library / pytorch.