### PR TITLE
Change dn161 act count

### DIFF
--- a/fastai/conv_learner.py
+++ b/fastai/conv_learner.py
@@ -10,7 +10,7 @@ model_meta = {
     wrn:[8,6], inceptionresnet_2:[-2,9], inception_4:[-1,9],
     dn121:[0,6], dn161:[0,6], dn169:[0,6], dn201:[0,6],
 }
-model_features = {inception_4: 3072, dn121: 2048, dn161: 4416,} # nasnetalarge: 4032*2}
+model_features = {inception_4: 3072, dn121: 2208, dn161: 4416,} # nasnetalarge: 4032*2}
 
 class ConvnetBuilder():
     """Class representing a convolutional network.


### PR DESCRIPTION
Either I am horribly wrong, or the creators of dn161 do not realize that they should be using powers of 2 for activation count to give their models superpowers :smile: 

The act count in conv_learner.py was 2048 but I think it should be 2208.