### PR TITLE
misc: wiki dump download directory set to path

### DIFF
--- a/courses/dl2/imdb.ipynb
+++ b/courses/dl2/imdb.ipynb
@@ -469,7 +469,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ! wget -nH -r -np http://files.fast.ai/models/wt103/"
+    "# ! wget -nH -r -np -P {PATH} http://files.fast.ai/models/wt103/"
    ]
   },
   {


### PR DESCRIPTION
Same fix mentioned [here](http://forums.fast.ai/t/part-2-lesson-10-in-class/14364/116) by @emilmelnikov

Normally it downloads to the same path as notebook and throws error when loading weights.