### PR TITLE
Tornado Version Issues #196

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -88,7 +88,7 @@ dependencies:
   #- terminado
 - testpath
 - tk
-- tornado
+- tornado=4.5.3
 - tqdm
 - traitlets
 - wcwidth


### PR DESCRIPTION
'IOLoop' has no attribute 'initialized' Error Fix due to release of Tornado( Ver 5.0) Framework.