### PR TITLE
refactored embedded dropout and putting up for review

### DIFF
--- a/courses/dl1/embedding_refactoring_unit_tests.ipynb
+++ b/courses/dl1/embedding_refactoring_unit_tests.ipynb
@@ -1,0 +1,365 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from torch.autograd import Variable\n",
+    "from fastai.rnn_reg import *\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def embedded_dropout(embed, words, dropout=0.1, scale=None):\n",
+    "    \"\"\" Applies dropout in the embedding layer by zeroing out some elements of the embedding vector.\n",
+    "    Uses the dropout_mask custom layer to achieve this.\n",
+    "\n",
+    "    Args:\n",
+    "        embed (torch.nn.Embedding): An embedding torch layer\n",
+    "        words (torch.nn.Variable): A torch variable\n",
+    "        dropout (float): dropout fraction to apply to the embedding weights\n",
+    "        scale (float): additional scaling to apply to the modified embedding weights\n",
+    "\n",
+    "    Returns:\n",
+    "        tensor of size: (batch_size x seq_length x embedding_size)\n",
+    "\n",
+    "    Example:\n",
+    "\n",
+    "    >> embed = torch.nn.Embedding(10,3)\n",
+    "    >> words = Variable(torch.LongTensor([[1,2,4,5] ,[4,3,2,9]]))\n",
+    "    >> words.size()\n",
+    "        (2,4)\n",
+    "\n",
+    "    >> dropout_out_ = embedded_dropout(embed, words, dropout=0.40)\n",
+    "    >> dropout_out_\n",
+    "        Variable containing:\n",
+    "        (0 ,.,.) =\n",
+    "          1.2549  1.8230  1.9367\n",
+    "          0.0000 -0.0000  0.0000\n",
+    "          2.2540 -0.1299  1.5448\n",
+    "          0.0000 -0.0000 -0.0000\n",
+    "\n",
+    "        (1 ,.,.) =\n",
+    "          2.2540 -0.1299  1.5448\n",
+    "         -4.0457  2.4815 -0.2897\n",
+    "          0.0000 -0.0000  0.0000\n",
+    "          1.8796 -0.4022  3.8773\n",
+    "        [torch.FloatTensor of size 2x4x3]\n",
+    "    \"\"\"\n",
+    "\n",
+    "    if dropout:\n",
+    "        mask = Variable(dropout_mask(embed.weight.data, (embed.weight.size(0), 1), dropout))\n",
+    "        masked_embed_weight = mask * embed.weight\n",
+    "    else: masked_embed_weight = embed.weight\n",
+    "    if scale: masked_embed_weight = scale * masked_embed_weight\n",
+    "\n",
+    "    padding_idx = embed.padding_idx\n",
+    "    if padding_idx is None: padding_idx = -1\n",
+    "    X = embed._backend.Embedding.apply(words, masked_embed_weight,\n",
+    "        padding_idx, embed.max_norm, embed.norm_type,\n",
+    "        embed.scale_grad_by_freq, embed.sparse\n",
+    "    )\n",
+    "    return X\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Initialize embedding matrix and input"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "embed = torch.nn.Embedding(10,3)\n",
+    "words = torch.autograd.Variable(torch.LongTensor([[1,2,4,5] ,[4,3,2,9]]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### propagate the input via the old method (embedded_dropout)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Variable containing:\n",
+       "(0 ,.,.) = \n",
+       " -0.0000 -0.0000  0.0000\n",
+       " -0.0000 -0.0000  0.0000\n",
+       " -0.8727 -1.3131 -1.2833\n",
+       " -0.0000 -0.0000 -0.0000\n",
+       "\n",
+       "(1 ,.,.) = \n",
+       " -0.8727 -1.3131 -1.2833\n",
+       " -0.7425 -4.4689  0.9931\n",
+       " -0.0000 -0.0000  0.0000\n",
+       " -1.3907 -0.6359 -3.4528\n",
+       "[torch.FloatTensor of size 2x4x3]"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "torch.manual_seed(88123)\n",
+    "dropout_out_old = embedded_dropout(embed, words, dropout=0.40)\n",
+    "dropout_out_old"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### propagate the input via the forward method in the new layer (EmbeddingDropout)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Variable containing:\n",
+       "(0 ,.,.) = \n",
+       " -0.0000 -0.0000  0.0000\n",
+       " -0.0000 -0.0000  0.0000\n",
+       " -0.8727 -1.3131 -1.2833\n",
+       " -0.0000 -0.0000 -0.0000\n",
+       "\n",
+       "(1 ,.,.) = \n",
+       " -0.8727 -1.3131 -1.2833\n",
+       " -0.7425 -4.4689  0.9931\n",
+       " -0.0000 -0.0000  0.0000\n",
+       " -1.3907 -0.6359 -3.4528\n",
+       "[torch.FloatTensor of size 2x4x3]"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "torch.manual_seed(88123)\n",
+    "embed_dropout_layer = EmbeddingDropout(embed)\n",
+    "dropout_out_new = embed_dropout_layer(words, dropout=0.4)\n",
+    "dropout_out_new"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(np.testing.assert_array_equal(to_np(dropout_out_old),to_np(dropout_out_new)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Initialize embedding and matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "embed = torch.nn.Embedding(10,7)\n",
+    "words = torch.autograd.Variable(torch.LongTensor([[1,2,4,5,2,8] ,[4,3,2,9,7,6]]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### get the input by propagating via the old method"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Variable containing:\n",
+       "(0 ,.,.) = \n",
+       " -0.1285  0.7315  0.1410 -1.6623 -3.7160 -1.1500  1.9748\n",
+       " -0.0000 -0.0000 -0.0000 -0.0000  0.0000 -0.0000  0.0000\n",
+       " -1.4062 -0.2985 -1.2622 -1.2019 -3.9978  2.7126  4.9408\n",
+       "  0.0000 -0.0000 -0.0000 -0.0000 -0.0000 -0.0000  0.0000\n",
+       " -0.0000 -0.0000 -0.0000 -0.0000  0.0000 -0.0000  0.0000\n",
+       " -0.0000  0.0000  0.0000 -0.0000 -0.0000  0.0000  0.0000\n",
+       "\n",
+       "(1 ,.,.) = \n",
+       " -1.4062 -0.2985 -1.2622 -1.2019 -3.9978  2.7126  4.9408\n",
+       "  0.0000 -0.0000  0.0000  0.0000 -0.0000  0.0000 -0.0000\n",
+       " -0.0000 -0.0000 -0.0000 -0.0000  0.0000 -0.0000  0.0000\n",
+       " -6.4958  2.6005 -2.2331 -7.8277 -0.9653  3.3815  1.9252\n",
+       " -0.0000 -0.0000  0.0000  0.0000 -0.0000  0.0000  0.0000\n",
+       "  0.0000  0.0000  0.0000  0.0000 -0.0000 -0.0000  0.0000\n",
+       "[torch.FloatTensor of size 2x6x7]"
+      ]
+     },
+     "execution_count": 72,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "torch.manual_seed(7123)\n",
+    "dropout_out_old = embedded_dropout(embed, words, dropout=0.64)\n",
+    "dropout_out_old"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### get the input by propagating input via the embedding layer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 73,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Variable containing:\n",
+       "(0 ,.,.) = \n",
+       " -0.1285  0.7315  0.1410 -1.6623 -3.7160 -1.1500  1.9748\n",
+       " -0.0000 -0.0000 -0.0000 -0.0000  0.0000 -0.0000  0.0000\n",
+       " -1.4062 -0.2985 -1.2622 -1.2019 -3.9978  2.7126  4.9408\n",
+       "  0.0000 -0.0000 -0.0000 -0.0000 -0.0000 -0.0000  0.0000\n",
+       " -0.0000 -0.0000 -0.0000 -0.0000  0.0000 -0.0000  0.0000\n",
+       " -0.0000  0.0000  0.0000 -0.0000 -0.0000  0.0000  0.0000\n",
+       "\n",
+       "(1 ,.,.) = \n",
+       " -1.4062 -0.2985 -1.2622 -1.2019 -3.9978  2.7126  4.9408\n",
+       "  0.0000 -0.0000  0.0000  0.0000 -0.0000  0.0000 -0.0000\n",
+       " -0.0000 -0.0000 -0.0000 -0.0000  0.0000 -0.0000  0.0000\n",
+       " -6.4958  2.6005 -2.2331 -7.8277 -0.9653  3.3815  1.9252\n",
+       " -0.0000 -0.0000  0.0000  0.0000 -0.0000  0.0000  0.0000\n",
+       "  0.0000  0.0000  0.0000  0.0000 -0.0000 -0.0000  0.0000\n",
+       "[torch.FloatTensor of size 2x6x7]"
+      ]
+     },
+     "execution_count": 73,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "torch.manual_seed(7123)\n",
+    "embed_dropout_layer = EmbeddingDropout(embed)\n",
+    "dropout_out_new = embed_dropout_layer(words, dropout=0.64)\n",
+    "dropout_out_new"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(np.testing.assert_array_equal(to_np(dropout_out_old),to_np(dropout_out_new)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/courses/dl1/lesson4-imdb.ipynb
+++ b/courses/dl1/lesson4-imdb.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -69,19 +69,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "imdbEr.txt  imdb.vocab  README  \u001b[0m\u001b[01;34mtest\u001b[0m/  \u001b[01;34mtrain\u001b[0m/\r\n"
+      "imdbEr.txt  imdb.vocab  \u001b[0m\u001b[01;34mmodels\u001b[0m/  README  \u001b[01;34mtest\u001b[0m/  \u001b[01;34mtmp\u001b[0m/  \u001b[01;34mtrain\u001b[0m/\r\n"
      ]
     }
    ],
    "source": [
-    "PATH='data/aclImdb/'\n",
+    "PATH='/home/apil/data/fastai/aclImdb/'\n",
     "\n",
     "TRN_PATH = 'train/all/'\n",
     "VAL_PATH = 'test/all/'\n",
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -118,7 +118,7 @@
        " '10001_4.txt']"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -137,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -146,7 +146,7 @@
        "\"I have to say when a name like Zombiegeddon and an atom bomb on the front cover I was expecting a flat out chop-socky fung-ku, but what I got instead was a comedy. So, it wasn't quite was I was expecting, but I really liked it anyway! The best scene ever was the main cop dude pulling those kids over and pulling a Bad Lieutenant on them!! I was laughing my ass off. I mean, the cops were just so bad! And when I say bad, I mean The Shield Vic Macky bad. But unlike that show I was laughing when they shot people and smoked dope.<br /><br />Felissa Rose...man, oh man. What can you say about that hottie. She was great and put those other actresses to shame. She should work more often!!!!! I also really liked the fight scene outside of the building. That was done really well. Lots of fighting and people getting their heads banged up. FUN! Last, but not least Joe Estevez and William Smith were great as the...well, I wasn't sure what they were, but they seemed to be having fun and throwing out lines. I mean, some of it didn't make sense with the rest of the flick, but who cares when you're laughing so hard! All in all the film wasn't the greatest thing since sliced bread, but I wasn't expecting that. It was a Troma flick so I figured it would totally suck. It's nice when something surprises you but not totally sucking.<br /><br />Rent it if you want to get stoned on a Friday night and laugh with your buddies. Don't rent it if you are an uptight weenie or want a zombie movie with lots of flesh eating.<br /><br />P.S. Uwe Boil was a nice touch.\""
       ]
      },
