### PR TITLE
remove an unused local variable

### DIFF
--- a/fastai/core.py
+++ b/fastai/core.py
@@ -43,7 +43,7 @@ def to_gpu(x, *args, **kwargs):
 def noop(*args, **kwargs): return
 
 def split_by_idxs(seq, idxs):
-    last, sl = 0, len(seq)
+    last = 0
     for idx in idxs:
         yield seq[last:idx]
         last = idx


### PR DESCRIPTION
remove an unused local variable `sl` in `split_by_idxs`