### PR TITLE
Bug fix:  RandomLighting image transformation was not doing randomization of parameters b and c

### DIFF
--- a/fastai/transforms.py
+++ b/fastai/transforms.py
@@ -383,8 +383,8 @@ class RandomLighting(Transform):
         self.c_rand = rand0(self.c)
 
     def do_transform(self, x):
-        b = self.b
-        c = self.c
+        b = self.b_rand
+        c = self.c_rand
         c = -1/(c-1) if c<0 else c+1
         x = lighting(x, b, c)
         return x


### PR DESCRIPTION
RandomLighting class was calculating random values b_rand and c_rand but was not using them for transformation. As a result, lighting change was always the same for every execution of image augmentation code.
This is a small fix to make randomization of lighting parameters work.