### PR TITLE
Minor changes to conv learner

### DIFF
--- a/fastai/conv_learner.py
+++ b/fastai/conv_learner.py
@@ -95,7 +95,7 @@ class ConvLearner(Learner):
     @classmethod
     def pretrained(cls, f, data, ps=None, xtra_fc=None, xtra_cut=0, precompute=False, **kwargs):
         models = ConvnetBuilder(f, data.c, data.is_multi, data.is_reg, ps=ps, xtra_fc=xtra_fc, xtra_cut=xtra_cut)
-        return cls(data, models, **kwargs)
+        return cls(data, models, precompute, **kwargs)
 
     @property
     def model(self): return self.models.fc_model if self.precompute else self.models.model

--- a/fastai/conv_learner.py
+++ b/fastai/conv_learner.py
@@ -93,7 +93,7 @@ class ConvLearner(Learner):
         self.precompute = precompute
 
     @classmethod
-    def pretrained(cls, f, data, ps=None, xtra_fc=None, xtra_cut=0, **kwargs):
+    def pretrained(cls, f, data, ps=None, xtra_fc=None, xtra_cut=0, precompute=False, **kwargs):
         models = ConvnetBuilder(f, data.c, data.is_multi, data.is_reg, ps=ps, xtra_fc=xtra_fc, xtra_cut=xtra_cut)
         return cls(data, models, **kwargs)
 

--- a/fastai/conv_learner.py
+++ b/fastai/conv_learner.py
@@ -23,7 +23,7 @@ class ConvnetBuilder():
         is_reg (bool): is a regression?
         ps (float or array of float): dropout parameters
         xtra_fc (list of ints): list of hidden layers with # hidden neurons
-        xtra_cut (int): # layers earlier than default to cut the model, detault is 0
+        xtra_cut (int): # layers earlier than default to cut the model, default is 0
     """
 
     def __init__(self, f, c, is_multi, is_reg, ps=None, xtra_fc=None, xtra_cut=0):


### PR DESCRIPTION
I fixed a typo and also thought that exposing the precompute arg in `ConvLearner.pretrained` might be a good idea - might benefit people new to the library.

On the other hand increases clutter so maybe this is not what we want