### PR TITLE
Upsampling: Allow redundant filenames in from_csv (csv_source)

### DIFF
--- a/fastai/dataset.py
+++ b/fastai/dataset.py
@@ -61,10 +61,11 @@ def folder_source(path, folder):
 def parse_csv_labels(fn, skip_header=True):
     skip = 1 if skip_header else 0
     csv_lines = [o.strip().split(',') for o in open(fn)][skip:]
+    fnames = [fname for fname, _ in csv_lines]
     csv_labels = {a:b.split(' ') for a,b in csv_lines}
     all_labels = sorted(list(set(p for o in csv_labels.values() for p in o)))
     label2idx = {v:k for k,v in enumerate(all_labels)}
-    return sorted(csv_labels.keys()), csv_labels, all_labels, label2idx
+    return sorted(fnames), csv_labels, all_labels, label2idx
 
 def nhot_labels(label2idx, csv_labels, fnames, c):
     all_idx = {k: n_hot([label2idx[o] for o in v], c)


### PR DESCRIPTION
Feature Request: http://forums.fast.ai/t/how-to-duplicate-training-examples-to-handle-class-imbalance/8348/2

csv_source removes duplicates filenames due to how it's processed (of dict keys).  I don't think this was intentional.  This modification keeps all the Filename duplicates that were passed to csv_source thereby providing an ability to UpSample Minority Class.

**Before:**
<img width="631" alt="screen shot 2017-11-26 at 4 54 19 pm" src="https://user-images.githubusercontent.com/1437573/33246595-4dab82ca-d2cb-11e7-8ee0-e68d886ad859.png">

**After**:
<img width="387" alt="screen shot 2017-11-26 at 4 55 34 pm" src="https://user-images.githubusercontent.com/1437573/33246599-54f581e8-d2cb-11e7-87d1-498a479d6743.png">

