### PR TITLE
Fix for out of memory issues when creating language models

### DIFF
--- a/fastai/text.py
+++ b/fastai/text.py
@@ -125,8 +125,11 @@ class LanguageModelLoader():
     def __iter__(self):
         self.i,self.iter = 0,0
         while self.i < self.n-1 and self.iter<len(self):
-            bptt = self.bptt if np.random.random() < 0.95 else self.bptt / 2.
-            seq_len = max(5, int(np.random.normal(bptt, 5)))
+            if self.i == 0:
+                seq_len = self.bptt + 5 * 5
+            else:
+                bptt = self.bptt if np.random.random() < 0.95 else self.bptt / 2.
+                seq_len = max(5, int(np.random.normal(bptt, 5)))
             res = self.get_batch(self.i, seq_len)
             self.i += seq_len
             self.iter += 1


### PR DESCRIPTION
For the first iteration we want the maximum possible seq_len.  Pytorch tensors are allocated as needed, so when we randomly create them we are reallocating new tensors multiple times causing out of memory issues.  This should help those with smaller GPUs build language models.

If you look at memory usage with the current implementation it climbs multiple times during the start of the run before settling down once garbage collection finally happens.  When you pre-allocate you prevent multiple tensors of different sizes from having to be created so the memory footprint is much smaller.  