### PR TITLE
initial testing setup for LayerOptimizer

### DIFF
--- a/fastai/torch_imports.py
+++ b/fastai/torch_imports.py
@@ -21,7 +21,7 @@ from .models.nasnet import nasnetalarge
 import warnings
 warnings.filterwarnings('ignore', message='Implicit dimension choice', category=UserWarning)
 
-def children(m): return m if isinstance(m, (list, tuple)) else list(m.children())
+def children(m): return m if is_listy(m) else list(m.children())
 def save_model(m, p): torch.save(m.state_dict(), p)
 def load_model(m, p): m.load_state_dict(torch.load(p, map_location=lambda storage, loc: storage))
 

--- a/tests/test_layer_optimizer.py
+++ b/tests/test_layer_optimizer.py
@@ -1,0 +1,96 @@
+import unittest
+
+from fastai.layer_optimizer import LayerOptimizer
+
+
+class Par(object):
+    def __init__(self, x, grad=True):
+        self.x = x
+        self.requires_grad = grad
+    def parameters(self): return [self]
+def params_(*names): return [Par(nm) for nm in names]
+
+class FakeOpt(object):
+    def __init__(self, params): self.param_groups = params
+
+class TestLayerOptimizer(unittest.TestCase):
+    def test_init_atomic(self):
+        lo = LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, 1e-4)
+        self.check_optimizer_(lo.opt, [(nm, 1e-2, 1e-4) for nm in 'ABC'])
+
+    def test_init_list(self):
+        lo = LayerOptimizer(
+            FakeOpt,
+            params_('A', 'B', 'C'),
+            (1e-2, 2e-2, 3e-2),
+            (9e-3, 8e-3, 7e-3),
+        )
+        self.check_optimizer_(
+            lo.opt,
+            [('A', 1e-2, 9e-3), ('B', 2e-2, 8e-3), ('C', 3e-2, 7e-3)],
+        )
+
+    def test_init_malformed_lr(self):
+        with self.assertRaises(AssertionError):
+            LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), (1e-2, 2e-2), 1e-4)
+
+    def test_init_malformed_wd(self):
+        with self.assertRaises(AssertionError):
+            LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, (9e-3, 8e-3))
+
+    def test_set_lrs_atomic(self):
+        lo = LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, 1e-4)
+        lo.set_lrs(1e-3)
+        self.check_optimizer_(lo.opt, [(nm, 1e-3, 1e-4) for nm in 'ABC'])
+
+    def test_set_lrs_list(self):
+        lo = LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, 1e-4)
+        lo.set_lrs([2e-2, 3e-2, 4e-2])
+        self.check_optimizer_(
+            lo.opt,
+            [('A', 2e-2, 1e-4), ('B', 3e-2, 1e-4), ('C', 4e-2, 1e-4)],
+        )
+
+    def test_set_lrs_malformed(self):
+        lo = LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, 1e-4)
+        # This should probably error instead of quietly working.
+        lo.set_lrs([2e-2, 3e-2])
+        self.check_optimizer_(
+            lo.opt,
+            [('A', 2e-2, 1e-4), ('B', 3e-2, 1e-4), ('C', 1e-2, 1e-4)],
+        )
+
+    def test_set_wds_atomic(self):
+        lo = LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, 1e-4)
+        lo.set_wds(1e-5)
+        self.check_optimizer_(lo.opt, [(nm, 1e-2, 1e-5) for nm in 'ABC'])
+
+    def test_set_wds_list(self):
+        lo = LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, 1e-4)
+        lo.set_wds([9e-3, 8e-3, 7e-3])
+        self.check_optimizer_(
+            lo.opt,
+            [('A', 1e-2, 9e-3), ('B', 1e-2, 8e-3), ('C', 1e-2, 7e-3)],
+        )
+
+    def test_set_wds_malformed(self):
+        lo = LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, 1e-4)
+        # This should probably error instead of quietly working.
+        lo.set_wds([9e-3, 8e-3])
+        self.check_optimizer_(
+            lo.opt,
+            [('A', 1e-2, 9e-3), ('B', 1e-2, 8e-3), ('C', 1e-2, 1e-4)],
+        )
+
+    def check_optimizer_(self, opt, expected):
+        actual = opt.param_groups
+        self.assertEqual(len(actual), len(expected))
+        for (a, e) in zip(actual, expected): self.check_param_(a, *e)
+        
+    def check_param_(self, par, nm, lr, wd):
+        self.assertEqual(par['params'][0].x, nm)
+        self.assertEqual(par['lr'], lr)
+        self.assertEqual(par['weight_decay'], wd)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I went with the builtin `unittest` framework, but I'm open to alternatives.

Run this guy like so:
```
(fastai) .../fastai/fastai$ python -m unittest tests.test_layer_optimizer
..........
----------------------------------------------------------------------
Ran 10 tests in 0.003s

OK
```

Of course the requirement to pinpoint specify the test is not ideal. I don't have a ton of expertise on how to resolve that, and am open to the idea of some testing framework alternatives to make the whole thing nicer.

It is also worth noting that two tests are verifying probably incorrect behavior (I commented them). I'm happy to fix that in a subsequent review, but wanted to separate it from the test.