### PR TITLE
Improve error cases for open_image

### DIFF
--- a/fastai/dataset.py
+++ b/fastai/dataset.py
@@ -127,14 +127,14 @@ def open_image(fn):
     """
     flags = cv2.IMREAD_UNCHANGED+cv2.IMREAD_ANYDEPTH+cv2.IMREAD_ANYCOLOR
     if not os.path.exists(fn):
-        print('No such file or directory: {}'.format(fn))
+        raise OSError('No such file or directory: {}'.format(fn))
     elif os.path.isdir(fn):
-        print('Is a directory: {}'.format(fn))
+        raise OSError('Is a directory: {}'.format(fn))
     else:
         try:
             return cv2.cvtColor(cv2.imread(fn, flags), cv2.COLOR_BGR2RGB).astype(np.float32)/255
         except Exception as e:
-            print(fn, e)
+            raise OSError('Error handling image at: {}'.format(fn)) from e
 
 class FilesDataset(BaseDataset):
     def __init__(self, fnames, transform, path):


### PR DESCRIPTION
Currently when `open_image` fails to real an image it prints a message including the path of the image, but doesn't raise an error. The function instead returns None, which is happily passed through a long chain of method calls mainly in `transforms.py` before something eventually tries to return its shape. The result is that the path is printed alongside a confusing error, followed by a very long confusing stack trace, and then a "Cannot read shape of None" message. For me as a beginner attempting to use the lesson 1 code with my own images this was very difficult to understand. I ended up going through the backtrace and didn't pay attention to the print with the path because the exception it was printed alongside was too confusing.

This commit changes the error behaviour to raise an `OSError` containing the path and a clear message, instead of returning None - we're always going to fail somewhere if we fail to read the image and it's better to have a shorter stacktrace and fail here. We raise the `OSError` from the original error, so it's fully preserved.

The result of this is that attempting to use the lesson 1 code with unclean data is much easier: if an image fails you find out immediately, with a short readable stacktrace and a clear error message.