### PR TITLE
Add jupyterlab to fastai conda env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -35,6 +35,7 @@ dependencies:
 - jinja2
 - jsonschema
 - jupyter
+- jupyterlab
 - jupyter_client
 - jupyter_console
 - jupyter_core


### PR DESCRIPTION
- Tested to be compatbile with notebook and can switch between the two easily