### PR TITLE
Add precompute option to set_data

### DIFF
--- a/fastai/conv_learner.py
+++ b/fastai/conv_learner.py
@@ -106,9 +106,15 @@ class ConvLearner(Learner):
     def create_empty_bcolz(self, n, name):
         return bcolz.carray(np.zeros((0,n), np.float32), chunklen=1, mode='w', rootdir=name)
 
-    def set_data(self, data):
+    def set_data(self, data, precompute=False):
         super().set_data(data)
-        self.freeze()
+        if precompute:
+            self.unfreeze()
+            self.save_fc1()
+            self.freeze()
+            self.precompute = True
+        else:
+            self.freeze()
 
     def get_layer_groups(self):
         return self.models.get_layer_groups(self.precompute)


### PR DESCRIPTION
This change allows users to get precomputed activations for new datasets after using set_data. This change won't affect user's current set_data calls, since its effect requires a new keyword argument.