### PR TITLE
convert test_layer_optimizer to use pytest instead of unittest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ prompt-toolkit>=1.0.15
 ptyprocess>=0.5.2
 Pygments>=2.2.0
 pyparsing>=2.2.0
+pytest>=3.5.0
 python-dateutil>=2.6.1
 pytz>=2017.2
 PyYAML>=3.12

--- a/tests/test_layer_optimizer.py
+++ b/tests/test_layer_optimizer.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 
 from fastai.layer_optimizer import LayerOptimizer
 
@@ -8,83 +8,81 @@ class Par(object):
         self.x = x
         self.requires_grad = grad
     def parameters(self): return [self]
-def params_(*names): return [Par(nm) for nm in names]
 
 class FakeOpt(object):
     def __init__(self, params): self.param_groups = params
 
-class TestLayerOptimizer(unittest.TestCase):
-    def test_init_atomic(self):
-        lo = LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, 1e-4)
-        self.check_optimizer_(lo.opt, [(nm, 1e-2, 1e-4) for nm in 'ABC'])
+def params_(*names): return [Par(nm) for nm in names]
 
-    def test_init_list(self):
-        lo = LayerOptimizer(
-            FakeOpt,
-            params_('A', 'B', 'C'),
-            (1e-2, 2e-2, 3e-2),
-            (9e-3, 8e-3, 7e-3),
-        )
-        self.check_optimizer_(
-            lo.opt,
-            [('A', 1e-2, 9e-3), ('B', 2e-2, 8e-3), ('C', 3e-2, 7e-3)],
-        )
+def check_optimizer_(opt, expected):
+    actual = opt.param_groups
+    assert len(actual) == len(expected)
+    for (a, e) in zip(actual, expected): check_param_(a, *e)
+    
+def check_param_(par, nm, lr, wd):
+    assert par['params'][0].x == nm
+    assert par['lr'] == lr
+    assert par['weight_decay'] == wd
 
-    def test_init_malformed_lr(self):
-        with self.assertRaises(AssertionError):
-            LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), (1e-2, 2e-2), 1e-4)
 
-    def test_init_malformed_wd(self):
-        with self.assertRaises(AssertionError):
-            LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, (9e-3, 8e-3))
+def test_init_atomic():
+    lo = LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, 1e-4)
+    check_optimizer_(lo.opt, [(nm, 1e-2, 1e-4) for nm in 'ABC'])
 
-    def test_set_lrs_atomic(self):
-        lo = LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, 1e-4)
-        lo.set_lrs(1e-3)
-        self.check_optimizer_(lo.opt, [(nm, 1e-3, 1e-4) for nm in 'ABC'])
+def test_init_list():
+    lo = LayerOptimizer(
+        FakeOpt,
+        params_('A', 'B', 'C'),
+        (1e-2, 2e-2, 3e-2),
+        (9e-3, 8e-3, 7e-3),
+    )
+    check_optimizer_(
+        lo.opt,
+        [('A', 1e-2, 9e-3), ('B', 2e-2, 8e-3), ('C', 3e-2, 7e-3)],
+    )
 
-    def test_set_lrs_list(self):
-        lo = LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, 1e-4)
-        lo.set_lrs([2e-2, 3e-2, 4e-2])
-        self.check_optimizer_(
-            lo.opt,
-            [('A', 2e-2, 1e-4), ('B', 3e-2, 1e-4), ('C', 4e-2, 1e-4)],
-        )
+def test_init_malformed_lr():
+    with pytest.raises(AssertionError):
+        LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), (1e-2, 2e-2), 1e-4)
 
-    def test_set_lrs_malformed(self):
-        lo = LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, 1e-4)
-        with self.assertRaises(AssertionError):
-            lo.set_lrs([2e-2, 3e-2])
-        self.check_optimizer_(lo.opt, [(nm, 1e-2, 1e-4) for nm in 'ABC'])
-        
-    def test_set_wds_atomic(self):
-        lo = LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, 1e-4)
-        lo.set_wds(1e-5)
-        self.check_optimizer_(lo.opt, [(nm, 1e-2, 1e-5) for nm in 'ABC'])
+def test_init_malformed_wd():
+    with pytest.raises(AssertionError):
+        LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, (9e-3, 8e-3))
 
