### PR TITLE
Bugfix - Pass correct arguments to from_data_frame

### DIFF
--- a/fastai/column_data.py
+++ b/fastai/column_data.py
@@ -60,7 +60,7 @@ class ColumnarModelData(ModelData):
 
     @classmethod
     def from_data_frames(cls, path, trn_df, val_df, trn_y, val_y, cat_flds, bs, is_reg, test_df=None):
-        test_ds = ColumnarDataset.from_data_frame(test_df, cat_flds, is_reg) if test_df is not None else None
+        test_ds = ColumnarDataset.from_data_frame(test_df, cat_flds, None, is_reg) if test_df is not None else None
         return cls(path, ColumnarDataset.from_data_frame(trn_df, cat_flds, trn_y, is_reg),
                     ColumnarDataset.from_data_frame(val_df, cat_flds, val_y, is_reg), bs, test_ds=test_ds)
 


### PR DESCRIPTION
The signature of `ColumnarData.from_data_frame` is:
```
def from_data_frame(cls, df, cat_flds, y=None, is_reg=True)
```
This change fixes a bug where `is_reg` was being passed as the 3rd parameter i.e. in place of `y`