-     "execution_count": 7,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -167,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -184,7 +184,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -217,7 +217,7 @@
        "\"I have to say when a name like Zombiegeddon and an atom bomb on the front cover I was expecting a flat out chop - socky fung - ku , but what I got instead was a comedy . So , it was n't quite was I was expecting , but I really liked it anyway ! The best scene ever was the main cop dude pulling those kids over and pulling a Bad Lieutenant on them ! ! I was laughing my ass off . I mean , the cops were just so bad ! And when I say bad , I mean The Shield Vic Macky bad . But unlike that show I was laughing when they shot people and smoked dope . \\n\\n Felissa Rose ... man , oh man . What can you say about that hottie . She was great and put those other actresses to shame . She should work more often ! ! ! ! ! I also really liked the fight scene outside of the building . That was done really well . Lots of fighting and people getting their heads banged up . FUN ! Last , but not least Joe Estevez and William Smith were great as the ... well , I was n't sure what they were , but they seemed to be having fun and throwing out lines . I mean , some of it did n't make sense with the rest of the flick , but who cares when you 're laughing so hard ! All in all the film was n't the greatest thing since sliced bread , but I was n't expecting that . It was a Troma flick so I figured it would totally suck . It 's nice when something surprises you but not totally sucking . \\n\\n Rent it if you want to get stoned on a Friday night and laugh with your buddies . Do n't rent it if you are an uptight weenie or want a zombie movie with lots of flesh eating . \\n\\n P.S. Uwe Boil was a nice touch .\""
       ]
      },
