### PR TITLE
Make path concatenation in load_img_id function more reliable

### DIFF
--- a/fastai/plots.py
+++ b/fastai/plots.py
@@ -71,7 +71,7 @@ def plots_raw(ims, figsize=(12,6), rows=1, titles=None):
         if titles is not None: sp.set_title(titles[i], fontsize=16)
         plt.imshow(ims[i])
 
-def load_img_id(ds, idx, path): return np.array(PIL.Image.open(path+ds.fnames[idx]))
+def load_img_id(ds, idx, path): return np.array(PIL.Image.open(os.path.join(path, ds.fnames[idx])))
 
 
 class ImageModelResults():


### PR DESCRIPTION
This is a fix to make patch concatenation more reliable. String concatenation is replaced with a call to os.path.join. It helps to handle the case when the base path doesn't end with "/".

Previously, if the path didn't end with "/", the call to load_img_id led to an error like this:

```
---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
<ipython-input-107-f89c9436f4c5> in <module>()
----> 1 plt.imshow(load_img_id(data.val_ds, 1, path))
      2 plt.show()

/notebooks/fastai/new/fastai/fastai/plots.py in load_img_id(ds, idx, path)
     72         plt.imshow(ims[i])
     73 
---> 74 def load_img_id(ds, idx, path): return np.array(PIL.Image.open(path+ds.fnames[idx]))
     75 
     76 

~/anaconda3/lib/python3.6/site-packages/PIL/Image.py in open(fp, mode)
   2280 
   2281     if filename:
-> 2282         fp = builtins.open(filename, "rb")
   2283 
   2284     try:

FileNotFoundError: [Errno 2] No such file or directory: 'datavalid/0/00005_00005.ppm'
```