### PR TITLE
Change references of RandomFlipXY to RandomFlip

### DIFF
--- a/courses/dl1/lesson7-cifar10.ipynb
+++ b/courses/dl1/lesson7-cifar10.ipynb
@@ -63,7 +63,7 @@
    "outputs": [],
    "source": [
     "def get_data(sz,bs):\n",
-    "    tfms = tfms_from_stats(stats, sz, aug_tfms=[RandomFlipXY()], pad=sz//8)\n",
+    "    tfms = tfms_from_stats(stats, sz, aug_tfms=[RandomFlip()], pad=sz//8)\n",
     "    return ImageClassifierData.from_paths(PATH, val_name='test', tfms=tfms, bs=bs)"
    ]
   },


### PR DESCRIPTION
Hi there!

I noticed that in edab9ef a number of transformations were renamed to not include the "XY" suffix. That commit also renames a reference to `RandomFlipXY` in the [/dl1/cifar10 notebook](https://github.com/fastai/fastai/blame/master/courses/dl1/cifar10.ipynb#L57), but I saw that [dl1/lesson7-cifar10 notebook](https://github.com/fastai/fastai/blob/master/courses/dl1/lesson7-cifar10.ipynb) wasn't updated.

I wasn't sure if this was intentional or not, so I figured I would make a quick PR just in case it wasn't!

Thank you so much for your time!