-     "execution_count": 10,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -237,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 8,
    "metadata": {
     "collapsed": true
    },
@@ -257,7 +257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 9,
    "metadata": {
     "collapsed": true
    },
@@ -268,7 +268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 10,
    "metadata": {
     "collapsed": true
    },
@@ -289,7 +289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -307,7 +307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -316,7 +316,7 @@
        "(4602, 34945, 1, 20621966)"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -334,7 +334,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 12,
    "metadata": {
     "scrolled": true
    },
@@ -345,7 +345,7 @@
        "['<unk>', '<pad>', 'the', ',', '.', 'and', 'a', 'of', 'to', 'is', 'it', 'in']"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -357,7 +357,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 13,
    "metadata": {
     "scrolled": true
    },
@@ -368,7 +368,7 @@
        "2"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -387,27 +387,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['picking',\n",
-       " 'up',\n",
-       " 'the',\n",
-       " 'jacket',\n",
-       " 'of',\n",
+       "['i',\n",
+       " 'have',\n",
+       " 'always',\n",
+       " 'loved',\n",
        " 'this',\n",
-       " 'dvd',\n",
-       " 'in',\n",
+       " 'story',\n",
+       " '-',\n",
        " 'the',\n",
-       " 'video',\n",
-       " 'store',\n",
-       " 'i']"
+       " 'hopeful',\n",
+       " 'theme',\n",
+       " ',',\n",
+       " 'the']"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -425,29 +425,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "Variable containing:\n",
-       " 3658\n",
-       "   67\n",
-       "    2\n",
-       " 5530\n",
-       "    7\n",
-       "   13\n",
-       "  293\n",
-       "   11\n",
-       "    2\n",
-       "  391\n",
-       " 1058\n",
        "   12\n",
+       "   35\n",
+       "  227\n",
+       "  480\n",
+       "   13\n",
+       "   76\n",
+       "   17\n",
+       "    2\n",
+       " 7319\n",
+       "  769\n",
+       "    3\n",
+       "    2\n",
        "[torch.cuda.LongTensor of size 12x1 (GPU 0)]"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -467,32 +467,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "(Variable containing:\n",
-       "   3658      2   1251  ...     687   1310    312\n",
-       "     67   8480   4536  ...    2035    735    863\n",
-       "      2     11  21594  ...       5     74     36\n",
+       "     12    567      3  ...    2118      4   2399\n",
+       "     35      7     33  ...       6    148     55\n",
+       "    227    103    533  ...    4892     31     10\n",
        "         ...            ⋱           ...         \n",
-       "     16      6    165  ...      29    135     30\n",
-       "     59    990     34  ...     155     10     78\n",
-       "      2    823    132  ...      20      4    470\n",
-       " [torch.cuda.LongTensor of size 64x64 (GPU 0)], Variable containing:\n",
-       "     67\n",
-       "   8480\n",
-       "   4536\n",
+       "     19   8879     33  ...      41     24    733\n",
+       "    552   8250     57  ...     219     57   1777\n",
+       "      5     19      2  ...    3099      8     48\n",
+       " [torch.cuda.LongTensor of size 77x64 (GPU 0)], Variable containing:\n",
+       "     35\n",
+       "      7\n",
+       "     33\n",
        "   ⋮   \n",
-       "      2\n",
-       "     18\n",
-       "     54\n",
-       " [torch.cuda.LongTensor of size 4096 (GPU 0)])"
+       "     22\n",
+       "   3885\n",
+       "  21587\n",
+       " [torch.cuda.LongTensor of size 4928 (GPU 0)])"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -517,7 +517,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 17,
    "metadata": {
     "collapsed": true
    },
@@ -537,7 +537,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 18,
    "metadata": {
     "collapsed": true
    },
@@ -557,7 +557,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 19,
    "metadata": {
     "collapsed": true
    },
@@ -578,19 +578,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Widget Javascript not detected.  It may not be installed or enabled properly.\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4146d1266fba4e6983bd939385726533",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "A Jupyter Widget"
-      ]
+       "model_id": "04fcfdf44a3d45a2b0029992fa060855"
+      }
      },
      "metadata": {},
      "output_type": "display_data"
