### PR TITLE
Added an option to ignore certain fields in df in proc_df

### DIFF
--- a/fastai/structured.py
+++ b/fastai/structured.py
@@ -324,8 +324,8 @@ def scale_vars(df, mapper):
     df[mapper.transformed_names_] = mapper.transform(df)
     return mapper
 
-def proc_df(df, y_fld=None, skip_flds=None, do_scale=False, na_dict=None,
-            preproc_fn=None, max_n_cat=None, subset=None, mapper=None, ignore_flds=None):
+def proc_df(df, y_fld=None, skip_flds=None, ignore_flds=None, do_scale=False, na_dict=None,
+            preproc_fn=None, max_n_cat=None, subset=None, mapper=None):
 
     """ proc_df takes a data frame df and splits off the response variable, and
     changes the df into an entirely numeric dataframe.
@@ -337,6 +337,8 @@ def proc_df(df, y_fld=None, skip_flds=None, do_scale=False, na_dict=None,
     y_fld: The name of the response variable
 
     skip_flds: A list of fields that dropped from df.
+
+    ignore_flds: A list of fields that are ignored during processing.
 
     do_scale: Standardizes each column in df. Takes Boolean Values(True,False)
 


### PR DESCRIPTION
I ran into a problem where I wanted to ignore a field when running proc_df. skip_flds drops fields when passed to it. But there was no option to maintain certain fields and not process them. I added the following:

- Added a ignore_flds option to the function call with a default option of None
- If ignore_flds is not none, copied those fields in into ignored_flds. If it is None, created an empty dataframe for ignored_flds
- Dropped ignored_flds from original df
- Added the ignored_flds back to the processed df just before creating res list

This works even if ignore_flds is None. I created feather files for the df returned by both versions of the functions and checked them after and they had equal values.

I submitted an earlier pull request, but found out that I was dropping the columns *before* subsetting. So the ignored_flds df had more rows in it. I fixed that in this pull request.

I also checked it in a dummy program and in a kaggle comp I'm working on. It works in both cases. Let me know what everyone thinks.

One potential issue is the ordering of the columns. Currently, I just concatenate the ignored_flds at the beginning of the df called pd.concat([ ignored_flds, df], axis=1), so they get added at the back afaik.

Thanks.