### PR TITLE
Handle None default value for val_idxs in ImageClassifierData.from_csv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ ENV/
 .mypy_cache/
 
 .vscode
+*.swp
 
 # osx generated files
 .DS_Store

--- a/fastai/dataset.py
+++ b/fastai/dataset.py
@@ -357,7 +357,8 @@ class ImageClassifierData(ImageData):
             csv_fname: a name of the CSV file which contains target labels.
             bs: batch size
             tfms: transformations (for data augmentations). e.g. output of `tfms_from_model`
-            val_idxs: index of images to be used for validation. e.g. output of `get_cv_idxs`
+            val_idxs: index of images to be used for validation. e.g. output of `get_cv_idxs`.
+                If None, default arguments to get_cv_idxs are used.
             suffix: suffix to add to image names in CSV file (sometimes CSV only contains the file name without file
                     extension e.g. '.jpg' - in which case, you can set suffix as '.jpg')
             test_name: a name of the folder which contains test images.
@@ -369,6 +370,8 @@ class ImageClassifierData(ImageData):
             ImageClassifierData
         """
         fnames,y,classes = csv_source(folder, csv_fname, skip_header, suffix, continuous=continuous)
+
+        val_idxs = get_cv_idxs(len(fnames)) if val_idxs is None else val_idxs
         ((val_fnames,trn_fnames),(val_y,trn_y)) = split_by_idx(val_idxs, np.array(fnames), y)
 
         test_fnames = read_dir(path, test_name) if test_name else None


### PR DESCRIPTION
`from_csv` has None as the default value for `val_idxs`, but isn't able to be executed with this default.

Since we have the number of files available inside the function, this change would set `val_idxs` automatically by running `get_cv_idxs` with this number (`len(fnames)`) and the default arguments (i.e. 0.2), if no other indices were specified (i.e. run it if `val_idxs` is None).

Does that make sense or is it too implicit?

(+ change to `.gitignore` to ignore vim swap files).