@@ -599,15 +601,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[ 0.      4.6754  4.5553]                                     \n",
-      "[ 1.      4.5344  4.4255]                                     \n",
-      "[ 2.      4.4838  4.389 ]                                     \n",
-      "[ 3.      4.5597  4.4271]                                     \n",
-      "[ 4.      4.4565  4.3472]                                     \n",
-      "[ 5.      4.4095  4.3167]                                     \n",
-      "[ 6.      4.5065  4.3852]                                     \n",
-      "[ 7.      4.4273  4.3122]                                     \n",
-      "[ 8.      4.3651  4.2831]                                     \n",
+      "[ 0.       4.85167  4.72509]                                    \n",
+      "[ 1.       4.65204  4.51418]                                  \n",
+      "[ 2.       4.52936  4.43176]                                  \n",
+      "[ 3.       4.57711  4.45321]                                  \n",
+      "[ 4.       4.49827  4.37943]                                  \n",
+      "[ 5.       4.41825  4.32227]                                  \n",
+      "[ 6.       4.40372  4.30466]                                  \n",
+      "[ 7.       4.52163  4.39423]                                  \n",
+      "[ 8.       4.48485  4.36614]                                  \n",
+      "[ 9.       4.43876  4.33174]                                  \n",
+      "[ 10.        4.40153   4.30196]                               \n",
+      "[ 11.        4.38985   4.27407]                               \n",
+      "[ 12.        4.31973   4.24876]                               \n",
+      "[ 13.        4.29297   4.2362 ]                               \n",
+      "[ 14.        4.31048   4.23348]                               \n",
       "\n"
      ]
     }
