### PR TITLE
fix SyntaxError: 'return' outside function

### DIFF
--- a/fastai/models/nasnet.py
+++ b/fastai/models/nasnet.py
@@ -617,4 +617,4 @@ def nasnetalarge(num_classes=1000, pretrained='imagenet'):
         model.std = settings['std']
     else:
         model = NASNetALarge(num_classes=num_classes)
-return model
+    return model


### PR DESCRIPTION
Hi, just found this typo that is preventing lesson3-rossman notebook from executing and fixed it.

Thanks,
Seb