### PR TITLE
include epoch, train_loss, val_loss, and val_stats in print statements

### DIFF
--- a/fastai/model.py
+++ b/fastai/model.py
@@ -79,6 +79,8 @@ def fit(model, data, epochs, opt, crit, metrics=None, callbacks=None, **kwargs):
     avg_mom=0.98
     batch_num,avg_loss=0,0.
     for cb in callbacks: cb.on_train_begin()
+    
+    names = ["train_loss","val_loss"] + [f.__name__ for f in metrics]
 
     for epoch in tnrange(epochs, desc='Epoch'):
         stepper.reset(True)
@@ -95,7 +97,8 @@ def fit(model, data, epochs, opt, crit, metrics=None, callbacks=None, **kwargs):
             if stop: return
 
         vals = validate(stepper, data.val_dl, metrics)
-        print(np.round([epoch, debias_loss] + vals, 6))
+        print_stats(epoch, names, [debias_loss] + vals)
+        
         stop=False
         for cb in callbacks: stop = stop or cb.on_epoch_end(vals)
         if stop: break
@@ -103,6 +106,11 @@ def fit(model, data, epochs, opt, crit, metrics=None, callbacks=None, **kwargs):
     for cb in callbacks: cb.on_train_end()
 
 
+def print_stats(epoch, names, values):
+    print_str = "{}: {:3d}, ".format("epoch",epoch)
+    print_str += ', '.join(("{}: {:.6f}".format(n, v) for (n, v) in zip(names, values)))
+    print(print_str)    
+    
 def validate(stepper, dl, metrics):
     loss,res = [],[]
     stepper.reset(False)


### PR DESCRIPTION
Added method for better printouts at the end of each iteration. The print method should automatically take care of variable number of validation-stats methods passed into it. 

Here're some screenshots of the results:

<img width="657" alt="screenshot 2018-01-15 20 58 09" src="https://user-images.githubusercontent.com/6851604/34968661-894fa4f2-fa38-11e7-8759-bdbedb6d41bb.png">

<img width="661" alt="screenshot 2018-01-15 20 57 35" src="https://user-images.githubusercontent.com/6851604/34968664-90931140-fa38-11e7-8dea-32d098fd01b0.png">

Sorry I don't have the entire notebooks. I just found today that my NVIDIA drivers have been totally corrupted, and now the GPUs just can't be found! Have a looong road ahead of me as I try to ameliorate this situation.