@@ -618,7 +626,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -629,21 +637,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "learner.load_encoder('adam1_enc')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "learner.load_cycle('adam3_10',2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
    "metadata": {
     "scrolled": true
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Widget Javascript not detected.  It may not be installed or enabled properly.\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e95863770c414e5fb1a23730865cb9b6",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "A Jupyter Widget"
-      ]
+       "model_id": "6df5311d05f640cd80aa9f8a0a8e1350"
+      }
      },
      "metadata": {},
      "output_type": "display_data"
@@ -652,127 +684,33 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[ 0.      4.5019  4.3872]                                     \n",
-      "[ 1.      4.4707  4.3654]                                     \n",
-      "[ 2.      4.4606  4.3432]                                     \n",
-      "[ 3.      4.4183  4.3185]                                     \n",
-      "[ 4.      4.3858  4.2928]                                     \n",
-      "[ 5.      4.368   4.2717]                                     \n",
-      "[ 6.      4.3286  4.2485]                                     \n",
-      "[ 7.      4.3101  4.2333]                                     \n",
-      "[ 8.      4.2913  4.2256]                                     \n",
-      "[ 9.      4.2581  4.2244]                                     \n",
-      "[ 10.       4.4615   4.3373]                                  \n",
-      "[ 11.       4.4281   4.3265]                                  \n",
-      "[ 12.       4.4209   4.3076]                                  \n",
-      "[ 13.       4.3941   4.2883]                                  \n",
-      "[ 14.       4.3655   4.2645]                                  \n",
-      "[ 15.       4.3298   4.242 ]                                  \n",
-      "[ 16.       4.3018   4.2229]                                  \n",
-      "[ 17.       4.2902   4.2097]                                  \n",
-      "[ 18.       4.2603   4.2021]                                  \n",
-      "[ 19.       4.2465   4.2011]                                  \n",
-      "[ 20.       4.4299   4.3136]                                  \n",
-      "[ 21.       4.4141   4.308 ]                                  \n",
-      "[ 22.       4.4116   4.2911]                                  \n",
-      "[ 23.       4.3732   4.2714]                                  \n",
-      "[ 24.       4.3494   4.2503]                                  \n",
-      "[ 25.       4.2977   4.2267]                                  \n",
-      "[ 26.       4.2706   4.2093]                                  \n",
-      "[ 27.       4.2783   4.1968]                                  \n",
-      "[ 28.       4.2793   4.1893]                                  \n",
-      "[ 29.       4.2252   4.1872]                                  \n",
-      "[ 30.       4.4068   4.3006]                                  \n",
-      "[ 31.       4.3984   4.2935]                                  \n",
-      "[ 32.       4.3713   4.2759]                                  \n",
-      "[ 33.       4.364    4.2602]                                  \n",
-      "[ 34.       4.3187   4.2406]                                  \n",
-      "[ 35.       4.3037   4.2196]                                  \n",
-      "[ 36.       4.2787   4.2003]                                  \n",
-      "[ 37.       4.2539   4.1871]                                  \n",
-      "[ 38.       4.2175   4.1801]                                  \n",
-      "[ 39.       4.2048   4.1788]                                  \n",
+      "[ 0.      4.3926  4.2917]                                       \n",
+      "[ 1.       4.37693  4.28255]                                  \n",
+      "[ 2.       4.37998  4.27243]                                  \n",
+      "[ 3.       4.34284  4.24789]                                  \n",
+      "[ 4.      4.3287  4.2317]                                     \n",
+      "[ 5.       4.28881  4.20722]                                  \n",
+      "[ 6.       4.24637  4.18926]                                  \n",
+      "[ 7.       4.23797  4.17644]                                  \n",
+      "[ 8.       4.20074  4.16989]                                  \n",
+      "[ 9.       4.18873  4.16866]                                  \n",
       "\n"
      ]
     }
    ],
    "source": [
-    "learner.fit(3e-3, 4, wds=1e-6, cycle_len=10, cycle_save_name='adam3_10')"
+    "learner.fit(3e-3, 1, wds=1e-6, cycle_len=10)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 24,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
     "learner.save_encoder('adam3_10_enc')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2b91e83ce196468e97ed5d74f7f38851",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "A Jupyter Widget"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[ 0.      4.2122  4.1803]                                     \n",
-      "[ 1.      4.4048  4.2924]                                     \n",
-      "[ 2.      4.4049  4.292 ]                                     \n",
-      "[ 3.      4.3769  4.2839]                                     \n",
-      "[ 4.      4.3734  4.2757]                                     \n",
-      "[ 5.      4.3558  4.2684]                                     \n",
-      "[ 6.      4.3471  4.2587]                                     \n",
-      "[ 7.      4.3372  4.2475]                                     \n",
-      "[ 8.      4.3426  4.2398]                                     \n",
-      "[ 9.      4.3155  4.2253]                                     \n",
-      "[ 10.       4.2975   4.2165]                                  \n",
-      "[ 11.       4.2747   4.2057]                                  \n",
-      "[ 12.       4.2725   4.1949]                                  \n",
-      "[ 13.       4.2533   4.1861]                                  \n",
-      "[ 14.       4.2281   4.1788]                                  \n",
-      "[ 15.       4.226    4.1729]                                  \n",
-      "[ 16.       4.222    4.1689]                                  \n",
-      "[ 17.       4.203    4.1655]                                  \n",
-      "[ 18.       4.1878   4.1646]                                  \n",
-      "[ 19.       4.1799   4.1646]                                  \n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "learner.fit(3e-3, 1, wds=1e-6, cycle_len=20, cycle_save_name='adam3_20')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "learner.load_cycle('adam3_20', 0)"
    ]
   },
   {
@@ -784,13 +722,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 25,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
     "learner.save_encoder('adam3_20_enc')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learner.load_encoder('adam3_20_enc')"
    ]
   },
   {
@@ -802,7 +749,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -811,13 +758,24 @@
        "64.3926824434624"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "math.exp(4.165)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "pickle.dump(TEXT, open(f'{PATH}models/TEXT.pkl','wb'))"
    ]
   },
   {
@@ -840,7 +798,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 28,
    "metadata": {
     "hidden": true
    },
@@ -851,7 +809,7 @@
        "\". So , it was n't quite was I was expecting , but I really liked it anyway ! The best\""
       ]
      },