-    def test_set_wds_list(self):
-        lo = LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, 1e-4)
-        lo.set_wds([9e-3, 8e-3, 7e-3])
-        self.check_optimizer_(
-            lo.opt,
-            [('A', 1e-2, 9e-3), ('B', 1e-2, 8e-3), ('C', 1e-2, 7e-3)],
-        )
+def test_set_lrs_atomic():
+    lo = LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, 1e-4)
+    lo.set_lrs(1e-3)
+    check_optimizer_(lo.opt, [(nm, 1e-3, 1e-4) for nm in 'ABC'])
 
-    def test_set_wds_malformed(self):
-        lo = LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, 1e-4)
-        with self.assertRaises(AssertionError):
-            lo.set_wds([9e-3, 8e-3])
-        self.check_optimizer_(lo.opt, [(nm, 1e-2, 1e-4) for nm in 'ABC'])
+def test_set_lrs_list():
+    lo = LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, 1e-4)
+    lo.set_lrs([2e-2, 3e-2, 4e-2])
+    check_optimizer_(
+        lo.opt,
+        [('A', 2e-2, 1e-4), ('B', 3e-2, 1e-4), ('C', 4e-2, 1e-4)],
+    )
 
-    def check_optimizer_(self, opt, expected):
-        actual = opt.param_groups
-        self.assertEqual(len(actual), len(expected))
-        for (a, e) in zip(actual, expected): self.check_param_(a, *e)
-        
-    def check_param_(self, par, nm, lr, wd):
-        self.assertEqual(par['params'][0].x, nm)
-        self.assertEqual(par['lr'], lr)
-        self.assertEqual(par['weight_decay'], wd)
+def test_set_lrs_malformed():
+    lo = LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, 1e-4)
+    with pytest.raises(AssertionError):
+        lo.set_lrs([2e-2, 3e-2])
+    check_optimizer_(lo.opt, [(nm, 1e-2, 1e-4) for nm in 'ABC'])
+    
+def test_set_wds_atomic():
+    lo = LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, 1e-4)
+    lo.set_wds(1e-5)
+    check_optimizer_(lo.opt, [(nm, 1e-2, 1e-5) for nm in 'ABC'])
 
-if __name__ == '__main__':
-    unittest.main()
+def test_set_wds_list():
+    lo = LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, 1e-4)
+    lo.set_wds([9e-3, 8e-3, 7e-3])
+    check_optimizer_(
+        lo.opt,
+        [('A', 1e-2, 9e-3), ('B', 1e-2, 8e-3), ('C', 1e-2, 7e-3)],
+    )
+
+def test_set_wds_malformed():
+    lo = LayerOptimizer(FakeOpt, params_('A', 'B', 'C'), 1e-2, 1e-4)
+    with pytest.raises(AssertionError):
+        lo.set_wds([9e-3, 8e-3])
+    check_optimizer_(lo.opt, [(nm, 1e-2, 1e-4) for nm in 'ABC'])


### PR DESCRIPTION
Run like so:
```
.../fastai/fastai$ python -m pytest tests/test_layer_optimizer.py 
========================== test session starts ================================
platform darwin -- Python 3.6.4, pytest-3.5.0, py-1.5.3, pluggy-0.6.0
rootdir: /Users/michael/go/src/github.com/mcskinner/fastai, inifile:
collected 10 items                                                                                                                                                                                                                                                                   

tests/test_layer_optimizer.py ..........                                                                                    [100%]

======================== 10 passed in 1.96 seconds ============================
```

For reasons that I still don't understand, running normal `pytest` incantations fails to import `fastai`, this despite doing the recommended `pip install -e .` to do a development install.

```
.../fastai/fastai$ pytest --ignore=courses
========================== test session starts ================================
platform darwin -- Python 3.6.3, pytest-3.2.1, py-1.4.34, pluggy-0.4.0
rootdir: /Users/michael/go/src/github.com/mcskinner/fastai, inifile:
collected 0 items / 1 errors                                                                                                                                                                                                                                                          

================================ ERRORS =======================================
____________ ERROR collecting tests/test_layer_optimizer.py ___________________
Hint: make sure your test modules/packages have valid Python names.
Traceback:
tests/test_layer_optimizer.py:3: in <module>
    from fastai.layer_optimizer import LayerOptimizer
E   ModuleNotFoundError: No module named 'fastai'
!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!!!!
======================= 1 error in 0.18 seconds ===============================
```