### PR TITLE
Add passing **kwargs to Learner.from_model_data

### DIFF
--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -26,8 +26,8 @@ class Learner():
         self.crit,self.reg_fn = None,None
 
     @classmethod
-    def from_model_data(cls, m, data):
-        self = cls(data, BasicModel(to_gpu(m)))
+    def from_model_data(cls, m, data, **kwargs):
+        self = cls(data, BasicModel(to_gpu(m)), **kwargs)
         self.unfreeze()
         return self
 


### PR DESCRIPTION
Allows us to pass arguments onto the constructor when calling `Learner.from_model_data`