-     "execution_count": 62,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -875,7 +833,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 29,
    "metadata": {
     "collapsed": true,
     "hidden": true
@@ -905,7 +863,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 30,
    "metadata": {
     "hidden": true
    },
@@ -913,19 +871,19 @@
     {
      "data": {
       "text/plain": [
-       "['performance',\n",
+       "['film',\n",
+       " 'movie',\n",
        " 'of',\n",
-       " 'friend',\n",
-       " 'actor',\n",
        " 'thing',\n",
-       " 'scene',\n",
-       " 'character',\n",
        " 'part',\n",
-       " 'line',\n",
-       " 'movie']"
+       " '<unk>',\n",
+       " 'performance',\n",
+       " 'scene',\n",
+       " ',',\n",
+       " 'actor']"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -946,7 +904,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 31,
    "metadata": {
     "hidden": true
    },
@@ -957,9 +915,7 @@
      "text": [
       ". So, it wasn't quite was I was expecting, but I really liked it anyway! The best \n",
       "\n",
-      "performance was the one in the movie where he was a little too old for the part . i think he was a good actor , but he was n't that good . \n",
-      "\n",
-      " the movie was a bit slow , but it was n't too bad . the acting ...\n"
+      "film ever ! <eos> i saw this movie at the toronto international film festival . i was very impressed . i was very impressed with the acting . i was very impressed with the acting . i was surprised to see that the actors were not in the movie . ...\n"
      ]
     }
    ],
@@ -989,7 +945,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 32,
    "metadata": {
     "collapsed": true
    },
@@ -1009,7 +965,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 33,
    "metadata": {
     "collapsed": true
    },
@@ -1021,7 +977,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 34,
    "metadata": {
     "collapsed": true
    },
@@ -1032,17 +988,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "('pos',\n",
-       " 'this was another great tom berenger movie .. but some people are right it was like')"
+       "('pos', 'ashanti is a very 70s sort of film ( 1979 , to be precise ) .')"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1060,7 +1015,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 36,
    "metadata": {
     "collapsed": true
    },
@@ -1071,7 +1026,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 37,
    "metadata": {
     "collapsed": true
    },
@@ -1092,7 +1047,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 38,
    "metadata": {
     "collapsed": true
    },
@@ -1104,41 +1059,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f13ea6a5dc0e48238969594dd240c546",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "A Jupyter Widget"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[ 0.       0.43352  0.24757  0.90585]                        \n",
-      "\n"
+      "Widget Javascript not detected.  It may not be installed or enabled properly.\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f9d95c82e3af466a82d5ab73a4a9456a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "A Jupyter Widget"
-      ]
+       "model_id": "c325f4fa12b54cb880178e5c68252d8a"
+      }
      },
      "metadata": {},
      "output_type": "display_data"
