### PR TITLE
Update lesson 2 to reflect changes in TTA

### DIFF
--- a/courses/dl1/lesson2-image_models.ipynb
+++ b/courses/dl1/lesson2-image_models.ipynb
@@ -765,8 +765,8 @@
    },
    "outputs": [],
    "source": [
-    "log_preds,y = learn.TTA()\n",
-    "preds = np.mean(np.exp(log_preds),0)"
+    "multi_preds, y = learn.TTA()\n",
+    "preds = np.mean(multi_preds, 0)"
    ]
   },
   {


### PR DESCRIPTION
As mentioned in "Change to how TTA() works" (http://forums.fast.ai/t/change-to-how-tta-works/8474),
it used to be that:

  TTA() is averaging the log of the softmax layer, rather than the probabilities.

This was changed to:

  return the actual individual TTA predictions, which you then average yourself

This commit attempts to update the lesson 2 notebook to align with that change.