### PR TITLE
Bug in model.validate

### DIFF
--- a/fastai/model.py
+++ b/fastai/model.py
@@ -150,7 +150,8 @@ def validate(stepper, dl, metrics):
     stepper.reset(False)
     for (*x,y) in iter(dl):
         preds,l = stepper.evaluate(VV(x), VV(y))
-        batch_cnts.append(len(x))
+        if isinstance(x,list): batch_cnts.append(len(x[0]))
+        else: batch_cnts.append(len(x))
         loss.append(to_np(l))
         res.append([f(preds.data,y) for f in metrics])
     return np.average(loss, 0, weights=batch_cnts).tolist() + np.average(np.stack(res), 0, weights=batch_cnts).tolist()


### PR DESCRIPTION
With a pdb.set_trace() I realized that in the validate function, x is always a list containing a Tensor with our minibatch. Then the current command batch_cnts.append(len(x)) always add ones instead of the actual size of the minibatch which makes the results false (the last minibatch usually has a smaller size).