### PR TITLE
plots: most_by_mask to return upto the length of the indexes

### DIFF
--- a/fastai/dataset.py
+++ b/fastai/dataset.py
@@ -274,6 +274,7 @@ class ArraysDataset(BaseDataset):
         super().__init__(transform)
     def get_x(self, i): return self.x[i]
     def get_y(self, i): return self.y[i]
+    def get_c(self): return int(self.y.max())+1
     def get_n(self): return len(self.y)
     def get_sz(self): return self.x.shape[1]
 

--- a/fastai/dataset.py
+++ b/fastai/dataset.py
@@ -274,7 +274,6 @@ class ArraysDataset(BaseDataset):
         super().__init__(transform)
     def get_x(self, i): return self.x[i]
     def get_y(self, i): return self.y[i]
-    def get_c(self): return int(self.y.max())+1
     def get_n(self): return len(self.y)
     def get_sz(self): return self.x.shape[1]
 

--- a/fastai/plots.py
+++ b/fastai/plots.py
@@ -21,7 +21,7 @@ def plots(ims, figsize=(12,6), rows=1, interp=False, titles=None, maintitle=None
 
 def plots_from_files(imspaths, figsize=(10,5), rows=1, titles=None, maintitle=None):
     """Plots images given image files.
-    
+
     Arguments:
         im_paths (list): list of paths
         figsize (tuple): figure size
@@ -76,11 +76,11 @@ def load_img_id(ds, idx, path): return np.array(PIL.Image.open(os.path.join(path
 
 class ImageModelResults():
     """ Visualize the results of an image model
-    
+
     Arguments:
         ds (dataset): a dataset which contains the images
         log_preds (numpy.ndarray): predictions for the dataset in log scale
-        
+
     Returns:
         ImageModelResults
     """
@@ -98,11 +98,11 @@ class ImageModelResults():
 
     def plot_val_with_title(self, idxs, y):
         """ Displays the images and their probabilities of belonging to a certain class
-            
+
             Arguments:
                 idxs (numpy.ndarray): indexes of the image samples from the dataset
                 y (int): the selected class
-                
+
             Returns:
                 Plots the images in n rows [rows = n]
         """
@@ -118,39 +118,40 @@ class ImageModelResults():
 
     def most_by_mask(self, mask, y, mult):
         """ Extracts the first 4 most correct/incorrect indexes from the ordered list of probabilities
-        
+
             Arguments:
                 mask (numpy.ndarray): the mask of probabilities specific to the selected class; a boolean array with shape (num_of_samples,) which contains True where class==selected_class, and False everywhere else
                 y (int): the selected class
                 mult (int): sets the ordering; -1 descending, 1 ascending
-                
+
             Returns:
                 idxs (ndarray): An array of indexes of length 4
         """
         idxs = np.where(mask)[0]
-        return idxs[np.argsort(mult * self.probs[idxs,y])[:4]]
+        cnt = min(4, len(idxs))
+        return idxs[np.argsort(mult * self.probs[idxs,y])[:cnt]]
 
     def most_uncertain_by_mask(self, mask, y):
         """ Extracts the first 4 most uncertain indexes from the ordered list of probabilities
-            
+
             Arguments:
                 mask (numpy.ndarray): the mask of probabilities specific to the selected class; a boolean array with shape (num_of_samples,) which contains True where class==selected_class, and False everywhere else
                 y (int): the selected class
-            
+
             Returns:
                 idxs (ndarray): An array of indexes of length 4
         """
         idxs = np.where(mask)[0]
         # the most uncertain samples will have abs(probs-1/num_classes) close to 0;
         return idxs[np.argsort(np.abs(self.probs[idxs,y]-(1/self.num_classes)))[:4]]
-    
+
     def most_by_correct(self, y, is_correct):
         """ Extracts the predicted classes which correspond to the selected class (y) and to the specific case (prediction is correct - is_true=True, prediction is wrong - is_true=False)
-            
+
             Arguments:
                 y (int): the selected class
                 is_correct (boolean): a boolean flag (True, False) which specify the what to look for. Ex: True - most correct samples, False - most incorrect samples
-            
+
             Returns:
                 idxs (numpy.ndarray): An array of indexes (numpy.ndarray)
         """
@@ -162,19 +163,19 @@ class ImageModelResults():
 
     def plot_by_correct(self, y, is_correct):
         """ Plots the images which correspond to the selected class (y) and to the specific case (prediction is correct - is_true=True, prediction is wrong - is_true=False)
-            
+
             Arguments:
                 y (int): the selected class
                 is_correct (boolean): a boolean flag (True, False) which specify the what to look for. Ex: True - most correct samples, False - most incorrect samples
-        """    
+        """
         return self.plot_val_with_title(self.most_by_correct(y, is_correct), y)
 
     def most_by_uncertain(self, y):
         """ Extracts the predicted classes which correspond to the selected class (y) and have probabilities nearest to 1/number_of_classes (eg. 0.5 for 2 classes, 0.33 for 3 classes) for the selected class.
-            
+
             Arguments:
                 y (int): the selected class
-            
+
             Returns:
                 idxs (numpy.ndarray): An array of indexes (numpy.ndarray)
         """
@@ -182,21 +183,21 @@ class ImageModelResults():
 
     def plot_most_correct(self, y):
         """ Plots the images which correspond to the selected class (y) and are most correct.
-            
+
             Arguments:
                 y (int): the selected class
         """
         return self.plot_by_correct(y, True)
-    def plot_most_incorrect(self, y): 
+    def plot_most_incorrect(self, y):
         """ Plots the images which correspond to the selected class (y) and are most incorrect.
-            
+
             Arguments:
                 y (int): the selected class
         """
         return self.plot_by_correct(y, False)
     def plot_most_uncertain(self, y):
         """ Plots the images which correspond to the selected class (y) and are most uncertain i.e have probabilities nearest to 1/number_of_classes.
-            
+
             Arguments:
                 y (int): the selected class
         """


### PR DESCRIPTION
Ref: http://forums.fast.ai/t/how-to-use-your-own-dataset-for-lesson-1/14195/3

When the Val. Dataset has less than 4 incorrect examples, it gives an error in plotting the incorrect examples.  In this pull request, I am changing it to return the minimum of 4 items or the length of the array.

