### PR TITLE
Replace kaggle-cli with official kaggle API client

### DIFF
--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -109,7 +109,7 @@ dependencies:
   - jupyter_contrib_nbextensions
   - plotnine
   - awscli
-  - kaggle-cli
+  - kaggle
   - ipywidgets
   - jupyter_contrib_nbextensions
   - git+https://github.com/SauceCat/PDPbox.git

--- a/environment.yml
+++ b/environment.yml
@@ -111,7 +111,7 @@ dependencies:
   - jupyter_contrib_nbextensions
   - plotnine
   - awscli
-  - kaggle-cli
+  - kaggle
   - ipywidgets
   - jupyter_contrib_nbextensions
     #- git+https://github.com/SauceCat/PDPbox.git


### PR DESCRIPTION
Since kaggle has released an official API client, we may replace `kaggle-cli` dependency with the official package. More details about the official client can be found at https://github.com/Kaggle/kaggle-api.