### PR TITLE
Fixing off by one error

### DIFF
--- a/fastai/nlp.py
+++ b/fastai/nlp.py
@@ -312,7 +312,7 @@ class TextDataLoader():
     def __init__(self, src, x_fld, y_fld):
         self.src,self.x_fld,self.y_fld = src,x_fld,y_fld
 
-    def __len__(self): return len(self.src)-1
+    def __len__(self): return len(self.src)
 
     def __iter__(self):
         it = iter(self.src)


### PR DESCRIPTION
When I used TextDataLoader to load test data, noticed that the last batch was missing. Here is the detailed explanation:

```python
%reload_ext autoreload
%autoreload 2
%matplotlib inline

import torchtext

from torchtext import vocab, data

from fastai.nlp import *
from fastai.lm_rnn import *
from fastai.learner import *
from fastai.column_data import *
from fastai.hiromi import *
```


```python
PATH = 'data/toxic/'
```


```python
train_df = pd.read_csv(f'{PATH}train.csv')
test_df = pd.read_csv(f'{PATH}test.csv')
sample_submit_df = pd.read_csv(f'{PATH}sample_submission.csv')
```


```python
# =========== SAMPLE ===================
train_df = train_df[:1000]
val_df = train_df[:200]
test_df = test_df[:200]
```


```python
bs=64
bptt=70
```


```python
TEXT = data.Field(tokenize=spacy_tok)
```


```python
FILES = dict(train_df=train_df, val_df=test_df, test_df=test_df)
md = LanguageModelData.from_dataframes(PATH, TEXT, 'comment_text', **FILES, bs=bs, bptt=bptt, min_freq=10)
```


```python
LABEL = data.Field(sequential=False)
```


```python
class MyDataset(torchtext.data.Dataset):
    def __init__(self, df, text_field, label_field, is_test=False, **kwargs):
        fields = [('text', text_field), ('label', label_field)]
        examples = []
        for i, row in df.iterrows():
            label = 'pos'
            if not is_test and row['toxic']==0:
                label = 'neg' 
            text = row['comment_text']
            examples.append(torchtext.data.Example.fromlist([text, label], fields))

        super().__init__(examples, fields, **kwargs)

    @staticmethod
    def sort_key(ex): return len(ex.text)
    
    @classmethod
    def splits(cls, text_field, label_field, train_df, val_df=None, test_df=None, **kwargs):
        train_data, val_data, test_data = (None, None, None)

        if train_df is not None:
            train_data = cls(train_df.copy(), text_field, label_field, **kwargs)
        if val_df is not None:
            val_data = cls(val_df.copy(), text_field, label_field, **kwargs)
        if test_df is not None:
            test_data = cls(test_df.copy(), text_field, label_field, True, **kwargs)

        return tuple(d for d in (train_data, val_data, test_data) if d is not None)
```

## Before the change:


```python
splits = MyDataset.splits(TEXT, LABEL, train_df=train_df, val_df=val_df, test_df=test_df)
```

We have 200 test data


```python
len(test_df)
```




    200



Really, it's 200!


```python
len(splits[1].examples)
```




    200




```python
bs=10
```


```python
md = TextData.from_splits(PATH, splits, bs)
```

But we only get 19 batches (190 rows)


```python
len(md.test_dl)
```




    19



## After the change:


```python
splits = MyDataset.splits(TEXT, LABEL, train_df=train_df, val_df=val_df, test_df=test_df)
```


```python
md = TextData.from_splits(PATH, splits, bs)
```


```python
len(md.test_dl)
```




    20


