### PR TITLE
Added GoogleNetResize augmentation

### DIFF
--- a/fastai/transforms.py
+++ b/fastai/transforms.py
@@ -61,7 +61,6 @@ def center_crop(im, min_sz=None):
     start_c = math.ceil((c-min_sz)/2)
     return crop(im, start_r, start_c, min_sz)
 
-<<<<<<< HEAD
 def googlenet_resize(im, targ, min_area_frac, min_aspect_ratio, max_aspect_ratio, flip_p):
     h,w,*_ = im.shape
     area = h*w
@@ -81,7 +80,7 @@ def googlenet_resize(im, targ, min_area_frac, min_aspect_ratio, max_aspect_ratio
     out = scale_min(im, targ, interpolation=cv2.INTER_CUBIC)
     out = center_crop(out)
     return out
-=======
+
 def cutout(im, n_holes, length):
     *_,h,w = im.shape
     mask = np.ones((h, w), np.int32)
@@ -98,7 +97,6 @@ def cutout(im, n_holes, length):
     mask = mask[:,:,None]
     im = im * mask
     return im
->>>>>>> master
 
 def scale_to(x, ratio, targ): return max(math.floor(x*ratio), targ)
 


### PR DESCRIPTION
Settings for GoogleNetResize can be passed through a parameter gnet_resize_params as a dictionary to both tfms_from_model and tfms_from_stats.

Default parameters are as follows:
```gnet_resize_params={'min_area_frac':0.08, 'min_aspect_ratio':0.75, 'max_aspect_ratio':1.333, 'flip_p':0.5, 'random_state':None}```

Output from CropType.NO only:
<img width="602" alt="screen shot 2018-04-08 at 5 53 42 am" src="https://user-images.githubusercontent.com/10195639/38461576-da586024-3af1-11e8-940f-abddadb4cf9f.png">

Output from CropType.GOOGLENET only with default parameters:
<img width="598" alt="screen shot 2018-04-08 at 5 53 57 am" src="https://user-images.githubusercontent.com/10195639/38461579-f4c82f52-3af1-11e8-9277-b8260b3fbc2d.png">