@@ -1147,7 +1082,31 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[ 0.       0.29882  0.1976   0.92504]                        \n",
+      "[ 0.       0.45074  0.28424  0.88458]                        \n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Widget Javascript not detected.  It may not be installed or enabled properly.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bb4cb440a80340c1806aeb3a61c32666"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ 0.       0.29202  0.19023  0.92768]                        \n",
       "\n"
      ]
     }
@@ -1161,21 +1120,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 40,
    "metadata": {
     "scrolled": true
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Widget Javascript not detected.  It may not be installed or enabled properly.\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e65f58990d7341c7a684e28e80cc6add",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "A Jupyter Widget"
-      ]
+       "model_id": "f5102883a24b48ea97058c8e7dbab533"
+      }
      },
      "metadata": {},
      "output_type": "display_data"
@@ -1184,22 +1145,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[ 0.      0.275   0.1847  0.9306]                            \n",
-      "[ 1.      0.2528  0.1781  0.9336]                            \n",
-      "[ 2.      0.2448  0.1729  0.9365]                            \n",
-      "[ 3.      0.2052  0.1721  0.9378]                            \n",
-      "[ 4.      0.2239  0.1619  0.9413]                            \n",
-      "[ 5.      0.1956  0.1628  0.9417]                            \n",
-      "[ 6.      0.2093  0.158   0.9421]                            \n",
-      "[ 7.      0.1733  0.1591  0.9432]                            \n",
-      "[ 8.      0.1916  0.1552  0.9443]                            \n",
-      "[ 9.      0.1652  0.157   0.9451]                            \n",
-      "[ 10.       0.1749   0.1609   0.9427]                        \n",
-      "[ 11.       0.147    0.1579   0.9441]                        \n",
-      "[ 12.       0.1554   0.1626   0.942 ]                        \n",
-      "[ 13.       0.1302   0.1603   0.9437]                        \n",
-      "[ 14.       0.1346   0.1802   0.9384]                        \n",
-      "[ 15.       0.1425   0.1711   0.941 ]                        \n",
+      "[ 0.       0.29053  0.18292  0.93241]                        \n",
+      "[ 1.       0.24058  0.18233  0.93313]                        \n",
+      "[ 2.       0.24244  0.17261  0.93714]                        \n",
+      "[ 3.       0.21166  0.17143  0.93866]                        \n",
+      "[ 4.       0.2062   0.17143  0.94042]                        \n",
+      "[ 5.       0.18951  0.16591  0.94083]                        \n",
+      "[ 6.       0.20527  0.16631  0.9393 ]                        \n",
+      "[ 7.       0.17372  0.16162  0.94159]                        \n",
+      "[ 8.       0.17434  0.17213  0.94063]                        \n",
+      "[ 9.       0.16285  0.16073  0.94311]                        \n",
+      "[ 10.        0.16327   0.17851   0.93998]                    \n",
+      "[ 11.        0.15795   0.16042   0.94267]                    \n",
+      "[ 12.        0.1602    0.16015   0.94199]                    \n",
+      "[ 13.        0.15503   0.1624    0.94171]                    \n",
       "\n"
      ]
     }
