### PR TITLE
Set a default threshold in default multi_accuracy when fitting on mul…

### DIFF
--- a/fastai/conv_learner.py
+++ b/fastai/conv_learner.py
@@ -87,7 +87,7 @@ class ConvLearner(Learner):
         self.crit = F.binary_cross_entropy if data.is_multi else F.nll_loss
         if data.is_reg: self.crit = F.l1_loss
         elif self.metrics is None:
-            self.metrics = [accuracy_multi] if self.data.is_multi else [accuracy]
+            self.metrics = [accuracy_thresh(0.5)] if self.data.is_multi else [accuracy]
         if precompute: self.save_fc1()
         self.freeze()
         self.precompute = precompute


### PR DESCRIPTION
…tilabel.

Hi,

I tried fitting a multilabel classification model without specifying a metrics.  
It crashed, this should fix it.

You can reproduce the crash on notebook `lesson2-image_models` by removing the metrics before fitting:

    learn = ConvLearner.pretrained(f_model, data) #, metrics=metrics)
    lrf=learn.lr_find()
    learn.sched.plot()

It crashes with:

```
/fastai/fastai/fastai/model.py in <listcomp>(.0)
    110         preds,l = stepper.evaluate(VV(x), VV(y))
    111         loss.append(to_np(l))
--> 112         res.append([f(to_np(preds),to_np(y)) for f in metrics])
    113     return [np.mean(loss)] + list(np.mean(np.stack(res),0))
    114 

TypeError: accuracy_multi() missing 1 required positional argument: 'thresh'
```
