### PR TITLE
Use one byte instead of four for n-hot label bits

### DIFF
--- a/fastai/dataset.py
+++ b/fastai/dataset.py
@@ -88,7 +88,7 @@ def copy_or_move_with_subdirs(subdir_lst, src, dst, r, move=False):
             do(f, os.path.join(dst, subdir, os.path.split(f)[1]))
 
 def n_hot(ids, c):
-    res = np.zeros((c,), dtype=np.float32)
+    res = np.zeros((c,), dtype=np.int8)
     res[ids] = 1
     return res
 


### PR DESCRIPTION
`dataset.nhot_labels` easily runs out of RAM when parsing labels for big datasets. The issue is especially bad when there are lots of labels. E.g. [Google landmark recognition competition](https://www.kaggle.com/c/landmark-recognition-challenge/data) with 15k labels and 1M photos can't be processed with 30 GB of RAM (looks like it would require well over 60 GB). This change mitigates the issue, but please comment if you can think of a more complete fix (using index lists instead of nhot?).

Works on the landmark dataset, but I'm not adept with this codebase yet so please try and think if anything could break.