### PR TITLE
fix fp16 stepper issue

### DIFF
--- a/fastai/model.py
+++ b/fastai/model.py
@@ -40,7 +40,7 @@ class Stepper():
         else: self.m.eval()
         if hasattr(self.m, 'reset'): 
             self.m.reset()
-            if self.fp16: self.fp32_params = copy_model_to_fp32(self.m, self.opt)
+            #if self.fp16: self.fp32_params = copy_model_to_fp32(self.m, self.opt)
 
     def step(self, xs, y, epoch):
         if self.fp16: return self.step_fp16(xs, y, epoch)


### PR DESCRIPTION
after commit fafa8a934c6bae3e82b63559667afea6385eb674
there is an issue in stepper when calling fit

~/tensoralex/repos/fastai_tensoralex/courses/dl2/fastai/model.py in reset(self, train)
     41         if hasattr(self.m, 'reset'):
     42             self.m.reset()
---> 43             if self.fp16: self.fp32_params = copy_model_to_fp32(self.m, self.opt)
     44 
     45     def step(self, xs, y, epoch):

AttributeError: 'Stepper' object has no attribute 'fp16'


I don't believe copy_model_to needs to be called in reset method at all, since it is being called anyway later in Stepper constructor.
