### PR TITLE
Make to_np accept np.arrays

### DIFF
--- a/fastai/core.py
+++ b/fastai/core.py
@@ -36,6 +36,7 @@ def VV_(x): return create_variable(x, True)
 def VV(x):  return [VV_(o) for o in x] if isinstance(x,list) else VV_(x)
 
 def to_np(v):
+    if isinstance(v, (np.ndarray, np.generic)): return v
     if isinstance(v, (list,tuple)): return [to_np(o) for o in v]
     if isinstance(v, Variable): v=v.data
     return v.cpu().numpy()


### PR DESCRIPTION
This makes fastai more consistent, otherwise few methods need tensors.
While they could be used with numpy arrays as well.
Here is an example that would break without this change:
```py
show_img(md.val_ds.denorm(md.trn_ds[0][0])[0])
```