### PR TITLE
[bugfix nasnet] return value within method body

### DIFF
--- a/fastai/models/nasnet.py
+++ b/fastai/models/nasnet.py
@@ -617,4 +617,4 @@ def nasnetalarge(num_classes=1000, pretrained='imagenet'):
         model.std = settings['std']
     else:
         model = NASNetALarge(num_classes=num_classes)
-return model
+    return model


### PR DESCRIPTION
Importing the library fails because the model is returned outside the body of the method. Fixed by return the model within the method body.