### PR TITLE
ADDED: support for both min and max zoom

### DIFF
--- a/fastai/transforms.py
+++ b/fastai/transforms.py
@@ -318,7 +318,12 @@ class RandomScale(CoordTransform):
     def set_state(self):
         self.new_sz = self.sz
         if random.random()<self.p:
-            self.mult = random.uniform(1., self.max_zoom)
+            max_z = self.max_zoom
+            min_z = 1.
+            if isinstance(self.max_zoom, tuple):
+                min_z = self.max_zoom[0]
+                max_z = self.max_zoom[1]
+            self.mult = random.uniform(min_z, max_z)
             self.new_sz = int(self.mult*self.sz)
             if self.sz_y is not None: self.new_sz_y = int(self.mult*self.sz_y)
 

--- a/fastai/transforms.py
+++ b/fastai/transforms.py
@@ -318,7 +318,11 @@ class RandomScale(CoordTransform):
         self.sz,self.max_zoom,self.p,self.sz_y = sz,max_zoom,p,sz_y
 
     def set_state(self):
-        self.store.mult = random.uniform(1., self.max_zoom) if random.random()<self.p else 1
+        min_z = 1.
+        max_z = self.max_zoom
+        if isinstance(self.max_zoom, collections.Iterable):
+            min_z, max_z = self.max_zoom
+        self.store.mult = random.uniform(min_z, max_z) if random.random()<self.p else 1
         self.store.new_sz = int(self.store.mult*self.sz)
         if self.sz_y is not None: self.store.new_sz_y = int(self.store.mult*self.sz_y)
 


### PR DESCRIPTION
Allow transformations to accept the old singular value for max zoom amount or alternatively a tuple of (min, max) values.