### PR TITLE
allow to pass a stepper class to fit()

### DIFF
--- a/fastai/model.py
+++ b/fastai/model.py
@@ -61,7 +61,7 @@ def set_train_mode(m):
     else: m.train()
 
 
-def fit(model, data, epochs, opt, crit, metrics=None, callbacks=None, **kwargs):
+def fit(model, data, epochs, opt, crit, metrics=None, callbacks=None, stepper=Stepper, **kwargs):
     """ Fits a model
 
     Arguments:
@@ -72,7 +72,7 @@ def fit(model, data, epochs, opt, crit, metrics=None, callbacks=None, **kwargs):
        epochs(int): number of epochs
        crit: loss function to optimize. Example: F.cross_entropy
     """
-    stepper = Stepper(model, opt, crit, **kwargs)
+    stepper = stepper(model, opt, crit, **kwargs)
     metrics = metrics or []
     callbacks = callbacks or []
     avg_mom=0.98


### PR DESCRIPTION
This PR is to allow implementing "selective negative sampling" as advocated in https://arxiv.org/abs/1703.07737. Basically, we want to:
- take a batch of genuine data (all implicitly labeled as 1 since this is real data)
- generate corrupted samples by copying some features from other samples within that batch (all implicitly labelled to 0 since this is corrupted data)
- do forward passes on the corrupted samples
- sort the corrupted according to the output (e.g. sigmoid)
- refactor the batch to now contain the genuine data and the most offending corrupted samples

I found that Stepper is probably the place where this should happen. I was unsure if I should pass the class or an instance to fit(). Passing the class allowed for minimal changes...