### PR TITLE
Allow setting figure size for confusion matrix

### DIFF
--- a/fastai/plots.py
+++ b/fastai/plots.py
@@ -39,13 +39,13 @@ def plots_from_files(imspaths, figsize=(10,5), rows=1, titles=None, maintitle=No
         plt.imshow(img)
 
 
-def plot_confusion_matrix(cm, classes, normalize=False, title='Confusion matrix', cmap=plt.cm.Blues):
+def plot_confusion_matrix(cm, classes, normalize=False, title='Confusion matrix', cmap=plt.cm.Blues, figsize=None):
     """
     This function prints and plots the confusion matrix.
     Normalization can be applied by setting `normalize=True`.
     (This function is copied from the scikit docs.)
     """
-    plt.figure()
+    plt.figure(figsize=figsize)
     plt.imshow(cm, interpolation='nearest', cmap=cmap)
     plt.title(title)
     plt.colorbar()


### PR DESCRIPTION
This change allows the user to optionally provide a figure size for the confusion matrix. This makes it difficult to interpret the plot when there are more than 5 classes (see screenshot below).

<img src="https://i.imgur.com/EkQAGss.jpg" width="360">