### PR TITLE
Fixed bug in `model_summary` so it works for models with batchnorm

### DIFF
--- a/fastai/model.py
+++ b/fastai/model.py
@@ -184,8 +184,8 @@ def model_summary(m, input_size):
     m.apply(register_hook)
 
     if isinstance(input_size[0], (list, tuple)):
-        x = [to_gpu(Variable(torch.rand(1,*in_size))) for in_size in input_size]
-    else: x = [to_gpu(Variable(torch.rand(1,*input_size)))]
+        x = [to_gpu(Variable(torch.rand(3,*in_size))) for in_size in input_size]
+    else: x = [to_gpu(Variable(torch.rand(3,*input_size)))]
     m(*x)
 
     for h in hooks: h.remove()


### PR DESCRIPTION
- Using 1 in the batch size dimension fails on models that include batch_norm (which is most). You get the error "ValueError: Expected more than 1 value per channel when training, got input size [1, 1024]"
- This was due to a change in PyTorch 0.3. See discussion here: https://github.com/pytorch/pytorch/issues/4534
- Short version is that because BatchNorm does (x - mean(x)) / std(x), the numerator will always be 0 when the batch size is only 1, and thus the output would be entirely zero, which doesn't really make sense, so PyTorch started throwing this error.
- Considering the prevalance of BatchNorm, this essentially means that batch sizes must always be greater than 1.
- I just changed it to 3, which was an arbitrary choice, but the output is correct again.


#### Before
![image](https://user-images.githubusercontent.com/2524396/38004404-f184ce40-31f0-11e8-9cc7-4263bc77c155.png)


#### After
![image](https://user-images.githubusercontent.com/2524396/38004425-032955a8-31f1-11e8-8163-b526b5c69abd.png)


Note the after photo is from me simply re-assigning the `model_summary` function to the new function reflected in this change. It runs and seems to print reasonable output