### PR TITLE
Update model.py

### DIFF
--- a/fastai/model.py
+++ b/fastai/model.py
@@ -40,7 +40,7 @@ class Stepper():
         output = self.m(*xs)
         if isinstance(output,(tuple,list)): output,*xtra = output
         self.opt.zero_grad()
-        loss = raw_loss = self.crit(output, y.long())
+        loss = raw_loss = self.crit(output, y)
         if self.reg_fn: loss = self.reg_fn(output, xtra, raw_loss)
         loss.backward()
         if self.clip:   # Gradient clipping
@@ -51,7 +51,7 @@ class Stepper():
     def evaluate(self, xs, y):
         preds = self.m(*xs)
         if isinstance(preds,(tuple,list)): preds=preds[0]
-        return preds, self.crit(preds,y.long())
+        return preds, self.crit(preds, y)
 
 from . import lm_rnn
 def set_train_mode(m):


### PR DESCRIPTION
Fixing the error:
```
Expected object of type Variable[torch.cuda.FloatTensor] but found type Variable[torch.cuda.LongTensor] for argument #1 ‘target’
```
for the rossman notebook. I don't know the impact of that change to the other notebooks nor do I know why it was casted to `long` in the first place. Maybe @jph00 could shed some lights on this.