@@ -1210,7 +1169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 41,
    "metadata": {
     "collapsed": true
    },
@@ -1221,16 +1180,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.94511217948717952"
+       "0.94310897435897434"
       ]
      },
-     "execution_count": 79,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/fastai/lm_rnn.py
+++ b/fastai/lm_rnn.py
@@ -1,7 +1,7 @@
 import warnings
 from .imports import *
 from .torch_imports import *
-from .rnn_reg import embedded_dropout,LockedDropout,WeightDrop,EmbeddingDropout
+from .rnn_reg import LockedDropout,WeightDrop,EmbeddingDropout
 from .model import Stepper
 
 

--- a/fastai/lm_rnn.py
+++ b/fastai/lm_rnn.py
@@ -1,7 +1,7 @@
 import warnings
 from .imports import *
 from .torch_imports import *
-from .rnn_reg import embedded_dropout,LockedDropout,WeightDrop
+from .rnn_reg import embedded_dropout,LockedDropout,WeightDrop,EmbeddingDropout
 from .model import Stepper
 
 
@@ -56,6 +56,7 @@ class RNN_Encoder(nn.Module):
 
         super().__init__()
         self.encoder = nn.Embedding(ntoken, emb_sz, padding_idx=pad_token)
+        self.encoder_with_dropout = EmbeddingDropout(self.encoder)
         self.rnns = [torch.nn.LSTM(emb_sz if l == 0 else nhid, nhid if l != nlayers - 1 else emb_sz, 1, dropout=dropouth)
                      for l in range(nlayers)]
         if wdrop: self.rnns = [WeightDrop(rnn, wdrop) for rnn in self.rnns]
@@ -76,7 +77,7 @@ class RNN_Encoder(nn.Module):
             dropouth, list of tensors evaluated from each RNN layer using dropouth,
         """
 
-        emb = embedded_dropout(self.encoder, input, dropout=self.dropoute if self.training else 0)
+        emb = self.encoder_with_dropout(input, dropout=self.dropoute if self.training else 0)
         emb = self.dropouti(emb)
 
         raw_output = emb


### PR DESCRIPTION
Not a major change, only refactored the embedded_dropout method so that it now is actually layer. Just thought this was more in the spirit of defining other layers like LockedDropout, WeightDropout and so forth..

### Main purpose

learner.model now spits out the following. That's about it!

<img width="489" alt="screenshot 2017-12-11 21 38 56" src="https://user-images.githubusercontent.com/6851604/33864768-543c54c8-debc-11e7-9220-b808b205625e.png">

### Test

I attached a small set of tests to show that that propagating the input via the new EmbeddingDropout layer was identical to the usage of the previous method. View them here [link](https://github.com/apiltamang/fastai/blob/refactor_embedding_dropout/courses/dl1/embedding_refactoring_unit_tests.ipynb):

### Loss

Here [link](https://github.com/apiltamang/fastai/blob/refactor_embedding_dropout/courses/dl1/lesson4-imdb.ipynb) are the losses and performance I obtained after running lesson-4-imdb.ipynb with this code..

Guess it's not really a big deal, so feel free to ignore if you like.  I can revert changes on the notebooks if we decide to go ahead and merge this change. I'm glad this worked anyways, because in an earlier attempt, this had failed, and I was really curious to see why.