### PR TITLE
Default to 2 CPUs for multi-processing on OS X

### DIFF
--- a/fastai/core.py
+++ b/fastai/core.py
@@ -78,10 +78,13 @@ def one_hot(a,c): return np.eye(c)[a]
 def partition(a, sz): return [a[i:i+sz] for i in range(0, len(a), sz)]
 
 def partition_by_cores(a):
+    return partition(a, len(a)//num_cpus() + 1)
+
+def num_cpus():
     try:
-        return partition(a, len(a)//len(os.sched_getaffinity(0)) + 1)
+        return len(os.sched_getaffinity(0))
     except AttributeError:
-        return partition(a, len(a)//2)
+        return os.cpu_count()
 
 
 class BasicModel():

--- a/fastai/core.py
+++ b/fastai/core.py
@@ -78,7 +78,10 @@ def one_hot(a,c): return np.eye(c)[a]
 def partition(a, sz): return [a[i:i+sz] for i in range(0, len(a), sz)]
 
 def partition_by_cores(a):
-    return partition(a, len(a)//len(os.sched_getaffinity(0)) + 1)
+    try:
+        return partition(a, len(a)//len(os.sched_getaffinity(0)) + 1)
+    except AttributeError:
+        return partition(a, len(a)//2)
 
 
 class BasicModel():

--- a/fastai/text.py
+++ b/fastai/text.py
@@ -75,7 +75,10 @@ class Tokenizer():
     def proc_all(self, ss): return [self.proc_text(s) for s in ss]
 
     def proc_all_mp(self, ss):
-        ncpus = len(os.sched_getaffinity(0))//2
+        try:
+            ncpus = len(os.sched_getaffinity(0))//2
+        except AttributeError:
+            ncpus = 2
         with ProcessPoolExecutor(ncpus) as e: return sum(e.map(self.proc_all, ss), [])
 
 

--- a/fastai/text.py
+++ b/fastai/text.py
@@ -75,10 +75,7 @@ class Tokenizer():
     def proc_all(self, ss): return [self.proc_text(s) for s in ss]
 
     def proc_all_mp(self, ss):
-        try:
-            ncpus = len(os.sched_getaffinity(0))//2
-        except AttributeError:
-            ncpus = 2
+        ncpus = num_cpus()//2
         with ProcessPoolExecutor(ncpus) as e: return sum(e.map(self.proc_all, ss), [])
 
 


### PR DESCRIPTION
`os.sched_getaffinity` is not supported on OS X. `multiprocessing.cpu_count()` is an alternative but seems to return unreliable numbers in some environments (see [here](https://github.com/python/mypy/issues/1196)). I've added a default of `2` cpus in case `os.sched_getaffinity` is not available.

Feel free to close this PR if you don't think this is necessary.