### PR TITLE
Updating model.py

### DIFF
--- a/fastai/model.py
+++ b/fastai/model.py
@@ -122,7 +122,7 @@ def predict_with_targs(m, dl):
     m.eval()
     if hasattr(m, 'reset'): m.reset()
     res = []
-    for *x,y in iter(dl): res.append([get_prediction(m(*VV(x))),y])
+    for *x,y in dl: res.append([get_prediction(m(*VV(x))),y])
     preda,targa = zip(*res)
     return to_np(torch.cat(preda)), to_np(torch.cat(targa))
 


### PR DESCRIPTION
changing iter(dl) to dl, in predict_with_targs. using iter seems to load up all images at once (over 8GB of RAM + overloading 8GB swap on Ubuntu as well, when using test set for dogscats on resnet 50) and uses very high RAM, simply dl seems to function more as intended.