### PR TITLE
Adds use_clr_beta

### DIFF
--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -84,7 +84,7 @@ class Learner():
     def load_cycle(self, name, cycle): self.load(f'{name}_cyc_{cycle}')
 
     def fit_gen(self, model, data, layer_opt, n_cycle, cycle_len=None, cycle_mult=1, cycle_save_name=None, best_save_name=None,
-                use_clr=None, metrics=None, callbacks=None, use_wd_sched=False, norm_wds=False, wds_sched_mult=None, **kwargs):
+                use_clr=None, use_clr_beta=None, metrics=None, callbacks=None, use_wd_sched=False, norm_wds=False, wds_sched_mult=None, **kwargs):
 
         """Method does some preparation before finally delegating to the 'fit' method for
         fitting the model. Namely, if cycle_len is defined, it adds a 'Cosine Annealing'
@@ -160,6 +160,12 @@ class Learner():
             cycle_end = self.get_cycle_end(cycle_save_name)
             self.sched = CircularLR(layer_opt, len(data.trn_dl)*cycle_len, on_cycle_end=cycle_end, div=clr_div, cut_div=cut_div, 
                                     momentums=moms)
+        elif use_clr_beta is not None:
+            div,pct = use_clr_beta[:2]
+            moms = use_clr_beta[2:] if len(use_clr_beta) > 3 else None
+            cycle_end = self.get_cycle_end(cycle_save_name)
+            self.sched = CircularLR_beta(layer_opt, len(data.trn_dl)*cycle_len, on_cycle_end=cycle_end, div=div, 
+                                    pct=pct, momentums=moms)
         elif cycle_len:
             cycle_end = self.get_cycle_end(cycle_save_name)
             cycle_batches = len(data.trn_dl)*cycle_len


### PR DESCRIPTION
Matches the 1cycle policy of Leslie Smith (https://arxiv.org/pdf/1803.09820.pdf). 
Typical use is use_clr_beta = (div,pct,max_mom,min_mom)
The two last args can be skipped if you don't want to use cyclical momentum.
The first one is the amount to divide the passed learning rate to get the minimum learning rate, the second one the part of the cycle (in percent) that will be devoted to the LR annealing after the traingular cycle.