### PR TITLE
Add get_c method to ArraysDataset

### DIFF
--- a/fastai/dataset.py
+++ b/fastai/dataset.py
@@ -274,6 +274,7 @@ class ArraysDataset(BaseDataset):
         super().__init__(transform)
     def get_x(self, i): return self.x[i]
     def get_y(self, i): return self.y[i]
+    def get_c(self): return int(self.y.max())+1
     def get_n(self): return len(self.y)
     def get_sz(self): return self.x.shape[1]
 


### PR DESCRIPTION
`get_c` required method is missing in ArraysDataset causing error when instantiating it.

**Before:**

<img width="653" alt="screen shot 2018-03-29 at 9 21 31 am" src="https://user-images.githubusercontent.com/1437573/38100832-544aa4b2-3333-11e8-8b55-d991a2073e5c.png">

**After:**

<img width="390" alt="screen shot 2018-03-29 at 9 24 51 am" src="https://user-images.githubusercontent.com/1437573/38100836-56fa8772-3333-11e8-89c3-70d2fc3e8035.png">

