### PR TITLE
Adding LazyThreadPoolExecutor class

### DIFF
--- a/fastai/executors.py
+++ b/fastai/executors.py
@@ -7,36 +7,23 @@ class LazyThreadPoolExecutor(ThreadPoolExecutor):
     def map(self, fn, *iterables, timeout=None, chunksize=1, prefetch=None):
         """
         Collects iterables lazily, rather than immediately.
-        Docstring same as parent class: https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Executor
+        Docstring same as parent: https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Executor
         Implmentation taken from this PR: https://github.com/python/cpython/pull/707
         """
-        if timeout is not None:
-            end_time = timeout + time.time()
-        if prefetch is None:
-            prefetch = self._max_workers
-        if prefetch < 0:
-            raise ValueError("prefetch count may not be negative")
-
+        if timeout is not None: end_time = timeout + time.time()
+        if prefetch is None: prefetch = self._max_workers
+        if prefetch < 0: raise ValueError("prefetch count may not be negative")
         argsiter = zip(*iterables)
-
-        fs = collections.deque(self.submit(fn, *args) for args in itertools.islice(argsiter, self._max_workers + prefetch))
-
-        # Yield must be hidden in closure so that the futures are submitted
-        # before the first iterator value is required.
+        fs = collections.deque(self.submit(fn, *args) for args in itertools.islice(argsiter, self._max_workers+prefetch))
+        # Yield must be hidden in closure so that the futures are submitted before the first iterator value is required.
         def result_iterator():
             nonlocal argsiter
             try:
                 while fs:
-                    if timeout is None:
-                        res = fs[0].result()
-                    else:
-                        res = fs[0].result(end_time - time.time())
-
+                    res = fs[0].result() if timeout is None else fs[0].result(end_time-time.time())
                     # Got a result, future needn't be cancelled
                     del fs[0]
-
-                    # Dispatch next task before yielding to keep
-                    # pipeline full
+                    # Dispatch next task before yielding to keep pipeline full
                     if argsiter:
                         try:
                             args = next(argsiter)
@@ -44,9 +31,7 @@ class LazyThreadPoolExecutor(ThreadPoolExecutor):
                             argsiter = None
                         else:
                             fs.append(self.submit(fn, *args))
-
                     yield res
             finally:
-                for future in fs:
-                    future.cancel()
+                for future in fs: future.cancel()
         return result_iterator()

--- a/fastai/lazy_threadpool_executor.py
+++ b/fastai/lazy_threadpool_executor.py
@@ -1,0 +1,52 @@
+import collections
+import itertools
+from concurrent.futures import ThreadPoolExecutor
+import time
+
+class LazyThreadPoolExecutor(ThreadPoolExecutor):
+    def map(self, fn, *iterables, timeout=None, chunksize=1, prefetch=None):
+        """
+        Collects iterables lazily, rather than immediately.
+        Docstring same as parent class: https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Executor
+        Implmentation taken from this PR: https://github.com/python/cpython/pull/707
+        """
+        if timeout is not None:
+            end_time = timeout + time.time()
+        if prefetch is None:
+            prefetch = self._max_workers
+        if prefetch < 0:
+            raise ValueError("prefetch count may not be negative")
+
+        argsiter = zip(*iterables)
+
+        fs = collections.deque(self.submit(fn, *args) for args in itertools.islice(argsiter, self._max_workers + prefetch))
+
+        # Yield must be hidden in closure so that the futures are submitted
+        # before the first iterator value is required.
+        def result_iterator():
+            nonlocal argsiter
+            try:
+                while fs:
+                    if timeout is None:
+                        res = fs[0].result()
+                    else:
+                        res = fs[0].result(end_time - time.time())
+
+                    # Got a result, future needn't be cancelled
+                    del fs[0]
+
+                    # Dispatch next task before yielding to keep
+                    # pipeline full
+                    if argsiter:
+                        try:
+                            args = next(argsiter)
+                        except StopIteration:
+                            argsiter = None
+                        else:
+                            fs.append(self.submit(fn, *args))
+
+                    yield res
+            finally:
+                for future in fs:
+                    future.cancel()
+        return result_iterator()


### PR DESCRIPTION
From ThreadPoolExecutor docs: the iterables are collected immediately rather than lazily
This can cause memory/timeout issues for large or infinite

Original issue: http://forums.fast.ai/t/memory-error-not-cuda-out-of-memory-error/12481
Fixed in this PR: c0e9bd96e7599898e215a7e0668bae357020a1fb. Just adding an alternative

Original method copied from this PR - https://github.com/python/cpython/pull/707 
Has not been merged to the CPython library. Made a few style changes here: c112c3f

Tested here: https://github.com/bearpelican/fastai/commit/e72df561d52102977b6e0b3ecac370dac79f3002