### PR TITLE
Bug: get_cv_idxs error when val_pct > 0.3

### DIFF
--- a/fastai/dataset.py
+++ b/fastai/dataset.py
@@ -5,12 +5,15 @@ from .transforms import *
 from .layer_optimizer import *
 from .dataloader import DataLoader
 
-def get_cv_idxs(n, cv_idx=4, val_pct=0.2, seed=42):
+def get_cv_idxs(n, cv_idx=None, val_pct=0.2, seed=42):
     np.random.seed(seed)
+    if cv_idx is None: cv_idx=int((1-val_pct)/val_pct)
     n_val = int(val_pct*n)
     idx_start = cv_idx*n_val
     idxs = np.random.permutation(n)
-    return idxs[idx_start:idx_start+n_val]
+    val_idxs = idxs[idx_start:idx_start+n_val]
+    if len(val_idxs) == 0: print("Warning: No Validation Indexes Selected.")
+    return val_idxs
 
 def resize_img(fname, targ, path, new_path):
     dest = os.path.join(path,new_path,str(targ),fname)

--- a/fastai/dataset.py
+++ b/fastai/dataset.py
@@ -5,15 +5,12 @@ from .transforms import *
 from .layer_optimizer import *
 from .dataloader import DataLoader
 
-def get_cv_idxs(n, cv_idx=None, val_pct=0.2, seed=42):
+def get_cv_idxs(n, cv_idx=0, val_pct=0.2, seed=42):
     np.random.seed(seed)
-    if cv_idx is None: cv_idx=int((1-val_pct)/val_pct)
     n_val = int(val_pct*n)
     idx_start = cv_idx*n_val
     idxs = np.random.permutation(n)
-    val_idxs = idxs[idx_start:idx_start+n_val]
-    if len(val_idxs) == 0: print("Warning: No Validation Indexes Selected.")
-    return val_idxs
+    return idxs[idx_start:idx_start+n_val]
 
 def resize_img(fname, targ, path, new_path):
     dest = os.path.join(path,new_path,str(targ),fname)


### PR DESCRIPTION
`get_cv_idxs` returns empty list when `val_pct` specified is > 0.25.  This is because of the `cv_idx` parameter is defaulted to 4.  More details - http://forums.fast.ai/t/understanding-get-val-idxs/8148

Fix is based on suggestion by Adrian Galdran in the same forum post.

Testing:
Current Status:
<img width="755" alt="screen shot 2017-11-21 at 11 50 45 am" src="https://user-images.githubusercontent.com/1437573/33093767-c8dd355a-ceb2-11e7-9f71-172607738106.png">

Fix:
<img width="702" alt="screen shot 2017-11-21 at 11 47 47 am" src="https://user-images.githubusercontent.com/1437573/33093781-d3d1bfd0-ceb2-11e7-91e9-16ab6a60b1d2.png">
