### PR TITLE
update get_sample docstring

### DIFF
--- a/fastai/structured.py
+++ b/fastai/structured.py
@@ -67,8 +67,8 @@ def get_sample(df,n):
 
     >>> get_sample(df, 2)
        col1 col2
-    2     3    a
     1     2    b
+    2     3    a
     """
     idxs = sorted(np.random.permutation(len(df))[:n])
     return df.iloc[idxs].copy()


### PR DESCRIPTION
The output's index order returned from `get_sample(df, n)` should always be in descending order. This is because `idxs` is sorted before returning `df.iloc[idxs].copy()`.