### PR TITLE
Don't push the numericalized variable to the GPU if no GPU device exists

### DIFF
--- a/fastai/nlp.py
+++ b/fastai/nlp.py
@@ -120,7 +120,7 @@ class LanguageModelLoader():
         self.bs,self.bptt,self.backwards = bs,bptt,backwards
         text = sum([o.text for o in ds], [])
         fld = ds.fields['text']
-        nums = fld.numericalize([text])
+        nums = fld.numericalize([text],device=None if torch.cuda.is_available() else -1)
         self.data = self.batchify(nums)
         self.i,self.iter = 0,0
         self.n = len(self.data)


### PR DESCRIPTION
This fixes a crash that occurs if you try and run the NLP module on a computer with no GPU device available. I noticed a USE_GPU flag in core.py that I'm ignoring, but it seems that flag is only used directly beneath it. Is there some plan for a global flag for not using GPU acceleration that I should be checking here as well?