### PR TITLE
New plots + minor fixes

### DIFF
--- a/Tests SGD.ipynb
+++ b/Tests SGD.ipynb
@@ -1,0 +1,3964 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "%reload_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastai.conv_learner import *\n",
+    "PATH = Path(\"../../Deeplearning/data/cifar10/\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " Volume in drive D has no label.\n",
+      " Volume Serial Number is 625A-AF7A\n",
+      "\n",
+      " Directory of D:\\Work\\Deeplearning\\data\\cifar10\n",
+      "\n",
+      "04/06/2018  09:19 AM    <DIR>          .\n",
+      "04/06/2018  09:19 AM    <DIR>          ..\n",
+      "04/05/2018  04:51 PM            35,978 experiment0.png\n",
+      "04/05/2018  04:57 PM            50,294 experiment1.png\n",
+      "04/05/2018  04:50 PM            60,942 experiment2.png\n",
+      "04/05/2018  07:02 PM            38,327 experiment3.png\n",
+      "04/05/2018  07:25 PM            60,254 experiment4.png\n",
+      "04/04/2018  11:25 AM                60 labels.txt\n",
+      "04/05/2018  09:57 PM            27,226 lr_plot.png\n",
+      "04/04/2018  11:51 AM    <DIR>          models\n",
+      "04/06/2018  09:19 AM            45,830 schedule.png\n",
+      "04/04/2018  11:50 AM    <DIR>          test\n",
+      "04/04/2018  01:07 PM            35,731 test.jpg\n",
+      "04/04/2018  01:09 PM            27,077 test.png\n",
+      "04/04/2018  11:50 AM    <DIR>          tmp\n",
+      "04/04/2018  11:48 AM    <DIR>          train\n",
+      "              10 File(s)        381,719 bytes\n",
+      "               6 Dir(s)  667,645,018,112 bytes free\n"
+     ]
+    }
+   ],
+   "source": [
+    "! dir {PATH}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "classes = ('plane', 'car', 'bird', 'cat', 'deer', 'dog', 'frog', 'horse', 'ship', 'truck')\n",
+    "stats = (np.array([ 0.4914 ,  0.48216,  0.44653]), np.array([ 0.24703,  0.24349,  0.26159]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_data(sz,bs):\n",
+    "    tfms = tfms_from_stats(stats, sz, aug_tfms=[RandomFlip()], pad=sz//8)\n",
+    "    return ImageClassifierData.from_paths(PATH, val_name='test', tfms=tfms, bs=bs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "size = 32\n",
+    "batch_size = 64"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = get_data(size,batch_size)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_iter = iter(data.val_dl)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x,y=next(data_iter)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAP8AAAD8CAYAAAC4nHJkAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAHLxJREFUeJztnWuMJNV1x/+nnzM9M7uzs89hH+yC8QM7NiYjhETkYMexiGMJW4otiGTxAXmtyEix5HxARIqJlA92FNtC+eBoHZBx5BgT28goIokRcUIcOZiF4GVheXuB3Z2dBzvvnp7prjr50E00jO8509MzU734/n/Sanvu7dt16ladqu77r3OOqCoIIfGR67YBhJDuQOcnJFLo/IRECp2fkEih8xMSKXR+QiKFzk9IpND5CYkUOj8hkVLYyGARuQHAXQDyAP5eVb/ivT9fKGixVAr25cS+DinScLvzdKL74KKI0+lgfaj7cV6na+Ta9qyDTp/j3FwrtoZO9s07d7LeZ9sUb8/CfUm9gTRJ2toF6fTxXhHJA3gBwO8DOAPgcQA3q+qz1pieSkUPv+udwb5SqcfcViOpBduXl+vmmDR8vWiSy5td7nRr+ENzOWeunQtN2qHza+ptzxjT4QXP+2ooHbiJf8Hu7FxUx4zE+MzUOUHyzn6JY2Paof2WLUnSMMcokmD79OtnUa8ttXVgNvK1/xoAL6nqK6q6DOA+ADdu4PMIIRmyEeffD+D1FX+fabURQt4GbOQ3f+irxa997xGRowCOAkChWNzA5gghm8lG7vxnABxc8fcBAOdWv0lVj6nqiKqO5AsbWl8khGwiG3H+xwFcISJHRKQE4CYAD26OWYSQrabjW7GqNkTkNgD/hqbUd4+qPuONyQlQzoevN/m8vQJfbxgrs8bqO7DWVc1eDE1SbzU6vL3U2Zo4q+xen6tVrl8BgniKhIe3uu0Y4u6buakOPy+xzwOxzhFPdXBkZzjnR+qcjx7WfrvzYfWtQ3DY0PdwVX0IwEMb+QxCSHfgE36ERAqdn5BIofMTEil0fkIihc5PSKRk+tSNiKBUCEt6XqyKJQNqzgl8cGSXNLXH5TyFzejzAjq8q2sn2wIA8SJZrC5HovLwjosXHGPSobzpbcsLtimYQVzO+eHKrFsQmNSBbCedqYpvgXd+QiKFzk9IpND5CYkUOj8hkULnJyRSsl3th6JQCKcfapS3meNKeWOFuLFkjvHSmDUcJcBfsbVyZHmf59jhrNjm3MAYZ8XZWNXvNGUYnICgjubKpUNFwhtnLqR7ATrhc7Q50B7nBYV5syGW8uCdV0Yar/XMIe/8hEQKnZ+QSKHzExIpdH5CIoXOT0ik0PkJiZRMpb5cTtDbE77e7HnXB8xxFybPBtunXp0xx8xX7eAdL7gk8WQe61rpBJ14+eBSJ2pGLHkTgKq9b2mHATz2tjrL/ddJDj9vSC5nz2PDkd/qabiqkx/4ZVeC8tL0iXqVoDwZMHzOmfkHASRG3sL1xBbxzk9IpND5CYkUOj8hkULnJyRS6PyERAqdn5BI2ZDUJyKnAcwBSAA0VHXE3Vghjz1Dg8G+khmlBOzYfSDYXj37tDlmQWy5xpOUxIm/suQaL+ebGbHV7DTxSj95cpMVadeJ9NayxOnz8tl1sj1Hgk06y+/nSXq2FU75NWc+BI687GAdM0+2tSMq29f6NkPn/7CqTm7C5xBCMoRf+wmJlI06vwL4iYg8ISJHN8MgQkg2bPRr/3Wqek5E9gB4WESeU9VHV76hdVE4CgCVSs8GN0cI2Sw2dOdX1XOt/8cBPADgmsB7jqnqiKqOlMvFjWyOELKJdOz8ItInIgNvvgbwMQAnN8swQsjWspGv/XsBPNCSkAoA/lFV/9Ub0FvI4crdvcG+pZ0Vc9yZiblguxhlvADArNIEuKWrPEnMEV6cjXnY8qY6EX+q9jXbSuDpX+a9PXPD2OxxHUyJFxXnyYBqRLj5hnhJP70ycJ6s682jbb8l6bkJUs3ztH2JtWPnV9VXANhxuISQixpKfYRECp2fkEih8xMSKXR+QiKFzk9IpGSawHOgt4QPvz8coXe+st8cNzN2PNheLodlQwDILSzYfV79ufUHgUGd5JLiyGGNhicpOZKN2g9LmYkiOyyrp16kmveZxkR6khecZKemhAlfYrNqHqapI7M6EYS5nGOHE13oE7bRk/o2I6qPd35CIoXOT0ik0PkJiRQ6PyGRQucnJFIyXe2vDA7g6k98NNj38/98zhx38NCuYPuZiX5zzIULU2ZfyQlWWe4kZ51zCfVWbHPO9KsXYORsT4ygFBFbIagn9rbKsMelXmBPuhxsb7g5Eu28i45A4+ZdtBSEXM7L++dNsK1+eBn88l7wUc4q12UHOiX18Py6wUCrN9v2Owkhv1HQ+QmJFDo/IZFC5yckUuj8hEQKnZ+QSMlU6kOhH7L32mBXeekxc9jLz74QbF+s1swxuZy9a2neHpc4chMQll7EybfnxVkUCraN4gW5OJtLkrBs5JWtymlYNmpuy7bDK1OWN2x0FDYkjo2JM5H5gm1j0gjvm4gzH865Uyo7JcVydqCZd45Y5ca8c6CRhM/h6owd0LYa3vkJiRQ6PyGRQucnJFLo/IRECp2fkEih8xMSKWtKfSJyD4BPABhX1fe12oYAfB/AYQCnAXxGVe0wujc/SxWlpbCUVnFKJCXVxWB7teZIVHln1+btcRWnhNayEVq27F5DvbJbtnxVLNoRXSWnTwyZqlSwt3Vkn50/ceyNJbNvYnra7OvrCVdkXqjZx3luft7sW0psCbZed+LpjNx/eScX397dQ2bfQJ99PBec3Iqzc/Y511cOz1Wa2vs8ccGWq9ulnTv/twHcsKrtdgCPqOoVAB5p/U0IeRuxpvOr6qMALqxqvhHAva3X9wL45CbbRQjZYjr9zb9XVUcBoPX/ns0ziRCSBVu+4CciR0XkuIgcn5x8Y6s3Rwhpk06df0xEhgGg9f+49UZVPaaqI6o6smvXzg43RwjZbDp1/gcB3NJ6fQuAH2+OOYSQrGhH6vsegOsB7BKRMwC+DOArAO4XkVsBvAbg0+1sLE0XsbB4MtiX9AyY4y45dDjYPlueNMcsLtsySbVSMfuKTqbIsemwmrk4P2uOSbzEjV40oFP6qeAk49w+GN63q9+1zxzzx3/4u2bf3x77F7Ovr+BIjqWwjRNTc+aYtG7LrMWCfcx6+raZfdWFsEyc1u3zo6+03ey7/porzb4TL502+07Njpp9wzvC9vf12cd52ZC/Z53ScatZ0/lV9Waj6/fa3goh5KKDT/gREil0fkIihc5PSKTQ+QmJFDo/IZGSaQJPXZjD0mP/Feybn7Sjng5ffjjYPnjZ5eaYWsOJznPq8dVTe9zEeFhanJq0Axq9SDUj4AwAMD09Y3c27Ei7nYPhJJJ5p/bfqRdtGerg8LDZd9iRRU+eOR9sLzjRlqVSyewb3LnD7Bt2bFRDTp2YsJ82rTvS7VPPPGP2XZgPy28AUFuwz4PpqbBk2lu097lgSHpu3cJV8M5PSKTQ+QmJFDo/IZFC5yckUuj8hEQKnZ+QSMlU6kuWEsy/HE76+MyTvzLHPblwKtg+4yRMrAwOmn19O+yorcEhW15597vDEV1Dg7vNMcjbkW+J2H1wknsuLtj12Jbmw/PbqNly5ETPLrNv53v3mn3pnC2XTTz/WrC97kQyzi/aSSlnRsPSIQCcP3/G7Kv0hqXPpZot94o4EaGJbf9i1ZZgPYlzaj58PNWpT7iwFJ4rr97hanjnJyRS6PyERAqdn5BIofMTEil0fkIiJdPV/lypgsqlvx3sG6zbq8r7zodXlZfO2ivAk+fHzL6z5+xAloWqveJcKIanq2KUpgKA3Xvs3Hl7hw+ZfYcutft27bMDWYbeGVYkSmX7UC+LEwS1bAernPvVK2bfZw79VrB9/Ow5c8zMlK0eTM/YpcGmFuxAnIW5sP15Z1F8ZtbODTl2PqxiAEDJcSdxgqBKPWFFYnzSyVFZCysS6uWMXAXv/IRECp2fkEih8xMSKXR+QiKFzk9IpND5CYkUUSeABABE5B4AnwAwrqrva7XdCeBzACZab7tDVR9aa2NXHNyrd33ppmDfaQyZ42aNeIm5hao55oVf2YFC5d5+s0/VlmTm5sKSUr1u5x+s1ew+cQJ7UqdclzplsirbwsVQhw8cMMfsP2hLh7t32MVVpydt+U3L4Xl0tWUnf2KpYI+cmDTrxKK3P1wGbmnJDt6Zm7WDoF51zquikyfxuefDwWkAMHE+LD33V+ychr194f06feplLC4stpXIr507/7cB3BBo/4aqXtX6t6bjE0IuLtZ0flV9FMCFDGwhhGTIRn7z3yYiJ0TkHhGxg+AJIRclnTr/NwFcDuAqAKMAvma9UUSOishxETk+Y5RLJoRkT0fOr6pjqpqoagrgWwCucd57TFVHVHVke1/4GWZCSPZ05PwisnJ5+FMATm6OOYSQrFgzqk9EvgfgegC7ROQMgC8DuF5ErgKgAE4D+Hw7G1tuNPCaUSbpiddeMsfVS+Gce9t32bnz+pzyTn39dn6/iTF7bbN/RzjXXd6RodKkYfY1GrYM2GvkngMAbdgyVWMxnA/u7HNPmWPGXnjW7JtatMtMDQ05+f0KYQl5oLdijik40ZH7du0x+1C1bdTecrB91pgnAKgYMhoAHDzyTrPvyGV2JOYlTt/jP/t5sP3l5+3SYLXl8DnQcMrUrWZN51fVmwPNd7e9BULIRQmf8CMkUuj8hEQKnZ+QSKHzExIpdH5CIiXTBJ7LjQSvT4Yj485PTgTbAWDfpWFJr6fPjs7bttOWocoVe9z//HdYdgGA3fvCctPe4UvMMYkTqfbq66+afcP7bWkoXbYlwoH+vmD7ngP2Plcqtvy2e9HeVr8jieWNqMTpKTtibtaQgQHguXN2stZqbc7sqyMste5wSqxdeuhys6+34kiwqR0h+94rrzL7jhwOy4cPPHC/OebFk0+bfe3COz8hkULnJyRS6PyERAqdn5BIofMTEil0fkIiJVOpr56kOD8bTuhRdxJnvnEhLAH1bAtH+wHA3Kyd3LPcZycVyTnS3HPPhiOXp6bsSMDZaVvaWqzZdQGLZVtSqs7bUWyD240IyCE7QWqtYUceJnW7D3n7mG3bFo6q3P+Od5hjLnESmnrRao0Fez5qRtLVC0Y7ALz44gtm37YddkTovz/8sNkH2HM1MBCWTCvOOXDJ/oPB9vlxO6nqanjnJyRS6PyERAqdn5BIofMTEil0fkIiJdPV/iRVXFgMrx6nqX0dmpoKr/bPVO08bJraK8dVZwV7cmLM7MsXw5+54KzoX3A+r1i2c9bNGvsMANV5e7+XjDlJnBX9/n476Oe182fMvj5n3KHD4VX9qtqr9uVyOCgJAHI5+1Rt5O0+2R5end+5zQ5Kmjn9itl36ZHDZt+QsS0AqDvlwZYXw6rP2MQ5c8x2o4xa3pmL1fDOT0ik0PkJiRQ6PyGRQucnJFLo/IRECp2fkEhpp1zXQQDfAbAPQArgmKreJSJDAL4P4DCaJbs+o6q25gVgqV7Hq2fPBvtyuZI5LlcMm5ku2YExmtq75gWy5BDOPQcAydJSsH1usbNAob6ecCkpAFiYtwNPFmbtvpwR7DQxPm6OOfu6LefVGnaA1KITHFPKG7Jovy2xlQfsEmueLFooOeeOYYc450CxbB8XLyCoWC6afWXnWA/uDAdd9Q7auRVnZsJ5C4tF24bVtHPnbwD4kqq+B8C1AL4gIlcCuB3AI6p6BYBHWn8TQt4mrOn8qjqqqk+2Xs8BOAVgP4AbAdzbetu9AD65VUYSQjafdf3mF5HDAD4I4DEAe1V1FGheIAA4ZVQJIRcbbT8LKCL9AH4I4IuqOitiJydYNe4ogKMAUCxl+jQxIcShrTu/iBTRdPzvquqPWs1jIjLc6h8GEFxRUtVjqjqiqiOFgv28PSEkW9Z0fmne4u8GcEpVv76i60EAt7Re3wLgx5tvHiFkq2jne/h1AD4L4GkRearVdgeArwC4X0RuBfAagE+v+UmqaCRhiaWYs6WQZUOWSRJbltPE/lkiBXu38zn7eri8HJbtqgu21OdRrdq551Inp+Gyk/tvLhce12srZTh44IDZV605NiZ2Ka+Z8XA04+ykLTkWnPJrO4bCUWwAkLNPA/QaefCcIVDnljg5YZcNazjyYcmR4NJG2JreXscnjLlPYZcMW82azq+qP4OdffD32t4SIeSigk/4ERIpdH5CIoXOT0ik0PkJiRQ6PyGRkukjdwrAyp1ZFzvBYaJh+UIcOS+fsx8oUkNuBICcE9ElSVjqKw84Dy85ykulYke4NZwkozu2O7JXKSwpLdecBJINW7Ir99iRZbV5e1zRkFO9slv9zkNgjfkZs29+zk5oWl0I99XVFvsKJfscKDhScJp4c2wfz0XjWO/caR9nNXxi2Yl0XQ3v/IRECp2fkEih8xMSKXR+QiKFzk9IpND5CYmUjKU+gRrXm0pvOPoKABaq4SSSiXPpGhjcZvYVnKQiVsJHAKidMZKPOkk6B7bZdlQqtox2fnTU/syBcJJOANi9N5xQKe9ImI2GLVHNTYcTRQLA/Lwd8Vc0kmqKFzXpyJtLy+HkqQCwfcCWTHt7wuGMi3UnInHW3udR57gUnQQ32wft5KRvjIZr8k2dsyMIYUh9S0bdvxC88xMSKXR+QiKFzk9IpND5CYkUOj8hkZJxLm0B8lYuM3ultGSsHKfOtatqKAQA0JfrM/u8wBMrXbkVZAEAy8v2qrKX/rzkBJckRoARALx2Jlx6a2i3vdo84OTO6/VKVznBKnkjZ13B2eeak5vQOT1QdcqlWQFS5R67xNe+3eHyWQDQ4wQf5Zy8izuNklwAMDYeVhASR4UZ6A0rRbU2U+oDvPMTEi10fkIihc5PSKTQ+QmJFDo/IZFC5yckUtaU+kTkIIDvANiHZpWjY6p6l4jcCeBzACZab71DVR/yP03RSMO50+aNXGsA0GvUmio4dZW8HHjV6VmzL1+0p6Qg4e3VHXllYtwuT1V0Sjjt2rXbtsMpNzY9MxVsry3YwSqDg4NmX75gS319jkS4bMhUXkmrnCOjpU5ptsTJ15gzAokqRsAPACxU7XNx23Y7iEjFtqPq5Ek8dPnh8JgFW67uKYTPnek37OO8mnZ0/gaAL6nqkyIyAOAJEXm41fcNVf2btrdGCLloaKdW3yiA0dbrORE5BWD/VhtGCNla1vWbX0QOA/gggMdaTbeJyAkRuUdE7EfICCEXHW07v4j0A/ghgC+q6iyAbwK4HMBVaH4z+Jox7qiIHBeR44nz6CwhJFvacn4RKaLp+N9V1R8BgKqOqWqiqimAbwG4JjRWVY+p6oiqjuSdBR1CSLas6fzSjD65G8ApVf36ivbhFW/7FICTm28eIWSraGe1/zoAnwXwtIg81Wq7A8DNInIVmgWpTgP4fDsbzBsBcHknt1vdkIfEKYWVOuWYkrr988PLC5jmDanPka96DJkSAGo1Oy9d6tT5aohtf9HITzg7+YY5Jqnb0WPiyGhe3sVKf7hvcdGWr3J1WzLtcaLwymVH6jPk2Tem7PkoORKsd16VSk5EnXNeWRGQ24fsZTQ1pGzJtR/V185q/88QDqhcQ9MnhFzM8Ak/QiKFzk9IpND5CYkUOj8hkULnJyRSMk3g2ag3MDEWjnIb2mVHluXKYSlEDBkHAOpOFBWcBw3Tmi2xlSph2W5h3o4C6x+wI98GttkRYgUnujA1IiMBoMdIdjrnRB56SUbry04pr9kZs68wFT42O3bYiSy9iD9VW37zyo1ZmT97nKi+HidpaW3Jlme9eYQz/3krWnTJ/jwraayTS/bX4J2fkEih8xMSKXR+QiKFzk9IpND5CYkUOj8hkZJxrT4bL2liPgnLPOWyLdfUHdklWba1vrwhlQFAshS+Vlq1BAFflvPsdxNWNmy5adGYR68Onlcz0KtD6NUMhKz/1BKnIF+a2ttKU3tczohKLDpJUD3J0ZXzHLw5hnWOOHOfmnPfvtbHOz8hkULnJyRS6PyERAqdn5BIofMTEil0fkIi5aKR+jwppFgMS2leVJ8nsXliSNGpt6ZG4s/tTq07b7+sOnIA0PCSajqSWK0alvTc+XAkJc9Gr6/S1xds92Q0RzFFpzUfisX1J11NnLnqlLpzPNXYN+8cgJWok1F9hJC1oPMTEil0fkIihc5PSKTQ+QmJlDVX+0WkB8CjAMqt9/9AVb8sIkcA3AdgCMCTAD6rqmtGPVgrxAWnRJLFUm3R6bODX3KwV/Qbea90VXi6pGh/Xj7vqAdmD5B3ymSlib1Sbc2Jt9pfcIJcvFx3vZWK2ZcvrP++4h2z0rawegAADUcJSNPwZxYdaaHeYRk1K18gADdIp27lBfQCrtJ1LOsbtHOElgB8RFU/gGY57htE5FoAXwXwDVW9AsAUgFs3bA0hJDPWdH5tMt/6s9j6pwA+AuAHrfZ7AXxySywkhGwJbX03E5F8q0LvOICHAbwMYFpV3/z+eQbA/q0xkRCyFbTl/KqaqOpVAA4AuAbAe0JvC40VkaMiclxEjm/G7xRCyOawrlUZVZ0G8B8ArgUwKPL/6VoOADhnjDmmqiOqOrKe2uGEkK1lTecXkd0iMth63QvgowBOAfgpgD9qve0WAD/eKiMJIZtPO4E9wwDuFZE8mheL+1X1n0XkWQD3ichfAfhfAHev9UEidqDLkpcbrR7u8wJS3JxpzjeQutqSmNTDkkypaEtedq41wAsf8X4iLTulyHKGZGqV8QKA/gGnbFjelmBVbMkxZ8miznEpGEE4a+EFOlnzuGycU80x9jFLPDnPOaDeedDoKJDIKtfV/k/rNZ1fVU8A+GCg/RU0f/8TQt6G8Ak/QiKFzk9IpND5CYkUOj8hkULnJyRSZD3SwIY3JjIB4NXWn7sATGa2cRva8VZox1t5u9lxqarubucDM3X+t2xY5LiqjnRl47SDdtAOfu0nJFbo/IRESjed/1gXt70S2vFWaMdb+Y21o2u/+Qkh3YVf+wmJlK44v4jcICLPi8hLInJ7N2xo2XFaRJ4WkadE5HiG271HRMZF5OSKtiEReVhEXmz9v6NLdtwpImdbc/KUiHw8AzsOishPReSUiDwjIn/aas90Thw7Mp0TEekRkV+IyC9bdvxlq/2IiDzWmo/vi4hT4KwNVDXTfwDyaKYBuwxACcAvAVyZtR0tW04D2NWF7X4IwNUATq5o+2sAt7de3w7gq12y404Af5bxfAwDuLr1egDACwCuzHpOHDsynRM00wD3t14XATyGZgKd+wHc1Gr/OwB/spHtdOPOfw2Al1T1FW2m+r4PwI1dsKNrqOqjAC6sar4RzUSoQEYJUQ07MkdVR1X1ydbrOTSTxexHxnPi2JEp2mTLk+Z2w/n3A3h9xd/dTP6pAH4iIk+IyNEu2fAme1V1FGiehAD2dNGW20TkROtnwZb//FiJiBxGM3/EY+jinKyyA8h4TrJImtsN5w+lQumW5HCdql4N4A8AfEFEPtQlOy4mvgngcjRrNIwC+FpWGxaRfgA/BPBFVZ3Nartt2JH5nOgGkua2Szec/wyAgyv+NpN/bjWqeq71/ziAB9DdzERjIjIMAK3/x7thhKqOtU68FMC3kNGciEgRTYf7rqr+qNWc+ZyE7OjWnLS2ve6kue3SDed/HMAVrZXLEoCbADyYtREi0iciA2++BvAxACf9UVvKg2gmQgW6mBD1TWdr8SlkMCfSTOx3N4BTqvr1FV2ZzollR9ZzklnS3KxWMFetZn4czZXUlwH8eZdsuAxNpeGXAJ7J0g4A30Pz62MdzW9CtwLYCeARAC+2/h/qkh3/AOBpACfQdL7hDOz4HTS/wp4A8FTr38eznhPHjkznBMD70UyKewLNC81frDhnfwHgJQD/BKC8ke3wCT9CIoVP+BESKXR+QiKFzk9IpND5CYkUOj8hkULnJyRS6PyERAqdn5BI+T99V2DifQPeAwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.imshow(data.trn_ds.denorm(x)[0]);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class SimpleNet(nn.Module):\n",
+    "    def __init__(self, layers):\n",
+    "        super().__init__()\n",
+    "        self.layers = nn.ModuleList([\n",
+    "            nn.Linear(layers[i], layers[i + 1]) for i in range(len(layers) - 1)])\n",
+    "        \n",
+    "    def forward(self, x):\n",
+    "        x = x.view(x.size(0), -1)\n",
+    "        for l in self.layers:\n",
+    "            l_x = l(x)\n",
+    "            x = F.relu(l_x)\n",
+    "        return F.log_softmax(l_x, dim=-1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn = ConvLearner.from_model_data(SimpleNet([32*32*3, 40,10]), data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn.opt_fn = optim.Adam"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b06eb29717f44ae5bde654a234befcee",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>HBox</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=1), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                                                                                                       \r"
+     ]
+    }
+   ],
+   "source": [
+    "learn.lr_find2(num_it=50,wds=1e-4, use_wd_sched=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ab10d767d9ad436ba1c963d9c5e27910",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>HBox</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=2), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 23%|███████████████▉                                                     | 180/782 [00:09<00:31, 18.89it/s, loss=1.97]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Exception in thread Thread-10:\n",
+      "Traceback (most recent call last):\n",
+      "  File \"C:\\Users\\Sylvain\\Anaconda3\\envs\\fastai\\lib\\threading.py\", line 916, in _bootstrap_inner\n",
+      "    self.run()\n",
+      "  File \"C:\\Users\\Sylvain\\Anaconda3\\envs\\fastai\\lib\\site-packages\\tqdm\\_tqdm.py\", line 144, in run\n",
+      "    for instance in self.tqdm_cls._instances:\n",
+      "  File \"C:\\Users\\Sylvain\\Anaconda3\\envs\\fastai\\lib\\_weakrefset.py\", line 60, in __iter__\n",
+      "    for itemref in self.data:\n",
+      "RuntimeError: Set changed size during iteration\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 27%|██████████████████▍                                                  | 209/782 [00:11<00:30, 18.93it/s, loss=1.96]\n"
+     ]
+    },
+    {
+     "ename": "KeyboardInterrupt",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-24-c8c2de38da4a>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mlearn\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mfit\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;36m0.01\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;36m1\u001b[0m\u001b[1;33m,\u001b[0m\u001b[0mcycle_len\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;36m2\u001b[0m\u001b[1;33m,\u001b[0m\u001b[0muse_clr_beta\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;36m10\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;36m10\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;36m0.95\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;36m0.85\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;32mD:\\Work\\Github\\fastai\\fastai\\learner.py\u001b[0m in \u001b[0;36mfit\u001b[1;34m(self, lrs, n_cycle, wds, **kwargs)\u001b[0m\n\u001b[0;32m    250\u001b[0m         \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0msched\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;32mNone\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    251\u001b[0m         \u001b[0mlayer_opt\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mget_layer_opt\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mlrs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mwds\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 252\u001b[1;33m         \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mfit_gen\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mmodel\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mlayer_opt\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mn_cycle\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    253\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    254\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0mwarm_up\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mlr\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mwds\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;32mNone\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mD:\\Work\\Github\\fastai\\fastai\\learner.py\u001b[0m in \u001b[0;36mfit_gen\u001b[1;34m(self, model, data, layer_opt, n_cycle, cycle_len, cycle_mult, cycle_save_name, best_save_name, use_clr, use_clr_beta, metrics, callbacks, use_wd_sched, norm_wds, wds_sched_mult, all_val, **kwargs)\u001b[0m\n\u001b[0;32m    197\u001b[0m         \u001b[0mn_epoch\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0msum_geom\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mcycle_len\u001b[0m \u001b[1;32mif\u001b[0m \u001b[0mcycle_len\u001b[0m \u001b[1;32melse\u001b[0m \u001b[1;36m1\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mcycle_mult\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mn_cycle\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    198\u001b[0m         return fit(model, data, n_epoch, layer_opt.opt, self.crit,\n\u001b[1;32m--> 199\u001b[1;33m             metrics=metrics, callbacks=callbacks, reg_fn=self.reg_fn, clip=self.clip, all_val=all_val, **kwargs)\n\u001b[0m\u001b[0;32m    200\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    201\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0mget_layer_groups\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mmodels\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mget_layer_groups\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mD:\\Work\\Github\\fastai\\fastai\\model.py\u001b[0m in \u001b[0;36mfit\u001b[1;34m(model, data, epochs, opt, crit, metrics, callbacks, stepper, all_val, **kwargs)\u001b[0m\n\u001b[0;32m    118\u001b[0m         \u001b[0mi\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;36m0\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    119\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[0mall_val\u001b[0m\u001b[1;33m:\u001b[0m \u001b[0mval_iter\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0miter_batch\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mdata\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mval_dl\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 120\u001b[1;33m         \u001b[1;32mfor\u001b[0m \u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0mx\u001b[0m\u001b[1;33m,\u001b[0m\u001b[0my\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;32min\u001b[0m \u001b[0mt\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    121\u001b[0m             \u001b[0mbatch_num\u001b[0m \u001b[1;33m+=\u001b[0m \u001b[1;36m1\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    122\u001b[0m             \u001b[1;32mfor\u001b[0m \u001b[0mcb\u001b[0m \u001b[1;32min\u001b[0m \u001b[0mcallbacks\u001b[0m\u001b[1;33m:\u001b[0m \u001b[0mcb\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mon_batch_begin\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m~\\Anaconda3\\envs\\fastai\\lib\\site-packages\\tqdm\\_tqdm.py\u001b[0m in \u001b[0;36m__iter__\u001b[1;34m(self)\u001b[0m\n\u001b[0;32m    953\u001b[0m \"\"\", fp_write=getattr(self.fp, 'write', sys.stderr.write))\n\u001b[0;32m    954\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 955\u001b[1;33m             \u001b[1;32mfor\u001b[0m \u001b[0mobj\u001b[0m \u001b[1;32min\u001b[0m \u001b[0miterable\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    956\u001b[0m                 \u001b[1;32myield\u001b[0m \u001b[0mobj\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    957\u001b[0m                 \u001b[1;31m# Update and possibly print the progressbar.\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mD:\\Work\\Github\\fastai\\fastai\\dataloader.py\u001b[0m in \u001b[0;36m__iter__\u001b[1;34m(self)\u001b[0m\n\u001b[0;32m     82\u001b[0m                 \u001b[1;31m# avoid py3.6 issue where queue is infinite and can result in memory exhaustion\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     83\u001b[0m                 \u001b[1;32mfor\u001b[0m \u001b[0mc\u001b[0m \u001b[1;32min\u001b[0m \u001b[0mchunk_iter\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0miter\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mbatch_sampler\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mnum_workers\u001b[0m\u001b[1;33m*\u001b[0m\u001b[1;36m10\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 84\u001b[1;33m                     \u001b[1;32mfor\u001b[0m \u001b[0mbatch\u001b[0m \u001b[1;32min\u001b[0m \u001b[0me\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mmap\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mget_batch\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mc\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m \u001b[1;32myield\u001b[0m \u001b[0mget_tensor\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mbatch\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpin_memory\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     85\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m~\\Anaconda3\\envs\\fastai\\lib\\concurrent\\futures\\_base.py\u001b[0m in \u001b[0;36mresult_iterator\u001b[1;34m()\u001b[0m\n\u001b[0;32m    584\u001b[0m                     \u001b[1;31m# Careful not to keep a reference to the popped future\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    585\u001b[0m                     \u001b[1;32mif\u001b[0m \u001b[0mtimeout\u001b[0m \u001b[1;32mis\u001b[0m \u001b[1;32mNone\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 586\u001b[1;33m                         \u001b[1;32myield\u001b[0m \u001b[0mfs\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpop\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mresult\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    587\u001b[0m                     \u001b[1;32melse\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    588\u001b[0m                         \u001b[1;32myield\u001b[0m \u001b[0mfs\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpop\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mresult\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mend_time\u001b[0m \u001b[1;33m-\u001b[0m \u001b[0mtime\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mtime\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m~\\Anaconda3\\envs\\fastai\\lib\\concurrent\\futures\\_base.py\u001b[0m in \u001b[0;36mresult\u001b[1;34m(self, timeout)\u001b[0m\n\u001b[0;32m    425\u001b[0m                 \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m__get_result\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    426\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 427\u001b[1;33m             \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_condition\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mwait\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mtimeout\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    428\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    429\u001b[0m             \u001b[1;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_state\u001b[0m \u001b[1;32min\u001b[0m \u001b[1;33m[\u001b[0m\u001b[0mCANCELLED\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mCANCELLED_AND_NOTIFIED\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m~\\Anaconda3\\envs\\fastai\\lib\\threading.py\u001b[0m in \u001b[0;36mwait\u001b[1;34m(self, timeout)\u001b[0m\n\u001b[0;32m    293\u001b[0m         \u001b[1;32mtry\u001b[0m\u001b[1;33m:\u001b[0m    \u001b[1;31m# restore state no matter what (e.g., KeyboardInterrupt)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    294\u001b[0m             \u001b[1;32mif\u001b[0m \u001b[0mtimeout\u001b[0m \u001b[1;32mis\u001b[0m \u001b[1;32mNone\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 295\u001b[1;33m                 \u001b[0mwaiter\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0macquire\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    296\u001b[0m                 \u001b[0mgotit\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;32mTrue\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    297\u001b[0m             \u001b[1;32melse\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;31mKeyboardInterrupt\u001b[0m: "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 27%|██████████████████▍                                                  | 209/782 [00:30<01:22,  6.96it/s, loss=1.96]"
+     ]
+    }
+   ],
+   "source": [
+    "learn.fit(0.01,1,cycle_len=2,use_clr_beta=(10,10,0.95,0.85))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 128,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAK9CAYAAADL4nAVAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzs3Xl8nHW1+PHPyb4nTZvuTdNCS/dSGgoIyC5SEEQQcUHholXxKlxxQVyuiL+LyhXFFXpBEUWQpYCsBSq01EKhLd3TfaFNkzZp9j2ZOb8/5pmQplkmmXlmy3m/Xnll5plnnuc0hDn5bucrqooxxhgDkBDpAIwxxkQPSwrGGGM6WVIwxhjTyZKCMcaYTpYUjDHGdLKkYIwxppMlBWOMMZ0sKRhjjOlkScEYY0ynpEgHMFAjRozQoqKiSIdhjDExZe3atZWqWtDfeTGXFIqKilizZk2kwzDGmJgiIvsDOc+17iMRmSAir4tIiYhsEZGbeznvXBFZ75yz3K14jDHG9M/NlkIHcKuqrhORbGCtiLyqqlv9J4hIHvAH4KOq+r6IjHQxHmOMMf1wraWgqmWqus55XA+UAOO6nfYZYImqvu+cd8SteIwxxvQvLLOPRKQImAes7vbSVGCYiLwhImtF5PO9vH+RiKwRkTUVFRXuBmuMMUOY60lBRLKAp4BbVLWu28tJwHzgUuBi4IciMrX7NVR1saoWq2pxQUG/g+fGGGMGydXZRyKSjC8hPKKqS3o45SBQqaqNQKOIrADmAjvcjMsYY0zP3Jx9JMCDQImq3tPLac8CZ4tIkohkAKfhG3swxhjTxV0vlfDW7qOu38fNlsKZwHXAJhFZ7xy7HSgEUNX7VLVERF4GNgJe4AFV3exiTMYYE3NW7a7k/uV7yElL5owThrt6L9eSgqquBCSA8+4G7nYrDmOMiWUer/LT50sYl5fOjWdNcv1+VvvIGGOi2JJ1B9laVsd3PnoSacmJrt/PkoIxxkSpprYO7l66nZMn5HH53LFhuaclBWOMiVL3L9/DkfpWfnjZdHxzd9xnScEYY6JQWW0z96/YzWVzxjB/Yn7Y7mtJwRhjotDdS7fjVfjuR6eF9b6WFIwxJsrsrWxkybpSbjiziAn5GWG9tyUFY4yJMi9sPATA9R8qCvu9LSkYY0yUeXFTOacU5jEmNz3s97akYIwxUWRfZSNby+pYOHtMRO5vScEYY6LIi5vLALjEkoIxxpiXNpUzd0Ie4/LC33UElhSMMSZqHKhqYlNpLZfOHh2xGCwpGGNMlHjJ33U0KzJdR2BJwRhjosYLm8qZPS437GsTurKkYIwxUeBgdRMbDtRwSQS7jsCSgjHGRIWXN5cDsDCCXUfg7nacE0TkdREpEZEtInJzD+ecKyK1IrLe+fqRW/EYY0w0e3FTGTPG5FA0IjOicbi5HWcHcKuqrhORbGCtiLyqqlu7nfemql7mYhzGGBPVymqbWfd+Dd/6yNRIh+JeS0FVy1R1nfO4HigBxrl1P2OMiVVPrDkIwGVzwrORTl/CMqYgIkXAPGB1Dy+fISIbROQlEZkZjniMMSZatHu8PLJ6Px+eWhDxriMIQ1IQkSzgKeAWVa3r9vI6YKKqzgV+CzzTyzUWicgaEVlTUVHhbsDGGBNGS7eUc7iulS+cMTHSoQAuJwURScaXEB5R1SXdX1fVOlVtcB6/CCSLyIgezlusqsWqWlxQUOBmyMYYE1YPr9pPYX4G5540MtKhAO7OPhLgQaBEVe/p5ZzRznmIyAInnqNuxWSMMdFk66E63tlXxXWnTyQxITx7MPfHzdlHZwLXAZtEZL1z7HagEEBV7wOuBr4qIh1AM3CtqqqLMRljTNR4+K19pCUncE3xhEiH0sm1pKCqK4E+U5+q/g74nVsxGGNMtKppauOZ9aVcOW8cuRnJkQ6nk61oNsaYCHh8zQFa2r18/oyiSIdyDEsKxhgTZh6v8vBb+1kwKZ/pY3IiHc4xLCkYY0yYrdhZwcHqZq7/UFGkQzmOJQVjjAmzpZvLyU5N4sLpoyIdynEsKRhjTBh5vcqybUf48EkFpCRF30dw9EVkjDFxbGNpLRX1rVwUha0EsKRgjDFh9drWwyQmCOeeFJ3VGSwpGGNMGL1WcpjiicPIy0iJdCg9sqRgjDFhcqCqiW3l9Vw0Izq7jsCSgjHGhM2yksMAXBCl4wlgScEYY8LmtZIjnFCQyaQo2DehN5YUjDEmDOpa2lm99ygXRnHXEVhSMMaYsFixo4J2j0blgrWuLCkYY0wYvLb1MMMykjmlcFikQ+mTJQVjjHFZh8fL69srOH/aqKjZTKc3lhSMMcZlq3Yfpba5nQunR8eWm31xczvOCSLyuoiUiMgWEbm5j3NPFRGPiFztVjzGGBMJ9S3t/PDZzYzLS+ecKF3F3JWb23F2ALeq6joRyQbWisirqrq160kikgj8HFjqYizGGBN2qsoPn9nMgaomHv/yGWSkuPmRGxqutRRUtUxV1zmP64ESYFwPp34deAo44lYsxhgTCUvWlfLM+kPccuFUiovyIx1OQMIypiAiRcA8YHW34+OAK4H7whGHMcaEy56KBn747GZOm5TP1847MdLhBMz1pCAiWfhaAreoal23l38NfFdVPf1cY5GIrBGRNRUVFW6FaowxIdHW4eUbj71HSlICv7725KifcdSVqx1cIpKMLyE8oqpLejilGHhMRABGAAtFpENVn+l6kqouBhYDFBcXq5sxG2NMsB5ZvZ/NpXXcf918xuSmRzqcAXEtKYjvk/5BoERV7+npHFWd1OX8h4DnuycEY4yJJe0eLw+8uZdTi4Zx8czRkQ5nwNxsKZwJXAdsEpH1zrHbgUIAVbVxBGNM3HlhYxmlNc385IqZkQ5lUFxLCqq6Egi4I01Vr3crFmOMCQdV5b7lu5kyMovzTor+hWo9sRXNxhgTIst3VLCtvJ5FH55MQgwNLndlScEYY0LkvuW7GZ2TxhUn97QkKzZYUjDGmBBYf6CGt/dUceNZk0hJit2P1tiN3Bhjosj9y3eTnZbEp08rjHQoQbGkYIwxQVqzr4qXt5Rz3ekTyUqN/vpGfbGkYIwxQVj3fjXX//ldioZn8sWzJ0c6nKD1mxRE5BcikiMiySKyTEQqReRz4QjOGGOi2foDNXzhwXcYnpXCo186nfzMlEiHFLRAWgofcWoWXQYcBKYC33Y1Khe8u6+KotteYF9lY6RDMcbEgY0Ha7juwdUMy/QlhNG5aZEOKSQC6fxKdr4vBB5V1SqnVlFMeXLNQQDe2nOUohGZEY7GGBOrapva+dO/9/Lgyr3kZSTz6KLTGZsXW/WN+hJIUnhORLYBzcBNIlIAtLgbVuidODILgNz05H7ONMaY41U3tvHgyr08tGofDa0dXDxzFD+8bAbj4ighQABJQVVvE5GfA3Wq6hGRRuAK90MLrZML8wDITovtmQHGmPCra2nnY79bSWlNMwtnjeE/zz+R6WNyIh2WK/r9hBSRTwIvOwnhB8ApwE+BcreDC6VUZzFJa7s3wpEYY2LNnc9t5VBNM4996XROmzw80uG4KpCB5h+qar2InAVcDPwF+KO7YYVeWnIiAC0dfe7nY4wxx1hWcpgn1h7kpnNPjPuEAIElBf+n6KXAH1X1WSDm5l2lJTlJwVoKxpgAVTe2cduSTUwbnc03LpgS6XDCIpCkUCoi9wPXAC+KSGqA74sqqcm+kFvaraVgjAnMj/65hZqmNu655uSYrmc0EIH8K68BlgIfVdUaIJ8YXKfwQUvBkoIxpn8vbCzjuQ2HuPmCKcwYG5+Dyj3pNymoahOwG7hYRP4TGKmqr7geWYj5WwqtHdZ9ZIzpW0V9Kz94ZhNzx+fylXNOiHQ4YRVImYubgUeAkc7X30Tk6wG8b4KIvC4iJSKyxblO93OuEJGNIrJeRNY4g9muSE1KQARaraVgjOmDqvK9JZtobPPwy2vmkpQ4NLqN/AKZtH8jcJqqNgI4axbeAn7bz/s6gFtVdZ2IZANrReRVVd3a5ZxlwD9VVUVkDvA4MG3A/4oAiAipSQm0WEvBGNOHJetKea3kMD+4dDonjsyOdDhhF0gKFD6YgYTzuN86F6papqrrnMf1QAkwrts5DaqqztNMQHFRWnKijSkYY3pVVtvMj5/bwoKifG44c1Kkw4mIQFoKfwZWi8jTzvOPAw8O5CYiUgTMA1b38NqVwF34uqYu7eX9i4BFAIWFg9/AIi3JkoIxpmeqynee3IjHq9z9yTkkxugey8EKZKD5HuAGoAqoBm5Q1V8HegMRyQKeAm5xqq12v/7TqjoNX7K5s5cYFqtqsaoWFxQUBHrr46QlJ9Bs6xSMMd14vcodz23lzZ2VfG/hdCYOH7pFM3ttKYhIfpen+5yvztdUtaq/i4tIMr6E8IiqLunrXFVdISIniMgIVa3s79qDkZGSRHNbhxuXNsbEqNYOD998fAMvbCzjS2dP4nMxvp1msPrqPlqLr4/f34by9/eL87jPLYbEV1/7QaDEaW30dM6JwG5noPkUfCuljwYe/sCIwJH6Vrcub4yJMXUt7Xz54bW8teco3184nS99OPZ3TgtWr0lBVYMdZTkTuA7YJCLrnWO3A4XO9e8DrgI+LyLt+Epzf6rLwHPIbTl0XO+VMWaI8niV6x58hy2ltfzqU3O5ct74SIcUFVyrI62qK+lnlpKq/hz4uVsxdFeQnUqFtRSMMcDzGw+x4UANv/ykJYSuhtSqjAumjWRkdmqkwzDGRJjHq/xm2U5OGpXNlfPG9f+GIWRIJYXM1CQaW22g2Zih7oVNZeyuaOQbF0whYYhOPe1NIJvs5PdwuF5V212Ix1WZKYk0tXvwetV+EYwZovythKmjsrhk1uhIhxN1AmkprAMqgB3ATufxXhFZJyLz3Qwu1DJTk1CFZlvAZsyQ9eKmMnYdabBWQi8CSQovAwtVdYSqDgcuwVej6CbgD24GF2rZacmAbxqaMWbo8TqthCkjs1g4a0ykw4lKgSSFYlVd6n/ilM3+sKq+DcTUqO2ILN+GcZX1bRGOxBgTbpUNrfzvK9vZeaSBr1sroVeBTEmtEpHvAo85zz8FVItIIhBTNSNGODOPKhpagNzIBmOMcV1bh5fXtx/hiTUHeWP7ETq8yrknFXDpbGsl9CaQpPAZ4L+BZ/CtO1jpHEvEtytbzCjIcpKCrVUwJq5tOVTLk2sP8uz6Q1Q1tlGQncqNZ03iqvnjmTpq6JXDHoh+k4JTh6i3TXV2hTYcdw13uo+ONlr3kTHx6n9eLGHxij2kJCZw0YxRXD1/PGdPGTHkNssZrECmpE4FvgUUdT1fVc93Lyx3ZKQkkZ6cSFWDJQVj4tHbe46yeMUerp4/nh9cOp28jJRIhxRzAuk+egK4D3iAYzfbiUn5mSnWUjAmDjW1dfCdJzcycXgGd14xi/SUxEiHFJMCSQodqvpH1yMJkxHZqVQ22JiCMfHmFy9v50B1E/9YdIYlhCAE0sn2nIjcJCJjRCTf/+V6ZC4pyLKieMbEm7f3HOWhVfv4whlFLJgUsx9PUSGQlsIXnO/f7nKs3/0UolVBdirrD1RHOgxjTBDaPV5W7qpke3k9O8rrWbGzgonDM/jOR0+KdGgxL5DZR3G1e3VBdipHG9vo8HhtNoIxMajd4+Wrf1vLayVHABidk8aMsbl85+KTyEhxbTeAIaOv7TjPV9V/icgnenq9v+01o1VBdiqqUNXUxsjstEiHY4wZAI9X+ebjG3it5Ag/uHQ6nyyeQG56cqTDiit9pdVzgH8BH+vhNQX6TAoiMgF4GBiNb+XzYlW9t9s5nwW+6zxtAL6qqhsCC31wui5gs6RgTOxQVb7/9Cae23CI710yjS+eHZM92FGvr+04/9v5fsMgr90B3Kqq60QkG1grIq+q6tYu5+wFzlHVahG5BFgMnDbI+wWks/6RrVUwJqb87KVtPPbuAb5x/ol8+ZwTIh1O3Apk8Voqvr2Uizh28dpP+nqfqpYBZc7jehEpAcYBW7ucs6rLW94GXN8Tz7+YpabJkoIxseLZ9aXcv2IP150+kf+6aGqkw4lrgYzKPAvUAmuBQc3lFJEiYB6wuo/TbgReGsz1B2JYhq//sabJymcbEwu2lddx21ObWFCUz48+NgMRq27qpkCSwnhV/ehgbyAiWcBTwC2qWtfLOefhSwpn9fL6ImARQGFh4WBDAegclKq2loIxUa+2uZ0v/3Ut2WlJ/O6z80i2GYOuC+QnvEpEZg/m4iKSjC8hPNLbbCURmYOvhMYVqnq0p3NUdbGqFqtqcUFBwWBC6ZSUmEB2WpK1FIyJcvUt7dzy2HuUVjfzx8+dYhNDwiSQlsJZwPUishdf95EAqqpz+nqT+Np4DwIlqnpPL+cU4pvFdJ2q7hhQ5EEYlpFiYwrGRKmWdg9/e3s/v399F9VN7dz58VnMn2irlMMlkKRwySCvfSZwHbBJRNY7x24HCgFU9T7gR8Bw4A9OP2GHqhYP8n4By8tIptpaCsZEFVXl+Y1l/OylbZTWNHP2lBF85+JpzB5vG2KFU1+L13KcMYD6wVxYVVfia1X0dc4XgS8O5vrBGJWTxu4jDeG+rTGmFzsP1/OjZ7fw1p6jzBybw91Xz+FDJ46IdFhDUl8thb8Dl+GbdaQc+wEfs7WPAIqGZ/DmzgpU1WYyGBNBqsof3tjNr17dQWZqEnd+fBafWVBIou2fHDF9LV67zPkeV7WPwNdSaGn3UtfSYUvkjYmQlnYPtz21kWfWH+KyOWO44/KZDHcqDpjICah6lIgMA6YAncP/qrrCraDcNirH9884XNdiScGYCKiob+Urf1vL2v3VfPvik7jp3BOs1R4lAlnR/EXgZnyrjdcDpwNvATG3HaffmFxfUjhU02ybeBsTJh6vsmp3JU+uPcjSLeUA/OGzp7Bw9pgIR2a6CqSlcDNwKvC2qp4nItOAO9wNy11j8tIBKKttiXAkxgwN+yobWfTXNew43EBOWhJXzx/P588osj/KolAgSaFFVVtEBBFJVdVtIhLTO1n4K6UeqbMd2Ixx26rdlXz1b+tIELj32pO5eOZo0pJtu8xoFUhSOCgiecAzwKsiUg0ccjcsd6UkJZCdmsSB6qZIh2JM3FJVHln9Pj/+5xaKRmTy4BeKmTg8M9JhmX4EsvPalc7DH4vI60Au8LKrUYXJspLDkQ7BmLh0oKqJ25/exJs7KzlnagG//cw8ctJsUkcs6DMpiEgCsFFVZwGo6vKwRBUGE/IzqGyw7iNjQqWqsY0dh+t5d28Vf1y+GwHuuHwm150+kQRbdxAz+kwKquoVkQ0iUqiq74crqHAoLhrGs+tjuhfMmKjw9p6j3P70JvZUNHYeO++kAn565WzGOZM6TOwIZExhDLBFRN4BOv+rq+rlrkUVBmW1LdQ2t1Pb1E5uhjVrjQlES7uH5jYPuenJtHu9/PKVHfzfm3uYmJ/B9xdOZ+robE4alc3oXKtoGqsCSQoxPf20N6lJvqrhj777Pl+xrf2M6deafVV8+a9rOdrYRmKCkJaUQGObh8+eVsj3L51ORkpAa2FNlAvkv+JCVf1u1wMi8nMgpscXLpk1huc3llHVaCW0jenPs+tL+fYTGxk3LJ2vnnsCNU3t1DS3ceH0UZx70shIh2dCKJCkcBHw3W7HLunhWEw5y6nAuHjFHm5fOD3C0RgTve5fvpu7XtrGgkn53P+5+QzLTIl0SMZFfZXO/ipwEzBZRDZ2eSkb+LfbgbktO82ausb055Ut5dz10jYumzOGe645mZQk2w4z3vVXOvsl4C7gti7H61W1ytWowiAhQThxZBa7bF8FY3q0t7KRWx/fwOxxufzvJ+daQhgiev2vrKq1qrpPVT+tqvu7fAWUEERkgoi8LiIlIrJFRG7u4ZxpIvKWiLSKyLeC+YcMxiWzRpMg4PVquG9tTNRZtauS//fCVv7x7vtsPFjDV/66lqRE4Y+fO8XKUgwhbvahdAC3quo6EckG1orIq6q6tcs5VcA3gI+7GEevRmSl4lU42thGQbbVcTdDg9er7KlspKmtg/TkRGqb27l32U7e3Fnp+yPJ+RtJBB7+jwWMH5YR2YBNWLmWFFS1DChzHteLSAkwDtja5ZwjwBERudStOPoy1llYc6im2ZKCiXurdlXy+zd2sfFALfWtHce8lpeRzPcXTudzp0+krLaZTaW15KQnc/aUgghFayIlLKOtIlIEzANWh+N+gTpxZBYAV/z+3+z7WUTykjFhcbC6iS//bS05aclcMW8sJ08YRl56Mi0dHjxe5bxpIztrE00uyGJyQVaEIzaR4npSEJEs4CngFlWtG+Q1FgGLAAoLC0MW26QRH1Rs9HrV6rOYuNTh8XLzY+tRhUe/dDqFw607yPTO1ekEIpKMLyE8oqpLBnsdVV2sqsWqWlxQENrm7NfO861m3nu0sZ8zjYlN9y7bydr91fy/K2dZQjD9ci0piG/D1QeBElW9x637BOvyueMAuPe1nRGOxJjQ8nqVB97cw+9e38XV88dzxcnjIh2SiQFudh+dCVwHbBKR9c6x24FCAFW9T0RGA2uAHMArIrcAMwbbzTQY/nGFf244xG8+PS9ctzXGVUcbWvnWExt4fXsFF80YxR2Xz4x0SCZGuDn7aCXQZye9qpYD492KIRCJCcKniifw9HultHZ4SE2y+dgmNnm8yqtby3luYxn/KjmCR5WfXOHbz8DXcDemf1brATh/+kj+seYAa/ZVc6ZTE8mYWKKqfPvJDSxZV8rwzBSumj+Oz59RxNRR2ZEOzcQYSwr4iuOlJCawfEeFJQUTkxav2MOSdaV8/fwTufmCKSQlWkkKMziWFIDM1CSKi4bx5s7KSIdizIAtKznMz172Fa375kVTravIBMX+nHDMnziMHYfraei20tOYaLa5tJZvPPoes8bmcvfVcy0hmKBZUnCcWpSPx6tsPFAT6VCMCciBqiZueOhd8jJSeOALxaSn2CQJEzxLCo7pY3IA2FZeH+FIjOlfVWMbX/jzO7S2e3johlMZlWN7IpvQsDEFx4isFPIzU9hx2JKCiW6bS2v56iNrOVzXyt9uPI0pNsPIhJAlBYeIMG10Nu+9X4OqWt+siSoer7K3soE3tldw99LtDMtI4dEvnc78icMiHZqJM5YUuvjorNH86NktbDxYy9wJeZEOxxgA/vHu+/z0+ZLOctdnnjic31w7j+FZVu7dhJ6NKXTx8Xm+2jBX/P7fthubiQqLV+zmu09tYpazJebSWz7M3248zRKCcY21FLrw15MH2Fhay8nWWjARUtPUxq9f28lDq/Zx2Zwx3HPNybZHsgkL+y3rZuV3zwPg37tsIZsJv4PVTfzv0u2c9fPX+ctb+/jCGRO599p5lhBM2FhLoRv/frR3L93OZ08rJC8jJcIRmXh3qKaZZSWHeX5jGav3VgGwcPZobr5gKieNtplFJrwsKfRgWEYy1U3t/PzlbVw6eyxnTbF6SCa0th6qY+mWcl4rOcyWQ75K8ZNHZPLNi6Zy5bxxTMi3zXBMZIhqbA2oFhcX65o1a1y9R3ltC6fftazzeclPPmqrRU1IbCuv4+6Xt7Ns2xFEYH7hMC6cMYoLp4/khIIsmwptXCMia1W1uL/zrKXQg9G5aXx6QSGPvvM+AG/tqeT8aaMiHJWJRl6vsrWsjqIRmWSl9vy/U3VjG8u2HeHp9w6yavdRslKT+PbFJ3HtqRNsFpGJOpYUenHH5TPJSU/i/uV7ePzdg5YUzDHaPV4e+vc+/vr2ft6vaiIlMYEzThhOSlICFfWtJCYIOWlJlNW2dJZOmTg8g5svmML1HyqysSoTtVxLCiIyAXgYGA14gcWqem+3cwS4F1gINAHXq+o6t2IaiJSkBL53yXRa27385a19HKxu6hyENkNbu8fLLY+t54VNZSwoyuemc09g15EG3thRQaIIBdmpKEpFQysF2alcOnsMZ04ZwbwJedY9ZKKemy2FDuBWVV0nItnAWhF5VVW3djnnEmCK83Ua8Efne9S48axJPLRqH79/fRd3fWJOpMMxEdba4eGb/9jAC5vK+P7C6Xzpw5M7X/tBBOMyJlRcm/ysqmX+v/pVtR4oAcZ1O+0K4GH1eRvIE5ExbsU0GP5ZII++c4ADVU0RjsZE0tr9VSy8980eE4Ix8SIsK2JEpAiYB6zu9tI44ECX5wc5PnEgIotEZI2IrKmoqHArzF79/KrZAJz3v2/gsfIXQ067x8vdS7dx9X1v0dLu5aEbTrWEYOKW6wPNIpIFPAXcoqp13V/u4S3Hfeqq6mJgMfimpIY8yH586tRCfv3aTspqW3hj+xEumG6DzvGuqa2DR985QFlNM+/sq2LjwVquKR7Pjz42s9dZRsbEA1d/u0UkGV9CeERVl/RwykFgQpfn44FDbsY0WE999UN86Gf/4sa/rOG2S6ahCl85Z7INHMahXUfquemRdew43EB6ciKjclL57afn8bG5YyMdmjGuc3P2kQAPAiWqek8vp/0T+E8ReQzfAHOtqpa5FVMwxualc+mcMbywsYyfvbQNgNMn5zOv0OrZx4u2Di9/+vde7n1tJxkpifz1xgWcPaUg0mEZE1ZuthTOBK4DNonIeufY7UAhgKreB7yIbzrqLnxTUm9wMZ6g/ebaeVx1yji2ldfzi5e3s2r3UUsKMWzFjgr+vbuSw7UtlNe1sLeykcN1rVw0YxR3XjGL0bm2xaUZeqzMxSBd/cdVVDW2sezWc6wLKcbUNrVzx3NbWPJeKSmJCYzMSWV0ThqjctO46pRxtlDRxCUrc+GyaxcU8q0nNrB4xR4WfdjGFmLFv7Yd5ntLNlHZ0MY3zj+R/zx/ipWlNqYLSwqD9LG5Y1i8Yjd3vbSNB1bu5cwThjNrXC43njXJEkSU+tPKvfzk+a1MHZXFA58/ldnjcyMdkjFRx/5EGqTUpET+/qXTAaiob+WZ9Yf46QslrHu/OsKRmZ78a9th7nxhKx+ZMYrnvn6WJQRjemEthSCMyEpl1W3ns3Z/NeeeVMDcO17hje0VzJ+YH+nQhryy2mae31DGxtJa9lY2sKO8gZljc/j1tSeTmmRl0I3pjSWFII3NS2dsXjoAxUX53L98D+dPG2mzksKovLaFlzeXsafTCKsvAAAgAElEQVSykfOmjWTyiEyuuf8tDte1Mi4vnSmjsig+zVe4LiPFfuWN6Yv9HxJC931uPqfftYxn1x9i7vg8EhJsbMFtlQ2tXPXHVZTWNJOSmMDDb+0nKzWJ5EThhW+cxcyx1k1kzEDYmEII5WemcOYJw3lo1T4m3/4idz6/lZqmNjYcqIl0aHGptcPDTY+so7Khlae+egab77iYWy+ayri8dP5642mWEIwZBFunEGI1TW1864kNvFZy5Jjjj3/5DBZMsrGGwThQ1cRDq/bx9HuljB+WzpknjmBsXjp/WbWPXUca+PWnTubj846ro2iM6SLQdQqWFFxS3djG3a9s55n3Smlq81CQncq3P3ISCHxy/nibttqFqrK5tI7SmmZ2Haln/YEaTijIYkRWKu/uq+K1ksMkiHDRjFEcqW9l/YEaPF5lQn46d14xi3NPGhnpf4IxUc+SQhR5dn0pNz+2vvP5f104lZsvnBLBiKLHyp2V/OT5Lew43NB5bPKITA5UN9HuUUblpHLlvPF84UMTGZPrG9Bv6/ByqKaZ0blppCXbTCJjAmErmqPIx+aM5YWNZbyy9TBTRmbxq9d2UNfSzg8unR63LYZ2j5en3yultcPLjDE5TBudTXpyIkveK2XroTqmjspib2Uj//fmHopGZPKzT8xm1rhcxuWlMywzhaa2DprbPD1ubJ+SlEDRiMwI/KuMiX+WFMIgIUG473PzKXX+uv3ekk08uHIv771fzW8+PS8m9n4+UNXE8KyUY6Z0qiobDtby0qYyXis5zKicNM6eUkBdSztLt5Szp6Kx81wRGJ6ZQmVDG8mJQrvH10K9dPYYfnH1HDK77VGQkZJk00eNiQDrPooAVeW+5Xv4/eu7mD4mm8e/fEZUtxhKyuq4/HcryUlLZlhmCiOzU5k2OoelW8oprWkmKUE444Th7DvayIGqZhIThLnjc/nKOScwY2wOJWX1lJTVsfNIA2dPGcGV88ZRVtPC8KyU45KBMcYd1n0UxUSEr557AnkZyXxvySYeX3OAT51aGLF41u6vYvn2Cr58zgnHfUi3dni47amN5KQlM3/iMLzOoPC7+6o4e0oBt1w4hY/MGE1uRjKqSlObh6REOWbV8PhhGVw049jKo4XDo791ZMxQZEkhgq6eP55HVu/ntiWbmDk2l1njwj+v/vE1B/jOkxsBeH17BZfNGcPC2WN470ANJ4/P4wfPbmbDwVp+/5lTuHTOGAA6PF7aPUp6yrGDvCJif/kbE+Os+yjCapvaOesX/+KSWaP5xdVzw3rvzaW1fPK+t5hXmMfV88dz99LtlNW2HHNOYoLwP1fOimhLxhgTvIh3H4nIn4DLgCOqOquH14cBfwJOAFqA/1DVzW7FE61yM5JZUJTP2v3uV1dVVV7depixeem8ubOSP7y+i7yMZO655mRG56bxiVPG8+6+Kp5+r5Rzphaw4UANH583jqmjsl2PzRgTHdxs6z8E/A54uJfXbwfWq+qVIjIN+D1wgYvxRK1TJg5j2bYj3PVSCZfOHsN779fwsbljyc9MCeq65bUtvLOviuQEISstidLqZm5bsqnz9bOnjODnV805ZtvJU4vyObXIt/L64pmjg7q/MSb2uJYUVHWFiBT1ccoM4C7n3G0iUiQio1T1sFsxRatPLyhkw4EaFq/Yw/3L9wDwq9d28D9XzubME0fw8uYyLpg+ite3HeHP/97H0cZWFkwazqWzR7O9vIGvnDu5c2C3rLaZmx9bT1ltMzVN7dS3dAC+KaEAZ544nAunj+LUovyIjGEYY6JbJEcFNwCfAFaKyAJgIjAeGHJJIT8zhcWfL+bJtQd5eXM5C2eP5v7le7jpkXVdztp0zHuWbi7nuQ2HAF+l0CtOHsvuigZ+/dpO6ls6uGC6r/TD5XPHkpAgvLSpjJy0ZP7roqk2GGyM6ZWrA81OS+H5XsYUcoB7gXn4PvGmAV9U1Q09nLsIWARQWFg4f//+/a7FHC3aPV6WlRxmzb5qRuem8ZtlOzlpdDZfOecEZo7NpbXDw64jDbywqYwl60o73zcmN40HvlBsFUKNMceIitpHfSWFbucJsBeYo6p1fZ0bb7OPAtXQ2kFGcuJxezSoKmv2V9PQ2sHkEZmMy0snKdEqohtjjhXx2Uf9EZE8oElV24AvAiv6SwhDWVYvXT4i0jkwbIwxwXJzSuqjwLnACBE5CPw3kAygqvcB04GHRcQDbAVudCsWY4wxgXFz9tGn+3n9LcDqRxtjTBSxzmdjjDGdLCkYY4zpZEnBGGNMJ0sKxhhjOsVclVQRqQAGu3ptBFAZwnDcFkvxxlKsYPG6KZZihaET70RVLejvpJhLCsEQkTWBLN6IFrEUbyzFChavm2IpVrB4u7PuI2OMMZ0sKRhjjOk01JLC4kgHMECxFG8sxQoWr5tiKVaweI8xpMYUjDHG9G2otRSMMcb0wZKCMcaYTnGTFETkoyKyXUR2ichtPbyeKiL/cF5f3XWrUBH5nnN8u4hcHK2xishwEXldRBpE5HduxxmCeC8SkbUissn5fn6Ux7tARNY7XxtE5MpojbXL64XO78O33I41mHid7Xabu/x874vWWJ3X5ojIWyKyxfn9Tev+/miJV0Q+2+Xnul5EvCJy8qADUdWY/wISgd3AZCAF31afM7qdcxNwn/P4WuAfzuMZzvmpwCTnOolRGmsmcBbwFeB3MfCznQeMdR7PAkqjPN4MIMl5PAY44n8ebbF2ef0p4AngW1H+sy0CNofjdzYEsSYBG4G5zvPhbn4mhOp3wTk+G9gTTCzx0lJYAOxS1T3q27TnMeCKbudcAfzFefwkcIGz49sVwGOq2qqqe4FdzvWiLlZVbVTVlUCLi/F1F0y876nqIef4FiBNRFKjON4mVe1wjqcBbs/CCOb3FhH5OLAH3882HIKKN8yCifUjwEZ1tgZW1aOq6onieLv6NPBoMIHES1IYBxzo8vygc6zHc5z/8Wvx/QUQyHtDKZhYIyFU8V4FvKeqrS7FeVwsjgHFKyKnicgWfPuGf6VLkoiqWEUkE/gucIeL8XUX7O/CJBF5T0SWi8jZURzrVEBFZKmIrBOR77gca7DxdvUpgkwKEduOM8R6+kuk+195vZ0TyHtDKZhYIyHoeEVkJvBzfH+BuS2oeFV1NTBTRKYDfxGRl1TVrZZZMLHeAfxKVRvC+Id4MPGWAYWqelRE5gPPiMhMdW8L3mBiTcLXTXsq0AQsE9/+xstCG2JAsQR8joichm+L483BBBIvLYWDwIQuz8cDh3o7R0SSgFygKsD3hlIwsUZCUPGKyHjgaeDzqrrb9WhD9PNV1RKgEd9YiFuCifU04Bcisg+4BbhdRP7TxViDitfpnj0KoKpr8fWfT43GWJ3jy1W1UlWbgBeBU1yMNdh4/a4lyFYCEDcDzUn4+lYn8cEgzcxu53yNYwdpHncez+TYgeY9uDvQPOhYu7x+PeEbaA7mZ5vnnH9VjPwuTOKDgeaJ+P6nHBGNsXY758eEZ6A5mJ9tgf//K3yDqaVAfpTGOgxYhzPxAHgNuDRaf7bO8wR8SWNy0LG4/YsUri9gIbAD318g33eO/QS43Hmchm+Wxi7gna4/POD7zvu2A5dEeaz78P110OD8EsyI1niBH+D7a3t9l6+RURzvdfgGbdc7Hwofj9ZYu13jx4QhKQT5s73K+dlucH62H4vWWJ3XPufEuxn4RTT/bJ3XzgXeDkUcVubCGGNMp3gZUzDGGBMClhSMMcZ0sqRgjDGmkyUFY4wxnSwpGGOM6WRJwcQVEWkIwz0u76mKpcv3PFdEPhTOe5qhKV7KXBgTUiKSqL0UQVPVfwL/dOGeSdp7raVz8a1NWRXq+xrTlbUUTNwSkW+LyLsislFE7uhy/Bnx7e+wRUQWdTneICI/EZHVwBkisk9E7nCKom0SkWnOedeLs5+FiDwkIr8RkVUiskdErnaOJ4jIH5x7PC8iL/pf6xbjGyLyPyKyHLhZRD7m1Mp/T0ReE5FRTt38rwD/5dTLP1tECkTkKeff966InOnmz9IMHdZSMHFJRD4CTMFXkliAf4rIh1V1BfAfqlolIunAuyLylPrq8mTiq/n/I+caAJWqeoqI3AR8C/hiD7cbg6+A2jR8LYgngU/g20NgNjASKAH+1Eu4eap6jnPPYcDpqqoi8kXgO6p6q/g2pWlQ1f91zvs7voJ4K0WkEFgKTB/0D8wYhyUFE68+4ny95zzPwpckVgDfkA92VZvgHD8KePBtWtPVEuf7Wnwf9D15RlW9wFYRGeUcOwt4wjleLiKv9xHrP7o8Hg/8Q0TG4KuBs7eX91wIzOhSITVHRLJVtb6P+xjTL0sKJl4JcJeq3n/MQZFz8X2gnqGqTSLyBr6aMgAtPYwj+Pd/8ND7/y9d94iQbt8D0djl8W+Be1T1n06sP+7lPQn4/g3NA7iPMf2yMQUTr5YC/yEiWQAiMk5ERuIrN1ztJIRpwOku3X8lcJUztjAK30BxIHLxVRAF+EKX4/VAdpfnrwCdpbIlmD15jenCkoKJS6r6CvB34C0R2YSvnz8beBlIEpGNwJ3A2y6F8BS+KrabgfuB1fh2yurPj4EnRORNoLLL8eeAK/0DzcA3gGJnEH0rvoFoY4JmVVKNcYmIZKlvZ7Th+Eodn6mq5ZGOy5i+2JiCMe55XkTy8A0Y32kJwcQCaykYY4zpZGMKxhhjOllSMMYY08mSgjHGmE6WFIwxxnSypGCMMaaTJQVjjDGdYm6dwogRI7SoqCjSYRhjTExZu3ZtpaoW9HdezCWFoqIi1qxZE+kwjDEmpojI/kDOs+4jY4wxnSwpGGOM6WRJwRhjTCdLCsYYYzpZUjDGGNPJkoIxxoTA5tJa4qHqtCUFY4wJUklZHZf9diXv7quOdChBs6RgjDFBqmxoBeCo8z2WWVIwxpggNbZ6AGhq80Q4kuBZUjDGmCA1tXUc8z2WWVIwxpgg+VsI1lIwxhjTpaVgScEYY4Y8fzJobrekYIwxQ94H3Uc2pmCMMUOedR+FkIicJCLru3zVicgtkY7LGGMC1eRMSW2Og6QQ8U12VHU7cDKAiCQCpcDTEQ3KGGMGoNFpKTTGQVKIeEuhmwuA3aoa0A5BxhgTDToHmm1MIeSuBR6NdBDGGDMQtk7BBSKSAlwOPNHDa4tEZI2IrKmoqAh/cMYY04cPWgqWFELpEmCdqh7u/oKqLlbVYlUtLigoiEBoxhjTO5t95I5PY11HxpgYZOsUQkxEMoCLgCWRjsUYYwaqqdWXDOJhRXPEp6QCqGoTMDzScRhjzECpKk3tHhIThHaP0tbhJSUpKv7eHpTYjdwYY6JAS7sXVRiemQLE/mCzJQVjjAmCf+HaiKxUAJraY3tcwZKCMcYEwd8yGJ7laynE+gwkSwrGGBMEf0uhwGkpWPeRMcYMYU3WUjDGGOPnr5DqH1NojPG1CpYUjDEmCN0Hmq37yBhjhjB/EhiR7cw+sqRgjDFDl7+l8ME6Bes+MsaYIcvfUiiwloIxxphGZ6A5P9NmHxljzJDX1NZBalICyYkJpCUnxHxRPEsKxhgThKY2DxkpiQBkpiTR2GpjCsYYM2Q1tnWQkeIrOJ2ekmhTUo0xZihr7tJSyEhJtDEFY4wZyhrbPGSk+lsKSTTF+JhCVGyyY4wxsaq5rYNMf0shOTEk6xTqW9r53AOryctIYe6EPE6ekMvc8XkMd1ZNuykqkoKI5AEPALMABf5DVd+KbFTGGNO/xlYPY/OSAV/3UXlde9DX3HG4ng0Haxmbm8abOyvwqu/4l8+ZzPcumR709fsSFUkBuBd4WVWvFpEUICPSARljTCCaugw0Z6QmhWRMoay2BYAHrz+VicMz2Fxax4YDNcwcmxP0tfsT8aQgIjnAh4HrAVS1DWiLZEzGGBOorlNSM5ITaQpB91G5kxTG5KaRkZLEgkn5LJiUH/R1AxENA82TgQrgzyLynog8ICKZXU8QkUUiskZE1lRUVEQmSmOM6YEvKXwwJTUULYXy2hZSkxLITU8O+loDFQ1JIQk4Bfijqs4DGoHbup6gqotVtVhViwsKCiIRozHGHEdVne6jD6akhmKdQnldC6Nz0xCRoK81UNGQFA4CB1V1tfP8SXxJwhhjolprhxevQkbqB0mhw6u0dXiDuu7huhZG56SFIsQBi3hSUNVy4ICInOQcugDYGsGQjDEmIP6uooxkX1JId7qRgm0tlNX6WgqREPGBZsfXgUecmUd7gBsiHI8xxvTLX+fIv3jN343U1N5BLoMbD1BVjtS1Du2koKrrgeJIx2GMMQPhbylkphybFPzltAejqrGNNo936HYfGWNMrPJPP/1goDn47iP/GgVLCsYYE2M6xxS6zD7yHR/8WoXDdU5SiFD3kSUFY4wZpA+SwgfrFICgiuKVW1IwxpjY1Nl9lHpsSyGY7qPy2hYSBArCUPyuJ5YUjDFmkI7rPkpOOub4YJTXtlCQnUpSYmQ+ni0pGGPMIHVOSe3WfRRM+ezyCC5cA0sKxhgzaN1bCplON1JjkC2FUZYUjDEm9jS1eUhJTCDZ6epJS0rsPD5Y5XUtjInQIDNYUjDGmEFrauvoHGQGSEgQ0oPYfa2xtYP6lg5GxUNSEJFMEUlwHk8VkctFJPx1X40xJkya2jyddY/8MoIon+2fjhovLYUVQJqIjAOW4atf9FAIr2+MMVHF11I4tlpQehDlsw87q5njZUxBVLUJ+ATwW1W9EpgRwusbY0xU6brrml8oWgrxMvtIROQM4LPAC86xqCi4Z4wxbmhqPT4ppKck0TjIMYXOukdx0n10C/A94GlV3SIik4HXQ3h9Y4yJKo1tHZ1rFPwyg+k+qmshJy3puGuGU8jurKrLgeUAzoBzpap+I1TXN8aYaNPcS/dRTVP7oK5XHsHNdfxCOfvo7yKSIyKZ+HZO2y4i3w7V9Y0xJto0tnV07qXgl56SRPMgC+L59mZOD0VogxbK7qMZqloHfBx4ESgErgvkjSKyT0Q2ich6EVkTwpiMMcY1TW2eztIWfhnJiYMunV1e28LonMgUwvMLZcdVsrMu4ePA71S1XUR0AO8/T1UrQxiPMca4RlVpavN0lrbwSx/k7KN2j5eKhta4aincD+wDMoEVIjIRqAvh9Y0xJmq0ebx4vHrcoHCGM9CsOpC/iaGivhXVyE5HhRAmBVX9jaqOU9WF6rMfOC/QtwOviMhaEVkUqpiMMcYtTa3HFsPzy0hJpMOrtHm8A7reB5vrRLb7KJQDzbkico+IrHG+fomv1RCIM1X1FOAS4Gsi8uFu117kv25FRUWoQjbGmEFr7LY/s99g92k+3Lk3c/x0H/0JqAeucb7qgD8H8kZVPeR8PwI8DSzo9vpiVS1W1eKCgoIQhmyMMYPT3G0rTr8P9mkeWFKIhoVrENqB5hNU9aouz+8QkfX9vcmZwpqgqvXO448APwlhXMYYE3KNbT13H6UPMikcrmshJSmBYRmRrSMaypZCs4ic5X8iImcCzQG8bxSwUkQ2AO8AL6jqyyGMyxhjQq5zf+bjWgqD6z4qq/XtuCYioQlwkELZUvgq8BcRyQUEqAKu7+9NqroHmBvCOIwxxnX+gebuU1I/6D4a2FqFSG/D6RfKMhfrgbkikuM8t+moxpi41dTeT/fRAFc1H65rYc74vNAEF4Sgk4KIfLOX4wCo6j3B3sMYY6JNU2tv3UdOUmgNPCmoKmW1LVw8Mz5aCtkhuIYxxsSU3gaa/bWQBtJ9VNPUTluHN6Kb6/gFnRRU9Y5QBGKMMbGkuZeBZn/30UCK4kXDNpx+oZx9ZIwxQ0Zjm4ekBCEl6diP0cGsUzhS3wrAyOzIrmYGSwrGGDMoPe2lAJCWNPCk4G91ZKZGfrNKSwrGGDMIja3H77oGkJAgpCcndn7QB8Lf1ZSefHySCbeQpSURSQWuAoq6XldVbXWyMSbuNLV7yEjt+UM8IyWxcyA6oGs553bfmyESQtlWeRaoBdYCrSG8rjHGRJ2m1uN3XfPLSB3YPs3+c9PiqaUAjFfVj4bwesYYE7Uae9h1zS8jOWlAU1JbelkIFwmhHFNYJSKzQ3g9Y4yJWs1tHjJ7+RAf6O5rze2+mUzJiZEf5g1lS+Es4HoR2Yuv+0gAVdU5IbyHMcZEhca2DgpTMnp8zb/7WqCa2jxRMcgMoU0Kl4TwWsYYE9V6m5IKvqRQ09Qe8LVa2nvvigq3UG7HuR/IAz7mfOU5x4wxJu74pqT21n2UNKAVzc19jE+EWyi347wZeAQY6Xz9TUS+HqrrG2NMNGlu95DRy2KzjOREGlsHtk4hHruPbgROU9VGABH5OfAW8NsQ3sMYYyKurcNLu0d7HWge6JTUpjZPVExHhdDOPhKg60/B4xzr/40iiSLynog8H8J4jBmyjja0DugvVTMw/umm6b2tU0hJpKndg6oGdL2W9t7HJ8ItlEnhz8BqEfmxiPwYeBt4MMD33gyUhDAWY4YsVeUTf1zFT1/YGulQ4pZ/ELm3/ZQzUpLweJU2jzeg60VT91EoB5rvAW7Atw1nNXCDqv66v/eJyHjgUuCBUMVizFC2qbSW/Ueb2FZeH+lQ4lZVUxsAwzJSenzd/wEfaBdSU5uHtChpKYRi57UcVa0TkXxgn/Plfy1fVav6ucSvge9gm/UYExJLt5QD8P7RpghHEr+qG52kkNlzUuhaPjuv56UMx2iJs3UKfwcuw1fzqGsHmjjPJ/f2RhG5DDiiqmtF5Nw+zlsELAIoLCwMQcjGxK+lWw4DcLSxjYbWDrKioBxzvKlykkJ+by2FzqQQ2LhOczyNKajqZc73Sao6ucvXJFXtNSE4zgQuF5F9wGPA+SLytx7usVhVi1W1uKCgINiQjYlbuysa2HWkgQVF+QAcqLLWghuq/d1HmT2PKfi7lY42tAV0vbgcUxCRZYEc60pVv6eq41W1CLgW+Jeqfi5UMRkz1LzitBJuPHsSAO9bUnBFVWM7yYnSayts/LB0AEprmvu9ltertLR7o2ZKaijGFNKADGCEiAzjg2moOcDYYK9vjAnc0i3lzB6Xy+mThgPWUnBLdWMbwzJSEOl51v3YPF9SOFjdf1Jo6YieCqkQmjGFLwO34EsAa/kgKdQBvw/0Iqr6BvBGCOIxZkgqr21h/YEavvWRqeRmJJOTlmQtBZdUNbWR38sgM/j2RRiRlUppAEmhOYo22IEQJAVVvRe4V0S+rqq2etmYCFm+4wgAH5k5GoDC4RmWFFxS09TW63RUv/HD0gPqPvLXSIqb7iM/Vf2tiMwCZgBpXY4/HKp7GGN6V1rTgghMHpEJQGF+hq1VcElVYxsnje57Fv24YelsKa3t91qdLYUoSQqhHGj+b3x1jn4LnAf8Arg8VNc3xvStqrGV3PRkkpyNWibkZ3CwqhmvN7BSCyZw1U3tAbUUDtW09Pvzb46iXdcgtGUurgYuAMpV9QZgLpAawusbY/pQ3dh+TD93YX4GbR4vh+tbIhhV/PF4lZp+xhQAxuel0+bxUtnQ95b1cdtSAJpV1Qt0iEgOcIQ+Fq4ZY0LraGPrMYupJub7upH228rmkKprbservZe48BvnTEs90M9gc5N/TCEOWwprRCQP+D98s5DWAe+E8PrGmD701FIAW6sQav66R/22FIb5fv79DTa3tEVX91EoB5pvch7eJyIvAzmqujFU1zfG9O1oYxvzCvM6n4/JSyMxQWytQoj1V/fIb5yzVqG/aan+MYVo6T4KxeK1U/p6TVXXBXsPY0zfVJXqbv3cyYkJjM1Ls5ZCiFU7ZbN7q3vkl5maRF5GMger+/75x11SAH7pfE8DioEN+BawzQFWA2eF4B7GmD7UNXfg8epxXRqF+bZWIdQ+aCn0XPeoq0DWKvgHmuNmTEFVz1PV84D9wClO4br5wDxgV7DXN8b0r7f6/oX5GdZ9FGKBjimArwup3+6jOJ59NE1VN/mfqOpm4OQQXt8Y04vOUs5Zx35QTcjPoLKhzbbmDKHqxjZSkhIC+hAfl5fBwermPrflbG73kJwoJCeG8uN48EIZRYmIPCAi54rIOSLyf9gWm8aERW/1/f0zkA70069tAlfV2EZ+H8Xwuho/LJ3mdk/nOERPmts9UVPiAkKbFG4AtuDbb/kWYKtzzBjjMn8/d/cuDf+0yANV/dfgMYGpbmrrd+aRn3+tQl+Dzc1RtOsahHZKagvwK+fLGBNGR3tJCmNzfWXIyutsVXOoVDW2kR/AIDMcOy11zvi8Hs+Jpl3XIDRTUh9X1WtEZBPHbscJgKrOCfYexpi+VTe1kZqUcNyHy/CsVJIShPJaaymESk1Te+d+Cf2ZEMACtua26Oo+CkVL4Wbn+2UhuJYxZhCONvjWKHTv505MEEblpFFWYy2FUOlvL4WuctKTyEpN6nOzneZ2T9TspQCh2U+hzPm+fzDvd3ZuW4GveF4S8KSq/newcRkzlHRfuNbVmNw0ymotKYRCh8dLbXP/FVL9RITxw9L7Tgpt8dd9VE8P3Ub4FrCpqub0c4lW4HxVbRCRZGCliLykqm8HG5sxQ8XRxt6TwujcNLYcqgtzRPGptrkd1cDWKPiNy+t7AVtzu4e8jMDGKMIhFIvXslU1p4ev7AASAurT4DxNdr6sALwxA1DdR1LwtRT6nitvAlPtLFwbyIf4uGHpfc8+iuMpqQCIyEgRKfR/BfieRBFZj6/c9ququjrUcRkTz/wbyfdkdG46Le1eavqYK28CU9Xo1D0aQEth/LB06ls6qGvp+ecfbVNSQ7nz2uUishPYCywH9gEvBfJeVfWo6snAeGCBs61n12svEpE1IrKmoqIiVCEbExdaOzzUt3b0+kHln5Zq4wrB8y8SDHRMAXyrmqH3aqnRNiU1lC2FO4HTgR2qOgnfLmz/HsgFVLUGeAP4aLfji52aSsUFBQUhCteY+OBvAfQ1pgBQXmfTUoNVPYC6R34fLGDrJSm0eaKmGB6ENim0qxTeo/QAACAASURBVOpRIEFEElT1dQKofSQiBc7mPIhIOnAhsC2EcRkT14429P1BNSbX96EUry2FVbsrOf+Xb7B0S7nr96rupfBgX8YP8y9gO35cweNVWju8UdV9FLIVzUCNiGThm176iIgcAQKpwjUG+IuIJOJLUo+r6vMhjMuYuNbfX68F2akkJkjcrVVQVe5fsYdfvLwNr8LLm8u5eOZoV+9Z3dhGenLigNYVDM9MIS05occZSC3t0bXrGoQ2KVwBNAP/BXwWyAV+0t+bnN3Z5oUwDmOGlN5KXPglJgijslPjqqXQ0NrBtx7fwMtbylk4ezT1LR1sOFDj+n2rum15GggRYWxez2sVom2DHQht99EiYKyqdqjqX1T1N053kjHGRb0Vw+tqdG5aWMYUvF7l1sc38OZOdyeE/M+LJbyytZwfXDqd33/mFE6fPJw9lY3UNrs7w8pXDG/gawrGD8vosaXQucFOnCaFHGCpiLwpIl8TkVEhvLYxphf+lkJeeu8fVmNy08PSUlixs4Kn1h3kR89uocPjdeUeOw7X89g773Pd6RP54tmTERHmOsXmNh2sdeWeflV9TP3tS2+b7XS2FKKo+yhkSUFV71DVmcDXgLHAchF5LVTXN/Hhje1HePitfZEOI65UN7aRl5FMUh+btIzJ9dU/cnsB2yOr3+f/s3fe8W3edeJ/f7RteY84cWxn76ZJmrTp3i1tj7ZwHBx7FCizcFy5Yx1Q4DjuDg7ufoyDXoGy2lIo0BZKR7pH2ma32cMZHrHjPSTLWt/fH48eWZYlW7IkW06+79crr9iPHkkfP3r0/Xw/224VjnZ6+OOOlpy8x789sg+308anr14aPba6rhSAXc25dSH1eCenFOrKC+jy+PH6R4dZTUshn2IKuRj1cwpoA7qAWTl4fc0MJRRW/MufdvP1h/dG8701mWMOfRmP2aUuhgIh+odyN4Gtrc/HU/tPccvFC1g9t5T/99QhAlm2Fp4/1MEzBzq47crFo9xlpQV2Fla5cx5X6B6ncnw8assS14qYlsJp6T4SkY+JyDPAk0AV8GHdNlsTy5P72mnuGSIYVjzy+snpFue0IZWFKpqWmsO4wm+3NBEKK955XgP/eM1SmrqH+N3W5qy9fiis+OZf9lFfUcD7Lpw/5vE19WU5tRQCoTADvuCkLIUKtxOAXu/ozdDpHmieB/yDUmqVUuqrSqm9WXxtzWnA3S8do7bUxeJZRTy0s3W6xTltSGUS2OwcVzUHQ2Hu23KCS5ZUMa/SzeXLqlnXUMYPnjrEcDCUlff4/bYm9rcN8LnrluO0jV1E19SV0t4/TFuO/saRIsH0A83lkV5JZpsMkxH3UTYTQTMjmzGFzyuldmbr9TSnF57hIC8d6eIt6+t487q5vHqse9zOkZrU6UrBfRR1X+SoVuGZAx2c7PPxro1GuzMR4fZrltHa58uKtbCzqZdv/Hkf5zSU8Ter5yQ85+x6I9icK2shWrg2CfeRaV30xFsK/tPbUtBoknKgfQCA1XNLuWyp0apkKvLKT3eUUkaH1KLxF6rqIicWIWcT2O559QTVxU6uWjGSdHjR4koWVLl59mBm6an7Tvbzvp+9Srnbzo/etX7MICGTlXNKsFkkZ/eVGQebSAEnwnTv9XgSu49cjvxZivNHEs1pzYE2Qyksn13Cwmo3AIdPDY73lDOKX798nGu/92x055gq/b4gwbCacKGyWS3MKs7NsJ1uj59nDpzirevrsMdkQIkI5zSUs+NEz6Szno50DPKen75Cgd3KPR86P+oGS4TLbmXFnJLcWQqeyVsKhQ4rDquFbm0paDQGB9oGKHRYqSsvoNBhY25ZAUc6tFIwueeVExxsH+TeV0+k9bxUCtdMjAK27CuF5w91EFZwzcqxpUnnzCujc9BPU3f6FoovEOI9dxld9H/z4Y3UVxRO+Jyz60p5rbmPcDj7qbfdk2iGZyIilLvt9MbHFE7zQHNes7Opl3+8f6dOhZwm9rf1s7SmGIvFMP0XzyrSlkKEE11e9p7sx2G18ONnj0T74aTCRC0uYqktc9GagzjOswc7KC+0c3akgCyWcxrKAdh+oift1913sp/WPh933LSKRdVFKT1nTX0ZA74gR7s8ab/fRJgKeLJT0soLHWMthUAIh9Uybo3JVJM/kuSYbs8wf9jewtHO7N8smvFRSnGgbYDls4ujxxbPKuJIx2DaO7qmbi8vHu7MtojTitnd81/fdBanBob57ZamlJ+bjqVQX1FIU/dQ1rKBwGhr8dzBTi5ZUo3VMtbXv7SmGLfDOimlYLocz547VtkkY60ZbM5BXKHHG8DtsCbMfEqF8kLH2JRUfwiXPb+W4fySJoc0REzPpu7kY/E0uaFjYJgeb4BlcUrBFwinlYG09Vg3N/7gBd7z01dy3uNmKvnr7pOsqi3hrRvqOHd+Of/7zJGUF+7uNJTC2roy/KEw+04OZCRvLHtP9tM5OBxNHojHahHW1JdNSinsbxvAHXE5psqi6iIKHVZey0G7ix7PxKm/41Huto/xVAz5Q3nV4gLOIKVQV24oheNdWilMNWbmUaxSMN0Bh1OMKwz4Arz3Z6+iFISV4Q48HWjv97H9RC/XnzUbEeEfrl5KW7+P2+7ZkZIbKR0/99oGYxe9cxILdDLMzKJLllYlPeechnL2nRwY0+JhIvad7Gfp7BGXYypYLcLquaVZuT/2t/Vz94tHo3UP3d7JVTOblBc66PGOjSnkU40CnEFKwWW3MrvExQltKUw5pstucYxfePEs4+cjKcYVjnd58fpDfOWNK7EIbDuevYVtOjFdR9edZcwBuGhxFV+9cSVP7GvnHf/38oQxsB6PH4fNklLvnDmlBdSUOLOqUJ892MGq2hJmFSfPCjpnXhmhsEpr966UYn/bAMtnl6Qt09r6Mva29uMPZtZi4wdPHeaOh/dywb8/ybvuepkDbQOTqmY2qXAb7qNYl+lQIJRXLS7gDFIKYLiQtPto6jne5aXAbqW62Bk9VuF2UOF2pBxsNt1MS2uKWTGnhG3Hu3Mi61Tz2J42FlW7WTxrxIr6wEUL+N93ncPe1n6+/vCecZ9vFq4ly92PZ01dWdaUQr8vwPbjPUldRybr6tMPNrf3D9M3FGDFnOKJT47j7IibzIxJTJambi9r6kr51JVLaOoe4mSfjznjpMRORFmhg7AyrpuJLxCiQMcUpo+GykKOd+tA81RzvMtDQ0XhmIVrcXVRymmpZtZMbZmL9fPK2XmiN2etmaeKUFix/XgvlywZu6hed9YcLl5cxYH28a9PT5oN2tY2lHGsyzumiGoyvHS4i2BYTagUyt0OFla52X48dWW0r60fgGU16SuFNfVGx9SdGdYrNPUMsbK2lM9cs5Rn/+ly/nzbxXzuuuWTfj2zPUasC8nr1+6jMYhIvYg8LSL7RGSPiHw6V+/VUFFIe/9wWil/msw53uVlXuXYHPNFs9wpWwqtvUO47BYq3A7WzyvH4w9FYxUzlcaOQYYCIVbPLU34eH1FIc0J5vrG0pWuUohk52S6YILhOipy2jhnXvmE565Ls4ht/8mRYsd0mVtWQFWRI6MMJM9wkG6Pn/oKI8gtIpw1tzSjQHNZxPUU6xI0so+0+yieIHC7UmoFcD7wCRFZmYs3WjnHuMEe2J69zo2a8QmHFce7kyiF6iJ6vAG6BocnfJ2W3iFqywqiVbIA22d4XOH1FsPHflYSpVBXXsCAL0ifN3mmVU+awc+z68oQgZ0nMlMKSimeO9jBRYsrR1UxJ+OceWV0efwpx/QOtPVTW+qidBI1ASLC2XVlvJaB4muKKOP68okL5lLFrDqPTUv1BXT20RiUUieVUtsjPw8A+4C5uXivq1bMorbUxRN723Px8poEtA/48AfDzKt0j3nMDDanYi209PqYW2bs2urKC6gudrIjw4Vtutnd0o/LbmFR9dhrAyMZc03jWAvdg+kphSKnjaWzijOOK5zo9tLSO8TFCVxfiUi3iG1/28CobLV0WVNXxqFTgwwOT25+hFmBnUoVdaqYn1OspeD165jCuIjIfGAd8EqOXp/zF1Wyt7U/Fy8/pRxoG5gRQfNjnYaMiSyFqFJIIa7Q2jtEbWmMKV9bwp4Z8jm+3NjFv/557xg//u6WPqOJW5Kdtpmfn8yF5A+GGRgOpp0muTYydyCTKWwvNxrj1y9YWJHS+Utriily2lLKGvMHwxw+NcjyOem7jkzW1Jei1OTHc5rfrfo0aiQmwqyEju2UqlNSx0FEioAHMGYy9Mc9dquIbBWRrR0dmXVcXD67mFMDw1kJtE0X4bDiDf/9HJf859Pc/MMXufBbT3J/GlWwU8mJSGB/fgJLoba0gAK7dUJLYTgYomNgmNqykS/oqtpSDncMphQfGhwO8q67XuYf7tvBgztbcj6SMp6fv3iUu144yjXfe47HIymo4bBiT2tfUtcRjOxSk/UNmmwr57UNZfR6AxzLoGbn5cZuqoocKbefsFqE9fPK2Xyka8JzGzsHCYbVqAr4dDFbbkzWhdTU46XQYc2oLiGeIqcNu1VGBZp1SmoSRMSOoRB+o5T6Q/zjSqk7lVIblFIbqqtTM1eTsTSSzbA/w3S16WR368juZ1dTLyf7fXzxj6+zuyW3Q8snw7EuLzaLJEzls1iEhdUTB5vNGQBzY3ZtZ80tIRRWKX2Ou1v6ePFwF5v2neLT9+3koV1TO+Bnd0s/G+aVM6vYya2/2saupl6Odnnw+EPjKoXSAjvFLltSS8F0Q1ROwlIA2Nk0uZiMUoqXG7vYuLAy5VRYMFppH+nwTDgExwwyr8jAUqhwO2ioKJx0x9Sm7iHqy8dmzGWCiFBW6IhuSENhhT8YzqtmeJAHSkGMq/5TYJ9S6ru5fj8zm+FrD+8Z04dkpvDU/lOIwDOfvZxf3HIeO798LQ6bhd+8kl6HzcmQ7i77aIeRjprMRbJ4VhGNHeOnCcemo5qsqjUW0z2tEytCM7j50CcvYk1dKd/4875Jt8kIhxVPHziVcgZbj8dPS+8Q16ys4f6PXkCxy8adzzVGFXiyzCOT+vJCmnqSWApmK+c0C6qW1hRT6LBOOths5uyfv7AyredduMioen7pyPi9q/a19WO3CguqEsdaUuXsulJ2NU1uo9Tc441mHmWTikJH1MIzO6SmUng4lUy7UgAuAt4DXCkiOyP/bsjVm9WUOHn/hfPZ3zbA9586nKu3ySmbj3Sxem4p86vcXLa0mtJCO1evqOHR3SfTHpSulEprfOHHfr2dD/9yK6EUG9kdbB+IWmeJWDKriJbeIQZ8yRdps3Btboz7qK68gBKXjd0tE8cVmrq9WMRwx3zzzavp9gzzn4/uT0n+eP7y+kk+8PMtvPlHL6XUXNGMe5w1t5Qip413bZzHX3ef5C+vncRhs0TjKsmoKy9IaimYHVIrJxiwE0+mrSDSjSeYrJxTQnmhnZcmcCHtPznA4lnFKWU1jcfa+jJaeofoGJg4uy0WpRQnur3RQH82KSu00xNpn23OUnBppTAapdQLSilRSp2tlFob+fdIrt5PRLjjplW8aW0tv9p8PO2e/j0ePxv/bRP/s+lQjiQcH18gxI6m3jG7tBtWz6HHG2DrsfRcAo/vbef8bz3Jl/74+oRWwMH2AR7d08YTe9u587nGlGQ91uVh6Ti+YdNFMF6TttaI+yh2wIqIsKq2lL0pWgq1ZQXYrRbOmlvKu8+fx31bmibVRvpPO1qocDs42TfEjd9/gUMT1EqYrr5Vtcbf+YGL5mOzWHh8bzsr5pRMuPCZnU0TfTbRmMIkWi+sbShj78n+SdXsvNzYlVY8wcRiES5YVMlLhzvHvdcOtA2wIoN4gsma+snFFbo9frz+UFYzj0wq3CPts315OEsB8kApTBefv34FDpuFq/7rWT51746U3SKvtfTR3j/M9zYdTPgcz3CQbce7x80tz4Stx3rwB8OcH7dLu2hxJVaL8MLh9ALxL0XaUP/mlRNsnSAz5DcvH8dhtXD+wgrufO7IhNfsSMcgYTV+VarpUx/PDdTS66W62DmmZfGq2hL2tQ1MaB2d6PZGu+QCfPiShSil+PXLx8d9XjzdHj/PHuzgrevr+PNtFxMMh/n5S8fGfc7ulj7qyguihUs1JS7etK4WgNVzJ/aZ15UXMBQIJeyB1DU4+f7+6+rLCIQUe0+ml8EVjScsSC+eYHLBoipa+3xJg9w9Hj9t/b6M0lFNVtWWYBHYlWYGkumuy2bmkUm5e6R9dj4O2IEzWCnMLnXx3gvmAfDQrlaOTODXNjnQNvIlak3gdvnYb7bzlv/dzJt/9GJOpj9t2teO02YZYykUu+ysqy/jhUPpzRrY2dQbnW27aV/i+g1fIMSn79vBLzYf541r5vDmdXPp8QZonMB9cjDaHTX5jnJWsZOqIse46aUH2wcT5vKvrivFHwxPmJraFKcU6isKuWZlDfe+eiKtnfIjr58kGFbctLaWuvJC3nh2LQ/uaMEzTi78ntZ+zqodHTe49dKFOKwWzp0/sfulPlqrMNaq6fH6KS2wT8rNsjbSjyjduEJT9xCtfb4xm5JUuWiRcd8mm4lhJg5kko5qUuiwsbSmOO3K5mg6ag4shfJCOz3eAEopvH4dU8g7Pnb5It5zvqEYrvvv5/jor7ZNuOvcH+Pm2B+3y+r2+Hn+kLFTb+z08OyhxLv2yaZEhsOKJ/a2c/HiqoS5zRsXVvB6S1/K3SF9gRB7T/ZzydIqzl9YmbCozx8M8+FfbuWhXa3cduVivnHzWayPtDWYKOf8QNsgDqslYeGaiYiwsrY06cIeDisOtifulnn50lk4bRYe2Ja8Qt0zHKRz0D/mC/7+CxfQ4w3w0M7UM5Ee3NnCkllF0cr4d5zXgMcf4uEk2UwDvgBHOz2cFWcRLJ5VzMtfvIqb1tRO+J51FclrFdJtcRHL7FIXs0tcKcUVfvHSMf5n0yEGfIFoPCHdILPJgio3c0pdSYPNmxu7sAicVZu5UoDJ1WREq5lzohQchMKKfl9wJKagLYX8odhl5xtvOos5pS6CYcWje9qii3oy9rcNRBfF+HTIR14/iVLwwMcuoKrIyXcfPzgmIPutR/ZxxXeeiXZK/MtrJ/nMb3fyzIFTE8q7ubGLlt4hbkyymMyvdBNWpDy4Zu/JfgIhxbr6Mq5aMYvGDs+YgrjvbTrI84c6+Y+3nM3t1y7D7bSxsKqIEpeNHRNUpx5sH2BhtXvCneyq2hIOtQ8kHCzT3DOE1x9KmLNeWmjn+rNm86edLUkH3jf3JK5MPX9hBUtrivh9ii1Pmrq9bDnWw5vWzY26Tc5pKGNZTXHSucpmkeSqBBlGFe7UOptGLYUEtQrpNsOLZ239xB1T73nlBF99aA/f23SQy779DD978SiVbseEAfJkiAgXLqpi85GuhJb0o7tPcu78CiqLnAmenT5n1xk1GenMiG7qHqLC7aDImf2iMjP+0+Pxj8QUtKWQf3znrWt458YGY9e5vSXhOf5gmMaOQfa39XPR4irqKwrYF2MpDA4H+c7jBzi7rpR19eV86JIFvN7Sxy9ifM47TvTwk+caOdbl5f4tTfzPpkN84p7t/OX1k7z/51smVAw/e+EopQX2aO/9eOZHUviOpzif9vmDnYjA+nkV0dz12B37A9ua+fGzR3j7ufW8bUN99LjFIpwzr3xCS2H/yf5xM49MVtWWEAwrDiXoCLrf7JaZxMf89+c2MOAL8tfdJxM+bqajNsQpBRHh/IWV7GlJbcj7tx87gNNm4c3rRjqwiAjvOK+eXc19CWtEdpuZR7Xjp52Oh9tpo8LtSGgpdHv8GfX3X9tQxolub9LeU0/vP8WXH9zNFcuq+cPHL2RZTTH72wa4YNHk4gkmFy6qpMcbGBPPONIxyMH2Qa5Pcn9PBrNj6lP7U29t09zjzUk8AWJaXXj9UfeRjinkIRctruLf3ryaN6+by3MHO/AFQqNcMLtb+jj7a49x5X89S1jBZUurWD67ZJSl8OS+dnq9Ab78xpVYLMJHL1vEomo39756IuqS+t22ZgodVs6aW8K//mUf39t0kL9dN5cdX76G+ZWF46bIPn3gFE/uP8Wtly5Mam7Oiyx88U3HlFK8cKiTu55vHLV4bdrXzrr6MqqLnSybXYwIUUW39Vg3t/9uFxctquKrN64a817nLajgYPsgrx5NPNfgWKeH1j4f586fuIOmuWgmWljNa5xMuZy/sIL5lYX87MWjCV1/yZSC+b4ef4jjE7QL2XKsm4d2tfKRSxeOqqoGePM5dRQ7bXz/qbHZaLtb+qgpcY6aIzEZ6soLEsYUuj3+tAvXYonOM47JzmntHeLlxi7uffUEn7hnOyvmFPODd57DOQ3l3PPhjTzwsQv5yo2Z9au8aLFRrxBf3fzobnPg0JyMXj+W5bNLOG9BBf/6l308vX9iaxwMq7AuB64jGEkK6PX6dZ3CTOCixVUM+IIs//KjLPvyX/mvxw/Q3OPl/T9/FV8gjMNq4a3r61hXX86KOSU0dgxGRww+vqed6mIn6xtGFsHPXruMQ6cG+dMOo7XCU/tOcdnSar5x81lUuh186OIFfOeta3A7bbx1Qz3bjveMqe5VSvH8oQ4+/uvtLJ9dzAcump9U/upiJwV2a7TfkPn8T923k3f/9BX+9S/7uPEHL3D1d5/l73+ymddb+rh6ZQ1gBOUWVLqjSuEXm49T4rJx53vXJzRv33vBfOorCrj9dzuju/lYTDdcolkB8TRUFFJaYE/oyjjQNsC8ykLcSUx5EeGzb1jG7pZ+vvmXfWMeb+r2UuS0UZ4gQ2dlxG89XiV4KKz42sN7mFPq4qOXLxrzeGmBnQ9dspDH9rSPSn30DAd5av8pNqQQTJ6I+vJCmhMo+h5vZjODV88txRLTMfXHzx7hwn9/irff+TJf+MPrVBc7+dn7zo1eexGjVcV4U9ZSYXapi4XVbp7Y2z7K1//X3SdZ11A2KvU4U6wW4a73bWD5nGI++uttE7bZCIUVLb1DWe2OGstIU7xAVCnomEIec+2qGhZVuxEBpeD7Tx3m4v94ms5BP5+5eikHv3k9337rGiwWYU1dKeFIwy1fIMQzB05xzcqaUfNkrztrNivnlPC/zxzhRLeXtn4fFy6uYl1DOVu+dDX/ErEqAN66vo7SAjtfi5u09ezBDt7z01cZCoT4wTvPGbd5logwr7JwlPvoz6+d5OFdrXzs8kW88sWruP2apSysctPl8TO/spAbzx6JT6yYU8K+NmMQ+6O7T/J36+uTvl+R08b33raWHk+A6/77ef7597tGVYg/e7CT+oqChI3w4rFYhHMayhK6o/a39U84aOWNZ9dyy0ULuPulY2yKC5af6PZSn2DADxjWh90q42Yv3f3SMXa39PP565cnvRa3XDyf8kI733n8YPTY/Vub6BsKcMtFC8aVPRXqygto7h0a5eYaGA4SCKmMLAW308jO2dHUy5Zj3fzno/u5ZmUNv/rgeTx1+2U88ZnLmFWSvQU6lndvnMerx7p5bI/xeTV1e9nd0p9V15FJicvOL2/ZSENFIR/6xZZx4yjt/T4CIZWTamYY6VPV6/Xj8+uYQt7jtFn5y6cu4fU73sDmL1zJp65cTLHLxrqGMj5xxehdoml672jq5an9p/D4Q1y3avQNLSK878J5NHZ6+NVmIyd+4wJj5xg/jHxWiYu/P7eeVxq7R6VJmjN8f/q+DSkF91bWlrD9RA+hSNbO5x54jXUNZdx+zVJqSlx88sol3PneDWz6x8t45p+uGBWAXTGnmKbuIe56/iiBkOKdGxvGfa8N8yt44XNXcOulC/nD9hbe89NX8fqDBEJhNh/p5NIl1Sn7ntfPK+fQqcFR9R1G8Zs3pcZoX7hhOZVuB3+NuCBMjBqFxF9wh83C0pripDUSB9oG+I9H93P1ippxM4WKXXY+dvkinjvYwdMHThEIhbnr+aOcO788mpSQCfUVhfiDYVr7RlxI0RYXGTZsW9dgBJs/de8O6isK+e7b1nDJkmoWVhfhsOVueXjvBfNYVlPMN/68lyF/KOo6uj6LrqNYKtwOfv2hjVQWObnl7i2jRmLGMtIdNTeWQrHThs0i0QI50DGFvMdlt1LktDGntIB/vHYZW750NQ989MIxvXsqi5wsrSniqX2nuH9rE3NKXVFfaSyXRkYV3vXCUcoK7aOG18dz7vwK/KEwO0704guE8AVCPLnvFDesns1VK2pSkv+KZbPo8QbY2dQbDXL/5N3rk/YeiuWypbMAw41w/sKKlJRQWaGDL96wgjvfu549rX2872evcts9O/D4Q1y1YlZKMgPR6V3bY5q07T3ZTyisUmqMZrdaWNdQxo6Y55spoUtmJVcqqyItuGPdGN0eP0/tb+fT9+2gxGXj39+yekLl9t4L5rN4VhG3/nIrn/3dLlp6h/jIpWPdTZNhTaTjZ+z8iK5JNsOLZ219GQO+IJ2Dw/zgHedQ7Eq/EG4y2KwWvn7zKlp6h/jRM4f56+6TrKotyUkaqElNiYsfvescuj1+fvzMkYTnNCXJVssW0aZ4kZiCw2bBasle071soJXCBLjs1jG7epOb1tTy6rFunjnQwd+tr0v44c4pLeBNa41d5g2r5yR9LTDqDIpdNj77u12c/60nufQ/n+bUwDBXLk9NIQBcuqQaq0V4bE8bm/a1c+mS6pRdAKvrSqOyvmvjvJTfE+DK5TV8++/WcKTDw6N72vj89cu5YlnqSmFNXRlWi4yapmb6f89bkJpffl1DOY0dnqgb65XGbkJhxYWLkufUr6otpTtSRauU4pebj7Hx3zZxy91baezw8O2/W0NVCumRLruVBz56IRsXVPLgzlYWzyriyuWp//3jsWJOMQV26yj3WrYshY0LjEr4L92wgtV1k8+SmtR7L6zkTWtr+cmzjWw/0ZsT11E8Z80t5ea1tfzsxaMJe341dXsRGd18MduUR/of+QKhvLMSAPJrusMM4z0X8WYQ/gAAIABJREFUzKex00OB3cqHL12Y9LzvvHUNH7t8MUsm2HmXuOx8921r+b/nGhkOhdnT0ocIXLEs9XbhpYV2rls1O9qb6JqVqSsUgK/cuIqVtSVJ017H4y3r67h+9Wxae31p57G7nTZWzCkeNZnrpSOdLJ9dnHLO+rqGEZfeFctm8dKRLpw2y7gzhM3Csk1723n1WA8P72rlyuWz+MilCzlrbmnSAHciSgvt/PwD5/KzF46yYX7FuBuAdLBZLaytHx1zMS2FigxSUsFIY97+5WsoLZgaCyGeL96wgk37TuEPhbOadTQet1+zjEdeP8n/PHmQb/3t2aMea+rxMrvENaalSjYpj/Q/KimwaaVwulFaYCziE2GzWlLu5XLNyproQn6008PxLk/ahTyfumoJj+9tY01dWdqLe4Xbwa0ZuD0KHbZJFzZduKiKn794lNZeo3ho67Ee3n1+6hbLmroyLGK4WQyl0MmG+eXjZncsn12CCHz5wT3YrcLt1yzlE1csnvSCbrda+Mhl2XEbxbJhfjk/euYInuEgbqct2veoIs0OqYmYLoUARizt6zevYvORrknfN+nSUFnIuzbO45ebj/HBixeOet/m7txlHplUFDpo7BxkqMSVd+mooN1Hec2CKjeXp+GCMVk2u5hXvng193/kgrR2utPN+y6cj1Jw53ONbD/Rw3AwPK7rJx6308ay2SXsONFD5+Aw+9sGoj38x3vOuzfO450bG3j6s5dz21VLsrbDzybnzCsnFFbRmoJN+9pZWOXGnYeLSrr87Tl1fPuta6b0PW+7cjGFDtuYFupNPd5oa5FcUe62Gymp/vybugbaUjhtyeYYwaliblkBb143l3tfPcHhU4NYLZJyPMFkXUMZD+9sjWZtpaJUvvGmsyYl71RiDr7fdqyHqiIn24738MUblmd1MtiZRGWRk49cupD/euIgj+9p45qVNfhDYdr6fTm3FMoLHZHitWDepaOCthQ0ecbHr1iMRYSXG7v4m9Vz0s6GOW9+BQPDQb70x90UO20TTjabKZQW2FlaU8TW4z3c++oJ7FbhLefUTbdYM5oPXrKA+ooCbv3VNt74/Rf4ybONKJW7zCOT8kIHwbDiVP9wXrqPpt1SEJGfAW8ETiml8n/LpskpC6rcvHbHtdgsMqld8BvPnkOxy0ZTt5cF1UUppeLOFNbPq+DPr7Wyq7mXa1fNzlrTuDOVQoeNRz99KX/c0cKvNh/nu08YxYe56ntkYmaMtfYORfuV5RPTrhSAu4EfAL+cZjk0eUImYxhtVkvKNR0zjQ3zyqMdWd953viFhZrUcDttvPv8ebxrYwOvHO1m+4merBQcjofZcsXj1ympCVFKPSci86dbDo0m3zEXq4aKQi6Y5DwDTWLMrrmTnRORDrG1JVopaDSaSTOvspCLF1dx05ravMyQ0qRGbG1JPgaaZ4RSEJFbgVsBGhq02aw5MxERfv2hjdMthiZDyvNcKcyIKJxS6k6l1Aal1Ibq6tSrezUajSbfKHbZoi1x8tF9NCOUgkaj0ZwuWCxCWaSKPB9TUqddKYjIvcBmYJmINIvIB6dbJo1Go8klZrBZVzQnQCn1jumWQaPRaKYSMy1Vu480Go1GEw0260CzRqPRaKK9ybRS0Gg0Gg1lpqWg3UcajUajqXDrmIJGo9FoIpgxhXxMSZ327CONRqM507h21Ww6B/0sqp6aaXPpoJWCRqPRTDGlBXY+dnn2x7ZmA+0+0mg0Gk0UrRQ0Go1GE0UrBY1Go9FE0UpBo9FoNFG0UtBoNBpNFK0UNBqNRhNFKwWNRqPRRBGl1HTLkBYi0gEcn+TTq4DOLIqTa2aSvDNJVtDy5pKZJCucOfLOU0pNOLpyximFTBCRrUqpDdMtR6rMJHlnkqyg5c0lM0lW0PLGo91HGo1Go4milYJGo9FoopxpSuHO6RYgTWaSvDNJVtDy5pKZJCtoeUdxRsUUNBqNRjM+Z5qloNFoNJpxOG2UgohcJyIHROSwiHw+weNOEflt5PFXRGR+zGNfiBw/ICJvyFdZRaRSRJ4WkUER+UGu5cyCvNeIyDYReT3y/5V5Lu95IrIz8m+XiLw5X2WNebwhcj98NteyZiKviMwXkaGY6/vjfJU18tjZIrJZRPZE7l9XvsorIu+Kua47RSQsImsnLYhSasb/A6zAEWAh4AB2ASvjzvk48OPIz28Hfhv5eWXkfCewIPI61jyV1Q1cDHwU+MEMuLbrgNrIz2cBLXkubyFgi/w8Bzhl/p5vssY8/gDwO+CzeX5t5wO7p+KezYKsNuA1YE3k98pcrgnZuhcix1cDjZnIcrpYCucBh5VSjUopP3AfcHPcOTcDv4j8/HvgKhGRyPH7lFLDSqmjwOHI6+WdrEopj1LqBcCXQ/niyUTeHUqp1sjxPYBLRJx5LK9XKRWMHHcBuQ64ZXLfIiJvAhoxru1UkJG8U0wmsl4LvKaU2gWglOpSSoXyWN5Y3gHcm4kgp4tSmAs0xfzeHDmW8JzIF78PYweQynOzSSayTgfZkvctwA6l1HCO5BwjS4S05BWRjSKyB3gd+GiMksgrWUXEDXwO+FoO5Ysn03thgYjsEJFnReSSPJZ1KaBE5DER2S4i/5xjWTOVN5a/J0OlcLqM40y0E4nf5SU7J5XnZpNMZJ0OMpZXRFYB/4GxA8s1GcmrlHoFWCUiK4BfiMhflVK5sswykfVrwPeUUoNTuBHPRN6TQINSqktE1gN/EpFVSqn+bAs5gRypnGPDcNOeC3iBJ0Vkm1LqyeyKmJIsKZ8jIhsBr1JqdyaCnC6WQjNQH/N7HdCa7BwRsQGlQHeKz80mmcg6HWQkr4jUAX8E3quUOpJzabN0fZVS+wAPRiwkV2Qi60bgP0XkGPAPwBdF5JM5lDUjeSPu2S4ApdQ2DP/50nyUNXL8WaVUp1LKCzwCnJNDWTOV1+TtZGglAKdNoNmG4VtdwEiQZlXcOZ9gdJDm/sjPqxgdaG4kt4HmScsa8/j7mbpAcybXtixy/ltmyL2wgJFA8zyML2VVPsoad84dTE2gOZNrW21+rzCCqS1ARZ7KWg5sJ5J4AGwC/iZfr23kdwuG0liYsSy5vpGm6h9wA3AQYwfypcixrwM3RX52YWRpHAZejb14wJcizzsAXJ/nsh7D2B0MRm6ClfkqL/AvGLvtnTH/ZuWxvO/BCNrujCwKb8pXWeNe4w6mQClkeG3fErm2uyLX9sZ8lTXy2Lsj8u4G/jOfr23kscuBl7Mhh65o1mg0Gk2U0yWmoNFoNJosoJWCRqPRaKJopaDRaDSaKFopaDQajSaKVgoajUajiaKVgua0QkQGp+A9bkrUxTLH73m5iFw4le+pOTM5XdpcaDRZRUSsKkkTNKXUQ8BDOXhPm0rea+lyjNqUl7L9vhpNLNpS0Jy2iMg/icgWEXlNRL4Wc/xPYsx32CMit8YcHxSRr4vIK8AFInJMRL4WaYr2uogsj5z3fonMsxCRu0Xk/4nISyLSKCJ/FzluEZEfRd7jzyLyiPlYnIzPiMi/icizwKdF5MZIr/wdIrJJRGoiffM/Cnwm0i//EhGpFpEHIn/fFhG5KJfXUnPmoC0FzWmJiFwLLMFoSSzAQyJyqVLqOeAWpVS3iBQAW0TkAWX05XFj9Pz/SuQ1ADqVUueIyMeBzwIfSvB2czAaqC3HsCB+D/wtxgyB1cAsYB/wsyTilimlLou8ZzlwvlJKiciHgH9WSt0uxlCaQaXUdyLn3YPREO8FEWkAHgNWTPqCaTQRtFLQnK5cG/m3I/J7EYaSeA74lIxMVauPHO8CQhhDa2L5Q+T/bRgLfSL+pJQKA3tFpCZy7GLgd5HjbSLy9Diy/jbm5zrgtyIyB6MHztEkz7kaWBnTIbVERIqVUgPjvI9GMyFaKWhOVwT4llLqJ6MOilyOsaBeoJTyisgzGD1lAHwJ4gjm/IcQyb8vsTMiJO7/VPDE/Px94LtKqYcist6R5DkWjL9hKI330WgmRMcUNKcrjwG3iEgRgIjMFZFZGO2GeyIKYTlwfo7e/wXgLZHYQg1GoDgVSjE6iAK8L+b4AFAc8/vjQLRVtmQyk1ejiUErBc1piVLqceAeYLOIvI7h5y8GHgVsIvIa8A3g5RyJ8ABGF9vdwE+AVzAmZU3EHcDvROR5oDPm+MPAm81AM/ApYEMkiL4XIxCt0WSM7pKq0eQIESlSxmS0SoxWxxcppdqmWy6NZjx0TEGjyR1/FpEyjIDxN7RC0MwEtKWg0Wg0mig6pqDRaDSaKFopaDQajSaKVgoajUajiaKVgkaj0WiiaKWg0Wg0mihaKWg0Go0myoyrU6iqqlLz58+fbjE0Go1mRrFt27ZOpVT1ROfNOKUwf/58tm7dOt1iaDQazYxCRI6ncp52H2k0Go0milYKGo1Go4milYJGo9FoomiloNFoNJooWiloNBqNJopWChqNRqOJklOlICLXicgBETksIp9P8HiDiDwtIjsiE6RuyKU8Go1Gkw9sPdbNyq88SrfHP92ijCFnSkFErMAPgeuBlcA7RGRl3Gn/AtyvlFoHvB34Ua7k0Wg0mnzhYPsgXn+I9n7fdIsyhlxaCucBh5VSjUopP3AfcHPcOQooifxcCrTmUB6NRqPJC/p9AQCGg+FplmQsuVQKc4GmmN+bI8diuQN4t4g0A48AtyV6IRG5VUS2isjWjo6OXMiq0Wg0U8ZARCn4AqFplmQsuVQKkuBY/OzPdwB3K6XqgBuAX4nIGJmUUncqpTYopTZUV0/YukOj0WjymgFfEDjzLIVmoD7m9zrGuoc+CNwPoJTaDLiAqhzKpNFoNNNO/9CZaSlsAZaIyAIRcWAEkh+KO+cEcBWAiKzAUAraP6TRaE5rzkhLQSkVBD4JPAbsw8gy2iMiXxeRmyKn3Q58WER2AfcC71dKxbuYNBqN5rQiqhTy0FLIaetspdQjGAHk2GNfifl5L3BRLmXQaDSafMPMPvKdSZaCRqPRaBKTz5aCVgoajUYzxZypdQoajUajiSMcVgwOa0tBo9FoNMCgP4iZTqMtBY1GoznDMeMJcObVKWg0Go0mDrPFBWhLQaPRaM54+oe0paDRaDSaCNpS0Gg0Gk0UM6ZQ7LRppaDRaDRnOmaNQlWxU7uPNBqN5kzHtBSqi5zaUtBoNJoznX5fAIfNQkmBjeHgGWYpiMh1InJARA6LyOcTPP49EdkZ+XdQRHpzKY9Go9FMN/1DQUpcNpw2K75A/lkKOeuSKiJW4IfANRgDd7aIyEORzqgAKKU+E3P+bcC6XMmj0Wg0+cCAL0Cxy47TZjnjLIXzgMNKqUallB+4D7h5nPPfgTFTQaPRaE5bBnwRS8Gen5ZCLpXCXKAp5vfmyLExiMg8YAHwVA7l0Wg0mmmnP9ZSOMOyjyTBsWRT1d4O/F4plfAKicitIrJVRLZ2dOhpnRqNZuYy4AtS7LLhslvPuOyjZqA+5vc6oDXJuW9nHNeRUupOpdQGpdSG6urqLIqo0Wg0U8uAL0BJNKYQJt8mEOdSKWwBlojIAhFxYCz8D8WfJCLLgHJgcw5l0Wg0mrzAtBScdmP5zTdrIWdKQSkVBD4JPAbsA+5XSu0Rka+LyE0xp74DuE/lm7rUaDSaLBMIhfH6QxS77LhsVgCG8yzYnLOUVACl1CPAI3HHvhL3+x25lEGj0WjyhUGz79EoSyEE2KdRqtHoimZNXtE3FODmH77IjhM90y2K5gzj8KkB3vTDF+n1+nP2HmaLi5KCGEvhTHEfaTST4ZXGLnY19fI/Tx6ablE0Zxh/2tHKzqZeGjs9OXsPsxlerKWQb03xtFLQ5BU7moxOJ88c6ODwqYFplkZzJvH84U4AfP7cLdKjlIK2FDSaidlxoocFVW6cNgs/feHYdIujOUPo9fp5rdnYkHhzqBSi7iOXHVeeWgo5DTRrNOkQCitea+7jrevraO8fZvORzukWSXOG8NKRLsz8x6EcLtL9Q4alUOKyR5WPthQ0miQcbB/A6w+xrqGciiIHg8PBiZ+k0WSB5w91IpEeDENTYCkY7qPY7KP8QSsFTd6w44Rhvq9rKKPYZYt+gTQj9A0FCITya2c501FK8fyhDtY3lAO5tRRilYLLbsQU8q0pnlYKmrxhd2sfpQV2GioKo/Nr/XlmWk83b/jec9z5XON0i3FacbzLS3PPENeuqgFy7D7yBSh0WLFZLdpS0Ggmon8oQIXbgYhQ5DTCXdqFNILXH6St38ehdp2VlU2eP2Q02bx6haEUchtoDlDsMu5tbSloNBMw5A9REPmiFLuMCs9B7UKK0u0xiqra+n3TLMnpxfOHOqmvKGBBlZsCuzWn2UDGLAXj3o5aCnmWfaSVQob88OnDvPdnrxLUft6M8fpDFDoMpVAU2U2Zed2aEaXQ3j88zZKcPgRDYTYf6eLixdWICAUOK15/7jYi/TGWQr42xNMpqRny7ccOAHBqYJjasoJplmZm4w2EKIl8YYq1+2gMXaal0OdDKYVIopElmnTY1dzLwHCQS5dUAVBgtzLkz90iPeALUl7oAIgWr51R7iMRuU5EDojIYRH5fJJz3iYie0Vkj4jck0t5cknHgN69ZcqQPxi1FLT7aCw9EaUwFAjRr69LVnjuYCcWgQsXRZSCw8pQIHfXdsAXpKTAuLetFsFulTMn0CwiVuCHwPXASuAdIrIy7pwlwBeAi5RSq4B/yJU8uSAcHun2/cJhXWiVKYb7yLAQTPfRwLB2H5mY7iOA9tMortDU7Y0Ge6eaFw53cnZdGaWFxkJtWApTE2gGcNnyb05zLi2F84DDSqlGpZQfuA+4Oe6cDwM/VEr1ACilTuVQnqwT6+/edlx39cyUIX+IAjOmYLqP9I44SleMUmjrO32UwnceP8DHfr19yt83GAqzq6mXjQsroseMmEIuK5qDo5SC0245cywFYC7QFPN7c+RYLEuBpSLyooi8LCLX5VCerNM5OOIy0gVFmeP1hyiMZh+ZloJWCiY9Hn+06vZ0yUBSSvHq0W4Gh4M5DfAm4mSfj2BYsbDKHT2Wy+wjXyCEPxSOZh+BEVfIt0BzLpVCoihY/HQ1G7AEuBxjAttdIlI25oVEbhWRrSKytaNjas1MpVRSTd4xMLJzy7fpSZB/jbbGIxxWDAVGso+cNgt2q0y6qjkYCufdDixTujx+FlQaC1j7aWIptPQOcTLyt3QN5m6OQSJOdHsBqK8ojB4rdFhzVrw20gxvtKWQb9/TXCqFZqA+5vc6oDXBOQ8qpQJKqaPAAQwlMQql1J1KqQ1KqQ3V1dU5EzgR33/qMMv+5dGEWTBdHsNSqC115d0C9NieNpZ/+VEOtM2MQidf5PoVRtxGIkKxyz5p99Fnf7eLv//Jy1mTLx/o9viZXeqivNB+2lgKW451R3+OtbynAlMpNMQohQJ77txHI22zz1xLYQuwREQWiIgDeDvwUNw5fwKuABCRKgx3Ul7V8N/zyglgJPMjls5IxtHc8oK8+2B/+vxRAI515W5gSDYxv4impQBGXGEyKal7W/v5085WjnQMZk2+fKDb46fC7aCmxHXaBJq3HBuJxXVOg6VgtwpzSkdSyQscuXMfxfY9MnHaziBLQSkVBD4JPAbsA+5XSu0Rka+LyE2R0x4DukRkL/A08E9Kqa5cyZQJiXYPnYN+LAI1Ja68Uwp7T/YDEAzFe+zyEzPjw6xoBkMpDEyieO17mw4Cxpcw3yy4TOj2+Kl0O5hd6jp9LIWj3SyZVQRA1zRYCnXlhVgtI57uXFoK5r1spqQCuOyWvFs7clqnoJR6RCm1VCm1SCn1zcixryilHor8rJRS/6iUWqmUWq2Uui+X8qTLT184Gv3yJVqcujzDVLidOS+NTxevPxjdYc+UiuARS2FkFzWZTql7W/t5Ym878yoNl0B3Agsvl4TDiq8+uJsn9rZn9XUDoTB9QwEq3E5ml7ho65v5dTE9Hj+HTg1y/VmzgdHZVVPBiS7vqHgCmHUKIZTK/maqfyiRpXBmuY9mPN/4897oz4l2Dx0DfqqKHJG0svz5YI/GzJg1h3rkO2bmSaz7qNiVvvto23HDR/3BixcAUx+8/N22Jn6x+Ti/39Y08clp0BMZJl/htlNT4qLLMzzjM962RtK4L1pcRbHTNi0xhYaK0V0IChxWlMpN64mBBDEFl92iex/NVBLdJF2eYaqLnYa2z6MPtqVnKPrzTLEUou4jR7z7KD2l0NwzhMNmYeWcEmBqg5cdA8N88y/7ADh0KrvxjB6P8TlWuJ3MLnWhlNFaZSaz9Vg3DquFNfVlVBY5pjSm0OcN0DcUGBVkhhH3ZS4K2BJmH2lLYeaSyDfdOThMpduB05ZdS+H5Qx08vCs+USt1WnpHlELfjLEUxgaai132tC2Fph4vdWUFVBc7gam1FL7+5734AmGuP2s2x7u8WZ0FYWa6VbgdzC5xATO/gO3VY92srivFZbdSWeSc0phCU4+ZeeQeddy8/7w52OT1+wKIgNtxhgaaTzcSfcF7PQHK3Q5cdivBsMqKOa+U4j0/fZXb7t0x6b75LT1DuOwW5lUWRv2Y+Y75JRyVfeSypZ2S2twzxNzyAiqLIkrBMzULTbfHz8O7Wrnl4gVcu6qGUFhxPIuZX2ZsxMw+gpnd6mLIH+L15j7OnW9UE1cVOaZUgR/vGpuOCiMzDnJlKRQ5bVhiAtsuu7YUZgxmK+y/Pccowk70wQ0Hwzht1pHdxXDmN1JsHxQzgyhdWnqHqC0roLTAPoPcR8biXxCziypy2vCHwmntpJp7hqgrL8TtsOK0WaZsoTHTXzcurGBxdTEAh7PoQuqJUQqzS2e+pbCzqZdgWHHufGMEZmWRc0pdfdEahcrRSsFMdMiFUuj3BUZVM4NhKeST6xm0UhhDKKwIhsLRLpS1kRzm+A9OKYU/FMZps0T79HiyUKYfm+U0WaXQ3DPE3LICSlz2GRRojlgKMSmppu81VReSZzhIt8dPXXkBIkJVkXPK/NRHIgpgcXURi2YZLolsKgUzM6e80E55oR2HzTKjLQWzaG3DvIil4HbQ7fUTCk9NCvWJbi+Vbkf0u2sSjSnkwn0U1/cIDEvBpy2F/OaWu7fwlh9v5qO/2gbArBLDDXHHw3tHneePWBIOmyVahZuN3i2xLZH3n5yk+6h3iLryAkoKbDOmxbI3UaDZlV5TPDOWUlduKPLKIkfK7qPhYIgLvvUkf9zRHH2tVV95lNeae1N6/pGOQZw2C7VlBRQ6bMwtK+BwFovnuj1+Sgvs2KwWRISaEmdWahVODfhYfcdj7GxK7e/MFjtO9LC0pijanbSq2IlSI1lWueZEt2dMOiqM3H+5UAoDSSwFcyOaL2ilEMezBzvY1dQbXUxuXhPfw8/AdCc5bRbckRtpMAvuI9NSqHQ72DcJS8HrN3bLM81SGPKHsMjIiEKAIqfxBUo1A6k5EjysKze+7JXu1P3Uh9oHOdnni1bYvtbUi8cfSrn77ZEODwuq3NFCqEWzirJqKZiFayZGrULmSuFYp5cBX5DdLX0Zv1Y6dA4a96hJpdsZOT41LiQjHTWBUojGFLK/mTJmKYy2FMzpa/lkLWilkIThYJi/XTc3upOB0fMTzMCzw2bBbVoKWejoaS6A586v4NTAcNoZGa2R3fLc8gJKZlBMwZylEDtNrDjNmQrNkVTc+qilkHpGi+mqOxap8TgWCUTG1nyMx5GOQRZFKnMBlswq4kjH4Kh7JhPMFhcm2Wp1Ye7Mp7pGoN8XGFXZW1lk/G1TEQMKhMK09voSK4VcWgrDgVE1CjAS2M6nuIJWChizED76q238+uXj0WOtvUM4Y/zbAMcjwSkYUQqGpZC90ZGmUjhvgeFrvf13u9J6vrkwzi0rpMRlwxeYum6hD+9q5f0/f5Uv/vH1tBfDoUBwlOsIRmYqpG4pGDUKVZHMo8oiB50ef0rVqXtbDaVgZqWYyiEVpeALhGjq9rKoekQpLJ5VhC8QHpUenAndHj/l8ZZCvy/jytve6VIKQ6NdKVURpTAVcpzs9REKqzFBZohJSc1FoDlBTMG0jPMpA0krBeBXm4/x6J42vvzg7uixsBrtygBGpYgOx1gKpZEdT68381256T66dKnRDfaZAx1pffFbYiwF02d6sG1qGsPd9cJRnjnQwT2vnOBomumYhqWQWCl4UlS2zZEaBTPlr8rtxB8Mp6SsTUuhtW8IXyAUlT8VpXC8y0tYwaLqkZz3xRGrIVsupK4491G52xFR+JktJj2Re3Yqx8kqpeiPc6WYinwqLIXj3cZnmshSyFVKqlKKweFggpiCOadZWwp5hRkLiF97TX+fSSiR+8hqjQajTw1kbs6bu+KaEiefvXYpAIE0mtq19AxhtQg1xU4uWFgJwObG3I8KDYUVB9r6OT8yxcrceaeKZzg0qhkeQKEzvV1bc88QdTFf9FRdEkop9p3sp6zQjlLGeEjTUmjtHZrQ0jLTUUdZCtXZUwpKKXri3EcFUbdDpkrBtBSmrkbA6w8RCqtRC2SJy47NIlNiKSRqmW1ibkyyrRTMv3ls9pG2FPKS/W2JFzCXbfQi9YvNx9jTagTkYmMKLruVEpctK20HBmKqHl2TSI9r6R1idokLm9XCrBIXi6rdvHQk941nj3d58AXC3LimFrtV0k6nHQoEx1gKplsu1awuo0YhJniZYgFbc88QA74g166sAQyr4dTAMEtmFRGOKInxMNNRF8ZYCuVuB5VuR1aUQr8vSDCsRimFydwbiej1TL2lkGiugMUiVKSRGJAJJ7q9OKyWaBFgLHarBZtFsh5TSPQ3wxloKYjIdSJyQEQOi8jnEzz+fhHpEJGdkX8fyqU8yYj1+8bmLcdbCi83dvM3/+8FYKTtheliqi7OTvFNp8dPWYEdi0UmFYRq7/cxp3TkZj9vQSU7TuQ+3XBfJH12TV0Zi2cVp20pmIHmWMzdcCqWgi8QotvjpzbmbzfdLRPtgk0Fdv3qOYA5pdiqAAAgAElEQVSRgQZwxfJZADR2jO9COtIxyNxIKmos86vc0V1pJsRWM5sUOCJZKxkuJtMRaDar7OMzcaqKnFNSgd7U7aWuomBUy+xYcjGnOdr3KEn20RlhKYiIFfghcD2wEniHiKxMcOpvlVJrI//uypU842G3jFwGt3Nkt2pq8Sdvv2zMc+J79RS57FlJST3UPhD1R0+mkGbIH4pmQwEsqCqkbyiQ8x5I+072Y7UIi2cVsXJOSfqWgj80JtBssUjK/e3NeE5sMDZVP/Xe1n4sAucvqKS0wM5zEaVweSSuM9GgoiMdnlFWgkmxy5aVgsaESiFblkLkunn9oZRjN5li7prj/euVRQ46piKm0JU4HdUkF63wE3VIhZE15oxQCsB5wGGlVKNSyg/cB9ycw/ebNDE6IfohwYi/L97XDSNKwdzNux3WjFNSlVIcaBtgaU3xqNf2peE39vpH++brIzn7E7lAJotSKuqTX1TtxmW3srK2hI6B4bRiLIkCzWAo3VQWq94hYzEpKxhZOM1FdKK01L0n+1lQ5abAYWV+ZWHUsji7vowKt4OjncmvnVLKSEeNiSfEyp6NHWcipeC0Z8ftEFssNlXWglk7E5uSChFLIccyKKU4MZFSyMGc5kSzFGDE03CmuI/mArFN5Zsjx+J5i4i8JiK/F5H6BI/nnNgAcqxFaS6utjgz0xgyP7r/v3uSoyNj6RgYpt8XjCoF00WQlqUQGL3jNjOQzMIuMIaLnP9vT2Y8v/m15l6WfflRFnzhEZ7cf4oVkXbVZtvq15tTL4hKqhSc1pSCfuaOtyymrsRhs1DsmrhP/4G2AZZHZJ5fZez4q4udFDltzK8s5Ghn8rjAyT4fXn9oVI2CSYHdllB2z3CQy7/9NK8e7R7zWCJ6oi0usm8p9HgD0SKyKVMKUUsh3n2U+5hC31CAgeHghJZCtt1Hyf7mqIt4plkKIvKAiPyNiKSjRBI57OLTaB4G5iulzgY2Ab9I8v63ishWEdna0dGRhggTo5Qald1jsQh3vmc9/3zdMq5aYQQebdbRf/ZwMMyQ3/gQTT9ykTNzV4HZksJc2CaTHueLVwpRS2EkbvL43jba+n1sPZ7aopSMlxu78AfD3HblYj5z9VI+ddUSANY1lFFaYOfBnam3/x7yBymw28YcdztSu66mUiiN230aTQHHf37X4HC0HfW8SkMpLIj8P7/KzbFxLAWzEthUhLEYlsLY927pHeJYlzeatDARA8OmPzp2OEvmloJSil6vP+qunKpg84h/Pd595GQoEMpKu5hkJOuOGksu5jSb1qfp0jSZyZbC/wLvBA6JyL+LyPIUntMMxO7864BRq4RSqkspZd6J/wesT/RCSqk7lVIblFIbqqurUxQ5NeJrrCwiXLtqNh+/fHF0gYkPSPliblxzAS50WDPukmpaLLaIPyv6xU+j+Gwozn1UWmin2GWL9o8HeO6QkaJqfkEmy4G2QWYVO7n92mV8+uolUReKy27l5rW1PLqnjb4UajeUUngDiS2FVIN+fab7qHD0QlPsso875zkUVnj8oWiCwfxIQZM5znNhlZu2fl/Sheq15j6sFhlHKYyV3YzvpFqUZ7rP3DHXp2ASrsV4BoeNrCZzRvJU+PNhxH0U70qJJgYM5E6OZN1RY8mW2y+WU/2+UTVNJjPWUlBKbVJKvQs4BzgGPCEiL4nIB0TEnuRpW4AlIrJARBzA24GHYk8QkTkxv94E7Ev3D8iU+BkIVhlr4MS7j3zB0JhB80VZcB+ZstisMuq1fSneoEopw30UFwOpLy+MxhR8gRCvNBopqscSFGadGvDxrb/uS6kK+kB7P8tmFyd87G0b6vEHwzz02sTWwnAwjFKMCTSDYSmkFWiOcbGAsfCMZymYVoi5QJnuo/j/k2UgvdbSx9Ka4oSyFziMXvnxnT9NRZly91d/EKfNMspiNeNdmeTTm9dsYXURIlNnKfT7grjsllHxOxjZRXfmMAPJVAqmBZ2IAntqLst0ODUwTHWRc1QbF4jJPpqBlgIiUgm8H/gQsAP4Hwwl8USi85VSQeCTwGMYi/39Sqk9IvJ1EbkpctqnRGSPiOwCPhV5/SklGPeFTaATElgKYQaGjS+qI2L+lRTYI26lyX+4piz2iFJINxfdHwoTTrC4Lq0p4vWWfpRSbDvew3AwTLHTltBS+M3LJ/jJs408vX98N10orDjUPsiymsRKYVVtCVVFTnanEFdItBM2ST3QHMBulTHWRskEg3rMx0xLYcXsEi5fVs1VK4x01HUN5ditwt0vHRvzXKUUrzX3sqauNOFrRwuh4j6/EUshtYww7/DojDKI2TBk0MLEVApVRQ4qCh1TGmiOzzwy5MhtVXMwFOaB7c0sn1085nrGUuCwZT3QfGrAFy1yjWXGtrkQkT8AzwOFwI1KqZuUUr9VSt0GjI2wRVBKPaKUWqqUWqSU+mbk2FeUUg9Ffv6CUmqVUmqNUuoKpdT+zP+k9IhvWWtJwVIY8ofoGhzddsAshMmkqtmUxXQfpesi8EXiHK44S+HCxVV0Dg5zsH2Q5w51YLcKb1xTy/Fuz5geRZv2tQPwxN72cd/rWJeH4WA4qaUgIpS4bCmNNfRE3G5FCRaKVE35Xm+A0gLHmJ1Yscs+bkM9c7dutukucFi5+wPnsXy24Q6aW1bALRcv4Pfbmtl+YnTH1OaeIXq9AVYnUQoFSYrv0nYf+ccW9rmyUHlrZh6Vux3G7IkpsxQCY+IJMFKBnivl9MD2Zho7PPzD1UvHPa/Absm+pdA/zKzisUrBYbUgMjMthR8opVYqpb6llDoZ+4BSakMO5MoprzX30jk4jC8Q4oXDo1tAJCpoGWMpBEN0e4apKIpVCsYHPpl21yZmwNsWtRTSyz4yz4t3H120uAqAFw938vzBTtbPK2dlbQm+QHhUFXZr7xB7Wvtx2iw8tb993B7vZuaSuXgmotCZ2i7fXLSLnAksBWdq7qO+If+YeAIYbqHxFt9k+eOx3HblEmpKnHz1wT2jXEG7IrMW1tSVJXyeOTAoPtY0mZiCO64wzpWF/PaoUii0U13spGPKLIXgmCwcSD2FeDL4AiH+e9Mh1tSX8YZVNeOeW+iwZT3YfWpgOGEFtYgYc5pnmqUArBCR6J0vIuUi8vEcyZRT+oYC3PSDF/ng3Vv45eZjfPKeHaMetyRQCubuszyy6JjVsxXuEc0/P5Kt8tstTWOenyrB8GhLId0Mk6hScIz+WOeWFTC/spAHd7Wy92Q/lyypjmZfxAagzWlYH7pkAT3eAHvGqUo2G8UtTpCKaVLosKWkFKKWgjOBpWBPnMETT48nQFmC3aepFJI1FRyIcx8loshp4/PXL+f1lr5oYRsYQWaH1RJNIY7HnaR3k6kUUo0peP2hUUWVYLgYrRbJSkyhrNBBVdEUuo+SWAouuzWSQpx999GvXz7OyT4fn3vDsjHWZCI5Mgngx+MLhOgbCiS0FMCojZqJlsKHlVLRXglKqR7gw7kRKbeYX6JdzX0JA2suW+JLsvMr13Dnew2jaDgQHtO1sr6ikKoiR9LS+VQwYwqmpeC0GaZlqkohmhGVILXzosVV7IpM17p0SXVUdjMHHkYWKdOyGK9vz+BwELtVEgZYTYpS3OUPmpZCgt2jaSlM1Iq7dyiQ0FIoctoJhVVSa8v8m+MzYeK5YfUc3A4rT+wbcau91tzLitqSaFwpHtN9ZNa0mKQbU/AMB8f4wEUEl82Ske/btBTKCiKWwsBwxq24UyFZTAGIjFDNrnIaHA7yo2eOcPHiKi6M3NvjUWC34g+FszYNzVxnZhWPtRTA8AjMuJgCYJEY9RppYeEY5/y8xdyNAwm/zMkWubLCkXmuI5bC6Eswt7wQfxodTcfIFnmu2XbD+OKnngnhi1oKY/8Gc6EvL7SzqrZkpN13TPsLs+Pm0ppibBaJdv9MRHzqayJSDRKP7NYTZR+lFlDt8/opLRh7S0YH9SRx1cQHmpPhtFm5ZEk1T+07hVKKcFixu6Wfs+cmjidA8t78UUshRfdRssK+TPPpe70Bil02bFZjBoUvEMaTgzkC8cS3zY4lnWl5qXLX8410e/z80xuWpXR+sgSByWLGGasTBJrBuLdmYp3CY8D9InKViFwJ3As8mjuxckeMTkiYfjreQmfeLA/ubMXrD41RCnaLZLS7CMalpEJ6JfdmQV2iv+GChZWIGMrBYpHorjq2jsBceIucNuZVFo6rFLz+4JgGcPGkWng2rvsocs09E9SAJLMUJlQKcYHm8bhqxSza+n3sae1nd2sfg8NBzk4SZIbkDf3SjSkMJogpgLGYZGopmCm81RHXRq7TUpVSE1oK2WyK5/UH+b/nGrlu1WzW1CeO/cTjyrZS6DcthcRKId8shYm/CQafAz4CfAyjUvlxYFqa12VKrKUQiLgkPnHFIlbOKWXb8R7euGZOsqdG/fAnI2MQK+OVgtUS3e1PhkBcSioYxVipDjNPFmgGI8Pke29by1mRnW2R04bNIqNe2/SjOm0WFlUXcWSc7qDJdq+xuJ22lAr6TPdRvN8cRirGDddY4i/VcDCE1x9KGFMwF59krhpzYU606MZzxfJZiBgZWi8d6aKs0M7VK5IHLZP15o9aCv4g4bBKGMeKxesPRWdLxFLgsGY0T6HHG4jGyaI1AoPDLKga29wvWwwFQgTDKmFMAYwMpC3HsmcpHO304PGHuHFNbcrPKfz/7Z15lGR1efe/T93aupbpdaZnmJmejQFmEBhgYASFoCxuEUSNQoh7Xo4mvupr3KJ5FfEYT8wbPe+bEANJ1BxzXDFR9KCoRDC4AMPOzDgwDDD7dE9v1V3Vtd7n/ePe361bVXetqttV1f37nDOH7lp/VNf9Pb9n+z5NKAk4IYo5rBLNQPd5Cp6MAjOr0LqavxLscoJHNcVMS2UViaiCj75Ka9B+3bn2BgHQwjkXbRw0ZKLrPYWw0poOe31JKqCdLsRJww27RLPgDedXpaeING+hJnxUriAaDoGIsGVVCr/cP45SRUVEaXw9K1XTepIxBdmiluR1Su4JdVmrjdkuWWtGbLLNegrJqOIpFzSSimHH+gHc8auDyBUr+MIbz6lRZa2natCsjQKzVm7qVPkEWOcUAL3JqqXwUdVTMIxCwJ6CnTCcYDgVw1SuiHJFbZCXaQYh7+Ika1FPu+c0j8/lEQ4RhhLW35VYuLs8Ba99Clt1wbq9RHRQ/At6cUFgblYrq2y54TkxkIgaIYfhlIWnoHsiL5zK4uu/fh5fue85/P29z+KHjx91X1tdSSoArEzHPZcKis7n+j4FO/r7IjXho0JJNRLtW1amUKowPnPXHkupCi+eQiIahsrufRbz+TJSsbDlidmu1t+MWF+/xUWXNjwF6+fP5RuHqTtx1bZR5IoV7Fg/gLfudNZv7DNyCo2JZpHTcatAKle0kZtWBjMeCbV0wtTCR9o6jPBRwBVIczay2YKRVBTM1TGhrSI6+dcP9bk8skqfTS6oWcYzBYykYrYeYTyidJVR8Bo++hqAzwD4MoBXAHgXrAXvup6akZoVtSZU4wWzta9PbIZDZGzsN/3Lgw1D26/bYSUSW6Wk2nsKbqdtoHqycYv1CwYSUUNyGtA8BSHJvGvTENYO9OGbDx7Crk1DDWvPlSoNOi71iMRxtlh29Cq0k7D1/UkPOQXh7ViFj1KGp2C9ycwXyp7yCYLXn3safvzkcfz19ee4hn2swkf5UgXFsoqtq1KaYme+jDX2aQkj8WtlgOMRpSVplZlsCQP693koGUWIFsFTEEbB5rsjPJfpXNEwVK1weDqHdDzs+l0141dexo2TcwXLbmZBLBzyHCJeDLwek/uY+V4AxMwvMvMtAF4Z3LKCw2wUSmXr0IgTA8nql6v+Qo2EQyjqIaBmXM+KauUpaMqRXqpCnHIKVgz0RYxadUA70YuGufVDCfz0Q5cBAE7MNnZpLxTLRuzVDmGc3CqQ5gtl2+ofuxCMGSvZbIFb+Ggub//eVowNJ/CTD16G7afZN+0JIkoIUSVU87cTaxVy1W7JZuFlWIWP4i1o9JQqmlSL+MyUEGEoGXwDmzF1zcYQu/29/HJoKof1gwnXA5UZu6qxZhnP5G2TzED3eQped8S8Lpv9LBG9n4iuB7AqwHUFhtkoTOdKvvsKrDTtBRGTpzCSagxl1IvvNd5fW5IKVCsWxjPu8hniSxyzqZuvpz9RaxQK5UqNSFk6HkEqFsYJi/f2lmj2Vjk052gUrEMwZmZyjfMGBKloGERV+el65gtl1x6FVuiLKlgwrV3kE9bpgmxuvQris7PLKTS7mVgJCI6kopgIUKEUcPcU0i6FAX45PJXzFToC2jerQjAxV8AqmyQzoF2v3ZRo9moUPgRN9+gD0OSt/wTAO4JaVJCYjcLx2QXfnYvmEEV9SCSshIxk8Zr+xi9ixmUkplVJqp9SwXypglg45BrWEAwmosaGqj2/6ikIRlfEbDwF90RzwkM+ANA8CbsQTsIIQbknmvstPIVQiJCKhu3DRz49Bb/UazdVjYL2/XAL/xiegmX4qHmNHiup8XbNGXfCmLpmk1Nop6egqowj0wu+ksyAfyFKJ0oVrdHVyVOIdVlJqqtR0BvV3sLM88x8hJnfxcxvYubfeXjuq4loPxEdIKJPODzuzUTERBS4jpLZKMTCId9xy4RpA6k/kUeUkNG8NmixQbkNe6nvaAaqXZDjHoxCoVTxnGQGNAOXLWoxbkAzKvE6OeM1/X0teAraZ+W28TltzMKwLDh6CprHl7Z5DSf9I6fQVTvoiyo1ooD1RsFt8xOfnVWeqC+iNK2SOm3hKaxMxQLvUxDXgJ13Jm5vVYYe0JLmhbJqTB/0il0pcTMII2vXzQz0oMwFM1cAXEh+gnIwjMltAF4DYDuAG4lou8Xj0tA8kAf9vH6zmI1CrlixDPM4YQ4Z1X8kEYWM6qNiRTWGlwhmXTwFEV4yh4+E0fJiFKxO+k4YDWz6ugpl1dB3F4yuiDd4CqouG9Hn1rzmoZwU0MtCbTZm8Xk7J5qL6O+L2MaNnQbtzOf9JZr9kojWxv3FZ71WeApuOQUjfGThKUSbzylYjfgUnkKQUheZhRJi4ZDt4aWd4aNq5ZE/o9DOklS3xjVA8xR6URDvMQA/JKK3EdEbxT+X51wM4AAzH2TmIoBvA7jO4nGfA/BFAM1rTvugwrVGIeoz0ey06YZD1ea1QklFNByqaXC741fPOb52ucIgqhXlG0xEEFHIW/io7M9TECWcIoRk7SnEMT5XqDGm4nTq6in4SDTbnfKVEOkzc+1fYzpXcqwusfMUVJUx76FPoBUSkVrFTWEUTuvv03IdbjkFp0RzWMspuOlCWWGVnB9JxVAoq64ebSvYieEJEhEFRN4lQJwQYo9OA3WsENdAOxLNJ3Uv27n6SEGxrC6K7pQXvO6IQwAmoVUcvV7/94cuz1kLwCwZekS/zYCIzgewnpl/7HEdLVOu8RTKtmJmdjhV9kTCZJz2ixUVsXAId77vUnzqtdsAwFX9saxyjZcAaN7IylTM05yGQkn1nGQGTJ2b+onIylNY3R9HReWaWHPOoUzSjNjInIwCM9s2ZxnrdJmpcHgqZ1TzWJGyMQpaYx1sDVI76LPwFIi0HpFUNGybABeI/2+rPgVxom0mHm2epSDYvFLrZH7m5Jzv1/OKnWy2IBQipGLO0/K8cmhSKwkXoTqvhELUcg+IYNxFDA+oHjS7Ja/gtaP5XU28tpUvb+zIejXTl+Fh2hoR3QzgZgAYGxtrYilVzKeqbKHiuyTV6SQeCYUMoyA8hU0jSfyPyzfjV89OuMaPtS7Oxo9NKFi64ddTEAbRKacgBtqfmM0bbfr1o0jtMHSLHDb0QllFWWXHEE4iZm8UVJVxYHweb3FoJEvHI5ZT5vzoHjVLIqrg2Ex17ZmFEtJ6o56dsTIjDKqVzIVoNNRCed7/7oDmXUUUqklgn6vPhXji8Awu2jjk6/W84uYpAFoSuh2J5sPTOYyuiPm6JgTtmqkwPlcAkXU1okBU/BVKalNrbTeergYi+hpMG7qAmd/t8LQjAMxX6joA5oG9aQAvAXCfHgteDeAuIrqWmXfXvc8dAO4AgJ07d7bkY5k9hYVSxb+n4HDxhRWCytpGVaioGIhWv/yxcAiTLieBssoNU94Arav5F/tO4uDEPDavtJ9f4NdTqDcKdp4CAByfzeM8/a8pQhpuTXKxcAhKiBwvLnHxO53Wkw4X6LHZBeSKFWwdtf9ctPBRY5jGq0JqKyTqZkzP5IpGlVTaZVQoUM2lWPWEiO9iMyfamVwRA4naSXUr0zGsHejDE3UjVH994BR+bRpG9frzTsO2Ne59GlZkFqoNc3Zo887bk1PwGzoSaHOaWz+5T8zlMZyMOUp2VD2FCoDgQple8Xo1mMM7cQDXo3aDt+JhAFuJaBOAowBuAPDH4k5mngVgiJsT0X0APlJvENpNffzVr6cwuiKOVekYbtq1oeE+Y5OtqCiW1RqDEzU1ttlhpzN08aZB/GLfSdx+/0H8zZvPtX1+vlzxtcGJ9xLr0kpaazcfEZY5YhrG4zV8RKSdRJ2SxMZ8ZseZufaegpj5cLqDsUzHrcMRc4vkKdTnFAb0TvhULOw4KhTQQpzxSMhyU2mldNIscWHm3HX9xtwNQAvvfezOJ3FsdgHhEKFUYbw4lcNtf3yB7/cEtEPA2LCz4J7btDyvHJ7KYdfm4aaeq6kTt8FTsBnDaUZcc+0c7NMKXsNH3zf/TkTfAvALl+eUiej90GS3FQBfZeY9RHQrgN1iTvNiU64zCn5O1oB2IT/0qass76v+cSt6I1j1tSNKyLV5rVxhy/DRzZdvwX8/ewpPHZ21eFaVQknFcNL7/0/Mg6cwmIxiOBmtGbhjhI88hCySMefpa0YIx8VTsHsNsa6tNtPPAC0cUSyrDc158x68lFax6lMQSfF0PFLTJ2JFtmgtmw34n8xnZjpXNU5mzl03gJ88fQLT2SIGk1E8NzGPozML+Pz1L8FNuzbgnV97CC+cslfPdSOTLznmFADNSLc6U6FYVnE8k/ddeSToa6Fb3My4i8QFUL0OC02WF7ebZmUItwJwDe4z893MfAYzb2Hmz+u3fdrKIDDzFUF7CUCtSioA39pHTgg3MF+y8BSUkLH52lFS1RrdIzMvWduPZ07OOW4AeZN2kRfMno2qMopltSGnAGgjN581GQWvnoJ4jFOS2ItRcPMUhpPRBsVaM3YNUYuRU+iLahVConrLbBS85RSsZbMBk0ZP0+GjRk/hvPWaEJOYP33ffm386B+csRKANnb2hVPZpipltFkKZdecQjoeablP4djMApiB9T6TzIJWFWgFJ10kLgCzce8OT8GrSuocEWXEPwA/gjZjoeeon3fgN6fgRLzGU6iN70fD7kaholp7CgDwktP6UdaTqnb4zSmI8FFJV+IE0OApAMDW0RSePTlnbAQ5I6fgbhS0+LCDp5B335idDMuz4/PY4jAnWqwBsDAKRiNVgCWpdTXvs6ZNcUXcvfooazNgB2htM9FmKTQa0nPW9oNImz8NAPc/M4HTV6UMWY5NI0lki5WmmtwKZRXFimrbzSywywH54ZDeo+C3m1lQXzXWDKJqz26OgqAnPQVmTjPzCtO/M+pDSr1CpcFTaKNREBdpudLQpevFKJQr1olmoFpWZyU5ISi0UH0kvpBWnsLWVWlk8mVjI6iGj9xP2G5VHCJp7eQpaHrzjRcMM+PZk3MNTYL1iE2/PqkrdHiC7WiuSn2IqWOGpxBz3/xyxYprY5/fzatcUTE5bx3WSMcj2LIyhScOz2ChWMGDz08ZXgIAbNQH8DzfRAjJkLiwGcVprKENJalGj0Ir4aMWPYXJbAEqOzeuAdV9o1tKUr16CtcTUb/p9wEiekNwywqOihqgp6CfsrOFMhZKlZoTaDQcQqHJRDNQndp00qFfIV+yDv/YIRr3imW1OnXNwlM4Xd90RQipWjvvJafgnGie81ABZGdQJ+YLyOTLHoyCtXy2l9BVq5ineOVL2knZnFPIl1THXFO2WLb1yMT3ze/mNZktapuVzQn23HX9eOLILH578BSKZbXGKGzSk8QvTDZhFPTP380zS8fDNQeVZjg8tYCIQq6ndDvcwp5eEN3MKx16FICqp9Atonhed8TP6NVCAABmnoE2X6HnqK9X99vR7ISw+KJJrcZT0BPNdrHY47ML+Nnek7bho5FUFETASYcpbNo8BB8lqUq1acbZU9A23Y/d+SR+/OQx04Q3j4lmB09h3kP1UVRRDAVZM0bl0Sr7JDNQNQr1p8/5vLbh+lXK9YNZhlnMrjB7CmIddngLH/nbTMRmNWpzgt2xfgCn5gv41kOHEY+EcPGmas/CaQNxRBTC86ca+z7cmHWRzRbYeXZ+ODyVw7rBRNN/23i09RGZwrN2TTR3WfOa1x3E6nHBHa8CpP50W1+N1Ari5Ca6f82iX1ElBGb793v8kJbYe9mWEcv7w0oII6mYrYR2RWWUKuzPUwiLnAIbnoJV+GllOoabL9+MmVwRP997ErliGUqIPBnUhEtJ6ozeROWUn7DzFESFyqjLRZeOWU85C1oMD6id4mWoufZV+xSs1mXGKdHcrFGoSi/YeQpaE9vP957EJZuHa74TYSWEsaFEUxVIbrLZArsckB8OT+d8dzKbSUTa4CnoXr1r+Eg0r/VSTgHAbiL6EhFtIaLNRPRlAI8EubCgEFvy687R5jGvbtK9tEKUO57SNelrjEJd+Wc9p3SBsne/fJPt64+uiBkXdD3iC+XLU7DIKVglqokIn3ztNpyxOo3J+aKmkBpRPA0u6YuEHRVOp7IFDCdjjq8lejzqvSyvHotIYs/XhY/mfE5dawbhAS0UK8bY0IFErVHIOOQVckV7w1VtXvN3wqwOkrferLatSRtVeebQkWDTSLK58JGLbLagHUqph6ZyTecTANGnUGlJj+ikET7y5j6pMj4AACAASURBVCn0VPURgP8JoAjgOwC+C2ABwJ8HtaggESWpYg/yp/3qjDhRTcxrG3d9TgGoGoX79o9j0qQnNDVvPyhGMJqO24aPjJO+jxyJEiKECChWKo6egmA4GcVktuhploIgoUtH211ck/NFx3JSwNRPURd7FydkN7mNpM1Mhvm8vRBfuzBUXotlC0/BPUySLVZsO8fNMhd+OJnJ69IL1ptVLKwYHctXnNk4S2vjcBLPn8r6FuIT4TvXRLP+uTgZSyfm8iXM5EpNVx4BmlFgbi2kMz6Xx2Ai0tAQWk9V5qKHPAVmzjLzJ5h5p/7vk8zcfAdLBxHf4zfsWItYOITtTbbrWyFOOMdmNKNQX30EaBtbJl/CO7/2MN73748a909lC1gRDzsmvkdS9kNQqp6CP+2UaDiEUoU9eRrDyRgm5wvI5EueT9huF9dktohhF/lyc0LcTM5jE10srCCqhBrCETO5omsoo1XM2vzihC6MoFuYpKR3xtsl9MNKCBGF/OcU5vIYTkYdK++u2jaKCzcMGtVGZjaOJFEoq5ZzNpzw6yk0Gz46PKUJ4TUrcQE0X9llRutmdo9EGP1NvZRTIKKfE9GA6fdBIronuGUFCGvy1FdtH8XeW1/t2Anrl2F9+LlIgJrDRxHTxibisaKWGtDCR8M2JzeBU3dw9aTvL3Eumuqqnob9BjuUimIqW8TRmTxOs5gsZ4XbvNvJbKFGXtxyjTahN3HBesmjpOKNn92JTB5r+tsXPrTCPGP6wPg8klHFeE+3MImYpZBw8GbiTZROetmsPnDlVnz/fZda3rdJNxR+8wqZfAlRh1kKAuNzadIotNqjALRnJKeXbmagVhCvG/C6g4zoFUcAAGaeRo/OaFYZCOkxo3ZXnYSVEFal48aX0nyarjaoqEaNt7mj9OBE1nVzTMUUZIsVS7ddnBbdXNV6oromv/F8R08hirKq9QZ43UyTLiM5p+aLGEo6XzhRh/BRPOJt/GgyptRsvqWKivG5QltzSlZUE81lPDs+h9NH00b+JGVTKiuo9nDY/03jEcV3LPrkXN7TZmWH0avgM68wly+7eglA64N2jhg9Cs0nmvtcDjNemJgreJrsqIQIEYV6LtGsEpEha0FEG2GhmtoLqMwIsAIRo6bN0nwBiM3x/977LF7Qy/nE/T/bcwL7jmdcY+siaZmzOL2I8Ix/T0GbAeFFDluEeXLFCtY4zC8w0xe1d8PzpQqyxUrT4aOFUsU1nyBIxWqlEybmCmAGVnv0eJrFHD569uR8TU+F+PvbdTXnPKjR9kX8l06ezBQw6iGsYceaFXHEwiH/nsJCyTWfALReffTiZA7peNhx8JIbrUiIAFpj5fhc3nOfRCzs37gHhdcs26cAPEBE9+u/Xw59vkGvoTJAlqMe2sOaFXE8ASAcoppKnsvOGEFEIZyczWNI9xByugrjY7oq5V/qw3jsMA+tqa9IEV9ePyWpQLXc8/B0DiGC45d42HSiP82jp+AUPprUK66aDR/lin6MglITjjiud4YHHT6K6HH/45k8xucKNUYhFg4hHCKH+dH2ozgF8UjIV9xbdDO7lfE6EQqRkWz2Q8ajpxANhxALh5quPnrq6Cy2rVnhqTrODnPYrxmmcyWUKuxajiqw69rvBF4TzT8FsBPAfmgVSH8BrQKp52BwWyuO6lltihebv5SxsILrdqzFi1NZzOgJt+ms9l9xgtxkkdQzYzQ7WVwsTtpFTgijcPBUFuuHEo6JbrMn49dTsDQKetLcLZcSNYXezCyUKoh7rIJK1TXRidLe1QEbBUA7dT6pC8yZ5z4QkeNMhVzBo6fgYzMR3cwrWwybbRxJ+DcKC+4DdgTpeKQpqYtSRcXe4xmcu7bf/cEO9EWbq+wSVHsUvH3OzYQBg8JrovlPAdwLzRj8BYBvALjFw/NeTUT7iegAEX3C4v73EtFTRPQ4ET1ARNv9Ld8/bMopBIE4aSsWaqcbhhI4mSngh49royiOzixg9wtTeG5i3pCScMJpvGWzOQUh6f38RNbVKJlLGL17CvY5BeEpuIXNbHMKxYonUT5A++w64SmI9/79cW3E5da67uuUg/ibKKF1arCL+5R4FsbQrpvZKxtHkjg8tdAgG+OEF9lsgZUo3jd++wK+8/Ahx+ftPzGHYlnFuesHHB/nRl9E9Jc0562IrnGvuZue8xQAfBDARQBeZOZXADgfwITTE4hIAXAbgNcA2A7gRotN/5vMfA4z7wDwRQBf8rP4ZlDVYD2FK7etwmVbR/Aeiya0a85ebfwsNrMfPXEM45k81niIbTt5Ckb4qImS1EJZxQuT7kahGU/BMXw07zF81IacQrpOkfTE7ALikVBLcWev9EUVlFVGX0RpmCU9korZ9p54UaONRxRfpYyGxEWLnsKm4SSKFRXHZrwFDMoVFUemFzwn9tPxRnXdr/3mBXzxp/tRdtCKEjNHzlvXqqfQWvWRmIHtduARxCJKz8lc5Jk5DwBEFGPm3wM40+U5FwM4wMwHmbkI4NsArjM/gJkzpl+TWITkNSNYT+GM0TS+8Z5deN8VWxruO3N1Gpdu0SZBXb19FOes7ceBiXlki5Wa8lU7Uoan0PhFFbf5lW2IKiEcmc4hV6xgs4tRiIZDSMfDSMfDnt/Hqd57KivCR83nFLwawVRdOe/xWc0QtxJ39orY1E9flWqolNo4nKwpTTbjRReqL6Ig78dTEGGNFnIKgH+11OdPZVEsq9h+mre+IE1Btvr3YmacmM1jMlvEQ89P2T7vySMz6O+LtFSOCriXUrtR36joRiwc6jlBvCN6n8IPAPyciH4I93GcawEcNr+GflsNRPTnRPQcNE/hAx7X0zQqB+spuLFBV5kcTESxeWUSvz4wCcDbZm505lp4Csap0iEpaUU0HMILukjgphH3ENZIKua5RwEwVUxZhY/mi4gqIdf/dztPIe/DU0jGtFnJItxxYjbfUrLVDwk9FGGl5jo2lMCx2QXL0IHRp+DoKYR85RTGMwXHbmavGL0KHstS9x7Xzn9eZzvXh48y+bKxQf/4qeO2z3vyyCzOXdffsrGPWxxmnj4669kz8tqoJ4jpHns34DXRfD0zzzDzLQD+N4B/BeAmnW31V2nwBJj5NmbeAm1oz19ZvhDRzUS0m4h2T0w4Rq1cYbZe2GIh3NpNI0mcb4p7eukQdgofOQ14d8IsaufldHXW6jTO9eGaGycui1OQ6GZ2u4DtcgoLJe85BcPL0o2T8BQWAxGKsGqU3DCcAHO1C9dM1ktJqs9hMOP6IPlW54isSseQjoWx/8Scp8fvOz6HiELY4jBL20w6HqnJAYk5IqlYGPc8fcIyhJQvVbD/xJyv76cd9SWp+VIFN/7z7/B3P3vG0/NnF0roiyiepfnjEaVrZC58C78w8/3ujwKgeQbrTb+vg7N38W0AX7F5zzsA3AEAO3fubCnExMyemp2C4oaLx3DN2auNoem3/GgvAOcQgcAp0ZwrlRENWw94d8L8pR1yCeMAwD/edAH8aITFwiEQWYePJucLnmKuTh3NXjWYzDLVqWgY43P5Rak8AqqG0cpTEJ7joalsQ7GBKLl1arKMhf11NJ/0MEjeC0SE89YP4PHDM+4PhuYpnL4q7XmTrA8fHZ/VjOYNF63HvzzwPB56fgqXnl6rKLzveAZllXHO2taSzID2nQuHyPBO7tlzAnP5MiZsZGbqySyUfeWres5TaJKHAWwlok1EFAVwA4Ca2cxEtNX06+sAPBvgegDUdjR3iqGkdjo2n5C9CLOJzWVKT2IJbRxACzV4GXpTj7hIIwp5ej4R+TKqRGQrQzyVdRfDAxwSzX5yCvGqQZ3MFlGq8KJUHgFmT8HKKGjeWf2cD0DzCJ16FMRr+5FH0Bqq2hM2O39sAL8/Mec4WU+w73gG29Z4l5RZEQ9jvlg2uveFp3DDxWPoiyiWISQxQlTMmW4V8/S1Ox85AkDTy/LCrMdGPUEvJpp9w8xlAO8HcA+AfQC+y8x7iOhWIrpWf9j7iWgPET0O4MMA3hHUegRBdzQ3ixdPgUhriLv9/oN47NA0zvvsz3D2Z36KqWxRn9DlX/FThBH6+9zDOM3SFw3bNq+5VR4BJokQi/CRn5wCoHUPiw0maIkLwYp4BH0RxZhzbGY4GUUyqlgahVzB/W/aF1FQrKieS0NPZtxnBnvlgrFBVFQ2NmM7Ts0XMDFX8CU+mY5HwFwb7iPSjOgrt62yDCE9eWQWI6lY2/6uIjR3YjaPXx84BUA7yHhh1jR21QvxHkw0NwUz363Pc97CzJ/Xb/s0M9+l//xBZj6bmXcw8yuYeU+Q6wGESmr3WAWhW++1muejr9KKvu5/ZgK5YgWlCuPgxLzmKfhMMgNVT2EwEVxpZiKqWNZ7z+XLnpqZjGFAppNUqaKirLLnnELaFHoToYjFyincfPlmfP1dF1mGgYgIG4aTeNEiYZt1mM8sMBQ2PWwo5YqKU/PtCR8B2oQ2AHj00LTj4/bpSWY/RiFVp5R6YjaPlSktF/KH56yxrEJ68sgMzmtDklkgZir852NHoTJw5VmrMJPzpsek9WT4CB9Flkf4qEvpLk9BnNS9lKQCwFsv0tI0z01UN5Hjs/mmPQURmnGa49AqVvNumVkbNenBGFolmhd89mWkTMqbJxaxmxkAThvow67Nw7b3bxhO4EWLstRcsewa0vOj5jmZLYIdZjP7ZTAZxeaRJB475JxX2Oez8ghoVJA9blK0veLMVQ0hpPlCGQcm5o2pce2gTw973vnIYezcMIgd6wcwXyjbDsoy499TaH38Z7tYdkZBVTufUzAjjILXzS0djyAZVQx5bkA7ReWKrXkK/QF6Cn0WRqFQ1k76Xjwkq5yCIeDntaM5Wg0fHZ/NI6KQp9DVYjA2nMARi+7g+ULFUTYbqM7P8LKhGGM42+QpAMCOsQE8dmjacULZvuNzWL0ijkEfn3e9UurxmQXDiPdFFSOEJO7fc3QWzGhL5ZGgL6rg0Ren8dxEFm++cB0G9PV7ySv4kfQApKfQUTrdp1DP1991Ed54wVpfG9RofxwHJ6pG4djsArIe4s9WVD2F4IxCMhpuSEaKE6AXoxBWQtqEOCuj4KOjGdDCR0entQ2mk1VoZjYMad3BIqwFaJ/P749nsGnYuUzYj5rnyTZ1M5u5YGwQp+aLODJtX7/vN8kMVL8XGVP4yBzue/tLN2B2oYS3f/UhZPIlI6/RTqOQiCqYzBYRC4fw2nPXGNfItEsISVUZcwVvoVFBLKygorJjt/ZiseyMQtAdzX45f2wQX3rLDl8b1OoVceNUoYQIJ2bzWCg1V31UDV8trqeQ9dCta0bMaRaIcIkf7SNACx+9OJXDhiHn7u3FZKO+8R8yJZvvefoECmUV1+44zfG51SYr981EiLS10yicP+acVyiUteFCfkJHAAyNpPl8GXP5EuYK5Zpw367Nw7jtpgvw9NFZvO1fHsSvnzuFtQN9ruKKfhAG91Vnr8aKeARDeoh12sVTmCuUwey9mxnorulry84oeK0e6GbM1RVbV6W0nEKhgr4mPIWK7vY3Y1C8kog21tJXPQVv7ysmxAmEkfEadosouhxzsYzDLQ51bzdjoizVlFf44RPHsG6wDxeMDTo+1/AUPHQ1nzS6mdsXNjtzNI1EVLHNKxwYn0dZZd9GoRo+Khthr/oS4ledvRpfuelC7Ds+h/v2T7TVSwCq3603XbgOADAgjILLHlLtZvZRktpFc5qXnVEoq4zJrLcGlG7FPMjnrNVpvDiZ1ZK2TWzsoirI64m9GawSzVljVoBXT6G2jluES7yGjwAtJHFiNo+pbLFlbZx2sqa/DxGFjLLUibkCHnh2AtftOM21ksaQePbQ1XxqvoChRNR3g6MTYSWEc9f123oK+3R1WK+aRwLzVLrjDiXEV20fxe1vuxCxcAiXbV3p6z3cWDvYhw3DCbxcb5IbTHoLH/nVPQKkp9BR+iIhX9o93chqQ56bcPGmYUznSprkQxMbu5Bnbua5XumLhBs2rayPnAKg9Sq0kmgGtI1GVMJscInVLyZKiLB+KIFDU1pF2Y+fPAaVgTfsaJAKa0CcML3kFPxWxHjlgrFB7D2WsVzD3mMZxCMhbBz2F65LRhUQaR5lVebc+rp9xVmr8Ninr8aNF6+3vL9ZPnrNmbj7A5cZpcSDHsNHhqfgM6cASE+hI1RU9i0v3W2ImHAqFsaFG6rhhWY8BWOQS4CfieYplGsqVOZ8GoVWcwrivUQpbzd5CoA2a0OMaf3h48ewfc0KS62kevxIPM/ly0gHYBTOHxtEWWVDttrMvuMZnLl6he956ERkSF2IZkMnZddENNz25suwEqrxZOMRBX0RxTV81IynELMZJNUJlpVR+OX+cfxi3zgyTQ4E7xZEwi0VC9fo6TQTAhJfXC8DxpulL6pA5dovvO9EsxJC0RQ3X/CZUxDvJco+uymnAGgaSHuPZ7Dlk3fj8cMzuM4lwSwQ//9epC4yC96H3PhBJJt3v1AbQlJVxr4TGWz3WXkkWBGPIKOHj4aT0a44zA0mIq7hI7G/+PEU4j76TYImuJhBF/KV+54DAMfyuV5AhI/S8TBCIcI/v30n9h7L4DUvWe3yzEY+/pqzcPbafly2dcT9wU1iHl4vvvxNVR+VGz0FPzkF0dU8kIgsynAdP7z7ZZuwIh6Gytr/6x/vGvP0PD/Na3P5UsOQn3YwkorhrNVp3P/MeM0ckSeOzGAmV8JLHRr3nBCjSqcrRawZWJxGQzcGk1HXPoVmPAVhQMRzO8myMgrBj/BZHEZSUYSouqFevX0UV28fbeq1EtEw3rKzvbHYekTjWK5UgQh2GQNkPIZ/IgpZho/85BTE59VtoSNAq0D68DVuc6saEQlKL0Yhky/7EmnzwyvPWoXbf3UQs7mS0Qj5i30noYQIV5yxqqnXFOGj6VzRUjeqEwwmooYgpR2ZhTKUkDeBSYHoU5qa73x15LIKH3WR5FFLhJUQVqZjvqesdQqxcedMkt/ZQhl9EcVzJUyDpyDCRz5mUouKlm4LHbVC3EeieS5fCqwf5cpto6iojPufrc47uXffOC7aONh0t7w2QrWEEyaJi04zkIi46h/N6mE6PzkOIVvfDSXzgRoFIno1Ee0nogNE9AmL+z9MRHuJ6EkiupeINgS6niBffJF54wXrcNW25k5gi43VcKB5j7pHgmhYaQgfxSMhX01/Yh0blpBRCIUI8UjIdWxkoVxBvqQGklMANHG8oWQU/7XvJADg8FQOvz8xh6u2NefBAlqvwsRcATO50qLpVLkxlIy6Vx/l/Vd5pWNhRBTCZBcYhcCOmkSkALgNwNXQBu48TER3MfNe08MeA7CTmXNE9D5oIznfGtSaRCdzFzU0N83HX31Wp5fgGat46Xyh4rlxDdASzYU6T8FPPgGoGoVuDB+1QioWsZzGZ0aojQblKSghwhVnrsS9+8ZRrqi4VzcOV7ZgFFLxsCHN0T2eQhSzCyVUVLatqJr1qXsEaNVWQ8moMbe8kwTpKVwM4AAzH2TmIrTJateZH8DMv2Rm0cb5O2jT2QJDGINukrlYDvRbGAWvCqmCmEVJqjQKGiIh64QwCkHlFADgqm2jmF0o4dFDM7j39+PYsjJpzHJuBrNycLd4CoMJbc6DU0K42X6QoWRsyYeP1gI4bPr9iH6bHe8B8JMA12MyCkG+i6QesRFlajyFsq+ciFX1kZ8kM6BJWEcUahh72eukYmFXT0F89ulYcFVXl20dQThE+OHjR/G7g5O4qsniB4F5HsFizb5wQ0wKdAohaaW//j/n4WS0K8JHQRoFq63Xsv6HiP4EwE4Af2tz/81EtJuIdk9MTFg9xOOCRPhIWoXFxMpTmM/7NApKY6LZr1G4ZvsoHvj4K9s2T6BbSMX8eArBGYV0PIJdm4fwrYcOoVThlvIJQG1j42JNyXPDi/7R7II/hVSBFj5a2kbhCABzreM6AMfqH0REVwH4FIBrmdkyoMbMdzDzTmbeuXJl8/om0lPoDLGwgngkVBs+KvpNNNeFj5rIKYRC1FaF0G4hFQ8bHeJ2VBuqgq1Yu/KsUaishVncxPzcEOGjgUTE9wEgKLzIZ2fy/uYzC4aS0SVfkvowgK1EtImIogBuAHCX+QFEdD6A26EZhPEA1yLeD4DMKXSC/r4IMgu1Jal+jUKpofqoOzaKTqOFj5zLJMUwmiAl0gHgSr0i7hVnrfItbVGPWGu3eAmAu/5RvlRBsaw2lVMYTkYxVyij4EHxNkgCOzYwc5mI3g/gHgAKgK8y8x4iuhXAbn1O898CSAH4nr5hH2Lma4Nak/iKSqOw+PT3Reqqj8r+qo/qPIV8qYJRBy2c5UQqFjZUZ+0QBjmoklTBhuEkPn/9S3DpltY75EX4qFsqjwAY0+PswkdV2ewmwkcp8dolrO7v3IEn0G8IM98N4O662z5t+vmqIN+/HnFwkTZh8TEbhXJFRb6kIuUj6RlVQihVGKrKCIUIuSbCR0uVlIfqo0y+BKJqd3mQ3LSrPe1GIny0ukuSzIDWgR9RyDZ81IzEhUB0NU9mCx2ttlpWHc0ifDTncgFJ2o/ZKFRnKfjzFAAY3kIz1UdLlVQsjGJFdQw7zOXLSMfCXTOC1AvitN1NngIRYTBhr38kcjfNlqQCne9qXlZGYSkmGXuFFSajMF/0J5sNVKWFDaNQlDkFQdo0utIOv4Pku4FVK2K4YGwAl2xpTlAvKAYT9lVCs03MUhCIctdOG4XeEM9pE0PJ3roolhJaoll4Cv6nvRmeQlkFMyNb9FfSupQxy4jYzSjO5MuBJ5nbTTyi4D/+7GWdXkYDg0l7/aO2hI86XIG0rDwFdYmopPYiK+IRzBXKqKhsms/sr08B0IxCvqSCWVN4lVQ/R6ewaCYfzCyF5chgwl7/qJWEfn9fBEqIOu4pLDOjoFmFs1Y3N/RD0jzi5JRZKFW7a31cOGZPIWvMlZbhI8BacLCeuR70FLqVAQej0Er4KBQiDCYiHe9qXlZGQUyDvPN9l3Z2IcsQc1fzYX3I0dpB71Ul5kRzTiSqpacAoCoJ7p5TkJ9XOxjSw0fm8bKCzEIJiaiCiEdJ+MbX7rwo3rIyChWVkYwqMhbdAcxG4dBkFtFwCKNp74l/c/hIegq1ePEUtPCR9BTawWAiirLKll3kzYrhCbpB6mJZGQWVWTaudQgxaCWTL+HQVA5jQwlf5ZER02BzkaiWOQUNw1OwMQqqnseROYX24KR/1KrxHU7GZPhoMWFGT9VpLyXMnsKLkznfg25iNZ6C/z6HpYxQPrUzCvPFMpiDFcNbTogqRqsGNukp9Biap9DpVSxPasJHUznfIzFrcwrSUzATj4SghMg2p1AdsCM/r3Yw4KB/lFlobQ72UDKKmVwJZZOky2KzDI2CtAqdQBiFgxNZ5IoVbBhu0iiYPQVpFABoXbZOMxVa0eORNDLoED5qZuqamWGhf+QyBzpIlplRkLMUOkUsHMJIKoqfPn0CAFoyCjmZaG4gFQvb9ikEPYpzuTGUsN+4M20IHwGd7WpeVkaBZfioYxAR3nTBOhyd0cpRx4b8jWk0qo8qFZN2kvQUBE7y2YanIEtS20I6HkaI0KB/VNErklrxyIZMonidIlCjQESvJqL9RHSAiD5hcf/lRPQoEZWJ6M1BrgUAVFXKZneSGy8eA6Cp1K7z0aMANHoKIarqIUl0pVS78NEizVJYLoRCZNnANteCGJ5guAtE8QK7qohIAXAbgNcA2A7gRiLaXvewQwDeCeCbQa3DjEw0d5aNI0m8/PQRrB9M+Bazi4W1xxfKKuYLZSSjYRkKNOE0ktMYxSkTzW1jMBHBdLbWMzMkLno8fBTkt+RiAAeY+SAAENG3AVwHYK94ADO/oN+3KKl2mVPoPF9+646aYTteMaqXciXkChUkZD6hhlQ8jMPTOcv7qrIi0lNoF1b6R62I4VVfV3tuJ0XxgvS/1wI4bPr9iH5bx2BmhGTEoaOsTMdw+qqU7+dFwyGkY2FM5YrafGdZeVRDOhY2mvrqmSuUEY+EjBCcpHW08FGdpyDmYLfgkYWVEAYSkaUZPkJ1+qWZpnRKiehmItpNRLsnJiaaXpAsSe1tBpNRTGeLyBWlp1CPU/gosyAlLtrNUDLSUJJqeAqJ1j7rTjewBWkUjgBYb/p9HYBjzbwQM9/BzDuZeefKlSubXpDKMtHcywwmIpjKlZAtSE+hnmQsjGyxgoqFPrymkCo/r3biFD5q1QAPJ6NLtvroYQBbiWgTEUUB3ADgrgDfzxWVWc5n7mHMnoIsR61FbPpCLNBMJt97U9e6nYFEFIWyioVidQRqpg05BWAJewrMXAbwfgD3ANgH4LvMvIeIbiWiawGAiC4ioiMA/gjA7US0J6j1AMB4pmAZ05L0BkP6GMRssYyEnM9cg6GUahFCyiyUZJK5zQj9oymTtzC7UEI4RC1/N4eSsSVbfQRmvhvA3XW3fdr088PQwkqLQl9UwfjxzmqVS5pnMKm57Ol4WIaP6nBSSp3Ll31rTUmcMSulrh3Qem6ER9ZqheNwUktiqyp3RMBzWZUjKCHChhF5cfQqQ8kocsUKpnMlmWiuw2kkpwwftR+hf2Se1Ty7UG45dARo3/OKyk2VbreDZWUUyiojLGtSexZxIRbLqvQU6kg7eAoZmWhuO1bhI63Kq/XPWYjidWquwrLaISuqCkW2NPcs4kIEpO5RPSl9pkJ9r0K+VEGxrMqS1DYzpMtRPDc+b9zWqkJq9bU729W8zIwCS6PQwwhPAZAKqfWIz6M+0SwlLoJhKBnFFWeuxFcfeB6n5rU8ZbvCdFWj0Jn857IzCmFpFHoWcbEAcsBOPWL6Wv3cYKPLVuYU2s5fvW47FkoV/N3PngHQumy2QIjiyfDRIlCWnkJPM2gyCklZklqDnacgB+wEx+mrUnjbJRvwnYcPYe+xjBY+asPnPCjyFR3SP1pWRkF6Cr3NgOkUCray9gAACt1JREFUlpA5hRrCSgh9EaVhpsLvT8wBgCxJDYgPXXkG+vsi+NQPnkKpwm3xFGJhBelYWHoKi0G5Ij2FXiashIyLTnoKjVjNVPjNc5NYlY5hy0p/Q40k3uhPRPDhq8/AY4dmALRvkNFQqnNdzcvKKOw9npFGoccReQVZfdRIum4kJzPjt8+dwstOH5GS8QFy48VjOHM0DaB1iQtBJ6Uulo1RODylac3bTaeS9AZCb172KTRS7yk8c3Iep+aLuGTLcAdXtfQJKyF85vXbEVEIG4fb45FponidMQrL5spaKGnCVW+9aKzDK5G0gvAUZEdzI/Xy2b8+cAoAcKk0CoFz6ekjeOqWV/meKGjHUDKKp47OtuW1/LJsPIVSRRvuJgbAS3oT0asgPYVGkrFaT+E3z01iw3AC6wZlknkxaJdBAKqieMxNjaBpiUB3SCJ6NRHtJ6IDRPQJi/tjRPQd/f4HiWhjUGsROvMRRcZWe5mRdAwRhRCPSONeT9pkFMoVFQ8enMSlW0Y6vCpJMwwnoyhVuKHvZDEI7LhFRAqA2wBcDW3gzsNEdBcz7zU97D0Appn5dCK6AcDfAHhrEOspVTSjIBPNvc27Lt2ISzYPy8SpBeacwtPHMpgrlGXoqEcxuprni4veYxLkcetiAAeY+SAzFwF8G8B1dY+5DsC/6T/fCeBKCuhqL+vho4gMH/U0q1bEcfkZzU/fW8qInAIzG/kEmWTuTYY6KIoXZGB2LYDDpt+PANhl9xhmLhPRLIBhAKfavZhH9Tpi6SlIliqpeBhllfHef38ETx2ZxVmr0xhJxTq9LEkTDOuewhfu3oeV6erf8JqzR3H9+cGOoAnSKFjtvvVZEy+PARHdDOBmABgba656aPtpK3D+2ABOX5Vq6vkSSbeza9Mwtq9ZgedPZZGKh/GOSzd2ekmSJtmyMoWLNw1hJlc09KsAYHJ+MPD3pqCy20R0CYBbmPlV+u9/CQDM/AXTY+7RH/NbIgoDOAFgJTssaufOnbx79+5A1iyRSCRLFSJ6hJl3uj0uyAD7wwC2EtEmIooCuAHAXXWPuQvAO/Sf3wzgv5wMgkQikUiCJbDwkZ4jeD+AewAoAL7KzHuI6FYAu5n5LgD/CuAbRHQAwBQ0wyGRSCSSDhFoBxAz3w3g7rrbPm36OQ/gj4Jcg0QikUi8I+szJRKJRGIgjYJEIpFIDKRRkEgkEomBNAoSiUQiMQisTyEoiGgCwItNPn0EAXRLB0gvrbeX1grI9QZJL60VWD7r3cDMrhoxPWcUWoGIdntp3ugWemm9vbRWQK43SHpprYBcbz0yfCSRSCQSA2kUJBKJRGKw3IzCHZ1egE96ab29tFZArjdIemmtgFxvDcsqpyCRSCQSZ5abpyCRSCQSB5aMUWhlHjQR/aV++34ielW3rpWIhonol0Q0T0T/EPQ627Deq4noESJ6Sv/vK7t8vRcT0eP6vyeI6PpuXavp/jH9+/CRoNfaynqJaCMRLZg+33/q1rXq951LRL8loj369zferesloptMn+vjRKQS0Y6mF8LMPf8PmgrrcwA2A4gCeALA9rrH/BmAf9J/vgHAd/Sft+uPjwHYpL+O0qVrTQJ4OYD3AviHHvhszwdwmv7zSwAc7fL1JgCE9Z/XABgXv3fbWk33fx/A9wB8pMs/240Anl6M72wb1hoG8CSA8/Tfh4PcE9r1XdBvPwfAwVbWslQ8hVbmQV8H4NvMXGDm5wEc0F+v69bKzFlmfgBAPsD11dPKeh9j5mP67XsAxIko6PmQraw3x8xl/fY4LKYAdstaAYCI3gDgILTPdjHoqrnrLrSy1msAPMnMTwAAM08yc6WL12vmRgDfamUhS8UoWM2DXmv3GP3CF/OgvTy3nbSy1k7QrvW+CcBjzFwIaJ0Na9HxtV4i2kVEewA8BeC9JiPRVWsloiSAjwP4bIDrq6fV78ImInqMiO4nosu6eK1nAGAiuoeIHiWijwW81lbXa+ataNEoBDpPYRFpZR60pznRbaRts6sXiZbXS0RnA/gbaCewoGlpvcz8IICziWgbgH8jop+wNvcjCFpZ62cBfJmZ5xfxIN7Keo8DGGPmSSK6EMAPiOhsZs60e5Eu6/DymDC0MO1FAHIA7iVtlOW97V2ip7V4fgwR7QKQY+anW1nIUvEUjgBYb/p9HYBjdo8hbR50P7Rpb16e205aWWsnaGm9RLQOwH8CeDszPxf4atv0+TLzPgBZaLmQoGhlrbsAfJGIXgDwIQCfJG3SYZA0vV49PDsJAMz8CLT4+RnduFb99vuZ+RQz56ANCrsgwLW2ul7BDWjRSwCwZBLNYWix1U2oJmnOrnvMn6M2SfNd/eezUZtoPohgE81Nr9V0/zuxeInmVj7bAf3xb+qR78ImVBPNG6BdlCPduNa6x9yCxUk0t/LZrhTXFbRk6lEAQ1261kEAj0IvPADwCwCv69bPVv89BM1obG55LUF/kRbrH4DXAngG2gnkU/pttwK4Vv85Dq1K4wCAh8wfHoBP6c/bD+A1Xb7WF6CdDub1L8H2bl0vgL+Cdtp+3PRvVRev923QkraP65vCG7p1rXWvcQsWwSi0+Nm+Sf9sn9A/29d361r1+/5EX+/TAL7YzZ+tft8VAH7XjnXIjmaJRCKRGCyVnIJEIpFI2oA0ChKJRCIxkEZBIpFIJAbSKEgkEonEQBoFiUQikRhIoyBZUhDR/CK8x7VWKpYBv+cVRHTpYr6nZHmyVGQuJJK2QkQK24igMfNdAO4K4D3DbK+1dAW03pTftPt9JRIz0lOQLFmI6KNE9DARPUlEnzXd/gPS5jvsIaKbTbfPE9GtRPQggEuI6AUi+qwuivYUEZ2lP+6dpM+zIKKvE9H/I6LfENFBInqzfnuIiP5Rf48fE9Hd4r66Nd5HRH9NRPcD+CARvV7Xyn+MiH5BRKO6bv57AfwvXS//MiJaSUTf1///HiailwX5WUqWD9JTkCxJiOgaAFuhSRITgLuI6HJm/hWAdzPzFBH1AXiYiL7Pmi5PEprm/6f11wCAU8x8ARH9GYCPAPhTi7dbA01A7SxoHsSdAN4IbYbAOQBWAdgH4Ks2yx1g5j/Q33MQwEuZmYnoTwF8jJn/grShNPPM/H/0x30TmiDeA0Q0BuAeANua/sAkEh1pFCRLlWv0f4/pv6egGYlfAfgAVaeqrddvnwRQgTa0xsx/6P99BNpGb8UPmFkFsJeIRvXbXg7ge/rtJ4jolw5r/Y7p53UAvkNEa6Bp4Dxv85yrAGw3KaSuIKI0M885vI9E4oo0CpKlCgH4AjPfXnMj0RXQNtRLmDlHRPdB05QBgLxFHkHMf6jA/noxz4iguv96IWv6+e8BfImZ79LXeovNc0LQ/h8WfLyPROKKzClIlir3AHg3EaUAgIjWEtEqaHLD07pBOAvASwN6/wcAvEnPLYxCSxR7oR+agigAvMN0+xyAtOn3nwEwpLKplZm8EokJaRQkSxJm/hmAbwL4LRE9BS3OnwbwUwBhInoSwOcA/C6gJXwfmort0wBuB/AgtElZbtwC4HtE9N8ATplu/xGA60WiGcAHAOzUk+h7oSWiJZKWkSqpEklAEFGKtclow9Ckjl/GzCc6vS6JxAmZU5BIguPHRDQALWH8OWkQJL2A9BQkEolEYiBzChKJRCIxkEZBIpFIJAbSKEgkEonEQBoFiUQikRhIoyCRSCQSA2kUJBKJRGLw/wFoai0w9Y9eeQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x864 with 3 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "learn.sched.plot(n_skip_end=20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 116,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iters = learn.sched.iterations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 117,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "490"
+      ]
+     },
+     "execution_count": 117,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(iters)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 118,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "val_losses = learn.sched.val_losses\n",
+    "losses = learn.sched.losses\n",
+    "rec_metrics = learn.sched.rec_metrics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 119,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "491"
+      ]
+     },
+     "execution_count": 119,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(rec_metrics)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x270155262e8>]"
+      ]
+     },
+     "execution_count": 67,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAD8CAYAAABn919SAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzt3Xl8XXWd//HX9+Zmu9m3NmmWhpSulKUlQtkKgkoRBGRwBgRE1MHlp6PMjAo6M46DzjjiOA4/RUQRUBGRTfZhXwSk0Jbu+76kaZKmzb7de7/zxz335ia52Zrkbryfj0ceuffck3s/Pel953s/53vOMdZaREQk8bliXYCIiEwOBbqISJJQoIuIJAkFuohIklCgi4gkCQW6iEiSUKCLiCQJBbqISJJQoIuIJAl3NF+suLjYVldXR/MlRUQS3sqVK5ustSWjrRfVQK+urmbFihXRfEkRkYRnjNkzlvXUchERSRIKdBGRJKFAFxFJEgp0EZEkoUAXEUkSCnQRkSShQBcRSRIKdBGRSWat5aEV++jx+qL6ugp0EZFJ9r/r6/n6w2v5nxe3RfV1FegiIpOstbsPgKb2nqi+rgJdRGSSWRub11Wgi4gkCQW6iEiSGDXQjTG/NsY0GGPWhy27zRiz2Riz1hjzmDEmf2rLFBGR0YxlhH4vsGzQsheAhdbak4CtwC2TXJeIiIzTqIFurX0daB607Hlrrde5+zZQMQW1iYgkNIOJ6utNRg/9M8Czk/A8IiIyARMKdGPMtwEvcP8I69xojFlhjFnR2Ng4kZcTEZERHHOgG2OuBy4BrrF2+FmX1tq7rLW11trakpJRL4knIpLwYjQN/diuKWqMWQZ8EzjXWts5uSWJiMixGMu0xQeAvwBzjTH7jTGfBX4K5AAvGGNWG2PunOI6RUQSRnR3hfYbdYRurb06wuK7p6AWEZGkEKuWi44UFRFJEgp0EZEkoUAXEUkSCnQRkSShQBcRmSImytNdFOgiIklCgS4ikiQU6CIik0yXoBMRkQlRoIuIJAkFuojIFNEsFxEROSYKdBGRJKFAFxFJEgp0EZEkoUAXEUkSCnQRkSShQBcRSRIKdBGRSWZjdBE6BbqISJJQoIuIJAkFuojIlInusf8KdBGRJKFAFxFJEgp0EZFJFrcXuDDG/NoY02CMWR+2rNAY84IxZpvzvWBqyxQRkdGMZYR+L7Bs0LKbgZestbOBl5z7IiISQ6MGurX2daB50OLLgPuc2/cBl09yXSIiMk7H2kOfbq09COB8nzZ5JYmIJLZoX6koaMp3ihpjbjTGrDDGrGhsbJzqlxMRibm43Sk6jEPGmDIA53vDcCtaa++y1tZaa2tLSkqO8eVERGQ0xxroTwDXO7evBx6fnHJERORYjWXa4gPAX4C5xpj9xpjPAj8APmyM2QZ82LkvIiJhot1Ld4+2grX26mEeumCSaxERkQnQkaIiIklCgS4iMsmCk1x+v3wv1Tc/jd8fnWkvCnQRkSnmi9I8RgW6iMgU82mELiKSHBToIiJJwqtAFxFJDhqhi4gkCa/fH5XXUaCLiEyxKOW5Al1EZKpphC4ikiTUQxcRSRKa5SIikqgGHRmqEbqISJJQoIuIJAkFuohIkujzaZaLiEhSiNY1oxXoIiJTLEpnz1Wgi4hMPfXQRURkHBToIiKTbPB4XC0XEZEkoZ2iIiIyLgp0EZEpppaLiEiSsFFK9AkFujHmJmPMBmPMemPMA8aYjMkqTERExueYA90YUw78HVBrrV0IpABXTVZhIiLJIlF2irqBTGOMG/AAdRMvSUQkucR9D91aewD4EbAXOAi0WGufn6zCRERkfCbScikALgOOA2YAWcaYayOsd6MxZoUxZkVjY+OxVyoikqBsAhz6/yFgl7W20VrbBzwKnDl4JWvtXdbaWmttbUlJyQReTkQkQcV7y4VAq2WJMcZjjDHABcCmySlLRCRxRatnPthEeujLgYeBVcA657numqS6RESSRrTy3T2RH7bWfgf4ziTVIiKSlOJ+louIiMQXBbqIyBRLhFkuIiIyBmq5iIgkqGidjGswBbqIyBRLlHO5iIjIIIFDc/olxOlzRURkKLVcRESSlFouIiLJQrNcRERkPBToIiJTTAcWiYgkCR1YJCKSJBToIiIyLgp0EZFJNnhArmmLIiJJQkeKiogkiRt/u5L39h6Z8tdRoIuIREFXn2/KX0OBLiISBbkZqVP+Ggp0EZEoyMtUoIuIxI1rfvU2tzy67ph+NivdPcnVDKVAFxEZoze3H+aBd/Ye08+mDDpH+lRQoIuIJAkFuohINEz9AF2BLiISDVHouEws0I0x+caYh40xm40xm4wxZ0xWYSIiiSpGV6Bjortd/wf4X2vtlcaYNMAzCTWJiCSdKAzQjz3QjTG5wFLg0wDW2l6gd3LKEhGJLxM9H4uJ81kuNUAjcI8x5j1jzK+MMVmTVJeISFzp88WojzIOEwl0N7AY+Lm1dhHQAdw8eCVjzI3GmBXGmBWNjY0TeDkRkdjx+Sc4Qp+kOkYykUDfD+y31i537j9MIOAHsNbeZa2ttdbWlpSUTODlRERixxerPZ3jcMyBbq2tB/YZY+Y6iy4ANk5KVSIiccY3jpZLpDWjMW1xorNcvgLc78xw2QncMPGSRETiz0RH6CYKTZcJBbq1djVQO0m1iIjErYn20KNBR4qKiIyBfxwj9EhTHOP+SFERkfeL8YzQxxP+k0mBLiIyBuMJdJ9/CgsZgQJdRGQMxjPqjrSuWi4iInFiXC2XGO1AVaCLiIzBeEbokaY4RmPaogJdRGQMvOPaKTp0mVouIiJxQi0XEZEk4R/HzJXILZepp0AXERmD8Rz6rxG6iEgcG9889EjTFrVTVEQkLoxvHvrQZWq5iIjEifG0UXTov4hIHBstz9/a0cSRjsBllSO3XKaiqoEU6CIiY2AjXrYioNfr55O/XM6n73kH0AhdRCSujZTRwRH5poNtwHDnctFOURGRuDDSqNvrTFIPjuJjdTEMBbqIyBiMlNHBAA9mfqwubqRAFxEZg0hXIQoKnucluIYOLBIRiWNj6aEH2zITvaD0sVKgi4iMwcg9dLVcREQSxkiDbu+ga86p5SIiEsfGMkIP0iwXEZE4NpZZLqH76qGLiMSvEWe5+AY+lrAtF2NMijHmPWPMU5NRkIhIPBopogeP0MdzubrJNBkj9K8CmybheURE4tZYjhQdy7pTaUKBboypAC4GfjU55YiIxKex9NBdZuD9aJvoCP0nwDeAcVxtT0Qk8YzUQw8GePAEXAkX6MaYS4AGa+3KUda70RizwhizorGx8VhfTkQkpkbqogTz24TuJ1igA2cBlxpjdgN/AM43xvxu8ErW2rustbXW2tqSkpIJvJyISOyMFNLB0bvXb+no8SbeCN1ae4u1tsJaWw1cBbxsrb120ioTEYkjI/bQw8L+e09v4lBrTxQqGkrz0EVExmCkHnp42Ne3dHHgaFcUKhpqUgLdWvuqtfaSyXguEZFY8/kt33l8PfuPdIaWjdxD738wVnPQQSN0EZEhVu87yn1/2cNND64OLRuphx5+ZGiM9ocCCnQRkSHS3YFo7OjxhZaNNPAOf2yki0lPNQW6iMggaU6gd/f1B/pIQR0+eo/VDBdQoIuIDBE82VYw0Lt6fbR3e4ddP7zlEsM8xx27lxYRiU/BUXa3N3AQfO33XqCjN2y0bm3oqFAYGOLv7GqOTpERaIQuIjJIn3OyrS4nxMPDHIbu+IzVkaGDKdBFRAbpH6H7Ij4+OL4V6CIicSrYQx8upwcfZKRAFxGJU4PPbz7Y4B2fo6weNQp0EZFBRjvac/AUxlhdQ3QwBbqIyCA+3yiBbgffj49A17RFEZFBwlsuI4V1r9ePMbGdex5OgS4iMkh4y6W7b2iDPJjxC//1OS4+sYxTZxZEq7QRqeUiIu8bPV4fTe2jn6s8/PD9tp6+IY/f/vI2erw+er1+HnvvQNy0XBToIvK+cdODq6n93oujBnBfWA890iH/P391B89vOBS6Hy8tFwW6iLxvPLu+HoCWrqGj7nC+sB56e0/kc7iEzz3/zhMbJqG6iVOgi8j7RoEnDYCGtpHbLqP10KH/FLvxJP4qEhGZIv3nOR/+zInQf6Ro4HbkQO8bZWpjLCjQReR9w+WcIXG4UXdQ+Ai9d5hA7+qLfJ6XWEqIaYuNbT109npJc7tIS3GR5naR7k4JnYReRGQsUlxOoA9z0q2g8B76cCPxzlFG+bGQEIF++0vb+O3be4YsT0txkZPhJjvDTXZ64Csnw01ORirZ6W5yM90UZaVTnJNOcXYaJdnpFGenk5eZistlIrySiCQqv9/S1u0lz5M67Dpu533fE2F07fNb/ulP6/jcOTUDQrxvmBF62wgXvIiVhAj0K0+tYFFVPr1eP70+P71ePz1eP23dXtp7+mjv9tLe46W120vd0W7ae9pp7/HS0tUX8XJQKS5DgSeVwqy0AV9FWelMy01nWk4G03LSKXG+UlP0SUAk3t32/Bbuen0nL/79uRxXnDXgsUOt3Vx393LqW7uB/pZLc0cvmw+2cubxxexqaueBd/axfFczl59SHvrZ4QK9tXvkmTKxkBCBfnJlPidX5o/75/x+S0tXH03tPTS29dDY3kNTey/NHT00d/SGvjbXt9Hc0cvRzqG/IJeBsrxMqgo9ga8iT+j2zCIPeZmpA65cIiKx8af3DuDzW7YeahsS6A+t2MfWQ+2h+5sOtvK1B1eH7m++dRnp7hQAWjr7BvTQh2u53PvW7kmsfnIkRKAfK5fLUJCVRkFWGrOn54y6fp/PHwr/htYeGtp6qG/pYt+RLvY2d/LS5oYhR5nlZLhD4V4ZDPrCLGYWeSjPz1RrRyRK3CmB91qkOeaDd2C+sPHQgPv/9fwWrj6tCgi0UsJntgw3Qo/HWS5JHejjlZrioiwvk7K8zGHX6ez1sre5k72HOwPfna/N9W28uLFhwB7xjFQXs0qyqS7O6h/VFwaCf0Z+ZmgHjYhMXLA12hLhk3ZX78BQPjoo9J9YU8eVp1YCgVktPv/oPfR4dMyBboypBH4DlAJ+4C5r7f9MVmHxypPmZl5pLvNKc4c85vNbDrV2s7e5k11NHWxvaGd7Qzsb61p5fkP9gL/oqSmGygIP1cWB0Xx1URbVxVnMKsliRp5G9vL+9es3dvH9Zzax5dZluEfYf7XncAdvbG/imtNnAv1TEscyQm/u6B1w/+OLKgYEd/h7tWeUKY7xZCIjdC/wD9baVcaYHGClMeYFa+3GSaot4aS4DDPyM5mRn8mSmqIBj/n8loMtXaHR/Z7mTvYc7mBXUydv7zxMZ9hFaDNSXVQVeqgsCIzmKws9VBZkUl6QyfTcDAo9aQp8SVr/9lQgQtq6vRRkpQ273hd+t4pNB1u58IRSirPTQxd0PtrVO2TdSLNawnl9/gGB7vP7SU0x9Pks3XE433w4xxzo1tqDwEHndpsxZhNQDrxvA30kKS5DRYGHigIPZ84a+Ji1lsa2HnY2dbCzsYMdje3sc1o5b+88POSK46kphuLs9AEzdGbkZ3JyRT4Ly3Mpz8/UjlpJSF1h/9ePdvVxz5u7uPaMmUzLyRiybjCkv/HwWrY1tIVG4S1dQ6cT9nhHHmV39fkG7Aj1+i3p7hT6fN5x7fzc/YOL+eCPXmVXU8eYf2YyTUoP3RhTDSwClk/G873fGGOYlpvBtNyMISN7ay1HOvvY29xJfUsX9S3dHHJ22jZ39NDc2ceew508s+5g6GNiToab+aW5zC/LYX5ZLvPKcpk7PYfMtJRY/PNExiw4rRDg5c0N3P7ydjbXt3HXp2qHrBu87NvLmxsAQgcaHu2MMEIf5UCi9h4vmw+2hu57fTbwfD1wuGPo843krOOLEjfQjTHZwCPA16y1rREevxG4EaCqqmqiL/e+Y4wJjcIZYepmd5+PTQdb2XiwlU0HW9l0sI2HV+4Pje5dBqqLs4YE/Yy8DI3mJW6En6p2e0NgmuFwgdo7aNQdvN/c0cu3HlvH355TE5q+ONqh/o+vruPx1XWh+4ER+rEdf+KK4ftpQoFujEklEOb3W2sfjbSOtfYu4C6A2tra+JvnkyQyUlNYVFXAoqr+K6f4/Zb9R7rCQr6VtQeO8vS6g6F18jJTmVcaCPiqQg9F2YEDrEpy0ikvyCQ7XROhZHibDrby0qZD/L8PHj8pA4Pwi0k0tgVG6+EzTnq9fn739h6uXTJz2NknG+pa2VDXyosbD3HqzALK8jJHHaEPFuihv48C3QR+e3cDm6y1P568kmSyuFwmcCBUkYdlC0tDy9u6+9hS3+aM6NvYXN/KH1fsG7BjNijfk0pNcRYVBR6yM9ykpbjwpKVwSmU+Z8wqIidj+MOsJb7tbGynMCuNfE//jseVe5pZUJY35vbcF363kj2HO7nwhNIxHesxmvAReqNzitvwkfgfV+zj357aSK/PH7EvnpPups05x0pDW0/o/OcnlueNq44+vw3Nax+vWH7gncjw6yzgOmCdMSZ4yNW3rLXPTLwsmUo5GanUVhdSW10YWub3W4529dHc0UtTe+CgqrqjgVk5OxraWbP/KB09Xnq8frp6AzuQUlyGUyrzOfv4YhbMyGV6bgbpbhedvT66en1kpLqYnptBRYF20sabhrZulv3kz1QXe3jua0sxxvDvz2zirtd3cuPSGr710flAoJX3o+e2cGVtBfNKc3lyTR1/eHcv991wGu4UF3sOdwKBUXEw0L0+P37LqCfPa+7o5em1dXyitpKM1MAfkI7eoYEefiKt4MUm6lu6h7RcAM6ZU8wz6+qHLO/sHd95V3r6fKS63kcjdGvtG4DepUnC5erv1R8/LXvEdXu9flbtPcKftzXyxrYmbn95GyNd0euEGblcMH86makpdPR46ej1Br73+MBAVloKWeluctIDJ1rLSnczIz+Ts2YVJ/QZNXu8Pn6/fC9VhR4umD992PXW7j/KugMt/E1t5YjzridqS30b/7u+nhuX1rB671F6fX62HmpnZ1MHMws9/M45Ad7LmxtCgf7s+oP86o1drN53lIe/eCa3PLqO9h4vq/YeZV5Z/4h8c31b6N982vdfoqWrj7+ureCHV548bD03P7KW5zceIs+TxqUnzwAGjtCb2gO98/ADhQ47R2ofau2OeFrbC08ojRjoOxrHt5Oytds74MA/t8sMmAUTlJeZOmTeeyxnFKtBKuOW5naxpKaIJTVFfP3CwIEcew93cqi1mz6fn8y0FDxpbrr7fGxvaOfhlfv56cvb8NvAf/asNDee9BSy091YC529PtqdoA//w5DvSeX8udM4e3YxB1u6eXb9QfIyU5mRl8nc0hyuOq1qSI/f77e8uOkQf1yxn8MdPXjSUrjqA1VceEJp1P84/PTl7fz/l7cD8JvPnMbSOSVD1nl9ayOf+vU7AKQYw1WnjTxxwO+3LN/VzJNr63h3VzM+a/n+5SdyxqyiEX8O4CcvbuXZ9fVkprkCf0wdb+88TFevj85eHyeW57HuQAt1R7uYkZ/J2v0tAKw70EKvN/C7be/xsnb/0QHB9ciq/dz04dk8+O6+UMD9ccV+fnjlyfzouS3kZLj5/LkD5+s2OuG8o6H/HCttYaekDQb2kc7e0CfIX/55F9B/KbnBCjzDz1sfzunHFbJ8V/OAZW3dXlLDWi6ZqSkDagu6bslMfvrK9gHLEnKELhKUl5nKiRV5nMjQPuXSOSV85uzj6PX68dvAzIHh2i9+v6Wzz0dHj5cNdS08sbqOV7Y08Oh7BwConVlAV6+P17c18tDK/dz52k6+cG4Ns6Zlk+52Ud/SzYPvBs6WNyMvg5qSbHYf7uArD7xHcXY6X73geD55+kxSXIb9Rzr5zuMbeHNHE4WeNC5fVM7ffKCSmUWBWRG9Xj/r61oo8KSxas8R/rT6ANcumcmFJ5RGrL25o5ff/GU3Fy0sY25pDp29Xn7zlz2cM7uYQ63dfPn3q/jWR+fz17WVoYPCdjd18OXfr2JeaQ6HO3p5aOX+iIHe0eMlK91NU3sP33tqI39aXYfbZVgwI5e1+1v492c28eRXzh7xd9Tn8/Pm9iYA3tl1BIBZJVm0dXt5e2cze5sDrZNvLpvHtXcv59UtjXzy9Co2HAhMXOtxPpUFw3r34Y5Qn/2fL1nArU9tZP2BFp5dV8/x07Jxuwyb69to6ewLBd7gQA8+186wKX7t3V5cZuBFl/02sO5tz20e8d8I4DmGqblXnVY5JNBbu/qYnpseup8+TKBbho7aY9leVKBLVIxldOxymdB57afnZnD+vOn4/ZaNB1vJzUilqsgTWve9vUf4j2c2872nNw14jpwMN/9xxYl84tQK3CkufH7L69sa+cVrO/jnxzfwwDv7+OC8Eu59czcWuPyUcupbu7nztR3c8eoOTqrIw2UMWw+1DdhJ7DLw521NfOHcWXzm7OoBB7o0tfdw7a+Ws7m+jfve2s1DXziTN7c30dLVx9c+NJuS7Az+8aE13PzoOvY2d/KNZfM42NLFdb9ejstl+OWnanl63UF+8OxmdjS2M6skG2stj646wM9e2U5dSxe//FQtf/fAexzp7OOyU2bwtQ/N4bjiLO55cxfffXJj6Oe6+3zc/tI2Ll9Uzpp9R5lflsvC8jzuf3sPrd1eCrPSeHd3M6kpLs50RvVPrKnDGPj4onLOOr6I8vxMXt3SwFUfqGRDXQsfO3kGT66p46EV+0N96z2HO3GZwO/r/HnTuPWpjexo7GBXUwdnHl/ERQvL+NvfrODuN3eFtlOP1xc6oyFAQ2tghH7waFdoWXuPl9zMVLr7fAOmGh7u6Amtv7gqn73NnaGWTLhpORnccc1ith1q579f3ArAvNKcUEsokrzMoTv2Dxztojy//5xO7rCPI9np7lAvP1IbJlF3iopMOZfLsDDCDIVFVQU8+Pkl7DncyeGOXtp7vEzPTQ/Mxglrw6S4DB+cO43z5pTwzLp6vvf0Rn72yg7OmV3Mv3/8RCoLA38kgqP7t3ceJsVl+MSpFZxeU0R9SzeZaSlcdsoM/uXxDdz52g7uX76HH/7VSVx4QinLdzXz9YfXBEbPly/kJy9u5eN3vIm1geA5dWZgx/ODn1/CPz60ljtf20F9SzevbW0MTMH73OlUFnq4YlE5tz23hXve3MWN58zii/evZENd/2Ed190daMsMbt1ceEIp331yIy9uPMSsc7N5ZNV+7ng18McJAm2rr184l1uf3sQHqgv40nnHc8O97wJwek0hbpfhiTV1WAv/dtkJGGM4dWYBK/ccYU9zJx29Ps45vphth9p4ZNV+AGpKsthS30aP18+c6dlUFARONLelvo361m6OK8rixPI8jAlcnCZo5e4j/OHdffzTJfPxpPWH4sGWbl7adIhFVQW0d3vJSnPjMobuvv7A/vmrO3nJOYDonk+fxpV3vjUg0HMy3Fy0sJTKwkyqijy0ze4LBfqiqoIRA93vh59+chFf/v17A5aH99DDbz/x5bM4/79eA/p33IZTD13kGBhjqC4OnNRsLOtefFIZF54wnY4e35Cr2pTmZfDVD83mq8we9jluu/Ikrl0yk5sfWcsX719FmttFr9dPVaGHB288g5Mr8zmlMp+rf/k2aW4X37104YDX/5ePLeBwRw9PrT1ITUkWP/irk0Ln+Z+Wm8F1S2Zy71u7+cM7+/D6Ld9cNo8bl9bwlx2Hufbu5eRmuDlndvGAmmbkZzJnejaPrjpAa3cfv3x914DHj3b28e3H1lM7s4BfXFdLgSeVOdOzaWrv5fJTyvFZyyubG7lg/rTQFNS5pTk8saaOt3ceBmDBjFyW1BSFQvHyU8r58QtbaWjr4dolVaSmuJiRn8FrWxsBOK4ki9K8DM6ZXcLrzjKAH7+wlRV7jvDEmjr+9WMLACjwpHLgaBefvW8FVywup63HS05GfyzVlGSxs7Ej9Mdk6ZwS8jypA9YBp1W0ZGbofvgf9bK8gacNCP7eaoqz2NnUwbyynIjHW6SGfaoMn8YZ3iO/9OQZPLrqwICfu2hhGT97ZceQ54sGBbq8r7hTXOR5jm3nqDGBaZpPfuVsnlxTx8o9R6gq9HDdGTPxpAXeSgvL83jr5vPJSE0ZcmBKXmYq995wGtbaiH3Wbyybyxvbm9h/pJM7rlnMR5x+/dmzi7njmsUsKMuN+HNfOu94vvbgarYcauPik8r4/uUL6erzkeFOYekPX6Gtx8s/X7IgcLQx8PAXzyQtxRWaKnjndacOeL55pYHZK4+tOkBqimHO9ByW1BRx71u7yUl3Dzg9xYKywKenmYVZvOH06GeVBGZJnTAjl9e3NnLRwlKeXV8/oFf+r08GTvl0wfzpPLwyENbbG9rJSnOHdpYDzJmWw86wGSo3L5sHQNagAM5KH9g7D99Ogy92kZPu5rC3l4+dPIObPjwH6J8OGS589opnmEA/b+40dv/gYqpvfjq0bGF53pBl0aJAFxmn1BQXVyyu4IrFFREfH+1gq+F2mnnS3Dzzd+fgtzYUtkEfPbFs2Oe7fFE5pXkZ+PyWs44PjOCDJ4n4zWdPY0djx4ArfuWOUt8cZz75O7ubOaUynzS3i/PmlnD1aVUsW1jKCTP6Tx29wLkdbF0Z0x+gN5xZzZ7DHdxy0XyeXV8fOmXtmbOKeGtHYPR/49Iarjm9ikdW7efx1XVUFHgoz88gPdXFlkMwa1oWbAi81hfPmxV6vVsvW8itT20MtWGy0oZGWVFWGp29Pi45qYyZRR4u/embAKFta+3A01kPFn4R6Myw30c8H1KRuJN8RZJQmts1JMzHYklNUSjMwy2qKuDKUyP/4RlORUH/zsClTosnIzWF/7jiRM6dU0JWuptcp+URHM1XFgZ+Zn5pbqj+abkZ3HHNqVQW9u/XOHVmAd90RtkQaHUtqirguOJs2rq97GpqJzczlQxn52lxdv9Mk+k5/beri7O4+9MfCN0fPGIHeP6mpaz4pw9hjOGkiv4/aMFztPSF7dAMP4jo3hsCzxt+DvXwOuL51NUKdBEZwBjDyRWBVsq5c6dFXOe5m5bywk1LQ+F93pxpnFZdyH//zSkR1w/+kSjOTuPkynzmleYwLSc99GmhJuwkWvmZaaGdkPmeVDJSAzEWWs3pAAAHp0lEQVQ1PXfoKXSDIk1XLMpOjxj0851R/vyy/k8a4SEdPBVCd5+Pn31yMefNLeEfPjIn9HiBJ/InnJMqIp9e4KmvnM09YX98ppJaLiIyxO1XL+L1rY0srop8hs+yvEzCDztYMCOXP37hjGGf77jiLDbXt4V2YD/2pbNCp78FBuzYzvekMq9sOs9vPMSJ5Xl8eEEpT66pC7VbIhnPSeSuP6Oaz559HIuGOXtpcBpjV6+Pi08q4+KTymho6z+tryfNTU1JFlcsKg8t23zrsmEvKRlpltZUUaCLyBAzi7K47ozRZw+N1d8uraG9x8s1pwVmogw++Vd4myffk8onTq3gwhNKyctM5QdXnMjVYQd9ReIZR6AXZ6dRUzL86S2C7aTwlkvmoDbYy/9w3oD7x9ImmwoKdBGZcourCvjtZ08f9vHwGUF5makYY0Ij5ax0N2dG2D8QLtLBQYMtLM9l/YHW0A7cwWaVZJHuTiHXea7wY4Yi7XSNR4lRpYgkveCpb8dzqttbLprHn7c1janl8tvPnM7hjt5hz3P+wk3nYkxgH8Lx07L53NnHhR47lh2ht115UtTPH6RAF5G48LNrFrNq75ER2yGDff7cWUPOETOcgqy0ES86HR7aL/79uWOuYTifqK2c8HOMlwJdROLC0jklEc9IGS9++Fcnjemo5FhSoIuIjMFffyD6I+7x0jx0EZEkoUAXEUkSCnQRkSShQBcRSRIKdBGRJKFAFxFJEgp0EZEkoUAXEUkSJvyqHVP+YsY0AnuO8ceLgaZJLGeqJEqdkDi1JkqdkDi1JkqdkDi1TmWdM621ox5GG9VAnwhjzAprbW2s6xhNotQJiVNrotQJiVNrotQJiVNrPNSplouISJJQoIuIJIlECvS7Yl3AGCVKnZA4tSZKnZA4tSZKnZA4tca8zoTpoYuIyMgSaYQuIiIjiPtAN8YsM8ZsMcZsN8bcHAf1VBpjXjHGbDLGbDDGfNVZXmiMecEYs835XuAsN8aY25361xpjFke53hRjzHvGmKec+8cZY5Y7dT5ojElzlqc797c7j1dHuc58Y8zDxpjNzrY9Ix63qTHmJuf3vt4Y84AxJiNetqkx5tfGmAZjzPqwZePehsaY6531txljro9Snbc5v/u1xpjHjDH5YY/d4tS5xRhzYdjyKc+GSLWGPfaPxhhrjCl27sdsm4ZYa+P2C0gBdgA1QBqwBlgQ45rKgMXO7RxgK7AA+CFws7P8ZuA/ndsfBZ4FDLAEWB7lev8e+D3wlHP/j8BVzu07gS86t78E3Oncvgp4MMp13gd8zrmdBuTH2zYFyoFdQGbYtvx0vGxTYCmwGFgftmxc2xAoBHY63wuc2wVRqPMjgNu5/Z9hdS5w3vfpwHFOHqREKxsi1eosrwSeI3BcTXGst2mormi8ESawMc8Angu7fwtwS6zrGlTj48CHgS1AmbOsDNji3P4FcHXY+qH1olBbBfAScD7wlPMfrSnsjRPavs5/zjOc225nPROlOnOdoDSDlsfVNiUQ6PucN6bb2aYXxtM2BaoHBeW4tiFwNfCLsOUD1puqOgc99nHgfuf2gPd8cJtGMxsi1Qo8DJwM7KY/0GO6Ta21cd9yCb6BgvY7y+KC8xF6EbAcmG6tPQjgfJ/mrBbLf8NPgG8Afud+EXDUWuuNUEuoTufxFmf9aKgBGoF7nPbQr4wxWcTZNrXWHgB+BOwFDhLYRiuJz20aNN5tGA/vuc8QGOkyQj0xq9MYcylwwFq7ZtBDMa813gPdRFgWF9NyjDHZwCPA16y1rSOtGmHZlP8bjDGXAA3W2pVjrCWW29pN4GPtz621i4AOAu2B4cRqmxYAlxH46D8DyAIuGqGWuP3/y/C1xbRmY8y3AS9wf3DRMPXE6v+AB/g28C+RHo6wLKq1xnug7yfQqwqqAOpiVEuIMSaVQJjfb6191Fl8yBhT5jxeBjQ4y2P1bzgLuNQYsxv4A4G2y0+AfGNM8OLg4bWE6nQezwOao1Bn8LX3W2uXO/cfJhDw8bZNPwTsstY2Wmv7gEeBM4nPbRo03m0Ys/ecs7PwEuAa6/Qm4rDOWQT+oK9x3lsVwCpjTGk81Brvgf4uMNuZRZBGYMfSE7EsyBhjgLuBTdbaH4c99AQQ3Ht9PYHeenD5p5w94EuAluBH4Klkrb3FWlthra0msN1ettZeA7wCXDlMncH6r3TWj8rIzFpbD+wzxsx1Fl0AbCTOtimBVssSY4zH+X8QrDPutmmY8W7D54CPGGMKnE8kH3GWTSljzDLgm8Cl1trOQfVf5cwYOg6YDbxDjLLBWrvOWjvNWlvtvLf2E5gkUU88bNOpaMxP8g6JjxKYSbID+HYc1HM2gY9La4HVztdHCfRGXwK2Od8LnfUN8DOn/nVAbQxqPo/+WS41BN4Q24GHgHRneYZzf7vzeE2UazwFWOFs1z8RmA0Qd9sU+C6wGVgP/JbA7Iu42KbAAwR6+30Eguazx7INCfSwtztfN0Spzu0E+szB99SdYet/26lzC3BR2PIpz4ZItQ56fDf9O0Vjtk2DXzpSVEQkScR7y0VERMZIgS4ikiQU6CIiSUKBLiKSJBToIiJJQoEuIpIkFOgiIklCgS4ikiT+D14qD1ZhoO0QAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.plot(learn.sched.iterations[:-10], learn.sched.val_losses[:-11])4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "accuracies = [learn.sched.rec_metrics[i]['accuracy'] for i in range(len(learn.sched.rec_metrics))]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(learn.sched.iterations[:-10], learn.sched.val_losses[:-11])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x270027427f0>]"
+      ]
+     },
+     "execution_count": 69,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD8CAYAAACMwORRAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJztnXmYHVWZ/79v1V16S6eTdNJkJSEkkLCEhBB2kB1EARUUcBwXHH4ujOIyIyiig+MMivuACjIqKuugLEIgKouyhgQIZA+dEJLOTrZOd6fvVuf3R9WpOrXdW/f23brzfp4nT99bdarq3Jvub731Pe95DwkhwDAMwwwttFp3gGEYhik/LO4MwzBDEBZ3hmGYIQiLO8MwzBCExZ1hGGYIwuLOMAwzBGFxZxiGGYKwuDMMwwxBWNwZhmGGILFaXbi9vV1Mnjy5VpdnGIYZlLz66qvvCiFGF2pXM3GfPHkyFi9eXKvLMwzDDEqI6J0o7diWYRiGGYKwuDMMwwxBWNwZhmGGICzuDMMwQxAWd4ZhmCEIizvDMMwQhMWdYRhmCMLizjDMAc3Dr29Cbypb1DFvdu3Bm117ir7Wlr378dTKbUUfVwos7gzDHLC8vmE3rr1/Cb758LKijrvo1hdw0a0vFH29i299AVfdVZ3JmyzuDMMcsPSlcwCArd39Vbne9n2pqlwHYHFnGIYZkrC4MwxzwCNErXtQfljcGYZhhiAs7gzDMEOQSOJOROcT0Woi6iSi6wL2/5iIllj/1hBR8TlCDMMwTNkoWM+diHQAtwE4B0AXgEVE9KgQYoVsI4T4ktL+XwHMrkBfGYZhmIhEidznAegUQqwTQqQB3Afg4jztrwBwbzk6xzDM0OPeVzZg8nWPY0eZ0wJv+vMKTL7u8aKOobL2IJwrf/Vy0X0bKFHEfTyAjcr7LmubDyI6GMAUAE+H7L+aiBYT0eIdO3YU21eGYYYADyw25WTDrr6ynvfXL7wNABB1mPry4tqdVb9mFHEPurmFfXuXA3hQCJEL2imEuEMIMVcIMXf06IJLADIMMwSptPbmjPoT91oQRdy7AExU3k8AsDmk7eVgS4ZhmBqSq8PIvRZEEfdFAKYR0RQiSsAU8Ee9jYjoMAAjALxU3i4yDDOUoAob3VEi978s34rzf/KP0BvBtx5Zhi/e93q5u1ZVCoq7ECIL4BoACwCsBPCAEGI5Ed1ERBcpTa8AcJ+oR8OLYZi6wyizVGjWTSMbQdz//Y9vYtXWfdi7PwMAEB6n+a6X3sEjS8IMisFBwVRIABBCzAcw37PtRs/7b5evWwzDDHUyWaOs59OIYAgBI4K4xzQzrh3K/jzPUGUYpiakcuUXdyBa5B6zwvxMzmxLVUuKrB4s7gzD1IRyR+7Sy48Sjcd0stqWtw/1BIs7wzA1QUbN5UJG7pHE3Yrc02XuQz3B4s4wTFWRBki5Uxa1oiJ3U/rk04N3QLXSVCPvhMWdYZiqQlQZS6Q0z51tGYZhmLJgR+55dHVXbxpPr/IvJL15z37cvfCdwIwYx3MvLNjSc2dxZxiGKRNahMj9k79dhE/9djF6U1nX9m8/uhzfeGgZVm3d5ztG1+R5C/dBt1Ih02Ue1I1KNWYDsbgzDFNdIkw26txminfWM+DZuaMHAJAOUHDHliks2HHrRpCqkbhXAxZ3hmFqQr6BTznYmvEItYx4g6J+KiJbRmdxZxjmQCebM/DK27t8FkmpRMlqkdrtjdxlyYKgNMpismXiVrZMKhtYwLbiVCM3h8WdYZi8/G3ldnz49pfwX/NXluV8cjZopMjdY79IcQ86tpg8dztyz3DkzjDMAcqOHnPFpI2795flfBTBc5cC7fXWZUQflOVSTOGwuM62DMMwBzjlsmMkxZQJ8NoyIk/kLj33KIXDHM+9RrYMT2JiGKbW9FniHkU0oxDFlpH4bRnzZ1B0bmU3RpvEZHvu1gzVkEMGcwVzFneGYfLSkzKj2950eSP4KCKczhlYuG4nJl/3OFZs7rY9d29ED5RWW6aQ524I4LAbnsAnfvNKwXPWGyzuDMPkRdoyQYJaClKgozwJZLIG/rrCnKn63Fs7FL8+X5579H4Wqm9jCIFU1sCzq3dEPmcUOFuGYZia02NF7OWaqm9H31E8d0MgEXNmk+azdIrx8p18+cLiPlhhcWcYJi8yci/XqkUy6I5SAyadM2xxz+QMJyMm4ClCL8KWkS0KeeqDWNujiTsRnU9Eq4mok4iuC2nzYSJaQUTLieie8naTYZhaUay45wyBj9z+Ep57K9jKyBURuWeyjrinc8LOiPHOXAWKKz9gZ91YP8N6oor7j/66Bt95bEXBc0ehLmrLEJEO4DYAFwCYCeAKIprpaTMNwPUAThZCHAHg2gr0lWGYGiAHVKN62bv70lj49i5ce9+SwP1Fee45YYu2EMK2XvJVhYxipcgm8j4Qtsieeq6fPfUW/vf5twueu16IErnPA9AphFgnhEgDuA/AxZ42/wLgNiHEbgAQQmwvbzcZhqkVzoBqNM+9P2PeDOQUfy9SmKN57u5r5vPV7cg9wsCvXJxDijeFqPtQ99zHA9iovO+ytqlMBzCdiF4gopeJ6PygExHR1US0mIgW79hR3tFnhmEqgy3uESP3XivSl3aKF3maMJtHnVikluRVWwcdKvPcixlQtcU9JHYv0zCD//pVyJeJIu5Bn9rbsxiAaQDeA+AKAHcSUZvvICHuEELMFULMHT16dLF9ZRimBvQU8Nz/tmIbfvzXNb72coq/F3ke+fPJZVvxzGrnYV/eHADTlgl6YgiKqO0892JsGeunGrm/uPZdpV3hc/36+bexZptTX/7pVdvs9M1aEovQpgvAROX9BACbA9q8LITIAHibiFbDFPtFZeklwzA1Q87iDIvcP/27xQCAz50xFcmYbkfeWojX4S3+9Zk/vAoAWH/zhQDc5Q6yhmFfV725BKZC5tnnxbZlAtpe+auFSl8Lngo3PbYCMY3Q+V/vBQB86rfm9yE/T62IErkvAjCNiKYQUQLA5QAe9bR5GMAZAEBE7TBtmnXl7CjDMNVHjVwLee4y4pY2eZhfXSjPvUcR93TWcEoOKNfPF51Hscl9tkyI5x61/EAxE6fU61eSguIuhMgCuAbAAgArATwghFhORDcR0UVWswUAdhLRCgDPAPg3IcTOSnWaYZjqoGpWIQFzvHnDd6yKbcuEKJwauWdywlbCdE7Y3ni+TJtI2TKyLzXy3KtBFFsGQoj5AOZ7tt2ovBYAvmz9Yw5A/r5mB9JZA6NaEnh1/W4s37wXXz7nMEwa1eRr+8iSTZg6ugWL1+9CUzKGy46dYOcvV5s3u/ZgeGMcB49qrsn16x1VKAvZHTLidiLz4Ejfnh0aktXS4xJ3J3JXB1fzPUQU0vYFy7fa57JTIYuI3NX+1XNhsUjizjCF+PivzcJKM8a2YuWWbgDAhl19+NPnTna1297djy968p/nTGrDoWOGVaejHi669QUAtfdH6xUp1ImYhnTWQM4QdrlcL31p05aRwhs2l6jQJCaZSgmYVoz0xzMRbZl8kfuLa9/F//v9q5Hamvv929T8/TrWdi4/wAwcNXrZutdZ0OG1DXt8bffuzwRsK2+1QaZ8yP/aYUkzDsxXGVJGwzLCD4vcnWyZ4P2qoKZzwn4vlGNLjZi7Pb9/hcQ9KGVxxea9yv76hcWdGTAyYgOA3X1+8VbpCVj4odyLQTDlQ4ppa2McQP7/KxlZy2PCXBzblgnZrwpuJme4Bj/zLdYRdLwXbwZPzrZlgp9Ggk7Vq/y+l3qTqUbEz7YMM2B29qRD92Vyhj1TMWcILNvc7WuzYks3Tpte2rwHwxB4c9NepDL+FXUa4jqOGj8cWoiN0LW7r6RrFsO6HT0wBHDomJaKX6sSSKFsbbAi9zzibkfuBcoLqJF7UBt1UyZn2LXXDUPY585vy4Tu8llKwh5QDTuX/2Tqd1DPkTuLOzNg7nzenfU6pb0Zb7/bCwC4b9FGfOyEgwGYk1W++fAyu92wZAz7Ulnc/MQqfPqUKfbqOMXw1Krt+BcrzzqI3181D6dOC75xnPK9Z4q+XjHsT+dw5g//DgB489vnorUhXtHrVQIplC2WuPekwpelk5F7ofIC6oIb3jVS1ePNcwrIr80QjkWTL1smX1TsvdEXmvAUtFv9XPXsubO4MwNG2jJ//OyJyOQEZk9qw6ot+3DxbS9gx76U3W7Hvn4AwB0fOxYtyRgObm/Gj/+6Bg++2oXedA7DG4sXd3n+266cgxFNjnhu35fCtfcvcV2/2vQp/vSe3sygFHcZ2TbEdAD5a7qnvbZMAXE3hHCthGQYAppGPlvGUGwew476A04s11DNo7i6x36R5ys1WavUMgLVKD/A4s4MmJ7+LKaNacGxB4+0t82a2IbmhO56hJVe5emHjUbSEotjDx5hinsqi+GNxYtfT8r0+E+b3o5hinhKUQ+zEcpVmzwfalQaNNYwGJBfU0Pc/P9S0xG9eAdUw6LinBLZp3JKHZmcgQZNt6+pkeW5W/uFEK4bgw9ZvjefuHsid7v8QEj7QpF5PUfuPKDKRCZnCPRncvY/+Ue0qzeN5qQ/TmhOxrB3f8b+Y+5JZRHXyRZ22QYwRTiTMwquRq9eFwC6rUyb5oT7+i3J/DZCudcD7c/kfJFqJuu8L/f18pEzRPkW1rC+66RdU10uKO2/RibnFvWwPqiFw9TIXb52rqlbee5O5O4M1pZmy3j3OTNUQwZU69pVzw+LOxOZ9/3P8zj8m0/a//79wTfx47+uwSvrd9nZFCqtjXE8+GoXpn59Pm59+i30prK+m0BL0hT6T/9uMaZ94wnM+OaTeHpVcNGl7z25Cod/80ncZC2Y8OSyLbj1mU4Afi+1IW7+aj+yZFPgub76wBv260QJXr/Kj/6yGod/80lc8vMXXNsHGrm/25PC5Osex+NvbinquLN++CxOv8UZT/jY/y7EuT/+e9HXBxzbIumJ3G94eBmO++7fkDOcGuvprMxz94v7tu5+TL7ucfxl+VbFWhF23RoAeHPTHky+7nEsXr/LuqaGTE64smUKVZQ024V/Hu/TRKFUyNNveTbvfvXwVVu7Mfm6x/O2DzquUrC4M5EQQmD11m6cNHUUvnb+4ThkdDPWbO/B6q1mNbyvnX+Y75jvXnKk/fr2f6xDTyrri7Dl+3d2mpkrhgDWbu8N7MMa61qyAt8zq8LLRhMRRjUn0JjQA/dvtvLxxw1vQCykemFUVlv9kd+FRLUwSkn3fGtbDwDgdy+tj3yMYQis39mHrt377Vosz731LtZY5yoWx5ZxlroDgLsXbsCu3jRS2ZydXigjd7swmKJgcmLb719+x1U4TH1Sk4tQP7zErEuYjGlWKqTiueezZSzyRdve3PpCtkwh1Gs9t+bdPC2rD4s7E4mUVcDp5EPb8dn3TMVhHcPQm8qiN53F7EltOGLccN8xxx8yCqOaE+YbYQpciydyD7JzwqJcuV1aLYUemY+bPDJUVHtTObzv6LG46JjxRRd9CjoXYH5HanErdfCxFHGXn6+Y3vUpKaFqPnapSBEN89xzhrAHKb0Dqqr+yqejTM5wzVBVzyf9cLktIcVd9kWxm4Iid7tdvsjdM2QQZTWofKifMWzmbq1gcWciIYVVinNzMobeVDYwGg+jN5VDc9IdSXvF3mwXIsiWbx1VKM0+hnju1o0mplHkFYbCUG9G6vXctkzxQluKb+4awC7DIK7Xc/dmy+QMYYe93gFVlbj07LOGskC225bx2t6m5+4eRLUnQAX8l8l9+QZUvX0rVBWyEOrZinkCrIaTz+LOFGRXbxqf/I1Zml9G2i3JGLbs7cfrG/b4BFtl9LAkAGBfKovF7+zyRepBkfsTy7biS/cvwVMrHe99464+LNtkPtp3bu9B5/Z9eGBxF4Bwz7wlqWPTnv2hs2KbEjHoGrlS7IolmzOwZKNTZqFHGThdopRf+OuKrb5j9/Zl8MGfv4CvKP6/ygudZmHVV97e5dp+8xOrQq0adYzhwp89h3sWbrDflzKbUh5iR+6eaaU5w5k16o3cve0AsySF25ZRInePwjq2jPneEM4kpiBbRm57ZMlm3PDw0sDP4xd3+ao0dVe/06D69fvTOXz49pdKOvdAYXFnCrJ66z4s3bQXp08fjVMObQfgiDYAVwqil+9+4CiMGZbEOTM7cObhY+wJTZL2lgQ+fcoUHDd5BKaObkZHaxJEwEOvb8JVdzmTk5ZuMut5HDGuFQDwD8XffOQad3EyyagWs4/r33V7+IYh0JvOoSWp26sFRVm9J4hdvebs3GbL21ej5e5+pxRD0Onf2r4Pr23Ygz++1hV4bnmuqaPdFSt/+fe1uPGR5YHHqOMVu/sy+PpDjsiVcv+SYphUIm/vftkm45mhqh7vquioinvAzGJJQ1x3VYVUs2UCbRlr04ZdffjDyxt8+719UylH5B5kyyx+Z5fv5lwtOM+dKYgUmS+fMx0HDW8AAMye5KyieOIho0KPPfbgEXjlG2eH7ici3PC+mfb7bzy0NFDsZPT9nUuOxAd//iK2WROibrn0aMwY2xp6bbX/EulLNydjykIQAvHwB5BQZL/OntmBR5Zsdj0l9KSyGJaM4bgpI7Hd6m/QsYApft41R2W/i7nvBM34lGRyBnStuA/p9dy9tkzGcDJY5LXdM0zNa6rHyc+TNQxXf/sz7nMndA09/VkgYNWkfJG7cx3hS3EMK1ZWKi7PPeAOETaeU41SwRy5MwWRXrdqoaheeZC1UiotyZjvjxxwhK6j1by5bO9O+frhpTmkkqE8V7PluQPhFQwLIT122S+v592cjIV6/+q2IH9cin8qz8QhL/nmCZTi4XuzZdJZI3QBayngqqDJvgfNbM0ZcOW578+4v4NkXEPGcDz6TAFx924K+t7C7n0lj4UWGFAd6IDtQODI/QBm0fpduO+VjfZ7AYFdvWmMak662q3faT7qhwl6PoEtFu+NQhYee3Gt6T+Pak5AI8eHzndjkTn0r72zB2ce3mFvVweHvZUMi+V/rbo6Yyyb6tuPLsdp00fjmxfOxAOLu3DI6Ga0JPVA33/Reudx/Qd/WY3vfuAo1355U1LFtJBYpLMGWpKxwOuVkhUkI8yYpoGsGaNPLHXGD1RxT2f9Ebb8fqWtppIzDJcA7/dk99ieu6Wg6sD3/KVb0Z/J2U8UgD97qjeVde2X1wwibCWmQqjXDBpQHWgm1kBgcT+A+cPL7+DxN7fYUeemPWbu96jmhO+P4rjJIzCqJWG/H9/WiFkThmN/JofpHeWreCitFMnqrftw5Pjh1uO5aQ80J2J2Xw8ZHb6C0vg2cxWonb3uqpVq5O4IaGmR+1OrtgMAzp7RgYde34Tlm7uxdkcv3j9rHACgtSGOhrjuEy4A2NPn9OvuhRvwrfcf4bJmepQUS0k+20W2HdmcCBb3ErKCpDbpGiGhmwt2XHu/s1hFOqBvqq8txX1Xrzn+oJFzzqwhXBG99/8grmvIKvXcs57B3DufW4drzpzm66ukN5XDKM+v5gATo3yoTwtBA6phN+NqSH4kcSei8wH8FIAO4E4hxM2e/Z8AcAsAOVR/qxDizjL2k6kAvakspncMw/wvngoA9uy6n1x+TGglRUlDXMcj15xS9j6dbA3Yqn0EzCj2PYeZfWq2qkkC5k0mjMaEjnHDG3yWQI8t7jpa0jF7W4fvDIXJGQJXn3YIJrc346HPnYzpNzwBAHjXqm3zmdOn4vWNuwNFuSeVw4yxrfjw3An4jz+vQG8qi0TMuYH2Btgy+Qp3AabYjmhOYMMufznj0mwZ8xiNTA/c+znSSm0Ye0BVaSLFvy+g/IK3TELGI966RhDC7dGrdPe7z+n1sYNucKGRexlS1INsmVIH6stBQc+diHQAtwG4AMBMAFcQ0cyApvcLIY6x/rGwDwJ6AiYVAeX10AeKjKx7lNIFMvUyEdMKrr0qJ8K4zmlFxC3JmJ2jX2pOeCpr2JkkatS9bZ8zJpDQ3TMtJT2pDFqSuv25vGIk+5TOOscWEuh0zrBrr3spxSKQ1yMie6k9laCnCm9VR8D5LOqTgFfcvcKrawQBJ9XS239vX7w6GlTPp9wF4wply1SjQF0YUQZU5wHoFEKsE0KkAdwH4OLKdoupBDlD4I+vduF3L63H715aj4279gfmqJfTQx8oC9ftghAC63b0oiXhTKACotWEietuQeruz+CnT62xzyPP9cZG/5KAT63cZqdRvtj5ru8GkM2Za4oG9eNHf1ltXUNHQtcghF+czDkCMfv73trtZNQIIbBlr/NeimghgU5lnJuNl7teWo/H3tyc9/hX39nlytuXgqkTIa77b5SBA6pKBC777b1xJXTNFHdFkb2fLWbNQZBbvbaM9ynCO8iqXnP9u714a9u+vN/f06u2FT0Aqt6wY0WIe73UlhkPYKPyvsva5uVDRPQmET1IRBODTkREVxPRYiJavGNHeF0QpjIs2bgbX/m/N3DjI8tx4yPLsWnPfkxudzzrk6aaKY0dwxpq1UUAwPDGOA4/yFww+68rttkWg/zjldG2N3UwCG+0ec09r9uToUYPS2LCCNPW+bOnOFdvKour7lqMq+5ahK17+3HlnQvx5QfcC3tL4UrGnX5IoZfLDY5ra7RnZ3rLEaSyBlIZAx2t5mDsq+/stvev8tapiTjwm84ZrqqbKrf/fR2uued1bAywbCQf+sVLuOQ2pwCaFF9Nk09B7uurkbt87Y7czdfebKG4Tsj6bBlv5G7eFO3FPTyRfcYbuXs+S78yzvGeHzyLc378j9CaNE8s24pP/XYxfvPi+sD9YahnC1rxq5aRe5QQLei519vjPwO4VwiRIqLPALgLwJm+g4S4A8AdADB37tzafeoDlD2W4PzuU/PsyUAjmx2P93efmod0zkBTxHICleKNb50LAPjM71/Fss177X6fd8RBAJzIPR5hunfc4xMvt7I25kxqQ2tDHK0Nccw9eITvEV9OQFq7o9d+vPcJrhR3RUyX33QebnhoGe5fvBGnHNqOjtYGp65KVgDW173P8ovfP2scZk1oc50PcP6vLjxqLB5fusVMGWyI5rkXuunt3Z9BYPQVgLxeQjcnfKWzBg7rGIY12/dBiODIXRU0ud/71CP7qEbjXiHUyIyMbc+9yMg9SFcLPfls2r0/734vhSLwQlUnK0mUyL0LcP0uTADgerYTQuwUQsglb34F4NjydI8pJ/IxdVxbA0a1JDGqJenyrGO6VnNhV2kflkBfOufKbgGcFMdSInf5cdXP2d6S9ImP+l7mYntvJXbkrvQjrmsY22Y++cgbp4zc1YUp1EHdmK4hGdMC68KMaI5b13KX0w0jnTUK2lV9IQXFgibWyO8urhMSMR1pq/CXXFXKnQoZni3jtWXkurpqmqf3qUAjgoAjkPksIbP/ns8TkJNS7rxz9RpBoUbozaRObJlFAKYR0RQiSgC4HMCjagMiGqu8vQjAyvJ1kRkohiGwfPNeuyRtPQ2Y5qPZytfu3GGWq1WLlgFAXIsg7rqGdZZvvq2735cWKc/nFfcVW5wo/Y0u04OWVotECpP3JiP7KW8kSUvIVGtCPhmon6lLiRrl08LIJvMGsbRrL7Z393vW7wwQ41zhyP3dnhT2WdfP5Azs7DHjMnXymBRjGR0nYhoSVuSeM4R9DTV6tiP3XHDkrq60Fdf9VpXXdiGyioXZ+92f1yv2/oU4/J+9UCpkoScjH4Ui93oeUBVCZAFcA2ABTNF+QAixnIhuIqKLrGZfIKLlRPQGgC8A+ESlOswUz99WbsOFP3seP392LWIalbScXS1oScSQzhp2HRWZZ99u1YwZ3lT4cxhCYMe+FFZv3YeLb33BFoAjxzslir2TjHb3pvGFe1+331//J7M+y979XnH32zJq/+T8gdZGU8B/88LbdptnrPz4EVZ0bwiBF9Y69XLkjUBG/5+9+zWc+v1nXNbE853++uHSlskn8J+7+zUc9e2/AAC+/qelOPY//4ZsznBll8jP7ETump15lDWcpwNZG0aj4Mg9bWUJ9WVyLgtQWmpq9O21XTQiGEphMr8t47Vh/OUHvBQqP/D7l9/Ju9+LCHntXK++PXcIIeYDmO/ZdqPy+noA15e3a0y5kGl5P738GEwbM6yurJd8qE8Y7z3qIIyzctr/3+mHYM7BI3DomMKTpz5+0mS8uHYntnb3Y/u+flw0axzOmdmBc2Y6We3mZKacXYtkZ697Ue3Ljp2AJ5dv9Yl4OsCWAYALjx6LjtYGzJpo3kDOnmFeKxPgL8+eaPrtMw5qdeWmyyeJkS3ObOFU1nBFt3s8TxJmmxySMQ2vfP0s/O6ld/Cjv65Ba0PMlxMuediqItmbzrnEU0bzGSVyl5lHhuFfdi8Z052KjR7P3awc6c7CSsR01/GAPzInMgUzLM894RlzCVtCT6XceecF11gN3V550efaMgcAUijOmdmBmeOCi2zVI2qa5olTnclNTYkYTp8+Ou8EJsmkkdYs1Z4UDAHMHNeK988a55qB25yMucrPypmhstLjUROG4yNzJ/om4khbRs2WAcwo98Spo+ybaEzXML6t0bcyU2tDzB7zmDiy0SVG8klihOfpRJ3p6itfawhkcqZl0taUsCt3HjwqfBav2p+gxUWcAVXNToXMGo71Y9/g4pptx3g9dynaTcqqWFKY1doy3hm0BHJly3iDYP97b+Tu/5zlLgfgEuk6SxFhcR/iCCHQm8qCCGgspexhDXHXrymt794c8qDxBtmmuz9jf1+AMxDanDDz4fvSOZegSmGKkm+fjGn2zUAIgX2eCWS6prmEx6w3r/v+z9Qywr5JPUqUrZKv3r56PfV8dtEy6zPGLasnZUXiMnJXB5Xl8TlD2P1OZx1xV7976bmnc4adH+4fUHVny3gJr80e/B6owICqS9vrS90Hx/M5UxLprIH33PIMNu/txzAlShwstCp14oclSxsnGGbN1vz+k6ut8/h/5WWbed99yrVdClBzMmZH+tNveAJr/+u9ANQ898LiqWbtXP+npfjTa+6Fu70rQvWmzRm5XivoC/c6ufbeSDedc99sRliDsVNHt+Dlddai05ZAA8AP/7LaFtSeVNb+HhK6hrU7erG3L4PrLO+9IaaMeDWfAAAgAElEQVTZM22z6oCqsiReX8rJ6GlM6NifyZnL6uUCInfl+LiuIWvkQgZUw+vQ+22X/B48UInIXXldxKmrkSHJ4j6E2dOXxua9/Th7xhhcNjdqZnP9MG/KSNxw4QwYQvhqzkSlrSmBWy49Gpv39CMZ13DWjDG+NmfP7MB1FxyOm59Y5dqesMVdt+cFuCL3EM89CFVUFyuTlSQxa1KPpCeVM0sXeM6tDvyGTceX/TnviA788LJZOOeIDtxtrcjUkowhlTUzhv7n6U772N6UU2HxkNHNWLV1n52lNGvCcIxqSdqTmNRsGXVQuXu/2becIdCg7JeirS7H6IrcdQIyQXnuZEXD7u3Xnj0NP33qrYJ57cEDquWO3NXspcLXryYs7kMYKQTvO3qcPQFoMNEQ1/HpUw8Z8HkK3dhaG+L4zOlT/eIua8bomr1ICWA+2msaOZ57kfn28QAbJ2bVWpGYteB1+9xtTXG0Ncaxfqcz6OoVqlTWbcsQET507ASXyDQnY4HpoD2pLNosf3/WhDas2rrPXmXq8nmTrH47qZBJz4CoLCcAmBFzQ0Iu7iEczz0ZHLk7i2d7xDAkcj+sYxiOO3ik7/N7xTRIW4tOdSxAwQHVGuo7e+5DGJlON1jy2usNKTrxmOb6Dr1lgqNMpkrGdJfn7kXXNFe2ilx4XJ47rmu+mjphk3q8Vo5qx4X9LqgDqlLkd1lZQ2phNNuW0f22jIzQzcjdWbnJ9tyVyF09Xt7svDaTZqXLeL8vTSNoGuDNaoziucua85XAZxLluVQ1NJ//6gcJNz+xCs93+uvxEAifP+NQnH+kE5mv3NKNrz+0FHutVLkoA2qMv6St/N6SMc01+Hnr0524+Jjx+PcH37T2R/Pc9+w3zx0UPcY0cnnOvaksDmp1nhZalCJnrY0xvNuT9kWu6Qg3m7CB6d60M6Daas2DeLcn7Tqfkwrp99yTMc0WW9WTf3b1dlxyjFmKSo3cZQXFdM6ArhGIAlIhYT4FeEVaI4Kuke979Ns0fgmtZOTue3Io65WKh8V9kPDQ612IaZpdUEvyfOe7eGrlNpe4L1y3E69v2IPTpo/GkeOHuybsMOH8/KNzcPfCd5CM6Zg6phmXHzcJdy/cgBkHtULTCJceOwEPvtqFF9fudNk03lTIIORCF4BjZdx39Qn2/phuVkCUlk9vKoumZAxjhzfg82dMxaXHTsR3HlsBwBHGMM89KHvnux84EpNGNmH+0q1YtN7v+aezhv3kIAdWZWaOvHklYhpSViTuZMvIdFDdvjkZQth9NAdLze3jhjupq/LcqYwBTTMF2/t5ZPkBr0jqVnuff57/LYDSl1MMQ82Q8Ufu7LkzEehN5XDZ3LH41vuPcG0/84fP+mqF9Frv7/jYsb4VlZhwzp7ZgbNnupfsuO6Cw+3XP7hsFvZncli5pdtVriDSgGrcGVBNZw18ZO5EnKAsLC7TAXNCQANZA6o6iAj/dp7ZBxm5n3l4B+59ZYM/cs8Fl0MAgI8efzAAcxzj3lc2+PZnDWELn8zPl6tfJZWxB+/TgXpDkTennCGgE+HkQ0chlXFsGXWsQa5atD+TQ0zToBP5CoHZ5Qc8IklW5F4oUg+ulVPBVMgINxenLU9iYmDlqqeDF9YIWi+zN5VFTKNIosMUR3NCR28qa090AqLluavCmMkJxGPutFRdc1dJ7LU8dxVpqcjFqr0etZ13n+f/3XtOSTbnRO4yZVH+Xqnibn8e7wxVq085IWAYZolgXdOQMYR9XnUxC3lj2p/JQaPglZCI3CsxSXQi6AGRu1cug3Lay23L5Kv6WOPAnSP3euc3L7yNlVu6IUTwYFhzIoYVW7rxk7+tQTprYHdfBq+9sxvNycGX1z4YaE7GsK07hV/+fa29Lcr37I3cE7r7iSpmWy0GXuzcjf2ZnO//W61jr2uEnz3diVkT27BhVx8+cdJkpHKO/x1G2EIsZuRuqpGcgCTLEtueeyxA3D3pl3IBjoSmWxlAhi3C6mIW8imhP5PDiKZ44PqjcotXQE2Pnlxe/P2LNvieYINL/pZX3G97Zq3yzn/BWuo7i3sdI4TATY+tQGPcXAv0GKsOicop09qxbNNe/ORvbwEAWhtiSMZ1nD49/xqoTGnMmzwSv3lhvf1+rmdB7zASum4vl9efyfl8evk+lTXwa6vA2BzPuaXYq2mTV921GABw+vTRkQZUx7QmA7fnDGE/CdiRu23L6PZ17f7qTn/VNvImoWlkTcwSyFiCGtOdcYsPz52IFzp3oj+TswdIJXMmteHSYydih1UTyRuhE5m+u4zMMzkDX/vjUt9nChLWTJltmT++1uVcz2fL5Inqy9qLYFjc65hMzpx6/bn3THWt8q7y+TMOxdjhDfjyA28AAP7nyjks7BXkgqOc6tbzv3Bq5Fo9Ms89ZU3H90bQTcparj2pLI6bPML3/yjHT7zVEQFTVMMKmXnPsf7mC3HktxagJ5XFxJGN2NadcuejS89d2jLWjUcV4NDIPSdgGAI6mWKurpMa0zT84LJZ+MFls7B8s7loSiYnENPJtmU0Av70uZMBAD97ygxYfJG7dTOQNWzC1r8NK4lcKYpJhawGbMrWMZmQWiFeylGDhSmeYtaaTcbMNEt7kY6E+/9J/r/1pnLoTfktGUApkxsgUP2ZnDK4Wfh3IGadSyOy7RNpWTRafduXktky5u+fK3KPObVjAGVlJcuG0TWy6+UEee6qf68T2baMas/I5r6ZqxrZ5YAB/0IgkmqkQqrUWsy9sLjXMflmNKqoIjNYyvkOBYqZPyDFL2zBFPn+kSWbrNmp/v9HeY4ggepJZUMLhwUhhVqKe9aqKAk4Yr5x137X+bSAyN1bgiEnBAwhoBEhbuXuy5uGuiyi2kdNc2wZ9RpyLMP7oKIpkXvX7j78Zfm2wM8Y6LkHPPWUi5fWuevrCwEs7fIvvC73VRoW9zomauSulr7taK3t4tYHAh+YPR4xjTCsIXoxMyl+d1kLME8Y0eTaL9/f/o91WPduL1oCbtKHdZhzHOZM8vv8vamcvXBGNHGXJQrMksTZnGKfeOqkyyhdpwBbxlOsLGd57jHdEmDF7lEj97YmZ+EOM3I3X6trTMvLebNedM3Jljnle8/gJiv/30s1yg+o/OFld4qpgMDDSzaHtK48LO51TCpi5D65vRlv3Hgu3vz2ua7VbpjK8MPLZuGNb50bSUQlUtz39WfR3pLEiVNHufZPaW/G9z50lP0+KHI//pBRWPrtc/HBORN8+3qVyD1KCqyuRO66FbnLAdWYpuGnlx/j67sqzjGNXKsvJe30TNNz14gQ0wkZQ9hVIWPKsojDG+M4dVq7fV4KsGXIypcJWjhb06hg+V5py6jeeyU993qDn+HrmEwRf6xRlpxjyoOmUdH1euSNYFdvGgcND85YGd/mRPNhYydhTws9qWykbBmJjM51yz7JGYZty8R1smepAiHibkXmTvE0s78yFVK3rJacMjlKPR5wShLLSFz2RyKbe71zTea5F/A2pKir94BKRu7+6+fZVy8rMRHR+US0mog6iei6PO0uJSJBRHPL18UDiw07+7BiczdWbO62/dlCkTtT/0jx29WXDp1IpHr4TUXePDq392Dv/oxps3hENAjZhgjQdXLZMrpGrihbRtWqOMuI3z+g6sxQjWmaOTnKcG4arj7oznnlqdV0dxnFB5UC1jQKrfMuEcIsj7BPXeCkgp677/pVu1IwBX+DiEgHcBuAcwB0AVhERI8KIVZ42g2DuTj2wkp09EBg5ZZuXPDT53zb1SiKGZyokfvRIbV+RjU7EX2hJ4NjJrZhyUZnsO63lpefjGmRJlXJgEGTImw4+ehxXQu8QaiWiYy2pcCqk5gMK1smrpNd/10e4+qD5vTBtmVcA6rmT2+ELm8GhW0Z4NJfvISlm/ba26ppywyG2jLzAHQKIdYBABHdB+BiAN5RjO8A+D6Ar5a1hwcQcim4r51/OKa0m+teNiZ0nDS1tIUqmPpBFb8w4Z40qgmTRjZhw64+e5JQGH/49PHYsS+FTM7ATX9egec7zUyNqOMAMt3RLBNg5aPb3jj5hFhul8ybMtLVxpnEZEbqukZoTMSwX0nRVJ8GANglGHTleqotIwXfP6AKV557GIYQLmEHqmvL5L33VEH3o4j7eAAblfddAI5XGxDRbAAThRCPEVGouBPR1QCuBoBJkyYV39shjpyMcebhY3CYp/ojM7hRRTdfVH7c5JHYsKsvdL+kJRmzU2BPnDrKFvco5Yfl8YCaCmkgo9oyATcXNaoe3hgPnNSUM6xUSI3scYNua6arNwtHir3bllEHVE28Ik5WXnyhVZWCIudq2jLlXq+1WKLc5oOe8exeE5EG4McAvlLoREKIO4QQc4UQc0eP5lmUXqS4c/31oYc6aafcE83UeQ5Ri8XJEgNkZbVkc2a2TMzKXAmyZdSoOhnT7WJnRI5w5xTPXc652Lvf9Ly954wrg7ryxqG5PHfzp7ccjJyhWkg8g0v+VlHca2zLRPlN6AKgrlM2AYCavDkMwJEAniWi9QBOAPAoD6oWz5PLtgIofTFopn5RF9HOF7mPHmb67sWMs6htN+3ZH+kY2QedYM8klTNLAb8/HrRN3q9imnMzyCnnkTedbkvcvcfLpwNdc2aoqm0oz4CqrpFd2jqMWotrjV2ZSLbMIgDTiGgKgE0ALgdwpdwphNgLwDaFiehZAF8VQiwub1eHPvIXnNMahx7uyD38z+7as6dh8qgm1+IrhTjr8I7CjTzIOjWaNYEoZ81QlQOtXgsFCBBnxVZRFxDJ2QOq5v79lgh7rZ64dUxMVycxBZQf8Ih0PEYIqiLppcauSP3bMkKILIBrACwAsBLAA0KI5UR0ExFdVOkOHkj0pLKYN2VkrbvBVAC1CmS+yL0hruPyeZOKKtc8vCmOK48vbgwroWTLyCXrcoZhi7p38BPwi7tsItMeAW+eu7lf5sJ7UyGl+Ku1ZVwfO2RANa5rkfLEax251/rmEunZTwgxH8B8z7YbQ9q+Z+DdOjDpTWcxZhiXDxiKqJF7U6L8YyrFVu6XA6DSL09lzAFVaa8USoU02wRH7obhTm9M54KzZexInhBoy4RF7omYZmf25KXWkXuNF/Lg2TF1wDOrtuNDv3gRb23rqcgfPlN71Mi9mGqSUSl2olvcVRVSs8sPqIINAKOUchZeq0a3bRUnL/6ehe9Yi147A7Dzl251XTOoD1L3o5QfSOhapIHRWkfuhbJ5Kg3PjqkD/rJiK5Z27cXxh4y0V4pnhhbtzUlcduwEdPdnAhddGShfPGsafvvievzyn+ZEaq966zIVMqsMqI4d3oAPzhmPi2aNs4/xZuKoZQnkcQusCo26pvlsHK/VZM+ShXMjiAVE7kG2TBThrrUtUusSwCzudUBPKodxbQ34/VXHF27MDEo0jXDLZbMqdv4RzQmsv/nCyO2lLZOMadBIpkIKO5qO6Rp+9OFjXMd4y0nLMgoyNVFFJ0KhYQNpyxA5wq8+geSboRolcq+1uOZfianynWNxrwPC6nczTKWQYwBxXQMR7AJfQZOXJF47Sc7H0DV/XrycRZoPexAVTraMuk6rM0PVf2yUTJQD3ZZhz73G3PncOqzc0l0RH5ZhwpCReyKmKZ67yFt0zDu5zl7TVfdH7nK1pCiYa6KabdWyC2EzVIFok5FqXdul1rYQi3sN2d2bxn8+vhK7+9KcAslUlcMPasWo5gTOOGyMy3MPym+XeKtZNsadRTx8mTARxD1nheSaUs9d1psBwqtCAtFqxNRaXDlb5gBGrv1408VH4ivnHlbj3jAHEvOmjMSr3zwHl8we71oxKSi/XaJ5onN1hqnuuSloAT68F7kYTUNMt22ZRIDnHkR/xpmdes7MjsAnjnL72uPbGvGhgIVSwqi1LcTiXkOkuLMlw9SSmK4hYzi1ZSIfp5Qq8HvuhEKnSimrOMkbgTqgqkb+3vP3KaUHwq5Ta887aKygmrC415CF63YCKFy7m2EqSUyumJTLb8t4UevQ+OvOkC/S9yLFPaFrtpC7B1Sdtt5zqZE7hUzhSmXKr65FTBzOb8uUoS+FYHGvIbcsWA0AGN/Gs1KZ2qFrZK2YZOS1ZSSHjmkB4ExCigVE7rIsbz5OsMaZTj603W7rtmXCI/f3HjXWfq1pwWIpbx7lotgB2lqnYrK415BU1sAHZ4/HoWO4djtTO+K6XOu0cOT+1ncvwJNfPBUA7JK/QVH6adPaXSWCgzjp0Has+s75mDdlpD0hyj1D1cF7rk+cNBknWYuMh0bu2eCqkUdPCF4JK4x/OXVKYJ8KwZ77AUrGWltysrXiEsPUCl0zPfdMLv+AKmAtwSdnt9p1aPzL8jUnY4jwEGBXp5QlkdU0e1eFyIAng5FWaYSwe0hY5F7MuALgLIBSrFTnWymqGmmaLO41oi9lRhXstzO1RnruOaPIAVXdqeTo9dxbkrHIee6Au0qlRD1lUOaNuppUEGGeexTrSUWeXojiPPda59mzuNeInrTMlOFCYUxt0UscUJU3AgG/YCZj/toy+ZCF1YIWyJZ99CLLIYRH7sG2TDH9Ms8vP2dxYl3rPHsW9xrhLKnHkTtTW+TAaH8mV1R1Sem5a1bkLkX2pKmjIg2oqthFyAIWyPZulyQUnz4oSu4Pi9wL3MDmTGrD7R871n5vFzAT4f5+EPlKJPAkpiFMD4s7UydIke7PGkVFtTJyt9MYrfPMGNtqbY/eB+lrq8e4BlQDThZXbKHgbJnSInciwuxJTuVO+fmEEEWmQkZvWwlY3GtEL09gYuoEKdJm5F685+7UdXe/L+ZG4Swe4i8/EHYu2woSwZFwqQOqGrkjdPmq2Gi71tkyrCw14K4X1+O/n1gJgMWdqT0xxZYpJXL3vi9F3KUto84qLeS5y36HFRELE/eCkTvc5Yrla6PIyP2jdy6M3rgCRIrcieh8IlpNRJ1EdF3A/s8Q0VIiWkJEzxPRzPJ3dejw2obdSOgavnrudEzv4Bx3prZIUTZEcZkkMo1RRqhxT4rk+LZGu+38L5ya91xS3LPKnP2wzBmJfMoISjnUNbKtTy/5yhoDAMhtCTkDqoOLgv+TRKQDuA3ABQBmArgiQLzvEUIcJYQ4BsD3Afyo7D0dQvSmspgwognXnDmt6JF7hik3uiLoxdgy8qkzkzVlL6Ysmwe4LZaZ41rznkvmuWfUtVGVrgTddOTNJGg9VZ0I6RJtGUJweqV5Dxk8f69RbtPzAHQKIdYJIdIA7gNwsdpACNGtvG3G4LvJVZWeVJbtGKZuUMVOLyJyl8kAKav8rhTEYicJAU4dd7WUb75JTIATgQfZMvk+RpRFRILsl3LmrddLtsx4ABuV913WNhdE9HkiWgszcv9C0ImI6GoiWkxEi3fs2FFKfwc9P/nbGizb1O1b+IBhaoWaGlhM5C7FXQqzPNJb/jcKMs89q0Th6lmCbhhx207yK2U+e6nQzWf7vn73gKr1srs/i2yEOvL1QhRxD/omfN+mEOI2IcRUAF8DcEPQiYQQdwgh5goh5o4ePbq4ng4R/vDyO2hK6LjomHGFGzNMFdBdkXt0YT7soGE4d2YHvnLudACODaPmpP/sitn4ziVHFjxXYgCRe1BpX7X576+ah386YZL9vtDTydodvS7VU4X+H28NnqA0ijfQBWCi8n4CgM152t8H4BcD6dRQpieVxT+fOBkfmB296D/DVJKYy3OPbsu0JGO445/n2u+lFqs3iItmRQti4gEWiytbhvzb8j1lqH045dB2HDFuOP7w8gYA0WyjoGwZIHxiVLFUY4HsKP+TiwBMI6IpRJQAcDmAR9UGRDRNeXshgLfK18WhQ84Q6M8YvuXKGKaWqLZMKX65ZCCeu+yDGrkHpUKqZ5Y3hCBbRkbnRLL8sP9c+aCQ1/szwROj6pGCKiOEyBLRNQAWANAB/FoIsZyIbgKwWAjxKIBriOhsABkAuwF8vJKdHqw8u3o7AP9CwwxTS2Il2jJetIDIPSp25O7y3P39ylfjXUU+gEiLSLV1oowrqNdRbzJhGTj1SKQQUggxH8B8z7YblddfLHO/hiS3/2MdAGDm2PxpYQxTTXSX8JU+ad323Iusugg4Qu3Oc3f2TxjRhLamffjIXMchztdXaTVJUXfPdi3cP3fkXv70x2pky7A/UEX60lmccdhonHRoe627wjA2qkgWUxXSizyyFFtGLq+n5rmr0fO44Q1YcuO5rmPkTSlIKKV+O/VvnH1R+ldM0TMA+PwZU3HbM2uLOqbScG2ZKtKbynGhMKbuUCP3gXjuUg8LrZ0ahCw65s6WCTh5wKagwUndk7lTqE5N2LlDLu2j2JtBNWBxryI8eYmpR2IucR+4LTOQAVWX566cJuiU0i4JjNw9Xnux4l4sVKS48wLZQ4zeVJYjd6bucEXuA7BltAFE7ge1movEqwtfuwY1A3xvdYWksH16gC1TfOQexcYp2KTqsLhXCcMQ6EuzLcPUH6rnPpAnSymyiRIGZUc0J7DsP87Dv555qL1N1cvgyN26bkAc7AzulmjLBJT8zYc6ceu7Hyg8aasasNJUiT4rP5aX1WPqDVXsBhJ8yHxzWeGxWLw3Fi0kHdHZaP4IjNytn0GpkAOZxBSGev5hDfGC7XmB7CHElj37AfDKS0z9oYrdgCJ36+dA0ilV3OJenO8RNFtWMpBJTIWuB9SPRcPiXgXW7ejBuT/5BwBgRFOixr1hGDdqffO2psJRZxi2LVNi5O6lUPTc3pIE4CzrBwCHtDcDABqtEsJB48PRPPfgNh2tycDt7trz9aHuLO5VYPOefggBfPmc6Tjz8DG17g7DuFAj9wkjmgZ8nmIqS+ZDfQIIGlCd3jEMD37mRHz9vTPsbT+7YjYe+fzJaLOCqKCFtcPE/egJw+3XrrVclXP8+V9PCTw2bO3XMKqRLcMeQRWQK8KcNWOMvXoNw9QL5UoNlBF7uc6n3iTCTjl38kjX+5ZkDJPbm/OWQgiLrNWxgrDyA6OaC0fuxVpIlYIj9yogF8PmgmFMPTKQ9EeVuO6fZToQEi6xjXaMNzsmWNyDjw0T/UJZO2b/wm9EA5kYNhBY3KtAb9oSdx5MZeqQgUxcUpG56uUKXNWUyqg+tmwmxTbouLBaMaHXiBCVh9k4QHDeP9eWGSJIW4ZnpzL1SLlslO996GjMmzISsye2leV8pWTdOOu3mu8DP1vIxw37HqJ8O/kW826M6zWpJsmRexXoTWWhEdAQ56+bqT/KZRsMb4rjU6dMKZvnrNoyUSN374zUIMEOO1OEwD0Ud+Tu3jd7UnludsXCalMFZMGwehloYRiVcnnu5caVLROxi3bxsjyee9jfYXjkXlzqpLd98BMIT2Ia9Dz6xmYsWL6VLRmmbimX515u3Nky0dRd83jtQamQYWcaSH6661jPaUopx1AOWHEqzAOLNqJ7fwafPHlKrbvCMIFoBFx67ATMmTSi1l1xEZaOmA/d47kHDWaGnSs8E6bwdfPludfqySjSLYWIziei1UTUSUTXBez/MhGtIKI3iegpIjq4/F0dnPSksphz8Ah89bzDat0VhgmEiPCDy2bhyuMn1borPqaNaQEQPXc8UuQeIZ3Rtb2I6wadJ8iWqUa2TEFxJyIdwG0ALgAwE8AVRDTT0+x1AHOFEEcDeBDA98vd0cFKbyrL+e0MUyJ29kvE9qTJ48yfwQOqhdMZXe0jXDxfm3LV2imWKFedB6BTCLFOCJEGcB+Ai9UGQohnhBB91tuXAUwobzcHL1zDnWFKJ2ixjXw4tky+AdWQYwcwoOqK3D37ylWOoViiiPt4ABuV913WtjCuAvDEQDo1lDBXX+KSAwxTCjLojeq5R8lzD7VfQv2awtdVr+M9TaAtU/iUAyZKSBn00QL7RkT/BGAugNND9l8N4GoAmDSp/vy9ciOEQC8v0MEwJeOsgRqtvWbbMvlmqAYTlu8f5dLuZJkoqZCVJ8pVuwBMVN5PALDZ24iIzgbwDQAXCSFSQScSQtwhhJgrhJg7evToUvo7qEhlDeQMweLOMCVCtude7ICq+T5IV0NtmTKlQnpPk6hjW2YRgGlENIWIEgAuB/Co2oCIZgO4Haawby9/NwcfqWwOT600vwrOcWeY0pB2R7G2TD6PPuxGEeq5R1pDNZ/n7pfZjbv6fNvKTUFxF0JkAVwDYAGAlQAeEEIsJ6KbiOgiq9ktAFoA/B8RLSGiR0NOd8Dw5ze24PP3vAYA6LAKKjEMUxzeAdJCSH3u2m2ufLZg+TZ73+RRTda5Qq41oNoy4ftiAeL+9zU7Ipx1YEQKKYUQ8wHM92y7UXl9dpn7Nejp3p8BAPzxsydhTo1qSzDMoMcSzaj1b+RNoLs/49v35LWnIWsIPBcirOEDrdGva75x7wvqejVWa2K/oEJkcmYVuBljh3FNGYYZIEEzTfMRNOVfLpRT+Rmq7gNKXcd1oNRnUYkhgBT3Wo2UM8xQwB4YLTJAyp9qGDaJqUx57p7mQcFdNdbvYOWpEOmsAaLarcLCMEMBKazFxkjZXHj99FIj93x/ymrtNW+zoOP0KhRrY1umQqRzAnFdY0uGYQaAMxmpODHMGmbs/pOPHOM/Z+i13Hue+ep7QADe6NoTuF9FrazpbRdsy4Seqmxw5F4h0lkDSbZkGKYsFB+5m+I+fkSjb1/4Unnu7VPamzG5vVnZH369fPZrsC3DnvugJZMzEI/x18swAyFK3noQWSN8zCvsTGH6HGUilVo/xtvVoPECFvdBTDpr1KxgEMMMFbwLXkelvSUJIDhrxj/gaf4MH1D1vvCj5rJ7mwXdNKqRLcOee4Xoy+TQxKV+GaYqPHntqVi1ZZ/9/tsXHYFHlmzGtI4WX1uvhmtEyAkBIsIPL5uFoyYMD2yfT45jeQqHBd2YWNwHMWapX64GyTADQQqjKLC6xeEHteLwg1rt9zPGtmLG2NbAtr48dCLkIKAR8KFj/Qbr1TsAAA4aSURBVNXKZft8Vop7n//8+dtXBrZlKkQPL9LBMANGSmBZVy4q1pYh988gXKmQ3ieDQFumQB/LAIt7Bdi7P4NX3t7F1SAZZoBUIsD1e+L5ywrLzaUUIws7jiP3QcqSjWZe7MFWoSKGYQaGKOPyFl4PnEK2+47Le87wdkFCzuUHBim9qSwA4CPHTSzQkmGYfEhhNMInnBaNV1alqA/ElnE57p6GLO5DiB5L3NlzZ5iBYXvu5Tyn13O3fob74IXLDueP3IPas7gPOhYs34oFy7YC4EU6GGagVEIDwyP00iN3VdL9A6r+A6tRc4rFvcx86f4leGrVdoxva8SwBhZ3hhkIHz3+YADAUeOHF2gZHV9krRWwZWS7yJG7u13QZMYTDxlVsJ8DhdWnjGRzBvrSOXzxrGn44lnTiq5BzTCMmzMOH4P1N19Y3pN6/iwb4zr27s/kqQopyw8E89o3z8GevnTo5VqScdf7733oKFfNmkrBkXsZ6U3lAACtjXEWdoapU7yRdVPCnGxYKHLP55Pnq+feEHfLbNTFvgdKJHEnovOJaDURdRLRdQH7TyOi14goS0SXlr+bg4OetDmQ2sIzUxmmbvGLb/4VmsKOs7cXOLZaYu6loLgTkQ7gNgAXAJgJ4AoimulptgHAJwDcU+4ODiZkCiRPXmKY+sUrtdJSyRnBOTlRFuugPAOqtVrSIUrkPg9ApxBinRAiDeA+ABerDYQQ64UQbwIoYzbq4KOHxZ1h6h5pr8yZ1IZXvn4WGi1b5rTpo0PaWz9DInCi/AOqPnGvkthHEffxADYq77usbYwHGblzCiTD1C9qLZkxrQ3oSztjZYHt7Tz34s7vPb7aRBH3oJ6VNKeAiK4mosVEtHjHjh2lnKIuEUJgT18a27tTAJwBGoZh6g/vxCjbTg37uy1Y753ckXsBW6ZaUh8lxOwCoM6jnwBgcykXE0LcAeAOAJg7d245J53VlK8/tAz3vrLBfj88JAJgGKb2SLGVZYSnjmnB6xv2hK6/EEWMo85erSZRxH0RgGlENAXAJgCXA7iyor0aZGzY1YuJIxvxqZOnYFRLEhNGcMEwhqlfrBrx1rtff/w4rNm2D4mQZTHt2jNhPge5B1t9nrvPg6+O2hcUdyFEloiuAbAAgA7g10KI5UR0E4DFQohHieg4AA8BGAHg/UT0H0KIIyra8zoinTUwoa0Jnzx5Sq27wjBMAaS2yuSYEc0JHB9hxmg+77wes2UijfwJIeYDmO/ZdqPyehFMu+aAJJ0TaErwfDCGGQzYWhtxBRCn/EDIfl+2TMj1Qt5XClakMmAuhs1fJcMMBuTfamPExIcoi3S7S/4GH19tOGevDGRyBpIhfh3DMPXFEeNa8W/nHYbLAtZLDcJOhQzd792ZP1avltizuJcBM3LnWjIMMxggInz+jEOLaO/+Gdgmnx9fxzNUmQJkckboSDvDMIObKIXDXO0L5LVz5D4IeHHtu7hn4Qbs7E2z584wQxVy/fDvJkJ/Judt7tpfC1iRBsD9izZiwfKtmDiiEScf2l7r7jAMUwGk5SJnqH7/0qNxzMQ2V5uDhjc47UMW4Paer9Jw5D4AevqzmN4xDI9/4dRad4VhmAojNfvDcydi7sEjcOYP/25uB1xP7rWyYbxw5D4AelJZXgSbYYY4UVIhg9qHIcq63Hc4LO4l8kLnu9i4qw/NvDAHwwxpyPMTcAt9sZG5UaXC6CzuJfKl+5dg895+TOsYVuuuMAxTQew1VPPMQgWAs2d0oK0pXtBTz0WcGTtQ2FMokb37M/jESZNx/QWH17orDMNUELX+u3cb4AyQ3vnxuQCAjbv68p7PCFnxqdxw5F4C2ZyBVNbAiKZEzdKcGIapDk6eu7qt9L/7Kmk7R+7FIITA8s3d2LHPXJSD/XaGGfoEDahGXZwjKPZjW6YOWb65G+/7n+ft96OHJWvYG4ZhqoHU4nwLZKuoN4FYwEGCxb3+kBH7dy45EjMOGuabyMAwzNBjvzX7tJS056Cl+apVZJDFvQh6rLUWT5gykrNkGOYAoTdliru6NnLUobagyL0hXh07l8W9AIYhkMqaial7+tIAgOYkf20Mc6DQl7YW0Fb+7vPluat1ZrQAcW9kca8PPvHbRfjHmh2ubcMa+GtjmAMFuXD2lPZme1s+/121Yg4LeMJvr9JYXSSVIqLzAfwU5hqqdwohbvbsTwL4HYBjAewE8BEhxPrydrU2rNm6D7MmDMcFR40FAIxva8SwhniNe8UwTLU474gO3HrlbJx/xEH2toaYE30nPBVhp7Q341f/PBfZnIETp47C3v0Ze99/XnIk5kwaUflOI4K4E5EO4DYA5wDoArCIiB4VQqxQml0FYLcQ4lAiuhzA9wB8pBIdrja96SxmTzoInzl9aq27wjBMDSAivO/oca5tYRaN5JyZHfZrKe6TRjbhn044uEK99BNl2HYegE4hxDohRBrAfQAu9rS5GMBd1usHAZxFQ2B2jxACvaksWthjZxhGYTAszhNFtcYD2Ki87wJwfFgbIUSWiPYCGAXg3XJ0UuWBRRvxq+fWlfu0gQiYs8l4AJVhmFKRHnxDvLo3hCiqFRSBe7Pwo7QBEV0N4GoAmDRpUoRL+2lrimNaR0tJx5bCjLGtrkcshmEYALjhwhlojTD+NmFEI75yznRcMnt8FXrlQIVmSxHRiQC+LYQ4z3p/PQAIIf5babPAavMSEcUAbAUwWuQ5+dy5c8XixYvL8BEYhmEOHIjoVSHE3ELtojwnLAIwjYimEFECwOUAHvW0eRTAx63XlwJ4Op+wMwzDMJWloC1jeejXAFgAMxXy10KI5UR0E4DFQohHAfwvgN8TUSeAXTBvAAzDMEyNiDRSKISYD2C+Z9uNyut+AJeVt2sMwzBMqdR/Pg/DMAxTNCzuDMMwQxAWd4ZhmCEIizvDMMwQhMWdYRhmCFJwElPFLky0A8A7JR7ejgqUNqgQg6Wvg6WfwODpK/ez/AyWvlaynwcLIUYXalQzcR8IRLQ4ygytemCw9HWw9BMYPH3lfpafwdLXeugn2zIMwzBDEBZ3hmGYIchgFfc7at2BIhgsfR0s/QQGT1+5n+VnsPS15v0clJ47wzAMk5/BGrkzDMMweRh04k5E5xPRaiLqJKLratyXiUT0DBGtJKLlRPRFa/tIIvorEb1l/RxhbSci+pnV9zeJaE6V+6sT0etE9Jj1fgoRLbT6eb9V0hlElLTed1r7J1e5n21E9CARrbK+2xPr8Tsloi9Z/+/LiOheImqol++UiH5NRNuJaJmyrejvkIg+brV/i4g+HnStCvTzFuv//k0ieoiI2pR911v9XE1E5ynbK64LQX1V9n2ViAQRtVvva/ad2gghBs0/mCWH1wI4BEACwBsAZtawP2MBzLFeDwOwBsBMAN8HcJ21/ToA37NevxfAEzBXrjoBwMIq9/fLAO4B8Jj1/gEAl1uvfwngs9brzwH4pfX6cgD3V7mfdwH4tPU6AaCt3r5TmEtLvg2gUfkuP1Ev3ymA0wDMAbBM2VbUdwhgJIB11s8R1usRVejnuQBi1uvvKf2caf3NJwFMsbRAr5YuBPXV2j4RZkn0dwC01/o7tftVjT+EMn65JwJYoLy/HsD1te6X0p9HAJwDYDWAsda2sQBWW69vB3CF0t5uV4W+TQDwFIAzATxm/dK9q/wR2d+t9Yt6ovU6ZrWjKvWz1RJN8myvq+8UzrrBI63v6DEA59XTdwpgskc0i/oOAVwB4HZlu6tdpfrp2fcBAHdbr11/7/I7raYuBPUVwIMAZgFYD0fca/qdCiEGnS0TtFh3dRcmDMF6zJ4NYCGADiHEFgCwfo6xmtWy/z8B8O8ADOv9KAB7hBDZgL64FjwHIBc8rwaHANgB4DeWhXQnETWjzr5TIcQmAD8AsAHAFpjf0auoz+9UUux3WA9/b5+CGQEjT39q1k8iugjAJiHEG55dNe/rYBP3SAtxVxsiagHwRwDXCiG68zUN2Fbx/hPR+wBsF0K8GrEvtfyeYzAffX8hhJgNoBemhRBGrb7TEQAuhmkPjAPQDOCCPH2py99di7C+1bTPRPQNAFkAd8tNIf2p1e9AE4BvALgxaHfAtqr2dbCJexdMf0syAcDmGvUFAEBEcZjCfrcQ4k/W5m1ENNbaPxbAdmt7rfp/MoCLiGg9gPtgWjM/AdBG5oLm3r7Y/bT2D4e5fGI16ALQJYRYaL1/EKbY19t3ejaAt4UQO4QQGQB/AnAS6vM7lRT7Hdbs780aaHwfgI8Ky7+ow35OhXlzf8P625oA4DUiOqge+jrYxD3KYt1Vg4gI5vqxK4UQP1J2qQuGfxymFy+3/7M1kn4CgL3yMbmSCCGuF0JMEEJMhvmdPS2E+CiAZ2AuaB7Uz5oseC6E2ApgIxEdZm06C8AK1Nl3CtOOOYGImqzfA9nPuvtOFYr9DhcAOJeIRlhPKuda2yoKEZ0P4GsALhJC9Hn6f7mVeTQFwDQAr6BGuiCEWCqEGCOEmGz9bXXBTLDYinr4Tith5FfyH8xR6DUwR8e/UeO+nALzkepNAEusf++F6aU+BeAt6+dIqz0BuM3q+1IAc2vQ5/fAyZY5BOYfRyeA/wOQtLY3WO87rf2HVLmPxwBYbH2vD8PMKqi77xTAfwBYBWAZgN/DzOKoi+8UwL0wxwIyMEXnqlK+Q5ied6f175NV6mcnTF9a/k39Umn/DaufqwFcoGyvuC4E9dWzfz2cAdWafafyH89QZRiGGYIMNluGYRiGiQCLO8MwzBCExZ1hGGYIwuLOMAwzBGFxZxiGGYKwuDMMwwxBWNwZhmGGICzuDMMwQ5D/D6Xrk5RZOfLzAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.plot(learn.sched.iterations[:-10], accuracies[:-11])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1445"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(learn.sched.val_losses)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.046875]},\n",
+       " {'accuracy': [0.0625]},\n",
+       " {'accuracy': [0.078125]},\n",
+       " {'accuracy': [0.078125]},\n",
+       " {'accuracy': [0.078125]},\n",
+       " {'accuracy': [0.078125]},\n",
+       " {'accuracy': [0.078125]},\n",
+       " {'accuracy': [0.078125]},\n",
+       " {'accuracy': [0.078125]},\n",
+       " {'accuracy': [0.078125]},\n",
+       " {'accuracy': [0.078125]},\n",
+       " {'accuracy': [0.078125]},\n",
+       " {'accuracy': [0.078125]},\n",
+       " {'accuracy': [0.078125]},\n",
+       " {'accuracy': [0.078125]},\n",
+       " {'accuracy': [0.078125]},\n",
+       " {'accuracy': [0.078125]},\n",
+       " {'accuracy': [0.078125]},\n",
+       " {'accuracy': [0.078125]},\n",
+       " {'accuracy': [0.078125]},\n",
+       " {'accuracy': [0.078125]},\n",
+       " {'accuracy': [0.078125]},\n",
+       " {'accuracy': [0.078125]},\n",
+       " {'accuracy': [0.09375]},\n",
+       " {'accuracy': [0.09375]},\n",
+       " {'accuracy': [0.109375]},\n",
+       " {'accuracy': [0.109375]},\n",
+       " {'accuracy': [0.109375]},\n",
+       " {'accuracy': [0.109375]},\n",
+       " {'accuracy': [0.109375]},\n",
+       " {'accuracy': [0.109375]},\n",
+       " {'accuracy': [0.109375]},\n",
+       " {'accuracy': [0.109375]},\n",
+       " {'accuracy': [0.109375]},\n",
+       " {'accuracy': [0.109375]},\n",
+       " {'accuracy': [0.125]},\n",
+       " {'accuracy': [0.125]},\n",
+       " {'accuracy': [0.125]},\n",
+       " {'accuracy': [0.125]},\n",
+       " {'accuracy': [0.125]},\n",
+       " {'accuracy': [0.125]},\n",
+       " {'accuracy': [0.125]},\n",
+       " {'accuracy': [0.125]},\n",
+       " {'accuracy': [0.125]},\n",
+       " {'accuracy': [0.125]},\n",
+       " {'accuracy': [0.125]},\n",
+       " {'accuracy': [0.125]},\n",
+       " {'accuracy': [0.125]},\n",
+       " {'accuracy': [0.140625]},\n",
+       " {'accuracy': [0.140625]},\n",
+       " {'accuracy': [0.140625]},\n",
+       " {'accuracy': [0.140625]},\n",
+       " {'accuracy': [0.140625]},\n",
+       " {'accuracy': [0.140625]},\n",
+       " {'accuracy': [0.15625]},\n",
+       " {'accuracy': [0.15625]},\n",
+       " {'accuracy': [0.15625]},\n",
+       " {'accuracy': [0.15625]},\n",
+       " {'accuracy': [0.15625]},\n",
+       " {'accuracy': [0.15625]},\n",
+       " {'accuracy': [0.15625]},\n",
+       " {'accuracy': [0.15625]},\n",
+       " {'accuracy': [0.15625]},\n",
+       " {'accuracy': [0.171875]},\n",
+       " {'accuracy': [0.171875]},\n",
+       " {'accuracy': [0.1875]},\n",
+       " {'accuracy': [0.1875]},\n",
+       " {'accuracy': [0.1875]},\n",
+       " {'accuracy': [0.1875]},\n",
+       " {'accuracy': [0.1875]},\n",
+       " {'accuracy': [0.1875]},\n",
+       " {'accuracy': [0.1875]},\n",
+       " {'accuracy': [0.1875]},\n",
+       " {'accuracy': [0.1875]},\n",
+       " {'accuracy': [0.1875]},\n",
+       " {'accuracy': [0.1875]},\n",
+       " {'accuracy': [0.1875]},\n",
+       " {'accuracy': [0.1875]},\n",
+       " {'accuracy': [0.203125]},\n",
+       " {'accuracy': [0.203125]},\n",
+       " {'accuracy': [0.21875]},\n",
+       " {'accuracy': [0.21875]},\n",
+       " {'accuracy': [0.21875]},\n",
+       " {'accuracy': [0.21875]},\n",
+       " {'accuracy': [0.21875]},\n",
+       " {'accuracy': [0.21875]},\n",
+       " {'accuracy': [0.21875]},\n",
+       " {'accuracy': [0.21875]},\n",
+       " {'accuracy': [0.21875]},\n",
+       " {'accuracy': [0.21875]},\n",
+       " {'accuracy': [0.21875]},\n",
+       " {'accuracy': [0.21875]},\n",
+       " {'accuracy': [0.21875]},\n",
+       " {'accuracy': [0.21875]},\n",
+       " {'accuracy': [0.21875]},\n",
+       " {'accuracy': [0.21875]},\n",
+       " {'accuracy': [0.21875]},\n",
+       " {'accuracy': [0.21875]},\n",
+       " {'accuracy': [0.21875]},\n",
+       " {'accuracy': [0.234375]},\n",
+       " {'accuracy': [0.234375]},\n",
+       " {'accuracy': [0.234375]},\n",
+       " {'accuracy': [0.234375]},\n",
+       " {'accuracy': [0.234375]},\n",
+       " {'accuracy': [0.234375]},\n",
+       " {'accuracy': [0.234375]},\n",
+       " {'accuracy': [0.25]},\n",
+       " {'accuracy': [0.25]},\n",
+       " {'accuracy': [0.25]},\n",
+       " {'accuracy': [0.25]},\n",
+       " {'accuracy': [0.265625]},\n",
+       " {'accuracy': [0.265625]},\n",
+       " {'accuracy': [0.265625]},\n",
+       " {'accuracy': [0.28125]},\n",
+       " {'accuracy': [0.28125]},\n",
+       " {'accuracy': [0.28125]},\n",
+       " {'accuracy': [0.28125]},\n",
+       " {'accuracy': [0.28125]},\n",
+       " {'accuracy': [0.28125]},\n",
+       " {'accuracy': [0.28125]},\n",
+       " {'accuracy': [0.28125]},\n",
+       " {'accuracy': [0.28125]},\n",
+       " {'accuracy': [0.296875]},\n",
+       " {'accuracy': [0.296875]},\n",
+       " {'accuracy': [0.296875]},\n",
+       " {'accuracy': [0.296875]},\n",
+       " {'accuracy': [0.296875]},\n",
+       " {'accuracy': [0.296875]},\n",
+       " {'accuracy': [0.296875]},\n",
+       " {'accuracy': [0.296875]},\n",
+       " {'accuracy': [0.296875]},\n",
+       " {'accuracy': [0.3125]},\n",
+       " {'accuracy': [0.3125]},\n",
+       " {'accuracy': [0.3125]},\n",
+       " {'accuracy': [0.328125]},\n",
+       " {'accuracy': [0.34375]},\n",
+       " {'accuracy': [0.34375]},\n",
+       " {'accuracy': [0.34375]},\n",
+       " {'accuracy': [0.34375]},\n",
+       " {'accuracy': [0.34375]},\n",
+       " {'accuracy': [0.34375]},\n",
+       " {'accuracy': [0.34375]},\n",
+       " {'accuracy': [0.34375]},\n",
+       " {'accuracy': [0.34375]},\n",
+       " {'accuracy': [0.34375]},\n",
+       " {'accuracy': [0.34375]},\n",
+       " {'accuracy': [0.34375]},\n",
+       " {'accuracy': [0.34375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.390625]},\n",
+       " {'accuracy': [0.390625]},\n",
+       " {'accuracy': [0.390625]},\n",
+       " {'accuracy': [0.390625]},\n",
+       " {'accuracy': [0.390625]},\n",
+       " {'accuracy': [0.390625]},\n",
+       " {'accuracy': [0.390625]},\n",
+       " {'accuracy': [0.390625]},\n",
+       " {'accuracy': [0.390625]},\n",
+       " {'accuracy': [0.390625]},\n",
+       " {'accuracy': [0.40625]},\n",
+       " {'accuracy': [0.40625]},\n",
+       " {'accuracy': [0.40625]},\n",
+       " {'accuracy': [0.40625]},\n",
+       " {'accuracy': [0.40625]},\n",
+       " {'accuracy': [0.421875]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.578125]},\n",
+       " {'accuracy': [0.578125]},\n",
+       " {'accuracy': [0.578125]},\n",
+       " {'accuracy': [0.578125]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.421875]},\n",
+       " {'accuracy': [0.421875]},\n",
+       " {'accuracy': [0.421875]},\n",
+       " {'accuracy': [0.421875]},\n",
+       " {'accuracy': [0.40625]},\n",
+       " {'accuracy': [0.40625]},\n",
+       " {'accuracy': [0.421875]},\n",
+       " {'accuracy': [0.421875]},\n",
+       " {'accuracy': [0.421875]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.578125]},\n",
+       " {'accuracy': [0.578125]},\n",
+       " {'accuracy': [0.59375]},\n",
+       " {'accuracy': [0.59375]},\n",
+       " {'accuracy': [0.59375]},\n",
+       " {'accuracy': [0.59375]},\n",
+       " {'accuracy': [0.578125]},\n",
+       " {'accuracy': [0.578125]},\n",
+       " {'accuracy': [0.578125]},\n",
+       " {'accuracy': [0.578125]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.578125]},\n",
+       " {'accuracy': [0.578125]},\n",
+       " {'accuracy': [0.578125]},\n",
+       " {'accuracy': [0.578125]},\n",
+       " {'accuracy': [0.578125]},\n",
+       " {'accuracy': [0.59375]},\n",
+       " {'accuracy': [0.59375]},\n",
+       " {'accuracy': [0.59375]},\n",
+       " {'accuracy': [0.59375]},\n",
+       " {'accuracy': [0.59375]},\n",
+       " {'accuracy': [0.578125]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.40625]},\n",
+       " {'accuracy': [0.421875]},\n",
+       " {'accuracy': [0.40625]},\n",
+       " {'accuracy': [0.390625]},\n",
+       " {'accuracy': [0.390625]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.390625]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.390625]},\n",
+       " {'accuracy': [0.40625]},\n",
+       " {'accuracy': [0.421875]},\n",
+       " {'accuracy': [0.421875]},\n",
+       " {'accuracy': [0.421875]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.421875]},\n",
+       " {'accuracy': [0.40625]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.40625]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.40625]},\n",
+       " {'accuracy': [0.40625]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.40625]},\n",
+       " {'accuracy': [0.390625]},\n",
+       " {'accuracy': [0.390625]},\n",
+       " {'accuracy': [0.390625]},\n",
+       " {'accuracy': [0.390625]},\n",
+       " {'accuracy': [0.390625]},\n",
+       " {'accuracy': [0.40625]},\n",
+       " {'accuracy': [0.40625]},\n",
+       " {'accuracy': [0.40625]},\n",
+       " {'accuracy': [0.421875]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.421875]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.34375]},\n",
+       " {'accuracy': [0.28125]},\n",
+       " {'accuracy': [0.28125]},\n",
+       " {'accuracy': [0.265625]},\n",
+       " {'accuracy': [0.265625]},\n",
+       " {'accuracy': [0.265625]},\n",
+       " {'accuracy': [0.265625]},\n",
+       " {'accuracy': [0.265625]},\n",
+       " {'accuracy': [0.265625]},\n",
+       " {'accuracy': [0.3125]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.390625]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.578125]},\n",
+       " {'accuracy': [0.59375]},\n",
+       " {'accuracy': [0.59375]},\n",
+       " {'accuracy': [0.59375]},\n",
+       " {'accuracy': [0.609375]},\n",
+       " {'accuracy': [0.578125]},\n",
+       " {'accuracy': [0.59375]},\n",
+       " {'accuracy': [0.5625]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.4375]},\n",
+       " {'accuracy': [0.390625]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.40625]},\n",
+       " {'accuracy': [0.40625]},\n",
+       " {'accuracy': [0.40625]},\n",
+       " {'accuracy': [0.40625]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.484375]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.53125]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.421875]},\n",
+       " {'accuracy': [0.375]},\n",
+       " {'accuracy': [0.359375]},\n",
+       " {'accuracy': [0.3125]},\n",
+       " {'accuracy': [0.296875]},\n",
+       " {'accuracy': [0.296875]},\n",
+       " {'accuracy': [0.296875]},\n",
+       " {'accuracy': [0.34375]},\n",
+       " {'accuracy': [0.34375]},\n",
+       " {'accuracy': [0.40625]},\n",
+       " {'accuracy': [0.453125]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.46875]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.5]},\n",
+       " {'accuracy': [0.515625]},\n",
+       " {'accuracy': [0.546875]},\n",
+       " {'accuracy': [0.578125]},\n",
+       " {'accuracy': [0.609375]},\n",
+       " {'accuracy': [0.625]},\n",
+       " {'accuracy': [0.625]},\n",
+       " {'accuracy': [0.59375]},\n",
+       " ...]"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "learn.sched.rec_metrics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lay_opt = learn.sched.layer_opt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'betas': (0.9, 0.999),\n",
+       "  'eps': 1e-08,\n",
+       "  'lr': 4.109705879287773e-05,\n",
+       "  'params': [Parameter containing:\n",
+       "   -7.6291e-03  1.0435e-02 -5.4283e-04  ...   1.1248e-02 -1.8135e-03 -1.7815e-02\n",
+       "    2.9777e-03 -1.2929e-02  1.5696e-02  ...  -3.3291e-03  1.4445e-02 -8.9108e-03\n",
+       "    3.8690e-03 -3.3641e-03 -1.6537e-02  ...   5.0355e-03  1.1230e-02  9.9307e-03\n",
+       "                   ...                   ⋱                   ...                \n",
+       "    1.4148e-02  3.4371e-03 -1.5090e-02  ...   1.0123e-02 -1.1727e-02 -8.7970e-03\n",
+       "   -4.1093e-03 -1.5130e-02  1.4766e-02  ...   9.7148e-03 -7.0287e-03  1.7132e-02\n",
+       "   -1.7386e-02  1.7735e-02 -8.2158e-03  ...   1.1735e-02  1.4976e-02  9.7531e-03\n",
+       "   [torch.cuda.FloatTensor of size 40x3072 (GPU 0)], Parameter containing:\n",
+       "   1.00000e-02 *\n",
+       "    -0.6478\n",
+       "     0.5530\n",
+       "     0.6499\n",
+       "     0.3658\n",
+       "     1.0449\n",
+       "     1.0604\n",
+       "    -1.3180\n",
+       "    -1.1204\n",
+       "     0.4309\n",
+       "     1.0034\n",
+       "     1.6303\n",
+       "    -1.6536\n",
+       "    -0.0545\n",
+       "    -1.2577\n",
+       "    -0.5422\n",
+       "    -1.2785\n",
+       "     0.5496\n",
+       "    -0.6565\n",
+       "    -0.4163\n",
+       "    -0.4368\n",
+       "    -1.3940\n",
+       "    -0.7818\n",
+       "    -1.0831\n",
+       "     0.7818\n",
+       "     1.0275\n",
+       "     0.9793\n",
+       "     0.0195\n",
+       "    -1.3346\n",
+       "    -1.3133\n",
+       "    -0.2081\n",
+       "    -0.3729\n",
+       "     0.9320\n",
+       "     0.3496\n",
+       "     0.3669\n",
+       "     1.1147\n",
+       "     1.6124\n",
+       "    -0.7178\n",
+       "     0.1441\n",
+       "     0.4453\n",
+       "    -0.0311\n",
+       "   [torch.cuda.FloatTensor of size 40 (GPU 0)], Parameter containing:\n",
+       "   \n",
+       "   Columns 0 to 9 \n",
+       "   -0.1426  0.0566 -0.1301 -0.1228  0.0535 -0.1250  0.0490 -0.0739  0.0604  0.0474\n",
+       "   -0.0363  0.0777  0.0732  0.0572  0.1273  0.0559  0.0490  0.1433 -0.1190 -0.0060\n",
+       "   -0.1559 -0.1048  0.1401  0.0019  0.1457  0.0968 -0.1382 -0.0399 -0.0048 -0.1287\n",
+       "    0.1296 -0.0523 -0.0673  0.0416  0.1386 -0.0060 -0.0297  0.0803  0.1256  0.1556\n",
+       "   -0.1501  0.0526 -0.0700 -0.0203 -0.0588 -0.1232 -0.1351  0.0979  0.1304  0.0408\n",
+       "    0.1175 -0.0047 -0.0823 -0.0959  0.1090 -0.1070 -0.0950  0.1547  0.1400 -0.0401\n",
+       "    0.0258 -0.0461  0.0418 -0.0975  0.0246  0.0307 -0.0224  0.1187  0.0031 -0.1588\n",
+       "    0.1203  0.0615  0.0523 -0.0894 -0.1512  0.0750  0.1487  0.1204 -0.1132  0.0531\n",
+       "    0.0779  0.0194 -0.0831 -0.1446  0.0351  0.0782 -0.1576  0.0667  0.1049  0.0791\n",
+       "    0.0809  0.0627  0.0631  0.0160 -0.1003 -0.0341  0.0648  0.1501 -0.0806  0.1394\n",
+       "   \n",
+       "   Columns 10 to 19 \n",
+       "    0.0117  0.0043 -0.0356  0.0869  0.1457 -0.1419  0.0217  0.1350 -0.0597 -0.0173\n",
+       "   -0.1130  0.1024  0.1532  0.0708  0.1153  0.1308 -0.0208 -0.1428  0.0050 -0.0038\n",
+       "    0.1485 -0.0161 -0.0540 -0.1282  0.1183  0.0996  0.0832  0.0034 -0.0123  0.1502\n",
+       "   -0.0511 -0.0482  0.0951 -0.0348  0.1558 -0.0772  0.1177 -0.1360 -0.0294  0.0406\n",
+       "   -0.0138 -0.0511 -0.0461 -0.0064  0.0514  0.0311 -0.0202  0.1401 -0.1324 -0.1067\n",
+       "   -0.0726 -0.1419 -0.1319 -0.0177  0.0993 -0.0573 -0.1162  0.1352 -0.1182  0.1136\n",
+       "    0.0194  0.1411  0.0179  0.1357  0.0085 -0.0817  0.0843  0.0468 -0.1510 -0.0252\n",
+       "    0.0997 -0.1157 -0.0855  0.1215 -0.0714  0.0711  0.0484  0.1327  0.1135 -0.0866\n",
+       "    0.1185 -0.1300 -0.0644 -0.1465 -0.0322  0.1077  0.1538 -0.0003  0.0654 -0.0773\n",
+       "    0.0242 -0.0197 -0.0163  0.1302  0.0272  0.0397  0.0246  0.1133 -0.0576 -0.0545\n",
+       "   \n",
+       "   Columns 20 to 29 \n",
+       "   -0.0183 -0.0011 -0.1366  0.1531  0.0643  0.0100  0.0449  0.0828 -0.0967 -0.0719\n",
+       "   -0.1458 -0.0323  0.0701  0.0003  0.0917  0.1036 -0.0076 -0.1246  0.1408 -0.0983\n",
+       "   -0.1540  0.1042  0.1362  0.0234  0.0066  0.1563  0.0734 -0.1524  0.0712  0.0894\n",
+       "   -0.0927 -0.0698 -0.1552  0.1076  0.0316 -0.0192 -0.0721 -0.0951 -0.0430 -0.1124\n",
+       "    0.0757 -0.0007  0.1138 -0.1056  0.0067 -0.1555 -0.1578 -0.0217  0.1040 -0.0337\n",
+       "    0.0424 -0.0239 -0.0572 -0.1091  0.1108  0.0904  0.1209  0.0989 -0.0048 -0.1496\n",
+       "   -0.0806  0.1350  0.0644 -0.0322  0.0221  0.1367 -0.0495 -0.1419 -0.0681 -0.0472\n",
+       "   -0.0535  0.0206 -0.1136  0.1417  0.0004 -0.1530 -0.0763  0.1485 -0.0179 -0.0576\n",
+       "   -0.0436 -0.0571 -0.0755 -0.1261  0.0690  0.0865 -0.0407 -0.0207 -0.0433 -0.1351\n",
+       "   -0.0501 -0.0150  0.0067 -0.0311  0.0773  0.0464  0.1391  0.0009  0.0794  0.0308\n",
+       "   \n",
+       "   Columns 30 to 39 \n",
+       "   -0.1037 -0.1370  0.1236  0.0920  0.1471  0.0372 -0.1496 -0.0727 -0.0705 -0.0472\n",
+       "   -0.0136 -0.1080 -0.1402  0.1457 -0.1062  0.1451  0.0733 -0.1505  0.0845  0.0229\n",
+       "    0.1123 -0.1047  0.1020 -0.0255  0.1541 -0.1098  0.0538 -0.1473 -0.0375 -0.0473\n",
+       "    0.0276 -0.0076  0.0060 -0.1390 -0.0187 -0.0727 -0.0829  0.0778  0.0028 -0.0529\n",
+       "    0.0608 -0.0001  0.0767 -0.0115 -0.0004 -0.1172 -0.0429 -0.0894 -0.0781  0.0203\n",
+       "   -0.0517  0.0411 -0.0269 -0.0786 -0.0754 -0.0099  0.1567 -0.0755 -0.0538 -0.0311\n",
+       "   -0.1493 -0.0269  0.0876  0.1301 -0.0422 -0.0162  0.0834 -0.1388  0.0736  0.0024\n",
+       "   -0.1297 -0.0137 -0.0586  0.1255  0.1000 -0.0037  0.1093  0.1128  0.0552 -0.1369\n",
+       "    0.0892 -0.1585 -0.1010  0.0894  0.1369 -0.1167 -0.1460  0.0895 -0.0303  0.1197\n",
+       "   -0.0660  0.0007 -0.0477  0.0207  0.1289 -0.1024 -0.1377 -0.1410  0.0534  0.0101\n",
+       "   [torch.cuda.FloatTensor of size 10x40 (GPU 0)], Parameter containing:\n",
+       "   -0.0787\n",
+       "   -0.0623\n",
+       "    0.0791\n",
+       "    0.1072\n",
+       "   -0.1191\n",
+       "   -0.0091\n",
+       "   -0.1562\n",
+       "    0.0570\n",
+       "    0.1000\n",
+       "    0.1516\n",
+       "   [torch.cuda.FloatTensor of size 10 (GPU 0)]],\n",
+       "  'weight_decay': 0.0}]"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lay_opt.opt.param_groups"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b143a7911f9648c1a826d7e481235f22",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>HBox</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=1), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0%|▏                                                                      | 1/391 [00:06<42:04,  6.47s/it, loss=2.31]\n",
+      "  1%|▌                                                                      | 3/391 [00:06<14:01,  2.17s/it, loss=2.32]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Exception in thread Thread-8:\n",
+      "Traceback (most recent call last):\n",
+      "  File \"C:\\Users\\Sylvain\\Anaconda3\\envs\\fastai\\lib\\threading.py\", line 916, in _bootstrap_inner\n",
+      "    self.run()\n",
+      "  File \"C:\\Users\\Sylvain\\Anaconda3\\envs\\fastai\\lib\\site-packages\\tqdm\\_tqdm.py\", line 144, in run\n",
+      "    for instance in self.tqdm_cls._instances:\n",
+      "  File \"C:\\Users\\Sylvain\\Anaconda3\\envs\\fastai\\lib\\_weakrefset.py\", line 60, in __iter__\n",
+      "    for itemref in self.data:\n",
+      "RuntimeError: Set changed size during iteration\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 71%|████████████████████████████████████████████████▉                    | 277/391 [02:36<01:04,  1.76it/s, loss=13.8]\n"
+     ]
+    }
+   ],
+   "source": [
+    "learn.lr_find()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEOCAYAAABmVAtTAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzt3Xl8lNXZ//HPlZ3skIQQ1iCLLLIpIIi7aN2p1Wq1Uvetda3dtMvPp+3zWGtri/sCtUVxR61Vq6KCgsoSENlFFlkEkhCWbGSZzPn9MUMaaYCAzNz3JN/36zWvzNxzZu4rh2GunOU+x5xziIiIAMR5HYCIiPiHkoKIiDRSUhARkUZKCiIi0khJQUREGikpiIhIIyUFERFppKQgIiKNlBRERKSRkoKIiDRK8DqAA5Wbm+sKCwu9DkNEJKbMnz9/q3Mub3/lYi4pFBYWUlRU5HUYIiIxxczWtaScuo9ERKSRkoKIiDRSUhARkUZKCiIi0khJQUREGikpiIhIIyUFEZEY8O6yYlaVVET8PEoKIiIx4IdTFvDS/K8ifh4lBRERn3POUR8MkhRvET+XkoKIiM81BB3OQUJ85L+ylRRERHwuEHQAJKilICIi9Q1BAJLUUhARkfqGcEshTi0FEZE2LxBuKWhMQUREqA+PKSRqTEFEROoDoZZColoKIiISCKr7SEREwnYPNCdqoFlERAK7k4JaCiIiUtc4+0gtBRGRNm/3lFS1FERE5D/LXGhMQUREdncfJSaopSAi0uY1DjTHKSmIiLR5AQ00i4jIbnUaaBYRkd3+c52CWgoiIm2elrkQEZFG9WopiIjIbrt3XtPsIxERaRxTiOnZR2bWzcymm9lyM1tqZrfso+wIM2swswsiFY+ISKyqD0Zv9lFCBN87ANzunFtgZhnAfDOb5pxb1rSQmcUD9wBvRzAWEZGYVR9oBaukOuc2O+cWhO9XAMuBLs0UvQmYCpREKhYRkVgWCAYxg/jWsvaRmRUCw4A5exzvApwHPBqNOEREYlF9g4vKIDNEISmYWTqhlsCtzrnyPZ7+K/Bz51zDft7jWjMrMrOi0tLSSIUqIuJL9Q3BqExHhciOKWBmiYQSwhTn3MvNFBkOPGdmALnAmWYWcM692rSQc+5x4HGA4cOHu0jGLCLiN4GGYFQuXIMIJgULfdNPApY75+5rroxzrmeT8n8HXt8zIYiItHX1QdcqWgpjgPHAYjNbGD52J9AdwDmncQQRkRYINASjMvMIIpgUnHOzgBanNufc5ZGKRUQkltU3uKhcuAa6ollExPfqG4KtZ/aRiIh8MwG1FEREZLf6KI4pKCmIiPhcfdBFbUqqkoKIiM8FGoIkRmGJC1BSEBHxPXUfiYhII01JFRGRRoGgWgoiIhIWaHAkaExBREQA6hqCJCaopSAiIoRaCpp9JCIiQHSXzlZSEBHxuboGp4FmEREJCc0+UveRiIiwe/aRWgoiIsLu2UdqKYiICLvXPlJLQUSkzQsGHUGHlrkQERGoDwYBNPtIRERCi+EBmn0kIiKh8QRAs49EREQtBRERaaK+QWMKIiISVhsIJYUkrZIqIiIVNfUAZKQkRuV8SgoiIj5WURMAIDMlISrnU1IQEfGx8l2hlkJmO7UURETavN0thQy1FEREpLwmui2F6KSeGFFVG+DZuevJapdIr47p9MpNJys1kZ3V9Tw9Zx0LN+zgnCGdOWdwAWZGoCHIrvoG0pMTWLa5nC+KK/myrIoeOakMKMgCoG9+OmbRmV8sIq1P+a56zCA9KTpf120uKQSDjrg4o6SihlXFlTw1ex2fF1cw+rAcPlhZysbtuxrLxhkc3imTkvIayqrqyE1PZtqyYn7/+jI6pCWxcfsuqusCdMpMYdPOmmbPV5CVwsn9OnJK/47kpicz+ZN17KpvYFCXLIrLa8hJSyI/M4UTD+9IXkZytKpBRGJEeU2A9OQE4qK0R3ObSQoNQccTM9cw4d0vSIgzKmpD/XSpSfEc0TmLF+dvZHCXLP703SHkpCWxfls1n67fwdJNO+mS3Y7bTu1Dv06ZTJ2/kdlry6isCTC8sD2ZKYms2FLBzaf04age7enWIZVFG3eypbyGXXUB3ltewssLvmLKnPUAJCfEkZoUzxuLNpOaFE91XQMACXFGj5xUeuSk0b1DauOc5G1VdXRISyIvPZn3VhTjHFw4vBtpyQmc0r8j8WZsKa8hOzWR1Cj9JSEi0VNeU09mlKajAphzLmonOxSGDx/uioqKDvh1z85dzx0vL+aUfh3pnN2O7h1S6V+QycDOmbRPS8I5F7Funpr6Bhas205ZVR1H9WhPTnoS1bUNtE9Loqa+gbVbq/jXZ5v4sqyK1SVVbN65i7qGIM5Bdmoi26vrqQsE6ZLdjoagY0t5qFXSIS2J6roANfVB4uOM3PQkeuSkccOJvTi+Tx7xUfrLQkQi5+p/FPHVjl38+5bjvtH7mNl859zw/ZWL2J+WZtYNmAx0AoLA4865CXuUGQf8Lvx8ALjVOTcrEvFccFRX8tKTOaV/x2a//CPZ75+SGM8xvXO/diw5Ib7xuf4FmfQvyNzr651zbK+uJzMlgUDQsX5bNRu2VfPaZ5vITU+mMDeNkvIaSsprmflFKVc8OY/c9GSOPqwDY/t3JDMlkfoGR7cO7RhQkKkxDpEYUlFTH7WZRxDZ7qMAcLtzboGZZQDzzWyac25ZkzLvAa8555yZDQZeAPpFIpjE+DjGDsiPxFtHnJnRIS0JgIR46JufQd/8DE7p/9+/T22ggWnLinlnaTFz1pbxxqLNX3u+S3Y7ThuYz7cGdmJEYQe1JkR8rrwmQJfsdlE7X8SSgnNuM7A5fL/CzJYDXYBlTcpUNnlJGhBbfVk+lJwQz9mDO3P24M4Eg44lm3YSdKEVFpduKuedpVuYMmc9T370JdmpiaQlJXBYXhpnDy7gWwM7kZ2a5PWvICJNlO+qp3+njKidLyptEjMrBIYBc5p57jzgbqAjcNZeXn8tcC1A9+7dIxVmqxMXZwzumt34eGDnLC4c3o2q2gAfrCxlxucl1Dc45q/bzs+nLuZXry7hhL55XDmmJ6N75aibScQHKmrqo3aNAkQhKZhZOjCV0HhB+Z7PO+deAV4xs+MJjS+MbabM48DjEBpojmzErV9acgJnDirgzEEFQGjMYvFXO3lj0WamLviKSybOYWDnTAqy2jG4axYXjehGfmaKx1GLtD3BoKOiNhC1dY8gwknBzBIJJYQpzrmX91XWOfehmfUys1zn3NZIxiVfZxZqUQzums1tp/bllU+/4rl5G1hXVsW7y4uZ8N4XnNA3j28NzGfc0C6kJMZ7HbJIm1BZF8C56K2QCpGdfWTAJGC5c+6+vZTpDawODzQfCSQBZZGKSfYvJTGei0d25+KRoW66L7dW8ey89by5eDPvryjh928sJz05NA4xuGs2Zw0q4IguWR5HLdI6Na6Q2q51tBTGAOOBxWa2MHzsTqA7gHPuUeB84AdmVg/sAi5ysXbhRCtXmJvGHWf05xen9+Pj1WX867NN1DUEWVlcwRMfruHRD1bz7aFduOCoruSkJ1FVG6C6roHhPTrQLkktCpFvonGF1NbQUghfb7DPkUrn3D3APZGKQQ4dM2NM71zGNLneoqKmngffX8VTs9fxyqdffa38Yblp3PvdwRzVo0O0QxVpNf6zQmorSArS+mWkJHLHmf350cm9Wbh+B5W1AdKSE6iqDfC715dx/iOf8K2B+fz0W/3o3THd63BFYs6O6joAslrT7CNp/TJTEjm+b97Xjp3QN49Js9by2AereX/Fh9x0ch8uObo7uela9E+kpcqqQkkhJz161w9pPwWJiLTkBG4+pQ8f/OwkThvQifumrWTU/73HT178jE07du3/DUSEbeGksHtFg2hQS0EiKjc9mYe+fyQ3b6ng2bnreXbuev69eDPjRxdy0Yhu9MxN8zpEEd/aWllLenJCVKeBq6UgUXF4pwzuOncg7/74BI7rk8fjH67mpD/N4Ion57JhW7XX4Yn4UlllXVS7jkAtBYmybh1SeXT8URSX1/DCvA089uEaTv7zDE4dkM+vzx5AQVb0Fv4S8bttVXXkRLHrCJQUxCP5mSncdEofvnNUV56ctZZn5q5nzppZnDW4gNMHdtLaSyKEuo+6tk+N6jnVfSSe6pLdjl+dPYDXbhzDwC5ZTJ2/kUsmzmHcQx/x7rJiqusCXoco4pnQNsBqKUgb1LtjBpOvHElNfQP/XPgVf5n2BVdPLiIx3ji6Zw53nTtQ1zpImxIMOrZXaUxB2riUxHguGtGdcUO7MO/LbXy0qowXijZw9gMzuWx0IReO6EavPCUHaf3Ka+oJBB0d0qJ7bY+SgvhSSmI8x/XJ47g+eVwxppD/fWM5T8xcw2MfruGwvDS+f3QPrjimkDjtHCet1NbK0DUK0e4+0piC+F5+Zgr3XzyMWT8/md+OG0huejK/e30Zl/99Hlsra70OTyQidl+4lhPlloKSgsSMztnt+MHoQp6/dhT/e94RzFlTxpkTZvLxam2/Ia1PWfgPnmhezQxKChKDzIzvH92Df944hoyUBL4/cQ63PPcpX26t8jo0kUNmqwfrHoGSgsSwfp0y+ddNx3L9Cb14Z2kxp9z3AXe8vIji8hqvQxP5xnbvpZCdGr0VUkFJQWJcalICPz+9Hx/87ETGj+rBS/M3Mu7Bj1hTWul1aCLfSGVtgMR4IzkhuptVKSlIq9AxI4W7zh3IazceS31DkG8/9BEvFG3wOiyRg1ZZEyA9OfoTRFuUFMzsFjPLtJBJZrbAzE6LdHAiB6p/QSZTbziGfgWZ/OylRfz61SXqTpKYVFUbID3Fp0kBuNI5Vw6cBuQBVwB/iFhUIt9AYW4az14ziquO7clTs9cx6u73+L83l1MXCHodmkiLVdQGSEvyb1LYfYXQmcCTzrnP2M/+yyJeio8zfn32AKbddjzfG9GNxz9cw6WT5rA9PKNDxO8qawJk+LilMN/M3iGUFN42swxAf3aJ7/XJz+Du7wxmwveGsnD9Dk657wMe/WA1JepSEp+rqvPxmAJwFfALYIRzrhpIJNSFJBITxg3twis/OoZ+nTL4w79XMOae9/nlK4upqW/wOjSRZlXWBEjzICm09IyjgYXOuSozuxQ4EpgQubBEDr2BnbN45ppRrC6t5MmP1jJlznrWlVXzxA+G0y4putP+RPanotbf3UePANVmNgT4GbAOmByxqEQiqFdeOr//9iD+dMEQPl69lcufnEtVrfZtEH+pqvV391HAOeeAccAE59wEICNyYYlE3vlHdeUvFw2laN12LvvbXCpq6r0OSQSAhqCjuq7Bk+6jliaFCjO7AxgPvGFm8YTGFURi2rihXXjw4mEs3LCDSyfNZecuJQbxXmW45ernlsJFQC2h6xW2AF2AeyMWlUgUnTGogEcuPYplm3Zy+l8/5MmP1rKrTgPQ4p0qvyeFcCKYAmSZ2dlAjXNOYwrSapw6IJ9nrxlFt/ap/M+/lnHsPe/z8IxV1AaUHCT6GlsKfh1oNrMLgbnAd4ELgTlmdkEkAxOJtuGFHXjh+tG8cN1oBnXN4o9vfc55D33Mi0UbGv+TikRDRY13LYWWnvGXhK5RKAEwszzgXeClSAUm4pWRPTswsudI3l1WzK9eXcJPX1rEhPe+4OaT+3Bc31wKstp5HaK0cr7vPgLidieEsLIDeK1ITBo7IJ+Pf3Eyz1xzNHFm/GzqIs6YMFOb+UjEedl91NIzvmVmbwPPhh9fBLwZmZBE/CMuzjimVy7v334CSzeVc9mTc7n4idmcOaiAhHjj+yN70D0n1eswpZWp9LD7qKUDzT8FHgcGA0OAx51zP9/Xa8ysm5lNN7PlZrbUzG5ppsz3zWxR+PZx+OI4Ed9JiI9jSLdsnrx8BN07pDL5ky+ZNHMtZ0z4kPeWF3sdnrQyXk5JbfEZnXNTgakH8N4B4Hbn3ILwAnrzzWyac25ZkzJrgROcc9vN7AxCiefoAziHSFQN696e568bDcDG7dXc8PQCbnh6AX+7fATH9sn1ODppLXYnBd9dvGZmFWZW3sytwszK9/Va59xm59yC8P0KYDmh6xualvnYObc9/HA20PXgfxWR6OraPpWnrhrJYXlpXDO5iLlrt3kdkrQSlbUBUhLjSIyP/tDtPs/onMtwzmU2c8twzmW29CRmVggMA+bso9hVwL9b+p4ifpCdmsTTVx9NQXYKP/jbHN5astnrkKQV2FldT0aKN4tGRDwNmVk6oW6nW8O7tzVX5iRCSaHZcQozu9bMisysqLS0NHLBihyE3PRkXrhuNP06ZXL90wv4+UuLtF+DfCNrtlZS6NEEhogmBTNLJJQQpjjnXt5LmcHARGCcc66suTLOucedc8Odc8Pz8vIiF7DIQcpNT+a5a0dx/Qm9eGnBRk64dwaz1zT7cRbZJ+ccK4sr6ZPvzZqjEUsKZmbAJGC5c+6+vZTpDrwMjHfOrYxULCLRkJIYzy/O6Mf7t59A5+wUbnh6Pss373PoTeS/lFbWsnNXPX06pnty/ki2FMYQWlX1ZDNbGL6daWbXm9n14TK/AXKAh8PPF0UwHpGo6JGTxsTLRhAfZ5zzwCyen7fe65AkhnxRXAlAX49aChGb7+ScmwXYfspcDVwdqRhEvNIzN41pt53ATc9+yq9fXcqgLtkM6NziuRnShq0srgBolS0FkTatfVoSE743lOzURC6ZOJs3F2tmkuzfFyWVZLVLJC8j2ZPzKymIRFBOeAC6R04aP5yygD+/87nXIYnPrS6ppHfHdELDstGnpCASYYflpfPidaO5cHhXHnh/FW8v3eJ1SOJjZVV1dPSolQBKCiJRkZQQx/+eN4h+nTK467WlfBHuNxbZ07aqOjqkJXl2fiUFkShJjI/jnvMHU1kT4PQJM3lo+iqCQed1WOIjDUHH9molBZE2Y0i3bGb89ETOGlTAvW9/zqWT5rBhW7XXYYlP7NxVj3MoKYi0JTnpyUz43lDu/s4gFm3cyXce+ZhVJZVehyU+sK2qFlBSEGlzzIyLR3bnlR8eg3PwvcdnN85Pl7arrLIOUFIQabP65Gfw3LWjiDM4/+GP+cu0ldQGGrwOSzyyvVpJQaTN690xnZeuP4Zj++Qy4b0vuOSJOVpltY0qqwolhZw0TUkVadO656TyyKVH8eAlw1i2qZxzHpzFzC+0THxbsz2cFNqnebOXAigpiPjK2YM7M/WGY2iXGM/4SXP5yzQtHtyWlFXVkZ6cQHJCvGcxKCmI+MyAzpm8devxnDOkMw9OX8XnWzQA3VZ4feEaKCmI+FJKYjy/PXcgmSkJ3PLcp43dCtK6bauqo72Sgog0p31aEn/93jDWbK1i/N/mUFOvWUmt3baqOnKUFERkb07om8fDlxzJkq/K+f0by7wORyKsrLKO9qlKCiKyD2MH5HPNcT15evZ65q/b7nU4EiGrSyvZUl7DQI83Y1JSEIkBt47tS256Eve+vQLntIhea/TWktCS6mcM6uRpHEoKIjEgLTmBH53Um9lrtvHwjNVKDK3Qm4s3c2T3bAqy2nkah5KCSIy4dFQPxg3tzL1vf87EmWu9DkcOoW1VdSzdVM7YAfleh0KC1wGISMskxsfxlwuHUhcI8oe3VjCkWzYje3bwOiw5BDbt2AXAYblpHkeiloJITImLM/54wWC6d0jlxmcWUFKhNZJag+LwWledPO46AiUFkZiTkZLII5ceSXlNPTdO+VSrqrYCm3eGk0JmiseRKCmIxKR+nTK594IhzP1yG9c/NZ9FG3d4HZJ8A8XlNcTHGXkZ3q2OupuSgkiMOmdIZ35z9gDmrN3GuIc+4r5pKzUrKUZt3llDXnoy8XHmdShKCiKx7MpjezLnzlM4/8iu3P/eFzz6wRqvQ5KDUFxeQ36W911HoNlHIjEvIyWRey8YTE19A/e+vYKeuamcfkSB12HJAdiys4ZeeelehwGopSDSKpgZ95w/mCHdsvnRM58ydf5Gr0OSA7BlZw2dfNJSUFIQaSXSkhN4+qqjGXVYB25/8TOen7fe65CkBapqA1TUBpQUROTQS0tOYNJlIziuTy6/+edSVpVUeh2S7MeWcv9MRwUlBZFWJyUxnj9/dwjtkuI5c8JMjv/jdK7+x7zGC6TEXzZsqwagc7b3F66BkoJIq9QxM4WnrzqaK44tZGi3bD5ZXcZFj33CmlK1HPxmd2uud8dWPtBsZt3MbLqZLTezpWZ2SzNl+pnZJ2ZWa2Y/iVQsIm3REV2yuOOM/tx/8TAmXzWSHbvqOev+WXy8eqvXoUkTq0sr6ZCW5PnezLtFsqUQAG53zvUHRgE/MrMBe5TZBtwM/CmCcYi0eUf16MBbtxxPfmYyv3xliZbG8JFVJZX09sl0VIhgUnDObXbOLQjfrwCWA132KFPinJsH1EcqDhEJ6ZSVwl3nDmTt1ir+NutLr8ORsFUllfTySdcRRGlMwcwKgWHAnGicT0Sad+LhHRnbP58H3v+CLTs18Oy1sspatlfX+2Y8AaKQFMwsHZgK3OqcKz/I97jWzIrMrKi0tPTQBijSxvzm7AEEgo47Xl5EXSDodThtmt8GmSHCScHMEgklhCnOuZcP9n2cc48754Y754bn5eUdugBF2qDuOan8+qz+TP+8lJueXUAwqEX0vLKqtA0lBTMzYBKw3Dl3X6TOIyIHbvzoQn51Vn/eXlrMfdNWKjF4ZFVJJe0S4ynwyYVrENkF8cYA44HFZrYwfOxOoDuAc+5RM+sEFAGZQNDMbgUGHGw3k4i03FXH9mTZpnIenL6KVz79ir9dPoLDO2V4HVabEhpkTiPOB0tm7xaxpOCcmwXs8zd1zm0BukYqBhHZOzPjngsGc8Lhefz+jeVcM7mIV380xjfz5duC1SWVvttnW1c0i7RhifFxjBvahUcvPZIt5TWMe2gWM78o1WY9UVBVG2DTzhpfjSeAkoKIELq47flrRxFocIyfNJfrnpqvcYYIW+3DQWZQUhCRsGHd2zP9Jyfy41P78s6yYu54eTGrSiq8DqvV8uN0VFBSEJEmUhLjuenk3lx+TCHPF23g9L/O5P0VxV6H1SqtKqkkIc7okZPmdShfo6QgIl9jZtx17kDm3HkK/QsyueHpBawrq/I6rFZnVUklPXJSSYz319ewv6IREd/Iz0xh4mXDccDD01d7HU6rs6q00nddR6CkICL7kJ+ZwsUjujF1wcbGzWDkm6sLBFlXVq2kICKx5/oTe5GUEMcvXl6kGUmHyLqyKhqCTklBRGJPQVY7fnXWAD5aVca1T83Xvs+HQOPMozz/XUGupCAi+3XxyG7cNrYvc9aWcfETs/lqxy6vQ4ppu5NCr47+mnkESgoi0gJmxi1j+zD1hmOoqWtg/KQ5bNxere6kg7SqtJIu2e1ITYrk8nMHx38RiYhv9c3PYNLlI7jqH/M49p7pxFloMPrI7u25ZWwf+ub7rzvEjz7fUkHffP+NJ4CSgogcoJE9O/DKD8fw1pLN1NQH2bi9mhkrS5m1aitTrj6aI7pkeR2ir9UGGlhVUsnJ/Tp6HUqzlBRE5ID17pjOjSf3aXy8YVs1Fz32CT9+YSFv3nwcCT67IMtPVpVUEgg6+hVkeh1Ks/QvJyLfWLcOqfzmnIGsLK7k0Q9WM2dNGfe+vYJ3lxVrxdU9rNgcWk9qQIE/u9rUUhCRQ+JbA/M58fA8/vTOyq8df+T7R3LGoAKPovKf5ZvLSU6Io9Bnax7tpqQgIoeEmTHpshG8vmgTO6rrOe/ILox78CMenrGa04/oRGiHXlm+pZzDO2X4tovNn1GJSEyKjzPGDe3CZccUkpmSyHXHH8bir3Zy+wufaZkMoKa+gYXrdzC4q38H45UURCRivnNkVy45ujv/XrKFK/8+j+q6gNcheWr6ihKq6ho44wj/dqcpKYhIxCQlxPF/5w3i8R8cxarSSn7zz6Veh+Sp1xdtJjc9iaN9ti9zU0oKIhJxx/XJ46aTevPS/I28WLTB63A8sWVnDe+tKOb0Izr5djwBlBREJEpuGduXo3t24K7XlrJ5Z9tbO+l3ry/DObjmuMO8DmWflBREJCri44x7LxhCg3P88pUl1AWCXocUNR+sLOWNxZu58aTevtt+c09KCiISNd1zUvnZt/rx/ooSzn1wFss2lXsdUsTV1Dfwm38u4bC8NK49wd+tBFBSEJEou/LYnjzxg+Fsraxj3EOzmLas2OuQIurNxZtZV1bNXecMJDkh3utw9ktJQUSi7tQB+bxz2/H0L8jkluc+5e43lzNtWTENrXAp7jlrtpHVLpFje+d6HUqLKCmIiCc6pCUx8QfD6ZWXzpMffck1k4s4/o/TmThzDYGG1jPeMPfLbYwo7EBcXGxc0a1lLkTEMx0zU/jXTccSaAjy7vISJn/yJb9/YzmvL9rMfRcO4bA8f+450FIl5TWs3VrFJSO7ex1Ki6mlICKeS4iP4/QjOvHMNaN44OJhrN1axVn3z+KdpVu8Du2gFJfXcOcri7l00hwARvj4YrU9KSmIiK+cM6Qzb996PH07ZXDDlAV899GPmf55iddhtVhxeQ3jHvyIF4s2EB8Xx8DOmQzs7M+9E5pjsbbW+fDhw11RUZHXYYhIhFXVBrhv2kreXV7M1opaXrvpWHr5vDtpXVkV1z01nw3bqnn+utG+2oXOzOY754bvt5ySgoj42eaduzhzwkzqAkHOGFTAMb1yOG9YF98txb2tqo4T750OwAOXHMkJffM8jujrWpoU1H0kIr5WkNWOF64bzWkDO/Hu8mJ+/MJn/HDKAhZu2OGrXd1mfF5CeU2AJ68Y6buEcCAilhTMrJuZTTez5Wa21MxuaaaMmdn9ZrbKzBaZ2ZGRikdEYlef/Az+ctFQPv31qdxxRj/eWVbMtx/6iDtfWeKbaxtmfF5KbnoSw7plex3KNxLJKakB4Hbn3AIzywDmm9k059yyJmXOAPqEb0cDj4R/ioj8FzPjuhN6ceHwbjz6wWoe+3ANX26tYvzoHhzROYvuOak451jyVTn9C6K3u1lD0PHhF6Wc3K9jzFyPsDcRqzHn3Gbn3ILw/QpgOdBlj2LjgMkuZDaQbWb+3X1CRHyhfVoSd5zZnz+eP5hFG3fwwymJjHNjAAALb0lEQVQLOOv+mWzYVs3EmWs558FZXDO5iMrayG/qs76smh9NWcCO6npOPLxjxM8XaVG5eM3MCoFhwJw9nuoCNF1cfWP42OZoxCUise3CEd0YOyCflcUVXPOPIr776CeUVtYyoCCTD1aWcvb9M7nvoqHsrK7n/RUlHNElk/OP7HrIWhDF5TVcMnE2O6vruXJMT04f2OmQvK+XIp4UzCwdmArc6pzbc0nE5tpZ/9VBaGbXAtcCdO8eO1cGikjkdUhLYtRhOTxwyTAmzlzL8X1z+fXZA1i2qZwfv/AZ3330ExqCjqSEOJ6aHWTyJ+s4dUA+l40upH1a0jc692/+uYRtVXU8d+0oBneN7bGE3SI6JdXMEoHXgbedc/c18/xjwAzn3LPhx58DJzrn9tpS0JRUEWmp8pp67n5zBQD/75wBvL+ihD+/8zlrtlYxplcuk68c+V9jABU19aQlJbBsczmvL9pMYrwxsHMm/1y4iS3lNQzpms1lxxTSEHSc+pcPuOmk3vz4tMO9+PUOiOfXKVhoEvE/gG3OuVv3UuYs4EbgTEIDzPc750bu632VFETkm3pmznrufGUxx/XJ5bLRhYwdkM+KLeX86pUlFK3bTlJCHHWBIAlxRoNzOAf5mcn0yEnjsw07cEBeejJlVbV89POTyUlP9vpX2q+WJoVIdh+NAcYDi81sYfjYnUB3AOfco8CbhBLCKqAauCKC8YiIAHDxyG5srazlubnruXpyEUO6ZbO2tJLkxHhuPrk3lbUN9MlP5/SBnSipqGXt1kpO7pdPUkIcJeU13DdtJZt21vCjgb1jIiEcCF3RLCJtVn1DkH98/CX/XrKF5IQ4/njBYLq2T/U6rIjwQ0tBRMTXEuPjuPq4w7j6OP9vkxktWuZCREQaKSmIiEgjJQUREWmkpCAiIo2UFEREpJGSgoiINFJSEBGRRkoKIiLSKOauaDazncAXTQ7lAlsjdLosYGcEXrO/Mnt7vrnjex7b1+NYrKv9lYtUXUHk6utg6qqlr4tUXTV3LNY/W179PwRvPls9nHP73yfUORdTN+DxPR4XRetch+o1+yuzt+ebO95Mfez1cSzW1f7KRaquIllfB1NXLX1dpOpqf/UVi58tr/4fRrK+Dvaz1fQWi91H//L5uVrymv2V2dvzzR3f89j+HkdKpOpqf+XaSl219HWRqqvmjvm5vvT/8CDFXPfRnsysyLVgkSdRXR0o1VfLqa4OjJ/rKxZbCnt63OsAYojq6sCovlpOdXVgfFtfMd9SEBGRQ6c1tBREROQQUVIQEZFGSgoiItKoVScFMzvRzGaa2aNmdqLX8fidmaWZ2XwzO9vrWPzMzPqHP1MvmdkNXsfjd2b2bTN7wsz+aWaneR2Pn5nZYWY2ycxe8ioG3yYFM/ubmZWY2ZI9jp9uZp+b2Soz+8V+3sYBlUAKsDFSsXrtENUVwM+BFyITpT8cirpyzi13zl0PXAj4clrhoXKI6utV59w1wOXARREM11OHqK7WOOeuimyk++bb2UdmdjyhL/TJzrkjwsfigZXAqYS+5OcBFwPxwN17vMWVwFbnXNDM8oH7nHPfj1b80XSI6mowoUvvUwjV2+vRiT66DkVdOedKzOxc4BfAg865Z6IVf7QdqvoKv+7PwBTn3IIohR9Vh7iuXnLOXRCt2JtK8OKkLeGc+9DMCvc4PBJY5ZxbA2BmzwHjnHN3A/vq8tgOJEciTj84FHVlZicBacAAYJeZvemcC0Y0cA8cqs+Vc+414DUzewNotUnhEH22DPgD8O/WmhDgkH9neca3SWEvugAbmjzeCBy9t8Jm9h3gW0A28GBkQ/OdA6or59wvAczscsItrIhG5y8H+rk6EfgOoT803oxoZP50QPUF3ASMBbLMrLdz7tFIBuczB/rZygH+FxhmZneEk0dUxVpSsGaO7bX/yzn3MvBy5MLxtQOqq8YCzv390Ifiewf6uZoBzIhUMDHgQOvrfuD+yIXjawdaV2XA9ZELZ/98O9C8FxuBbk0edwU2eRSL36muWk51dWBUXy0Xc3UVa0lhHtDHzHqaWRLwPeA1j2PyK9VVy6muDozqq+Virq58mxTM7FngE+BwM9toZlc55wLAjcDbwHLgBefcUi/j9APVVcuprg6M6qvlWktd+XZKqoiIRJ9vWwoiIhJ9SgoiItJISUFERBopKYiISCMlBRERaaSkICIijZQUJOLMrDIK5zi3hcuDH8pznmhmxxzE64aZ2cTw/cvNzBfrcplZ4Z7LPjdTJs/M3opWTBJ9SgoSM8LLEDfLOfeac+4PETjnvtYHOxE44KQA3Ak8cFABecw5VwpsNrMxXscikaGkIFFlZj81s3lmtsjM/qfJ8VcttOvbUjO7tsnxSjP7rZnNAUab2Zdm9j9mtsDMFptZv3C5xr+4zezvZna/mX1sZmvM7ILw8Tgzezh8jtfN7M3dz+0R4wwz+z8z+wC4xczOMbM5Zvapmb1rZvnhJZKvB24zs4Vmdlz4r+ip4d9vXnNfnGaWAQx2zn3WzHM9zOy9cN28Z2bdw8d7mdns8Hv+trmWl4V2zXvDzD4zsyVmdlH4+IhwPXxmZnPNLCPcIpgZrsMFzbV2zCzezO5t8m91XZOnXwVa5d4kAjjndNMtojegMvzzNOBxQitHxgGvA8eHn+sQ/tkOWALkhB874MIm7/UlcFP4/g+BieH7lxPa8Abg78CL4XMMILSePcAFhJa6jgM6Edpn44Jm4p0BPNzkcXv+c/X/1cCfw/fvAn7SpNwzwLHh+92B5c2890nA1CaPm8b9L+Cy8P0rgVfD918HLg7fv353fe7xvucDTzR5nAUkAWuAEeFjmYRWRk4FUsLH+gBF4fuFwJLw/WuBX4XvJwNFQM/w4y7AYq8/V7pF5hZrS2dLbDstfPs0/Did0JfSh8DNZnZe+Hi38PEyoAGYusf77F4OfT6hfQ2a86oL7QmxzEI77wEcC7wYPr7FzKbvI9bnm9zvCjxvZgWEvmjX7uU1Y4EBZo2rJWeaWYZzrqJJmQKgdC+vH93k93kK+GOT498O338G+FMzr10M/MnM7gFed87NNLNBwGbn3DwA51w5hFoVwINmNpRQ/fZt5v1OAwY3aUllEfo3WQuUAJ338jtIjFNSkGgy4G7n3GNfOxjatGYsMNo5V21mMwhtCwpQ45xr2ON9asM/G9j7Z7i2yX3b42dLVDW5/wCh7VxfC8d6115eE0fod9i1j/fdxX9+t/1p8cJkzrmVZnYUcCZwt5m9Q6ibp7n3uA0oBoaEY65ppowRapG93cxzKYR+D2mFNKYg0fQ2cKWZpQOYWRcz60jor9Dt4YTQDxgVofPPAs4Pjy3kExooboks4Kvw/cuaHK8AMpo8fofQipgAhP8S39NyoPdezvMxoaWVIdRnPyt8fzah7iGaPP81ZtYZqHbOPU2oJXEksALobGYjwmUywgPnWYRaEEFgPKH9gvf0NnCDmSWGX9s33MKAUMtin7OUJHYpKUjUOOfeIdT98YmZLQZeIvSl+haQYGaLgN8R+hKMhKmENj1ZAjwGzAF2tuB1dwEvmtlMYGuT4/8Czts90AzcDAwPD8wuo5kdtJxzKwhtS5mx53Ph118RrofxwC3h47cCPzazuYS6n5qLeRAw18wWAr8Efu+cqwMuAh4ws8+AaYT+yn8YuMzMZhP6gq9q5v0mAsuABeFpqo/xn1bZScAbzbxGWgEtnS1tipmlO+cqLbQX7lxgjHNuS5RjuA2ocM5NbGH5VGCXc86Z2fcIDTqPi2iQ+47nQ0Kbz2/3KgaJHI0pSFvzupllExow/l20E0LYI8B3D6D8UYQGhg3YQWhmkifMLI/Q+IoSQiulloKIiDTSmIKIiDRSUhARkUZKCiIi0khJQUREGikpiIhIIyUFERFp9P8BNiPMogZW3A4AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "learn.sched.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2c0540516f274c75a681bc8a4195f63f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>HBox</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=1), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch      trn_loss   val_loss   accuracy                                                                              \n",
+      "    0      1.649389   1.556277   0.451642  \n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[1.5562772328340555, 0.4516416139240506]"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "learn.fit(1e-2, 1, cycle_len=1, use_clr_beta=(10,10,0.95,0.85))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAuAAAAEKCAYAAABT6eBwAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzs3XlcVXX+x/HXB5BVFAXcAEURVAShMivLrGzBci+XZqum+TVbM6ljk+aWe4ulM01N00xNyyy55FqmmZntpRbIogjuiCJuCMrO9/cH1xliUK7Gvefey+f5eJyHl3PPubyvCnw45/v9fMUYg1JKKaWUUso5vKwOoJRSSimlVHOiBbhSSimllFJOpAW4UkoppZRSTqQFuFJKKaWUUk6kBbhSSimllFJOpAW4UkoppZRSTqQFuFJKKaWUUk6kBbhSSimllFJOpAW4UkoppZRSTuRjdQBnCAsLM9HR0VbHUEqpS7Z9+/bjxphwq3M4k37PVkq5K3u/ZzeLAjw6Oppt27ZZHUMppS6ZiBywOoOz6fdspZS7svd7tg5BUUoppZRSyom0AFdKKaWUUsqJtABXSimllFLKibQAV0oppZRSyom0AFdKKaWUUsqJHFqAi0iKiGSLSK6ITG7geT8RWWJ7/isRibbtDxWRzSJSIiJ/qnfOVSKSbjvnjyIijnwPSimllFJKNSWHFeAi4g28AAwG4oF7RSS+3mEPAqeMMd2BRcBTtv1lwHRgUgMv/WfgISDWtqU0fXqllFJKKaUcw5F9wPsBucaYvQAi8hYwHMiqc8xw4Anb4+XAn0REjDFngU9FpHvdFxSRjkArY8wXto/fAEYA7znwfSgPV1FVw+rUw6QkdCDYv4XVcZRSSillc6SolKVb86iuqXH65/75wBiC/BxTKjuyAI8ADtX5OA+45kLHGGOqRKQICAWOX+Q18+q9ZkRDB4rIQ9ReKadz586Xml01I4s/2M2LH+3ho92F/OneK9BRTUq5l+oaw7++PsiQxI60CfK1Oo5SqolU1xh+8eZ20vKKsOJH84+vi3bLAryhvypzGcdc1vHGmJeBlwH69u17sddUzdjW/Sd5acseotoG8O6OI9we357hyQ3+TqeUclH7jpfwxJpMMvKKeOqePlbHUUo1kTe/2E9aXhF/GJfscT+bHTkJMw+IqvNxJJB/oWNExAdoDZxs5DUjG3lNpexSUl7FxKWpRLYJ5J3fDOCqLm2YtiqD/NOlVkdTSl2C7u2C+dmArizZdoiv9p6wOo5SqgkcKSrlmQ3Z3BgXzrCkTlbHaXKOLMC3ArEi0lVEfIFxwJp6x6wB7rM9vgf40BhzwavVxpgjQLGIXGvrfvITYHXTR1fNwZy1WRw+VcpzY5JoHdCC58YkUV1jmLQsjZoavWmilDsZPyiOqLYBTFmZTnlVtdVxlFLf08zVmVQbw9zhCR45NNRhBbgxpgp4GNgA7ASWGmMyRWS2iAyzHfYKECoiucBE4D+tCkVkP/AccL+I5NXpoPJL4G9ALrAHnYCpLsP7mUdZsu0Qv7wphr7RbQHoEhrEjCHxfL7nBH//fL+1AZVSlyTA15u5IxLZW3iWP3+0x+o4SqnvYUPmUd7PKuCRQXF0Dg20Oo5DOHIMOMaYdcC6evtm1HlcBoy+wLnRF9i/DUhoupSquSksLmfKinR6d2rFI4PivvPc2Kuj+GBnAU+t38WA2DDi2gdblFIpdakG2m5Vv7h5D0P6dKJ7u5ZWR1JKXaKS8ipmrs6kZ4faoWWeSlfCVM2KMYbJb++guLyKxWOT8fX57peAiLBgVB+C/XwY/1YqFVXOb3uklLp804fE49/Ci6kr07nIiEallItauCGbguIyFoxKpIW355apnvvOlGrAW1sPsWnXMSan9CT2Ale3w4P9WDAqkawjZ1j0wW4nJ1RKfR/hwX5MubMXX+07ybLteY2foJRyGWmHTvP6F/v58bVduKJzG6vjOJQW4KrZ2H/8LHPeyeL67qHc3z/6osfe3rsDY/tG8dKWPWzdf7HGPEopVzO2bxRXR7dh/rqdnCgptzqOUsoOVdU1TFmRTnhLPybd0cPqOA6nBbhqFqqqa5i4NBUfL2Hh6CS8vBqfUT19aDxRbQKZsCSV4rJKJ6RUSjUFLy9hwahEzpZXMffdnVbHUUrZ4dXP9pF15AyzhvWmVTNYlVoLcNUsvLRlD98cPM2cEQl0bB1g1zkt/Xx4bkwS+adLmfNOloMTKqWaUvd2wfxyYAwrvz3MJzmFVsdRSl3EoZPnWLQxh1t7tSMloYPVcZxCC3Dl8dLzilj8QQ7Dkjpd8kpafaPb8subYli6LY8NmUcdlFAp5Qi/urk7XcOCmLYqg7JK7Q2ulCsyxjBjdQYiMMtDe343RAtw5dHKKqsZv+Rbwlr6MWf45XWvfGRQHL07tWLKinQKi3U8qVLuwr+FN/NGJHDgxDme/zDH6jhKqQa8m36EzdmFTLwtjogQ++5QewItwJVHe/K9XewpPMvC0Um0Dry8MWW+Pl4sHptMSXkVk9/eoa3NlHIj/buHcfeVkfxly16yjxZbHUcpVUdRaSWz1maRENGq0eYInkYLcOWxPskp5LXP9/PA9dHcEBv2vV4rtn0wk1N6smnXMd7aeqiJEiqlnGHqXb0I9vfh8ZXp1NToL9BKuYqn1u/iREk5T47qg48H9/xuSPN6t6rZOH2ugknL0ujeriWPpfRskte8v38013cPZc47Wew/frZJXlMp5Xhtg3yZdlc82w+c4l9fH7Q6jlIK2H7gJP/66iAPXN+VhIjWVsdxOi3AlUeavjqTEyUVLB6bjH8L7yZ5TS9bC0MfL2Hi0lSqqnWVTNU8iEiKiGSLSK6ITG7g+S4isklEdojIRyISWe/5ViJyWET+5LzU3zXqygj6x4Ty1PpdHDtTZlUMpRRQUVXb87tTa38m3hZndRxLaAGuPM7q1MOsTctnwm1xTf5bdcfWAcwZkcA3B0/z0pY9TfraSrkiEfEGXgAGA/HAvSISX++whcAbxpg+wGxgQb3n5wBbHJ31YkSEeSMTKa+qYZa2FVXKUn/9ZC+7C0qYPTyBID8fq+NYQgtw5VHyT5cyfVUGV3Vpw89v7OaQzzE8OYKhSZ1Y/EEO6XlFDvkcSrmQfkCuMWavMaYCeAsYXu+YeGCT7fHmus+LyFVAe+B9J2S9qK5hQfzm5u68u+MIm3cdszqOUs3S/uNn+cOmHAYndODW+PZWx7GMFuDKY9TUGB5dnkZVjeG5MUkOndAxZ3hvwlr6MX7Jt9pfWHm6CKDuzOM827660oC7bY9HAsEiEioiXsCzwKMOT2mnnw+MIbZdS6atyuBcRZXVcZRqVowxTFuVgZ+3F08M6211HEtpAa48xmuf7+ez3BPMGBJPl9Agh36ukEBfnhndhz2FZ3nyvV0O/VxKWayhVTHqtxKZBAwUkW+BgcBhoAr4FbDOGNNo6yAReUhEtonItsJCx61c6evjxfxRiRw+XcriD7Q3uFLOtCr1MJ/mHuf3KT1o38rf6jiW0gJceYScgmKeXL+LW3u1Y+zVUU75nANiw7m/fzSvfb5fl7pWniwPqPtFFQnk1z3AGJNvjBlljLkCmGrbVwRcBzwsIvupHSf+ExF5sqFPYox52RjT1xjTNzw83AFv47+ujm7Lvf2ieOXTfWTm6zAypZzh1NkK5ryzk+SoEH54TRer41hOC3Dl9iqqahi/JJVgPx8WjOrj1GVsJw/uSUx4EJOWpXH6XIXTPq9STrQViBWRriLiC4wD1tQ9QETCbMNNAKYArwIYY35ojOlsjImm9ir5G8aY/+miYoXJKb1oE+jLlBXpVGtvcKUcbv66nZwprWTBqES8vJrHcvMXowW4cnt/2LSbzPwzLBiVSHiwn1M/t38LbxaPvYITJRVMX53p1M+tlDMYY6qAh4ENwE5gqTEmU0Rmi8gw22E3AdkispvaCZfzLAl7CVoHtmDG0Hh25BXxxhf7rY6jlEf7Ys8Jlm3P42cDutGrYyur47gELcCVW9u2/yR//mgPY/tGcXvvDpZkSIxszfhbY1mbls/q1MOWZFDKkYwx64wxccaYGGPMPNu+GcaYNbbHy40xsbZjfmaMKW/gNV4zxjzs7OwXM7RPRwbGhbNwQzb5p0utjqOURyqvqmbqynSi2gbwyKBYq+O4DC3AldsqKa9i4tI0ItoEMH1o/bbEzvWLgTFc2TmEaasy9Ae5Um5CRJg7IoFqY3hijd7BUsoRXty8h73HzzJvRCIBvk2zMJ4n0AJcua05a7PIO3WORWOSaWlxI38fby+eG5NMdY1h0rI0anRMqVJuIaptIONvjeP9rAI2ZB61Oo5SHiX3WAl//mgPw5M7cWOcYydXuxstwJVbej/zKEu2HeIXA2PoG93W6jgARIcFMX1IPJ/vOcHfP99vdRyllJ0evKErPTsEM3N1JsVllVbHUcoj1NQYHl+Zjn8LL6bdZe1dalekBbhyO4XF5UxZkU58x1aMvzXO6jjfMe7qKAb1bMdT63exu6DY6jhKKTu08Pbiybv7UFBcxrPv77Y6jlIeYdn2Q3y97ySP39nL6Q0S3IEW4MqtGGOYsmIHxeVVLB6XjK+Pa/0XFhGevLsPwX4+jH8rlYqqGqsjKaXskBwVwk+u7cLrX+wn9dBpq+Mo5daOl5Qzf90u+kW3ZUxf56zN4W5cq3pRqhFLth7ig53HeCylJ3Htg62O06DwYD8WjEok68gZFn+gV9OUcheT7uhBu2A/pqxIp6paf3lW6nLNfSeLcxVVzB+VoD2/L0ALcOU2Dpw4y+x3sri+eygP9I+2Os5F3d67A2P7RvHSlj1s3X/S6jhKKTsE+7dg1rDe7Dxyhlc/22d1HKXc0ic5haxKzeeXA2Po3s41L5S5Ai3AlVuoqq5hwpJUfLyEhaOT3OI36ulD44loE8DEpamUlFdZHUcpZYc7enfg1l7tWbQxh0Mnz1kdRym3UlpRzdSVGXQLC+JXN3e3Oo5L0wJcuYW/fLyXbw6eZs6IBDq2DrA6jl1a+vmwaEwyh0+VMmdtltVxlFJ2EBFmD++Nl8D01RkYoy1FlbLXHz/M4eDJc8wdmYB/C+35fTFagCuXl3G4iEUbdzM0qRPDkyOsjnNJ+ka35RcDY1iy7RDva49hpdxCp5AAfnd7Dz7KLuSdHUesjqOUW9h19Ax//Xgv91wVSf+YMKvjuDwtwJVLK6usZvySVMJa+jFneG+r41yW8bfGEd+xFVNWpFNY/D8rdCulXNB9/aNJjGjNrLVZFJVqb3ClLqamxvD4inRaBbRg6p29rI7jFhxagItIiohki0iuiExu4Hk/EVlie/4rEYmu89wU2/5sEbmjzv4JIpIpIhki8m8R8Xfke1DWemr9LnKPlfDM6D6EBPpaHeey+Pp4sXhcMsXlVUxZsUNvaSvlBry9hAWjEjl5tpyn1u+yOo5SLu2fXx/km4OnmXpnL9oEuefPamdzWAEuIt7AC8BgIB64V0TqL4X0IHDKGNMdWAQ8ZTs3HhgH9AZSgBdFxFtEIoDfAn2NMQmAt+045YE+zTnO3z/bz/39oxkQ695L2Ma1D+axlJ58sPMYS7YesjqOUsoOCRGt+en1XfnXVwfZpt2MlGpQwZkynn5vF9d3D2XUle41TNRKjrwC3g/INcbsNcZUAG8Bw+sdMxx43fZ4OTBIRMS2/y1jTLkxZh+Qa3s9AB8gQER8gEAg34HvQVmk6Fwlk5alERMexOTBPa2O0yQe6B9N/5hQZr+TxYETZ62Oo5Syw4Tb4ogICWDKinRdWEupBsxam0l5dQ1zRyRSW8IpeziyAI8A6l7qy7Pta/AYY0wVUASEXuhcY8xhYCFwEDgCFBlj3ndIemWp6aszOF5SzuKxV3jMTGovWwtFby9hwpJUXehDKTcQ5OfD7OG9yTlWwl8/2Wt1HKVcyqadBaxLP8pvb+lO17Agq+O4FUcW4A39GlR/8OuFjmlwv4i0ofbqeFegExAkIj9q8JOLPCQi20RkW2Fh4SXEVlZbnXqYNWn5jL81lsTI1lbHaVKdQgKYOyKBbw6e5i8f6w9zpdzBoF7tuTOxA3/YlMP+43r3SimAs+VVzFidSWy7ljx0Y4zVcdyOIwvwPCCqzseR/O9wkf8cYxtS0ho4eZFzbwX2GWMKjTGVwAqgf0Of3BjzsjGmrzGmb3i4e48fbk6OFJUyfVUGV3YO4RcDPfMLelhSJ4b06ciijbvJOFxkdRyllB1mDu2Nn7cXU1el60RqpYBFG3dz+HQp80cl4uujTfUulSP/xrYCsSLSVUR8qZ0suabeMWuA+2yP7wE+NLXf2dYA42xdUroCscDX1A49uVZEAm1jxQcBOx34HpQT1dQYJi1Lo6rG8NyYZHy8PfMLWkSYOyKB0Ja+jF+SSllltdWRlFKNaN/Kn98P7slnuSdY+e1hq+MoZamMw0W8+tk+7u3Xmauj21odxy05rMKxjel+GNhAbZG81BiTKSKzRWSY7bBXgFARyQUmApNt52YCS4EsYD3wa2NMtTHmK2ona34DpNvyv+yo96Cc6/Uv9vNZ7gmmD4kn2sPHkoUE+rJwdBK5x0q0xZlSbuKH/TpzZecQ5r67k5NnK6yOo5QlqmsMU1ak0zbIj8kpntEkwQoOvcRojFlnjIkzxsQYY+bZ9s0wxqyxPS4zxow2xnQ3xvQzxuytc+4823k9jDHv1dk/0xjT0xiTYIz5sTFGVzbxADkFxTz53i4G9WzHuKujGj/BAwyIDef+/tH8/bP9fJpz3Oo4SqlGeHkJ80clcqa0kgXr9Oarap5e/3w/6YeLmDk0ntaBLayO47Y88x6/cisVVTWMX5JKkJ8PT97dp1m1MXospScx4UFMWpbG6XN6RU0pV9ezQyv+78ZuLNuexxd7TlgdRymnyj9dyrPvZ3NTj3CG9OlodRy3pgW4stwfNu0mM/8MC0YlEh7sZ3Ucpwrw9WbR2GSOl5QzfXWm1XGUUnZ4ZFAsndsGMnVlus7hUM2GMYYZqzOpNoY5wxOa1cUyR9ACXFlq2/6T/PmjPYzpG8kdvTtYHccSfSJDeGRQLGvT8lmdqpO7lHJ1/i28mTcygb3Hz/LiR3usjqOUU2zIPMoHOwuYcGscUW0DrY7j9rQAV5YpKa9i4tI0ItoEMGNob6vjWOqXN8VwRecQpq/KIP90qdVxlFKNGBAbzojkTvz5o1xyjxVbHUcphyouq2Tmmkx6dWzFT2/oanUcj6AFuLLM3HeyOHTqHM+NSaaln4/VcSzl4+3FojHJVNUYHl2eRk2N9hlWytVNGxJPoK8Pj6/I0K9Z5dEWbsjmWHE5C0Yl0sJDWwQ7m/4tKktszCrgra2H+MXAGO0hahMdFsT0IfF8lnuC1z7fb3UcpVQjwlr68fidPfl6/0mWbT9kdRylHOLbg6d448sD3HddNMlRIVbH8RhagCunO15SzuS3dxDfsRUTbo2zOo5LGXd1FIN6tuPJ9bvIKdDb2kq5ujF9o+jXtS3z1+3ieIl2xVWepbK6hikr0mkf7M/vbtef101JC3DlVMYYJr+dTnF5FYvHJevytfWICE/e3YeWfj6MX5JKRVWN1ZGUUhchIswfmUhpRTVz3smyOo5STeqVT/ex62gxTwzrTbC/9vxuSlr9KKdauu0QH+ws4LGUnsS1D7Y6jksKD/ZjwahEMvPP8IdNu62Oo5RqRPd2LfnlTTGsTs1ny+5Cq+Mo1SQOnTzH4g92c1t8e1ISmmeXMkfSAlw5zYETZ5m1Nov+MaE80D/a6jgu7Y7eHRjTN5I/f7SHbftPWh1HKdWIX90cQ7ewIKatSqe0QnuDK/dmjGHaqgy8RZg1rHl3KXMULcCVU1TXGCYuTcPbS1g4OgkvL23g35gZQ3sT0SaAiUvTKCmvsjqOUuoi/Hy8mTcykUMnS/njhzlWx1Hqe1m74whbdhfyu9t70CkkwOo4HkkLcOUUL23Zw/YDp5g7IkG/mO3U0s+H58Ykc+jUOebq2FJlIRFJEZFsEckVkckNPN9FRDaJyA4R+UhEIm37k0XkCxHJtD031vnpnee6mFBGXxXJXz/ey66jZ6yOo9RlKTpXyey1mfSJbM19erfaYbQAVw6XcbiIRRt3M6RPR4YldbI6jlu5OrotvxgYw1tbD7Exq8DqOKoZEhFv4AVgMBAP3Csi8fUOWwi8YYzpA8wGFtj2nwN+YozpDaQAi0XEo/uYPX5nL1oFtGDKinTtDa7c0pPrd3LqXCXzRybirXerHUYLcOVQZZXVTFiSSmhLX+aOSEBEv5gv1YRb4+jVsRWT396hbc6UFfoBucaYvcaYCuAtYHi9Y+KBTbbHm88/b4zZbYzJsT3OB44B4U5JbZE2Qb5MH9KLbw+e5p9fHbA6jlKXZOv+k/z760P89PpoEiJaWx3Ho2kBrhzq6fXZ5BwrYeHoJEICfa2O45Z8fbxYPDaZ4vIqJr+djjF6VU05VQRQd5WZPNu+utKAu22PRwLBIhJa9wAR6Qf4AnsclNNljEiO4PruoTy9PpuCM2VWx1HKLhVVNTy+Ip2IkAAm3KY9vx1NC3DlMJ/lHufVz/Zxf/9oBsR69EUvh+vRIZjf39GDD3YWsHSbrrinnKqh21b1fwucBAwUkW+BgcBh4D8zh0WkI/Am8IAxpsHm9iLykIhsE5FthYXu3cpPRJg3IpGK6hpmrc20Oo5SdvnLlj3kHCthzojeBPr6WB3H42kBrhyi6Fwlk5alERMexGMpPa2O4xF+en1XrusWyqy1WRw4cdbqOKr5yAOi6nwcCeTXPcAYk2+MGWWMuQKYattXBCAirYB3gWnGmC8v9EmMMS8bY/oaY/qGh7v/L+zRYUH8dlAs69KPsmmnzt9Qrm1vYQnPb87lrsSO3NKzvdVxmgUtwJVDzFiTQWFxOYvGJhPg6211HI/g5SUsHJOEt5cwcWka1TrBSznHViBWRLqKiC8wDlhT9wARCROR8z9PpgCv2vb7AiupnaC5zImZXcL/DehGXPuWzFidyVltJapclDGGqSsz8PPxYubQ+vOrlaNoAa6a3Jq0fFan5vPIoFj6RHp0wwOniwgJYM7wBLYfOMVLWzx+KK1yAcaYKuBhYAOwE1hqjMkUkdkiMsx22E1AtojsBtoD82z7xwA3AveLSKptS3buO7COr48XC0Ylcvh0KYs26qq2yjWt+OYwX+w9wWMpPWnXyt/qOM2GDvJRTepoURnTVqZzRecQfnlTjNVxPNLw5E5s3FnAoo27GRgXrjPVlcMZY9YB6+rtm1Hn8XJgeQPn/QP4h8MDurCrurTlB9d05tXP9jHiigj9elUu5eTZCua+m8WVnUP4Qb/OVsdpVvQKuGoyNTWGScvSqKw2LBqTjI+3/vdyhNoJXgm0DfJl/JJUyip12WulXNljKT0JbenHlBXpVFU3OAdVKUvMe3cnxWVVLBjVR1eodjKtkFSTef2L/Xyae5zpQ+KJDguyOo5HCwn05ZnRSeQeK+Gp9busjqOUuojWAS2YOTSe9MNFvP6F9gZXruHz3OO8/U0eD93YjR4dgq2O0+xoAa6aRE5BMU++t4tberbj3n5RjZ+gvreBceHcd10X/v7Zfj7NOW51HKXURdyV2JGbe4Tz7PvZHD5danUc1cyVVVYzdVUGXUID+e2gWKvjNEt2F+Aiopc0VYMqqmqYsDSVID8fnrw7UVe7dKLJg3sREx7EpGVpFJ2rtDqOUuoCRITZwxMwBmauztAFtZSlXtycy77jZ5k3IhH/FtqpzAqNFuAi0l9Esqid/Y6IJInIiw5PptzGHzflkHH4DPNHJtIuWGdQO1OArzeLxiZzvKSc6aszrI6jlLqIqLaBTLgtlg92HmND5lGr46hmKqegmD9v2cPIKyK4ITbM6jjNlj1XwBcBdwAnAIwxadS2lVKK7QdO8uJHuYy+KpKUhA5Wx2mW+kSG8MigWFv7x8NWx1FKXcRPr+9KfMdWzFyTyZkyvWulnKumxvD4ynSC/HyYelcvq+M0a3YNQTHG1F/7WtsuKM6WVzFhSRoRbQKYOay31XGatV/eFMMVnUOYviqDI0U6vlQpV+XjXdsbvLC4nIUbsq2Oo5qZJdsOsXX/KR4f3Iuwln5Wx2nW7CnAD4lIf8CIiK+ITMI2HEU1b3PfzeLQqXM8NyaZln7aUt5KPt5eLBqTTGV1bSvIGl0lUymXlRQVwk+ui+bNLw/wzcFTVsdRzURhcTkL1u3kmq5tGd030uo4zZ49BfgvgF8DEUAekAz8ypGhlOv7IKuAf399iF8MjOHq6LZWx1FAdFgQ04fE81nuCV7/Yr/VcZQLEpG+IrJSRL4RkR0iki4iO6zO1RxNuqMH7YP9eXxFOpXaG1w5wZx3siirrGH+KG2W4ArsKcB7GGN+aIxpb4xpZ4z5EaADh5qx4yXlTF6xg14dWzHh1jir46g67u0XxS092/Hke7vIKSi2Oo5yPf8E/g7cDQwFhtj+VE7W0s+HWcN7s+toMa98us/qOMrDfZR9jDVp+fzq5hhiwltaHUdhXwH+vJ37VDNgjGHKinTOlFWxeGwyvj7aSt6ViAhP3p1IkJ8PE5amUlGlV9bUdxQaY9YYY/YZYw6c36wO1Vzd0bsDt8e3Z/EHuzl08pzVcZSHKq2oZvrqDLqFB/HLm2KsjqNsLlg9ich1IvI7IFxEJtbZngDsahopIikiki0iuSIyuYHn/URkie35r0Qkus5zU2z7s0Xkjjr7Q0RkuYjsEpGdInLdJbxf9T0t25bHxqwCfn9HD105y0W1C/Zn/shEMg6f4Y+bcqyOo1zLTBH5m4jcKyKjzm9Wh2rOZg3vjY+XF1NXaW9w5RiLN+3m0MlS5o9MxM9He367iotdvvQFWgI+QHCd7QxwT2MvLCLewAvAYCAeuFdE4usd9iBwyhjTndp2h0/Zzo0HxgG9gRTgRdvrAfwBWG+M6QkkoRNCnebgiXPMWpvJdd1C+en1Xa2Ooy4iJaEDo6+K5MWPctl+4KTVcZTreIDaeTwp1A49OT8MRVmkY+sAJt0ex8e7C1mTlm91HOVhdh45w98+2ceYvpFc2y3U6jiqjgu2rjDGbAG2iMhrl3mLsh+Qa4zZCyAibwHDgaw6xwzMQ9kEAAAgAElEQVQHnrA9Xg78SWpnBgwH3jLGlAP7RCQX6CcimdT2IL/flrECqLiMbOoSVdcYJi5NxctLWDgmCS8vncDh6mYMjeeLvSeYsCSN9x4ZQJB2qlGQZIxJtDqE+q4fXxfNym8PM+edLG6Ka0frwBZWR1IeoLqmdshoSEALHr9Tp+65GnsG8J4TkWdEZJ2IfHh+s+O8CKBu//A8274GjzHGVAFFQOhFzu0GFAJ/F5FvbbdSg+zIor6nv3y8h20HTjFneAIRIQFWx1F2CPZvwXNjkjl06hxz381q/ATVHHzZwJ1IZTFvL2H+qEROnavkyfV6U1c1jX9+dYDUQ6eZNqQXIYG+VsdR9dhTgP8T2AV0BWYB+4GtdpzX0CXS+gPcLnTMhfb7AFcCfzbGXAGcBf5nbDmAiDwkIttEZFthYaEdcdWFZBwuYtHG3dzVpyPDkztZHUddgn5d2/LzG2P499eH+CCrwOo4yno3AKm2uTXahtCF9O7Umgdv6Mq/vz7E1/t02Jj6fo4WlfH0+mwGxIYxIrn+tU/lCuwpwEONMa8AlcaYLcaYnwLX2nFeHhBV5+NIoP4At/8cIyI+QGvg5EXOzQPyjDFf2fYvp7Yg/x/GmJeNMX2NMX3Dw8PtiKsaUlZZzYQlqbQJ9GXeiATtHeqGJtwWS6+OrZi8YgfHS8qtjqOslQLEArejbQhdzvhbY4kICeDxlemUV+mC0+ryPbEmk8rqGubqz22XZU8BXmn784iI3CUiV1BbEDdmKxArIl1FxJfaSZVr6h2zBrjP9vge4ENTOw18DTDO1iWlK7U/ML42xhyldmXOHrZzBvHdMeWqiT2zIZucYyU8MzpJb2G5KT8fbxaPTeZMaRVTVqRrp4XmzVxgUy4g0NeHuSMTyD1Wwstb9lodR7mpjVkFrM88ym8HxdIlVEfpuip7ZmXNFZHWwO+o7f/dCpjQ2EnGmCoReRjYQG3bwleNMZkiMhvYZoxZA7wCvGmbZHmS2iId23FLqS2uq4BfG2POXw74DfBPW1G/l9pZ/coBPss9ziuf7uO+67owME7vIrizHh2C+X1KD+a+u5Nl2/IYc3VU4ycpT/Qu/x3m50/t0MJsajtOKRdwc4923NWnI89vzuWuPh3ppoumqEtwtryKmasz6NE+mIdu7GZ1HHURFy3Aba3/Yo0x71A7QfLmS3lxY8w6YF29fTPqPC4DRl/g3HnAvAb2pwJ9LyWHunRFpZVMWpZGt/AgJg/W2dOe4KfXd2XTzmPMWpvJtd1C6RwaaHUk5WT1O6CIyJXAzy2Koy5g5tB4Pt5dyNSVGfzr/67RIQTKbs++v5v8ojLe/sEVtPDWhfJc2UX/dWxXnYc5KYtyITNWZ1BYXM7isckE+Grjfk/wnxaSIkxYmkp1jY48aO6MMd8AV1udQ31Xu2B/Jg/uyRd7T/D2N4etjqPcRHpeEa99vo8fXtOZq7q0tTqOaoQ9vx59LiJ/EpEBInLl+c3hyZRl1qTlszo1n98OiqVPZIjVcVQTiggJYPaI3mw/cIqXtuyxOo5ysnqrGk8SkX9R29pVuZh7r+5M3y5tmPduFifP6nIX6uKqqmuYvGIHoS39+H1KT6vjKDvYU4D3p3Z84GzgWdu20JGhlHWOFpUxbWU6yVEh/OqmGKvjKAcYkRzBXYkdWbRxNxmHi6yOo5yr7qrGftSOCR9uaSLVIC9bb/Disirmvau9wdXFvfb5fjLzz/DE0N60DtCFnNxBo5MwjTGXNO5bua+aGsOjy9OorDYsGpuMj44f80giwtwRCWzdf5IJS1JZ+5sb8G+hw4yaiSxjzLK6O0RkNLDsAscrC8W1D+bnA7vxwuY93H1lBP27h1kdSbmgw6dLeW7jbm7p2Y47EztYHUfZSSss9R9vfLGfT3KOM21IL7qGaesiT9YmyJdnRieRc6yEp9dnWx1HOc8UO/cpF/GbW2KJDg1k6qoMyiq1N7j6LmMMM1ZlYAzMGtZbJ+y6ES3AFQC5x4pZ8N4ubunZjh/062x1HOUEA+PCue+6Lrz62T4+yz1udRzlQCIyWESeByJE5I91tteobfWqXJR/C2/mjUxk3/GzvLA51+o4ysW8l3GUTbuOMfG2OKLaamcrd6IFuKKiqobxS1IJ8vPhybsT9TfoZmTy4F50Cw9i0rI0is5VNn6Cclf5wDagDNheZ1sD3GFhLmWH67uHMeqKCF7asoecgmKr4ygXcaaskifWZNK7UyseuD7a6jjqEjVagIvIqAa2QSLSzhkBleM9/2EOGYfPMH9kIu2C/a2Oo5wowLd2lczC4nJmrMmwOo5yEGNMmjHmdaC7Meb1OtsKY8wpq/Opxk29qxdBfj48vjKdGm0hqoBn1mdzvKScBaMSdc6WG7LnX+xB4G/AD23bX4GJwGci8mMHZlNOsP3AKV7YnMvoqyJJSdDJG81Rn8gQfjsoltWp+axJy7c6jnKsfiKyUUR2i8heEdknIrrmuRsIbenH43f2Yuv+UyzZdsjqOMpi2w+c4h9fHeC+/tHaLthN2VOA1wC9jDF3G2PuBuKBcuAa4DFHhlOOdba8iolLU+kUEsCMofFWx1EW+tVNMSRHhTBtZTpHi8qsjqMc5xXgOeAGahfg6YsuxOM2Rl8VybXd2rJg3U6OFevXaXNVWV3D4yvS6dDKn9/d3sPqOOoy2VOARxtjCup8fAyIM8acBHTQqBub++5ODp48x3Njkgn2176hzZmPtxeLxiZTWV3bilJvcXusImPMe8aYY8aYE+e3xk4SkRQRyRaRXBGZ3MDzXURkk4jsEJGPRCSyznP3iUiObbuvqd9QcyIizBuZSFllDXPe0d7gzdVfP9lLdkExs4b1pqVfo92klYuypwD/RETesX0TvQ9YDXwsIkHAacfGU46yaWcB//76ID+/MYZ+XXXJWgVdw4KYNqQXn+Qc540v9lsdRznGZhF5RkSus3dlYxHxBl4ABlN7B/ReEal/y2wh8IYxpg+1i7YtsJ3bFphJ7R3TfsBMEWnTtG+peYkJb8mvb+7O2rR8Pso+ZnUc5WQHT5zjDx/kcEfv9tzeW4eNujN7CvBfA68BycAVwBvAr40xZ3WRHvd0oqScx97eQa+OrZhwW6zVcZQL+UG/ztzcI5wF7+0i95h2W/BA11A77GQ+9q9s3A/INcbsNcZUAG/xv6tnxgObbI8313n+DmCjMeakbbLnRiDle7+LZu4XN3UjJjyIaasyKK3Q3uDNhTGGqavSaeHtxaxhCVbHUd9TowW4qbXcGDPBGDPe9ljvT7spYwxTVqRzprSKxWOT8fPRFRDVf4kIT93Th0Bfb8YvSaWiqsbqSKoJGWNubmC7pZHTIoC6s/7ybPvqSgPutj0eCQSLSKid56pL5OfjzfyRieSdKmXxpt1Wx1FOsiYtn09yjvPoHT3o0Fo7lrk7e9sQ5ohIkYicEZFiETnjjHCq6S3bnsf7WQX8PqUHPToEWx1HuaB2wf4sGJVIxuEzPP9hjtVxVBMSkfYi8oqIvGf7OF5EHmzstAb21b8IMwkYKCLfAgOBw9Qu8GPPueezPSQi20RkW2FhYSOR1DXdQhnbN4q/fbKPrHz9kezpTp+rYPbaLJKiQvjRtV2sjqOagD1DUJ4GhhljWhtjWhljgo0xrRwdTDW9QyfPMWtNJtd1C+Wn13e1Oo5yYSkJHbnnqkhe2JzL9gPaJtqDvAZsADrZPt4NjG/knDwgqs7HkdQu7PMfxph8Y8woY8wVwFTbviJ7zq3zGi8bY/oaY/qGh4fb926auSl39qRNYAumrEynWidOe7QF63ZxurSSBSMT8fbSxfI8gT0FeIExRqdbu7nqGsPEpal4ibBwTBJe+gWsGjFzaDwdWwcwcWkqZ8t1tXIPEWaMWUpte1mMMVVAY4OItwKxItJVRHyBcdSuoPkfIhImIud/nkwBXrU93gDcLiJtbJMvb7ftU00gJNCX6UPiSTt0mn98ecDqOMpBvtp7giXbDvGzG7oS30mvf3oKewrwbSKyRETurbsapsOTqSb18sd72br/FLNH9CYiJMDqOMoNBPu34LkxSRw8eY657+rv4B7irG1stgEQkWuBooudYCvSH6a2cN4JLDXGZIrIbBEZZjvsJiBbRHYD7YF5tnNPAnOoLeK3ArNt+1QTGZbUiQGxYTyzIVt7+Hug8qpqHl+ZTmSbAB65VZsmeBJ7Gki2As5Re+XiPAOscEgi1eQy84t4bmM2dyV2ZESyzn9S9rumWygP3diNv2zZy6292jGoV3urI6nvZyK1V69jROQzIBy4p7GTjDHrgHX19s2o83g5sPwC577Kf6+IqyYmIswdkcDtiz7miTWZvPTjq6yOpJrQSx/tZU/hWf7+wNUE+mrPb0/S6L+mMeYBZwRRjlFWWc2EJam0CfRl7ogERHToibo0E2+LY0t2IY+9vYP1428krKWf1ZHUZTLGfCMiA4Ee1E6QzDbG6IJqbq5LaBCP3BrL0+uz2ZhVwG3x+ouyJ9hTWMILm3MZ0qcjN/doZ3Uc1cQuOARFRH5v+/N5Eflj/c15EdX38cyGbHYXlPDM6CTaBPlaHUe5IT8fbxaPS+ZMaRVTVqSjXUjdl21RnTuBQdTe1fyNiEy0NpVqCv83oBs9OwQzY3UGJTpnw+0ZY5i6Mh3/Fl7MGFp/3SvlCS42Bvz8oM9twPYGNuXiPss9ziuf7uMn13VhYJx2FVCXr2eHVjx6Rw82ZhWwbFue1XHU5VsL3A+EAsF1NuXmWnh7MX9UIkfPlPHc+9ob3N0t357Hl3tPMnlwL9oFa89vT3TBISjGmLW2P193XhzVVIpKK5m0LI1uYUFMGdzL6jjKAzx4Q1c27Spg1tpMru0WSufQQKsjqUsXaVsuXnmgKzu34UfXdOG1z/cx8ooIEiNbWx1JXYYTJeXMW7eTvl3aMO7qqMZPUG7JnoV44kTkZRF5X0Q+PL85I5y6fDNXZ3CsuJxFY5MJ8NXVLtX35+UlLBydhJcIE5emat9h9/SeiNze+GHKXT2a0oOwln5MXrGDqmpdydYdzXt3J2fLq5g/KlFbBnswe9oQLgO+BaYBj9bZlItam5bPqtR8fntLLElRIVbHUR4ksk0gs0f0ZtuBU/zl4z1Wx1GX7ktgpYiU6srGnqmVfwueGNabzPwzvPb5fqvjqEv0ac5xVnx7mJ/fGENcex0d5snsKcCrjDF/NsZ8bYzZfn5zeDJ1WY4WlTFtVQbJUSH8+uYYq+MoDzQiOYK7EjuyaONuMg5ftIW0cj3PAtcBgbqysecanNCBQT3b8ez7u8k7dc7qOMpOZZXVTF2VTnRoIA/f0t3qOMrB7CnA14rIr0Sko4i0Pb85PJm6ZDU1hkeXp1FRVcOiscn4eNvzz6vUpTnfd7hNoC8TlqRSVtnYQorKheQAGUZb2Xg0EWH2iAREYMbqTO1c5Cb+9GEuB06cY97IRPxb6NBRT2dPhXYftUNOPue/HVC2OTKUujxvfnmAT3KOM21IL7qGBVkdR3mwNkG+PDM6iZxjJTyzIdvqOMp+R4CPRGSKiEw8v1kdSjW9iJAAJt4Wx4e7jvFexlGr46hG7C4o5qUtexh1ZQTXdw+zOo5ygosW4CLiBfzIGNO13tbNSfmUnXKPlTB/3U5u7hHOD/p1tjqOagYGxoXzk+u68Mqn+/gs97jVcZR99gGbAF+0DaHHu79/NAkRrXhiTSZnynS9JVdVU2OYsiKdYH8fpt6pXcuai4sW4MaYGmChk7Koy1RZXcOEJakE+nrz1D19dLVL5TRTBveiW1gQk5alUVSqP+BdnTFmljFmFvAc8Gydj5UH8vH2YsHIPhwvKefp9busjqMu4N9bD7L9wCkev7MXobrScLNhzxCU90XkbtGqzmU9vymH9MNFLBiVqA37lVMF+HqzaGwyx4rLmbk6w+o4qhEikiAi3wIZQKaIbBeR3lbnUo6TGNma+/t35Z9f1RZ5yrUcKy7jyfd2cV23UO65KtLqOMqJ7CnAJ1LbirD8UttWiUiKiGSLSK6ITG7geT8RWWJ7/isRia7z3BTb/mwRuaPeed4i8q2IvGNPDk/2zcFT/GlzLvdcFUlKQker46hmKCkqhN/eEsuq1HzWpuVbHUdd3MvARGNMF2NMF+B3wF8tzqQc7He3x9GxlT+Pr0inUnuDu5TZa7Mor6ph3sgEvXvdzDRagNvaVHkZY3wvpW2ViHgDLwCDgXjgXhGJr3fYg8ApY0x3YBHwlO3ceGAc0BtIAV60vd55jwA7G397nu1seRUTl6TSsXUAM4fW/6tVynl+fXMMSVEhTFuVwdGiMqvjqAsLMsZsPv+BMeYjQGdse7ggPx9mDU8gu6CYv36y1+o4ymZz9jHe2XGEh2/uTrfwllbHUU5mV586EWkjIv1E5Mbzmx2n9QNyjTF7jTEVwFvA8HrHDAfOL3W/HBhkG+oyHHjLGFNujNkH5NpeDxGJBO4C/mZPdk82b91ODpw8x3Njkgj2b2F1HNWM+Xh7sWhMEhVVNTy6PI0aXSXTVe0VkekiEm3bplE7MVN5uNvi25PSuwN/+CCHAyfOWh2n2TtXUcW0lRnEhAfx84Ha16I5smcp+p8BHwMbgFm2P5+w47UjgEN1Ps6z7WvwGGNMFVAEhDZy7mLg98BF76OJyEMisk1EthUWFtoR1718uKuAf311kIdu7MY13UKtjqMU3cJbMvWuXnySc5w3vzxgdRzVsJ8C4cDbwAogDLjfykDKeZ4Y1psW3l5MW5WhvcEttviDHA6fLmXBqD74+WjP7+bInivgjwBXAweMMTcDVwD2VLQNDWaq/xV/oWMa3C8iQ4Bj9qzEaYx52RjT1xjTNzw8vPG0buRESTm/X55Ozw7BTLwtzuo4Sv3HD6/pzE09wpm/bie5x0qsjqP+VwwQRe33/hbAIGovsKhmoENrf36f0oNPco6zOlXna1glM7+IVz7dx7iro+jXVdc1bK7sKcDLjDFlUDtp0hizC+hhx3l51H6jPy8SqP8V/59jRMQHaA2cvMi51wPDRGQ/tUNabhGRf9iRxWMYU9sv9ExpJYvHJetvzsqliAhP392HQF9vJixJ1QlfruefwKvAKGCIbRtqaSLlVD+8pgvJUSHMeSeL0+cqrI7T7FTXGB5fkU6bwBZMHtzT6jjKQvYU4HkiEgKsAjaKyGr+t5BuyFYgVkS6iogvtZMq19Q7Zg21K20C3AN8aFsieQ0wztYlpSsQC3xtjJlijIk0xkTbXu9DY8yP7MjiMZZvz+P9rAIevaMHPTs0OhdWKadr18qfBaMSST9cxPObcqyOo76r0Biz1hizzxhz4PxmdSjlPN5ewoJRiZwurWTBOu0N7mxvfrGftLwipg+JJyTQ1+o4ykI+jR1gjBlpe/iEiGym9ir1ejvOqxKRh6kdM+4NvGqMyRSR2cA2Y8wa4BXgTRHJpfbK9zjbuZkishTIAqqAXxtjqi/97XmWQyfPMWttFtd2a8uDN3S1Oo5SF5SS0JG7r4zkT5tzualnO67s3MbqSKrWTBH5G7WrYZaf32mMWWFdJOVsvTq24mcDuvKXLXsZdWWEziNykiNFpTyzIZsBsWEMS+pkdRxlMbFnIoaI3ADEGmP+LiLhQEtbdxK30LdvX7Nt2zarY3wv1TWGcS9/wa4jxbw3fgCRbQKtjqTURZ0pq2Tw4k/w8RbW/XYAQX6N/r6vGiAi240xfZvotf4B9AQy+e9EdmOM+WlTvH5T8YTv2a6utKKa2xdvoYW3F+89MkCHMzrBQ29s4+OcQt4fP5DOofoz3FPZ+z3bni4oM4HHgCm2XS2AZjXu2hW8/PFetu4/xazhvbX4Vm6hlX8Lnh2TxMGT55j7brNv2+8qkmyT0+8zxjxg21yq+FbOEeDrzdwRiewtPMtLH2lvcEfbkHmU97MKeGRQnBbfCrBvDPhIYBhwFsAYkw8EOzKU+q7M/CKe25jNnYkdGHlF/U6OSrmua7uF8tCAbvz764Ns2llgdRwFXzawIJpqpgbGhTMsqRMvbM5lT6F2LXKUkvIqnliTSc8OwfxsgA4fVbXsKcArbBMjDYCI6KppTlRWWc2EJam0CfRl3ohEXapWuZ2Jt8fRs0Mwj729gxMl5Y2foBzpBiBVRLJFZIeIpIvIDqtDKetMHxKPfwsvpq5M197gDrJwQzZHz5Qxf1QiLbztWv9QNQP2/E9YKiJ/AUJE5P+AD4C/OjaWOm/hhmx2F5Tw9D19aBOkM6aV+/Hz8WbxuGTOlFYxZYX+kLdYCrVdpW6ntv2gtiFs5sKD/ZhyZy++3HuSZdvzrI7jcdIOneb1L/bzo2u66GR09R2NFuDGmIXULhP/NrX9v2cYY553dDAFn+ce52+f7uPH13bhph7trI6j1GXr2aEVj97Rg/ezCvSHvIXqth7UNoTqvLF9o7g6ug3z1+3Uu1RNqKq6hikr0glv6cejKfYsn6KaE7vuhRhjNhpjHjXGTDLGbHR0KAVFpZVMWpZGt7AgHr+zl9VxlPreHryhK9d2a8usNZkcOnnO6jhKKRsvW2/ws+VVzNMJ003m75/tJ+vIGWYN600r/xZWx1Eu5oIFuIgUi8iZBrZiETnjzJDN0RNrMikoLmfR2GQCfLU9lHJ/Xl7CwtFJeIkwcWkq1TU6FEUpV9G9XTC/HBjDim8P82nOcavjuL1DJ8/x3Mbd3NqrHSkJHayOo1zQBQtwY0ywMaZVA1uwMUaXYHSgd3bks/Lbw/z2lliSokKsjqNUk4lsE8is4b3Zuv8UL3+src+UciW/urk7XcOCmLoqnbLKZr/23WUzxjBjdQYiMGt4gjZPUA3S6bgu5mhRGVNXZpAUFcKvb46xOo5STW7kFRHcmdiB5zZmk5lfZHUcpZSNfwtv5o1I4MCJczz/YY7VcdzWu+lH2JxdyMTb4ogICbA6jnJRWoC7EGMMjy5Po6KqhkVjkvDRdkXKA4kI80Yk0ibQlwlLUvVKm1IupH/3MO6+MpK/bNlL9tFiq+O4naLSSmatzSIhohX394+2Oo5yYVrhuZA3vzzAJznHmXpXL7qFt7Q6jlIO0ybIl6fv6cPughIWbsi2Oo5qhIik2HqH54rI5Aae7ywim0XkW1t/8Ttt+1uIyOu2fuM7RWTK/766cjVT7+pFsL8Pj69Mp0bnalySp9fv4kRJOU+O6qMX0dRF6f8OF5F7rIT563ZyU49wfnhNZ6vjKOVwN/Vox4+v7cLfPt3H57k66ctViYg38AIwGIgH7m1gNc1pwFJjzBXAOOBF2/7RgJ8xJhG4Cvi5iEQ7I7e6fG2DfJl6VzzbD5zi31sPWh3HbWw/cJJ/fnWQB67vSkJEa6vjKBenBbgLqKyuYeLSVAJaePP03X10woZqNqbc2ZNuYUFMWpZGUWml1XFUw/oBucaYvcaYCuAtYHi9YwxwfnJ+ayC/zv4gEfEBAoAKQLtouYG7r4ygf0woT763i2NnyqyO4/Iqqmp7fndq7c/E2+KsjqPcgBbgLuD5D3PZkVfEglGJtGvlb3UcpZwm0NeH58YmU1BczhNrMq2OoxoWARyq83GebV9dTwA/EpE8YB3wG9v+5cBZ4AhwEFhojDnp0LSqSYgI80YmUl5Vw6x3sqyO4/L++sledheUMHt4AkF+PlbHUW5AC3CLfXPwFC9szuXuKyNJSehodRylnC45KoTf3NKdld8e5p0d+Y2foJytoVty9QcG3wu8ZoyJBO4E3hQRL2qvnlcDnYCuwO9EpFuDn0TkIRHZJiLbCgsLmy69umxdw4L4zc3deXfHETbvOmZ1HJe1//hZ/rgph8EJHbg1vr3VcZSb0ALcQucqqpi4JJUOrfyZOaz+kEqlmo9f39ydpKgQpq7M4GiR3u52MXlAVJ2PI/nvEJPzHgSWAhhjvgD8gTDgB8B6Y0ylMeYY8BnQt6FPYox52RjT1xjTNzw8vInfgrpcPx8YQ/d2LZm2KoNzFVVWx3E5xhimrcrA19uLJ4b1tjqOciNagFto3rs7OXDyHM+OSdJlalWz1sLbi0VjkiivqubR5WkYo50XXMhWIFZEuoqIL7WTLNfUO+YgMAhARHpRW4AX2vbfIrWCgGuBXU5Lrr43Xx8vFoxK5PDpUhZ/oL3B61uVephPc4/z+5QetNchpOoSaAFukc27jvHPrw7y0IBuXNst1Oo4SlmuW3hLpt4Vzyc5x3nzywNWx1E2xpgq4GFgA7CT2m4nmSIyW0SG2Q77HfB/IpIG/Bu439T+FvUC0BLIoLaQ/7sxZofT34T6Xq6Obsu9/aJ45dN9unhWHafOVjDnnZ0kR4Xwg2u6WB1HuRmdKWCBk2creHT5Dnp2CGbi7TpbWqnzfnRNZz7IKmDeuzvpHxNG93baD98VGGPWUTu5su6+GXUeZwHXN3BeCbWtCJWbm5zSi41Zx5iyIp2Vv7oeby/t1jV/3U7OlFayYFSi/n2oS6ZXwJ3MGMOUFTs4U1rJorHJ+Pl4Wx1JKZchIjxzTx8CfL2ZsCSVyuoaqyMppYDWgS2YMTSeHXlFvPHFfqvjWO6LPSdYtj2Pnw3oRq+OrRo/Qal6tAB3suXb89iQWcCkO+L0i1apBrRr5c+CkYmkHy7i+U065lQpVzG0T0cGxoWzcEM2R4pKrY5jmfKqaqauSieqbQCPDIq1Oo5yU1qAO9Ghk+eYtTaLa7q25cEbGuzEpZQCBid2ZNSVEfxpcy7fHDxldRylFLV3qOaOSKDaGGaubr59+1/cvIe9hWeZOyKRAF+9i60ujxbgTlJdY/jd0jQAnh2TpOPFlGrEE8N607F1ABOXpHK2XNufKeUKotoGMv7/27vz8Kqqe43j3x8ZmWMwDDJIIiAQAoiUYhEci0CVqYharbb11nttbStiW4ZWwYpaLVLrpbZOV9vaKiIoKhVsQcWJQYaEAIEwTwYwSJgCIVn3j7PRmCYhhJyzd07ez/Pk4Zx99t7rzSJZ/NjD2kFOWi8AAByKSURBVFd2Yv6aPOZlf+p3nIjL3XOIJ97ZyNAe53BJJ02XKdWnAjxCnlq0iSVb8pk8NJ02ZzXwO45I4DVJjGPq6B5szT/ClLlr/Y4jIp5bL06lc8vG3PtaNgcLi/yOEzElJY4Js7NIjKvHr6/WszvkzKgAj4A1uwqYOj+Hwd1aMrJX2Sc4i0hF+qY147b+afx98TYWrMvzO46IEJq3/6FvdyfvYCFT56/3O07EzPxkB0s25zNhSBdSGif4HUdqORXgYVZYVMyYl1aS1CCeKSMyMNOlJyKn466BnejcsjG/mJnFZ4eO+R1HRICebZO4ue+5PP/RFlZt/9zvOGG379AxpsxdS5/2yYzu3fbUG4icggrwMJs6P4ecvIM8Mqo7yQ3j/Y4jUuskxMYw7bqeFBwtYvysLD0lUyQg7r7qfJo3TmD8rCxORPmUofe/sYYjx0/wwMhu1NM9XFIDVICH0Ycb9/H0+5v5bt9zufT85n7HEam1urRqwt1XhW78mvnJDr/jiAjQODGOyUPTWbO7gGc/2Ox3nLBZtGEvr67cxe2XnEeH5o39jiNRQgV4mBQUFnH3jFWkNmvI+CGd/Y4jUuvdenEaX09NZvLra9ief8TvOCICXJXekiu7tGDa2xui8vfy6PFiJs5eTdrZDfnRZR38jiNRRAV4mEx6LZu8g8d49LqeNIiP9TuOSK0XU8+YOroHAGNnrKK4RJeiiPjNzLhvWDr1DO55bXXUXSL2+IINbMs/wv0jupEYpzm/peaEtQA3s0FmlmNmuWY2rpzPE8zsJe/zxWbWvtRn473lOWZ2lbesrZktNLO1ZpZtZj8LZ/7qejNzN7NW7OQnl3egZ9skv+OIRI02ZzVg8tB0lmzJ56lFm/yOIyLAOUn1GTvwfBbm7OXNrN1+x6kx6z4t4Mn3NjHqwjZ847yz/Y4jUSZsBbiZxQDTgcFAV+AGMys7ceatwH7nXAdgGvBbb9uuwPVAOjAI+KO3vxPAWOdcF6Av8ONy9umrvIJCJr6aRY+2SfxYp6tEatzIXq0Z3K0lU+fnsGZXgd9xRAS45RvtyWjdlMmvr+HA0do/N3hJiWPCrCwaJ8YyYUgXv+NIFArnEfA+QK5zbpNz7jjwIjCszDrDgOe91zOBKyw0T98w4EXn3DHn3GYgF+jjnNvtnFsO4Jw7CKwFAjOxtnOOn8/MpLComGmjexAXoyt8RGqamTFlRAZJDeIZ89JKCouK/Y4kUufF1DMeHJnBZ4eO8du31vkd54y9sGQby7d9zq++1VUzmElYhLNCbA1sL/V+B/9ZLH+xjnPuBHAAaFaVbb3LVS4AFtdg5jPyt4+38t76vUz8VlfSUhr5HUckaiU3jOfhUd3JyTvI1Pk5fscREaBb66b8oF8qf1+8jWVb8v2OU215BYU8/M919OvQTA/Pk7AJZwFe3kSZZe/OqGidSrc1s0bAK8Cdzrlyz0Gb2W1mtszMlu3du7eKkatv495DTJm7lks6pXDT19uFvT2Ruu6y85tzU992PP3+Zj7cuM/vOCICjPlmJ1on1WfC7CyOn6idc4Pf9/oajhWXcP9wPTxPwiecBfgOoPTjotoAuypax8xigaZAfmXbmlkcoeL7BefcrIoad8496Zzr7ZzrnZKScobfSuWKiku466WVJMbF8Mio7vqFFYmQCUO60L5ZQ+6esYqCwtp/3alIbdcwIZb7hqWzPu9QrbxResG6PN7M2s1PL+9A6tkN/Y4jUSycBfhSoKOZpZpZPKGbKueUWWcOcIv3ehSwwIXmMJoDXO/NkpIKdASWeNeHPwOsdc49Gsbsp+V/F+SyascBHhyRQfMmiX7HEakzGsTH8ujoHuQdPMak17L9jiMiwBVdWjAkoyWP/XsDW/Yd9jtOlR0+doJfv5pNx+aNuG3AeX7HkSgXtgLcu6b7DmAeoZslZzjnss3sPjMb6q32DNDMzHKBu4Bx3rbZwAxgDfAW8GPnXDHQD/gucLmZrfS+hoTre6iKFdv2878Lc0MzM2S08jOKSJ10QbuzuOOyDsxasZM3M6NnCjSR2uzea9JJiKnHxFezas3c4NPeXs/Oz4/ywMgM4mM1iYKEV1ifEOOcmwvMLbPsnlKvC4FrK9h2CjClzLL3Kf/6cF8cOX6Cu2asomWTRCYNTfc7jkiddcflHXgnZw8TX82id/uzaKEzUSK+atEkkV8M7syvX13N7BU7Gdmrjd+RKrV65wGe/WAzN/Rpx9faJ/sdR+oA/RfvDEx5cy1bPjvM1NE9aJIY53cckTorLqYej17Xk8KiYu5+eVWtOeImEs1u7NOOC9olcf+ba9l/+LjfcSpUXOIYPyuL5IYJjBvU2e84UkeoAK+mhev28MLibfywfxp905r5HUekzjsvpRETh3Rh0YZ9/PXjrX7HEanz6nlzgxccLeKBuWv9jlOh5z/cQtbOA9x7TVeaNtDBNIkMFeDVkH/4OD+fmUnnlo0ZO7CT33FExHNT33O5pFMKD8xdS+6eQ37HEanzOrdswg8HpPHyJzv4aONnfsf5D7s+P8rU+Tlc0imFq7vrPi6JHBXgp8k5x/hZmRQcLWLadT1JiI3xO5KIeMyMR0Z1JzEuhrtmrKSouHbOQywSTX52RUfaJTdg4uysQD251jnHPa9lU+wc9w/vpimEJaJUgJ+mV5bvZF52HmMHdqJLqyZ+xxGRMpo3SeTBERlk7jjA4wty/Y4jUuclxsUwZUQ3Nu07zBPvbPQ7zhfmZefxr7V5jLmyE22TG/gdR+oYFeCnYXv+ESbNyaZPajL/1T/N7zgiUoHBGa0Y2as10xfmsnzbfr/jiNR5/TumMLznOTzxzsZAXB52sLCISXOy6dKqCT+4ONXvOFIHqQCvouISx9gZqwCYem0PYurpVJVIkE0amk7LJonc9dJKjhw/4XcckTrvV1d3pX58DBNmZ1FS4u9MRb+bl0PewUIeHJlBXIxKIYk8/dRV0dOLNrFkSz6Th6brVJVILdAkMY6po3uwNf8IU94M7gwMInXF2Y0SmDCkM0s25/PyJ9t9y7Fi237+8vFWbu57Lj3bJvmWQ+o2FeBVsGZXAb+bn8Pgbi0Z2au133FEpIr6pjXjh/3TeGHxNhau2+N3HJE6b3TvtvRJTeaBuevYd+hYxNsvKi5h/KwsWjRO5O6rzo94+yInqQA/hcKiYu6asZKkBvFMGZGhu6RFapmxAzvRuWVjfj4zk/wAPwxEpC4wMx4YkcHR48Xc/8aaiLf/7PubWffpQSYNTaexHqAnPlIBfgqPvr2edZ8e5OFR3UluGO93HBE5TQmxMUy7ricFR4sYPytTT8msBjMbZGY5ZpZrZuPK+bydmS00sxVmlmlmQ0p91t3MPjKzbDPLMrPEyKaXoOnQvBG3X3oer67cxaINeyPW7vb8I0z713q+2bUFg7q1jFi7IuVRAV6JjzZ+xlOLNnFT33Zcdn5zv+OISDV1adWEsQM7MS87j1eW7/Q7Tq1iZjHAdGAw0BW4wcy6llntV8AM59wFwPXAH71tY4G/Af/jnEsHLgWKIhRdAuz2S88j7eyGTJy9mqPHwz83uHOOX726mhgzJg9ND3t7IqeiArwCBYVF3P3yKto3a8iEIV38jiMiZ+i/+qfRJzWZSXOy2Z5/xO84tUkfINc5t8k5dxx4ERhWZh0HnHwwQlNgl/d6IJDpnFsF4Jz7zDkXnCexiG9Cc4NnsC3/CH9YsCHs7b2euZt31+9l7MDzOSepftjbEzkVFeAVmDQnm08LCnl0dA8axMf6HUdEzlBMPWPqtT0AGDtjFcU+T4NWi7QGSk9ZscNbVtok4CYz2wHMBX7iLe8EODObZ2bLzewX4Q4rtcdF5zXj2gvb8NR7m1j3aUHY2jlwpIj7Xs+me5um3PKN9mFrR+R0qAAvxz+zdjNr+U7uuKwDF7Q7y+84IlJD2iY3YNLQdJZsyeeuGSs5cFRXQ1RBeXeel/3fyw3Ac865NsAQ4K9mVg+IBS4GbvT+HGFmV5TbiNltZrbMzJbt3Ru564LFXxOGdKFJ/TjGzwrf3OAPvbWO/UeKeGBEhp7hIYGhArwcPdsl8f1+7bnj8g5+RxGRGvbtXq2588qOvJG5m6umvce761XsncIOoG2p92348hKTk24FZgA45z4CEoGzvW3fdc7tc84dIXR0vFd5jTjnnnTO9XbO9U5JSanhb0GC6qyG8fz66i6s2PY5LyzZVuP7X7oln38s2cYP+rWnW+umNb5/kepSAV6OVk3rc+816Xo6lkgUMjPuvLITs27/Bo0SY7nl2SWMn5XJoWN6WmYFlgIdzSzVzOIJ3WQ5p8w624ArAMysC6ECfC8wD+huZg28GzIvASI/95wE2vCerenXoRkP/3MdeQWFNbbf4ydKmDAri9ZJ9bnzyk41tl+RmqAKU0TqpB5tk3jjJxfz3wPSeHHpdq6a9h4f5u7zO1bgOOdOAHcQKqbXEprtJNvM7jOzod5qY4Efmtkq4B/A91zIfuBRQkX8SmC5c+7NyH8XEmRmxpThGRwvLmHy69k1tt8/v7uRDXsO8Zvh6TRM0L1cEixWF+bE7d27t1u2bJnfMUQkoD7Zms/dL2eyed9hbr7oXMYN7hyYm6/N7BPnXG+/c0SSxuy6afrCXB6Zl8Mzt/Tmii4tzmhfm/YeYtBji/hmlxZMv7Hcq55EwqKqY7aOgItInXfhucnM/Wl/vt+vPX/5aCuDH1vE0i35fscSqVN+2D+NTi0acc9r2Rw+g0vCTs75nRBbj3uvKTtlvUgwqAAXEQHqx8dw7zXpvHhbX0qcY/SfP+L+N9ZQWKRpq0UiIT62Hg+OzGDn50eZ9vb6au9n1vKdfLjxM345qDPNm+jBqxJMKsBFRErpm9aMt342gO/0acfT72/mW39YxIpt+/2OJVInXHhuMt/5ejue/WAzq3ceOO3t8w8f5/4319CrXRLf6dMuDAlFaoYKcBGRMhomxDJlRAZ/vbUPR48X8+0nPuTht9Zx7ISOhouE2y8HdaZZowTGz8riRHHJaW075c21HCw8wYMju1NPc35LgKkAFxGpQP+OKbw1ZgCjLmzDH9/ZyNDHP6jWUTkRqbqm9eO495quZO08wPMfba3ydh/m7uOV5Tu4bUAa57dsHMaEImdOBbiISCWaJMbx8KgePPu93uw/cpzh0z9g2tvrKTrNI3MiUnXfymjFZeenMHV+Drs+P3rK9QuLipn46mrObdaAn17RMQIJRc6MCnARkSq4vHML5o8ZwDU9zuGxf29g+PQPWPdpgd+xRKKSmXHfsG44B/e8ls2ppkz+48JcNu87zP3Du5EYFxOhlCLVpwJcRKSKkhrEM+26nvzppgvJKyjkmsffZ/rC3NO+TlVETq1tcgPGfLMj/1qbx7zsTytcb0PeQZ54dyPDe55D/44pEUwoUn0qwEVETtOgbi2Zd+cABnZtySPzcvj2nz4id89Bv2OJRJ0f9Eula6sm3Dsnm4LCov/4vKTEMWF2Fg0TYvnV1ZrzW2oPFeAiItXQrFEC02/sxeM3XMDWzw4z5A/v89R7myguif6nC4tESmxMaG7wvQePMXVezn98PmPZdpZu2c+EwV04u1GCDwlFqkcFuIjIGbimxznMHzOASzqlMGXuWq7780ds2XfY71giUaNH2yRuvqg9f/l461fm5N978BgPzF1Ln9Rkru3dxseEIqdPBbiIyBlq3jiRJ797IY+O7kFO3kEGP7aI5z/cQomOhovUiLEDO9GicSLjZ2V9MQPRb95YQ2FRCQ+MyMBMc35L7RLWAtzMBplZjpnlmtm4cj5PMLOXvM8Xm1n7Up+N95bnmNlVVd2niIgfzIyRvdrw9phL6JOazL1zsrnx6cVszz/idzSRWq9xYhyTh6Wz7tODPPP+Zt7J2cOcVbu4/dLz6NC8kd/xRE5b2ApwM4sBpgODga7ADWZW9g6JW4H9zrkOwDTgt962XYHrgXRgEPBHM4up4j5FRHzTsmkiz33/azw0MoOsnQcY9Pv3+PvibaecRk1EKndVeksGdm3B7/+1ngmzskhLaciPLjvP71gi1RLOI+B9gFzn3Cbn3HHgRWBYmXWGAc97r2cCV1joPNIw4EXn3DHn3GYg19tfVfYpIuIrM+P6Pu14687+9GibxITZWXzv/5Zy/ISmKxQ5E5OHpRNbrx67DhTywIgMEmI157fUTrFh3HdrYHup9zuAr1e0jnPuhJkdAJp5yz8us21r7/Wp9ikiEghtzmrA3279Oi8s3srGvYeJj9VtNyJnolXT+jz+nQvYuf8ofdOa+R1HpNrCWYCXd0dE2XOwFa1T0fLy/vUq97yumd0G3AbQrl27ilOKiIRRvXrGdy9q73cMkahx2fnN/Y4gcsbCeThmB9C21Ps2wK6K1jGzWKApkF/JtlXZJwDOuSedc72dc71TUvRkLBEREREJhnAW4EuBjmaWambxhG6qnFNmnTnALd7rUcACF7pTaQ5wvTdLSirQEVhSxX2KiIiIiARW2C5B8a7pvgOYB8QAzzrnss3sPmCZc24O8AzwVzPLJXTk+3pv22wzmwGsAU4AP3bOFQOUt89wfQ8iIiIiIjUtnNeA45ybC8wts+yeUq8LgWsr2HYKMKUq+xQRERERqS10S76IiIiISASpABcRERERiSAV4CIiIiIiEaQCXEREREQkgiw06190M7O9wNbT3OxsYF8Y4lRHkLJAsPIEKQsEK0+QskCw8tSmLOc65+rUwww0Zte4IOUJUhYIVp4gZYFg5QlSFqg8T5XG7DpRgFeHmS1zzvX2OwcEKwsEK0+QskCw8gQpCwQrj7JEnyD1Y5CyQLDyBCkLBCtPkLJAsPIEKQvUTB5dgiIiIiIiEkEqwEVEREREIkgFeMWe9DtAKUHKAsHKE6QsEKw8QcoCwcqjLNEnSP0YpCwQrDxBygLByhOkLBCsPEHKAjWQR9eAi4iIiIhEkI6Ai4iIiIhEkArwMsxskJnlmFmumY3zKcMWM8sys5Vmtsxblmxmb5vZBu/Ps8LU9rNmtsfMVpdaVm7bFvIHr68yzaxXhPJMMrOdXv+sNLMhpT4b7+XJMbOrajhLWzNbaGZrzSzbzH7mLY94/1SSxa++STSzJWa2yssz2VueamaLvb55ycziveUJ3vtc7/P2EcjynJltLtU3Pb3lYf859tqJMbMVZvaG9z7ifRON6vqY7bUVmHFbY3a18kS8f4I0Zp8ij2/jdtjHbOecvrwvIAbYCKQB8cAqoKsPObYAZ5dZ9jAwzns9DvhtmNoeAPQCVp+qbWAI8E/AgL7A4gjlmQTcXc66Xb2/swQg1fu7jKnBLK2AXt7rxsB6r82I908lWfzqGwMaea/jgMXe9zwDuN5b/ifgdu/1j4A/ea+vB16KQJbngFHlrB/2n2OvnbuAvwNveO8j3jfR9oXG7JNtBWbcriCLX+NSYMbsU+SJeP9UMk76Mi5Vkuc5fBq3CfOYrSPgX9UHyHXObXLOHQdeBIb5nOmkYcDz3uvngeHhaMQ59x6QX8W2hwF/cSEfA0lm1ioCeSoyDHjROXfMObcZyCX0d1pTWXY755Z7rw8Ca4HW+NA/lWSpSLj7xjnnDnlv47wvB1wOzPSWl+2bk302E7jCzCzMWSoS9p9jM2sDfAt42ntv+NA3UajOj9kQrHFbY3a18lQkbP0TpDH7FHkqEta/q0iM2SrAv6o1sL3U+x1U/ssRLg6Yb2afmNlt3rIWzrndEPolBppHME9FbfvZX3d4p52etS9P7UYsj3eK6QJC/0v3tX/KZAGf+sY7XbcS2AO8TehozefOuRPltPlFHu/zA0CzcGVxzp3smyle30wzs4SyWcrJWVN+D/wCKPHeN8OnvokyGrMrFrRxW2N2xXnAh/4J0phdXh6fx+2wj9kqwL+qvP+x+DFNTD/nXC9gMPBjMxvgQ4aq8Ku/ngDOA3oCu4GpkcxjZo2AV4A7nXMFla0a7jzlZPGtb5xzxc65nkAbQkdpulTSZljzlM1iZt2A8UBn4GtAMvDLSGQxs6uBPc65T0ovrqTNoIxDtUFQ+qq2jNngT59pzK48jy/9E6Qxu7w8fo3bkRqzVYB/1Q6gban3bYBdkQ7hnNvl/bkHmE3oFyPv5OkV7889EYxUUdu+9JdzLs/7RS0BnuLLU3Jhz2NmcYQGzhecc7O8xb70T3lZ/Oybk5xznwPvELouL8nMYstp84s83udNqfpp6+pkGeSd/nXOuWPA/xG5vukHDDWzLYQukbic0NEVX/smSmjMrlhgxm2N2ZXn8XvcDtKYXSaPX+N2RMZsFeBftRTo6N3pGk/oYvo5kQxgZg3NrPHJ18BAYLWX4xZvtVuA1yIYq6K25wA3e3cj9wUOnDytF05lrvMaQah/Tua53rsjORXoCCypwXYNeAZY65x7tNRHEe+firL42DcpZpbkva4PXEno+saFwChvtbJ9c7LPRgELnHM1dfSivCzrSv2Da4Su3SvdN2H7OXbOjXfOtXHOtSc0pixwzt2ID30ThTRmVyww47bG7Mrz+NE/QRqzK8njy7gdsTHb1fBdo7X9i9CdtesJXQs10Yf20wjd9bwKyD6ZgdD1RP8GNnh/Joep/X8QOgVWROh/dbdW1Dah0y7Tvb7KAnpHKM9fvfYyvR/8VqXWn+jlyQEG13CWiwmdVsoEVnpfQ/zon0qy+NU33YEVXrurgXtK/TwvIXTz0MtAgrc80Xuf632eFoEsC7y+WQ38jS/vuA/7z3GpbJfy5R31Ee+baPyijo/ZXluBGbcryFLnx+xT5Il4/1QyTvoyLlWSx9dxmzCO2XoSpoiIiIhIBOkSFBERERGRCFIBLiIiIiISQSrARUREREQiSAW4iIiIiEgEqQAXEREREYkgFeBSJ5jZh96f7c3sOzW87wnltSUiItWjMVuinaYhlDrFzC4F7nbOXX0a28Q454or+fyQc65RTeQTEZEvacyWaKUj4FInmNkh7+VDQH8zW2lmY8wsxsweMbOlZpZpZv/trX+pmS00s78TmuQfM3vVzD4xs2wzu81b9hBQ39vfC6Xb8p7Q9YiZrTazLDO7rtS+3zGzmWa2zsxe8J7yhZk9ZGZrvCy/i2QfiYgEhcZsiXaxp15FJKqMo9TRFG9QPuCc+5qZJQAfmNl8b90+QDfn3Gbv/Q+cc/neY3KXmtkrzrlxZnaHc65nOW2NBHoCPYCzvW3e8z67AEgHdgEfAP3MbA2hxxB3ds65k4/lFRGpwzRmS1TSEXCp6wYCN5vZSmAxoUcUd/Q+W1JqIAf4qZmtAj4G2pZaryIXA/9wzhU75/KAd4Gvldr3DudcCaHHEbcHCoBC4GkzGwkcOePvTkQkumjMlqigAlzqOgN+4pzr6X2lOudOHk05/MVKoesQrwQucs71AFYAiVXYd0WOlXpdDMQ6504QOoLzCjAceOu0vhMRkeinMVuiggpwqWsOAo1LvZ8H3G5mcQBm1snMGpazXVNgv3PuiJl1BvqW+qzo5PZlvAdc512zmAIMAJZUFMzMGgFNnXNzgTsJnQoVEanLNGZLVNI14FLXZAInvNOSzwGPETqVuNy7qWYvoSMZZb0F/I+ZZQI5hE5pnvQkkGlmy51zN5ZaPhu4CFgFOOAXzrlPvX8MytMYeM3MEgkdiRlTvW9RRCRqaMyWqKRpCEVEREREIkiXoIiIiIiIRJAKcBERERGRCFIBLiIiIiISQSrARUREREQiSAW4iIiIiEgEqQAXEREREYkgFeAiIiIiIhGkAlxEREREJIL+Hy2WIelgVxrSAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 864x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "learn.sched.plot_lr()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.9"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "learn.sched.layer_opt.opt.param_groups[0]['momentum']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "use_clr = (32,8,0.85,0.95)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a,b = use_clr[:2]\n",
+    "moms = use_clr[2:]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(0.85, 0.95)"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "moms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "070ff163ed0f482bb098dc52916f1213",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>HBox</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=4), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch      trn_loss   val_loss   accuracy                                                                              \n",
+      "    0      1.799052   1.690951   0.410843  \n",
+      "    1      1.710081   1.601665   0.433506                                                                              \n",
+      "    2      1.659519   1.556936   0.452476                                                                              \n",
+      "    3      1.652943   1.534778   0.460663                                                                              \n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[1.5347778, 0.4606629392971246]"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "learn.fit(1e-3, 1, cycle_len=4, use_clr=(10,4,0.85,0.95))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAucAAAEKCAYAAACxNfsJAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzs3Xt8VNW99/HPL3cSwiUkhFyURIlAgCRyCcRr1YJAIXmsglC8UG7S6uPp0dbiq/XWHu3x6OnNQxWEisChBLQ1iUWpUtQHSYAAGSBcg0GBAZJwCZAQJpf1/JFB0xjIAJnsmczv/XrtFzNr9t7zHTGTH2uvvZYYY1BKKaWUUkpZz8/qAEoppZRSSqlGWpwrpZRSSinlIbQ4V0oppZRSykNoca6UUkoppZSH0OJcKaWUUkopD6HFuVJKKaWUUh5Ci3OllFJKKaU8hBbnSimllFJKeQgtzpVSSimllPIQAVYHsFJkZKRJSEiwOoZSSl22zZs3VxhjoqzO0Z70O1sp5a0u5zvbp4vzhIQECgsLrY6hlFKXTUS+tDpDe9PvbKWUt7qc72wd1qKUUkoppZSH0OJcKaWUUkopD6HFuVJKKaWUUh5Ci3OllFJKKaU8hBbnSimllFJKeQi3FuciMlpE9ohIiYjMaeH1YBHJdr6+QUQSmrz2tLN9j4jc3aT9zyJSJiI7mp0rQkQ+EpF9zj+7u/OzKaWUUkop1dbcVpyLiD8wFxgDJAOTRSS52W7TgZPGmD7A74CXnccmA5OAAcBo4E/O8wEscrY1NwdYY4xJAtY4nyullFJKKeU13Nlzng6UGGO+MMY4gOVAVrN9soC3nY/fAe4SEXG2LzfGnDfGlAIlzvNhjPkMONHC+zU919vA/2nLD6Mu7tO95ew+etrqGEop9S8aGgxrd5eRv/+41VGUUh1ATW09L+QVU3H2vFvfx53FeRxwsMnzQ862FvcxxtQBlUAPF49tLtoYc8R5riNAz5Z2EpFZIlIoIoXl5eUufhR1MaeqHTz8542M/v3/01+ASimPIgIv5BXzP2v3WR1FKeXlqh11zHi7kLc+P8B6N9c77izOpYU24+I+rhx7RYwx840xQ40xQ6OifGrla7f4cMfRrx9PfWsja3eXWZhGKaW+ISJkpsWxfv9xyk7XWB1HKeWlTtfU8tDCjazfX8GrE1LJTI116/u5szg/BFzT5Hk8YL/YPiISAHSlcciKK8c2d0xEYpznigG0SmwHOUV2rosMY8szI0mK7sysJYV8sP2I1bGUUgqAzNRYjIH3t+n3klLq8p2scjDlzQ0UHTzFa5MHc9+QeLe/pzuL801AkogkikgQjTd45jbbJxd42Pn4PuCfxhjjbJ/knM0lEUgCNrbyfk3P9TCQ0wafQV3C0coaCkqPk5kWS0RYEMtmjiAlvhuPLtvCu5sPWR1PKaXo07MzA2K7kGNrrX9HKaX+VdmZGibNL2DPsTPMf2gI30uJaZf3dVtx7hxD/hiwGtgFrDDGFIvIr0Qk07nbQqCHiJQAT+CcYcUYUwysAHYCHwKPGmPqAUTkL0A+0FdEDonIdOe5/hMYKSL7gJHO58qN3t9mxxi+vrzTJSSQJdPTybi+B0+utLGk4EuLEyqlFGSlxWI7eIovj1dZHUUp5SUOnzrHxDfyOXiymkVTh3Fnv+h2e+8Ad57cGLMKWNWs7dkmj2uACRc59kXgxRbaJ19k/+PAXVeTV12eXJudQXFduS6q89dtoUEBLHx4GI8t28Iz7+3gnKOOWbddb2FKpZSvG5cSy0urdpNbZOf/3pVkdRyllIcrrajigQUbOF1Ty5LpwxnSu32XztEVQtUVKa2oYtuhSrLSvn1TREigP68/MIRxKTG8tGo3v/toL42jlZRSqv3FdutEemIEOTa7fhcppS5pz9EzTJyXz7naev4yc0S7F+agxbm6QrlFdkQae6RaEujvxx8m3ciEIfH8Yc0+Xvz7Lv2lqJSyTGZqLCVlZ9l15IzVUZRSHmr7oUomzc9HgOxZIxgY19WSHFqcq8tmjCHHdpjhiRH06hpy0f38/YSX701h6k0JLFhXyi/e20FDgxboSqn2N3ZQDAF+Qo7tsNVRlFIeqPDACX7wZgGhQQGsnJ1BUnS4ZVm0OFeXrdh+mi/Kq8hMbW1dKPDzE54bn8yPv3M9yzZ8xZMrbdTVN7RDSqWU+kZEWBC33RDF+7Yj2kmglPoX6/ZV8ODCjUSFB7Nydga9e4RZmkeLc3XZcm12Av2FMQN7ubS/iPDU6H787O6+/G3rYR5btpXzdfVuTqmUUv8qMzWWw6fOsfmrk1ZHUUp5iI93HmPaok307hFK9iMZxHbrZHUkLc7V5WloMOTZ7Nx+QxTdw4Iu69hH7+jDs+OS+bD4KLMWb+acQwt0pVT7GZkcTUigHzlFOrRFKQV5Njuzl26mf0w4y2eNICo82OpIgBbn6jJtOnCCI5U1jL/CpWun3ZLIy/cO4rN95Ux9ayNnz9e1cUKllGpZWHAA3+0fzartR6nV4XVK+bQVmw7y+PKtDL62O0tnDKdb6OV1OLqTFufqsuTY7HQK9Gdk8pVPxn//sGv5/f1pFH55kikLNnCq2tGGCZVS6uKy0uI4UeVgXUmF1VGUUhZZ9HkpT727jVv6RPL2tHTCQwKtjvQvtDhXLnPUNbBq+xFGJkcTGnR161dlpcXx+pTB7LKfZtL8AirOnm+jlEopdXG33xBF106B5BXZrY6ilLLA3LUlPJ+3k1HJ0Sx4eCidgvytjvQtWpwrl60rKedUdW2LCw9diVEDerFw6lC+PF7NxHn5HKk81ybnVUqpiwkK8GPMwF6sLj6q970o5UOMMbyyejevrN5DVlosc6cMJjjA8wpz0OJcXYbcIjvdQgO5NSmqzc55a1IUi6enU3b6PBPeyOer49Vtdm6llPuJyGgR2SMiJSIyp4XXe4vIGhHZJiKfiEh8s9e7iMhhEfmf9sqcmRZLlaOeNbuPtddbKqUs1NBgeCFvJ3PX7mdy+jX8dmIagf6eWwJ7bjLlUaoddfxj5zHGDIwhKKBt/7cZlhDBspnDOXu+jgnz1lNSpiv4KeUNRMQfmAuMAZKBySKS3Gy3V4HFxpgU4FfAb5q9/mvgU3dnbWp4Yg96hgeTq0NblOrw6hsMT/91O4vWH2DazYm8dM8g/P3E6liXpMW5csnHu8qodtS32ZCW5lLiu5E9K4P6Bpg4r4Bie6Vb3kcp1abSgRJjzBfGGAewHMhqtk8ysMb5eG3T10VkCBAN/KMdsn7N308YnxrLJ3vKqTxX255vrZRqR7X1Dfwku4jswoM8fmcfnhnXHxHPLsxBi3PlotwiO726hJCeEOG29+jbK5yVszMICfBj8vwCtuhCIUp5ujjgYJPnh5xtTdmAe52P7wHCRaSHiPgB/w38zO0pW5CZGoujvoHVO45a8fZKKTerqa3nR0u3kGezM2dMP54Y1dcrCnPQ4ly54FS1g0/3ljE+NQY/N18KSowMY8XsDCLCgnhgwQby9x936/sppa5KS18IptnznwK3i8hW4HbgMFAH/BhYZYw5yCWIyCwRKRSRwvLy8rbIDEBKfFcSeoSSY9MFiZTqaKoddcx4u5CPdx3j11kDmH379VZHuixanKtWfbjjKLX1hqy05h1i7hHfPZQVj2QQ160TU9/ayNrdZe3yvkqpy3YIuKbJ83jgXwZyG2PsxpjvG2NuBH7hbKsEMoDHROQAjePSHxKR/2z+BsaY+caYocaYoVFRbXczuoiQmRbH+v3HKTtd02bnVUpZ63RNLQ8t3Mj6/RW8OiGVBzMSrI502bQ4V63KKbJzXWQYA2K7tNt79uwSQvYjGSRFd2bWkkI+2H6k3d5bKeWyTUCSiCSKSBAwCchtuoOIRDqHsAA8DfwZwBgzxRhzrTEmgcbe9cXGmG/N9uJOmamxGAPvb9PvF6U6gpNVDqa8uYGig6d4bfJg7hsS3/pBHkiLc3VJRytrKCg9TmZabLuP1YoIC2LZzBGkxHfj0WVbeHfzoXZ9f6XUpRlj6oDHgNXALmCFMaZYRH4lIpnO3b4D7BGRvTTe/PmiJWFb0KdnZwbEdiHHprO2KOXtys7UMGl+AXuOnWH+Q0P4XkqM1ZGu2NUt86g6vPe32TGmsYfJCl1CAlkyPZ2Ziwt5cqWN6tp6HhzR25IsSqlvM8asAlY1a3u2yeN3gHdaOcciYJEb4rUqMzWW33ywmy+PV9G7R5gVEZRSV+nwqXNMebOAsjPnWTR1GDf1ibQ60lXRnnN1Sbk2O4PiunJdVGfLMoQGBbDw4WF8t39PnnlvB/M/229ZFqVUxzLe2fGgc54r5Z1KK6qY+EY+x6scLJk+3OsLc9DiXF1CaUUV2w5VWtZr3lRIoD+vPzCEcSkxvLRqN7/7aC/GNJ8UQimlLk9st06kJ0aQY7Prd4pSXmbP0TNMnJfPudp6/jJzBEN6d7c6UpvQ4lxdVG6RHREYl+oZ47YC/f34w6QbmTAknj+s2ceLf9+lv0yVUlctMzWWkrKz7DqiqxMr5S22H6pk0vx8BMieNYKBcV2tjtRmtDhXLTLGkGM7zPDECGK6drI6ztf8/YSX701h6k0JLFhXyi/e20FDgxboSqkrN3ZQDAF+onOeK+UlCg+c4AdvFhAaFMDK2RkkRYdbHalNaXGuWlRsP80X5VVkprbP3OaXw89PeG58Mj/+zvUs2/AVT660UVffYHUspZSXiggL4takSN63HdF/7Cvl4dbtq+DBhRuJCg9m5eyMDnkjtxbnqkW5NjuB/sKYgb2sjtIiEeGp0f342d19+dvWwzy2bCvn6+qtjqWU8lJZaXEcPnWOzV+dtDqKUuoiPt55jGmLNtG7RyjZj2QQ281zruy3JS3O1bc0NBjybHZuS4qie1iQ1XEu6dE7+vDsuGQ+LD7KrMWbOefQAl0pdflGJkcTEuhHTpEObVHKE+XZ7Mxeupn+MeEsnzWCqPBgqyO5jRbn6ls2HTjBkcoaMtOsn6XFFdNuSeTlewfx2b5ypr61kbPn66yOpJTyMmHBAXy3fzSrth+lVofJKeVRVmw6yOPLtzL42u4snTGcbqGe3XF4tbQ4V9+SY7PTKdCfkcnRVkdx2f3DruX396dR+OVJpizYwKlqh9WRlFJeJistjhNVDtaVVFgdRSnltOjzUp56dxu39Ink7WnphIcEWh3J7bQ4V//CUdfAqu1HGJkcTWiQdy0gm5UWx+tTBrPLfppJ8wuoOHve6khKKS9y2w2RdAkJIE8XJFLKI8xdW8LzeTsZlRzNgoeH0inI3+pI7UKLc/Uv1pWUc6q6liwvGdLS3KgBvVg4dShfHq9m4rx8jlSeszqSUspLBAf4M3ZQDKuLj+r9K0pZyBjDK6t388rqPWSlxTJ3ymCCA3yjMActzlUzuUV2unYK5NakKKujXLFbk6JYPD2dstPnmfBGPl8dr7Y6klLKS2SmxVLlqGfN7mNWR1HKJxljeCFvJ3PX7mdy+jX8dmIagf6+Va761qdVl1TtqOMfO48xdlAMQQHe/b/GsIQIls0cztnzdUyYt56SMl35TynVuuGJPegZHkyuDm1Rqt3VNxjmvLudResPMO3mRF66ZxD+fmJ1rHbn3RWYalMf7yqj2lHvtUNamkuJ70b2rAzqG2DivAKK7ZVWR1JKeTh/P2F8aiyf7Cmn8lyt1XGU8hm19Q38JLuI7MKDPH5nH54Z1x8R3yvMQYtz1URukZ1eXUJIT4iwOkqb6dsrnJWzMwgJ8GPy/AK26AIjSqlWZKbG4qhvYPWOo1ZHUcon1NTW86OlW8iz2Zkzph9PjOrrs4U5aHGunE5VO/h0bxnjU2Pw62CXkBIjw1gxO4OIsCAeWLCB/P3HrY6klPJgKfFdSegRSo5NFyRSyt2qHXXMeLuQj3cd49dZA5h9+/VWR7KcW4tzERktIntEpERE5rTwerCIZDtf3yAiCU1ee9rZvkdE7m7tnCJyl4hsEZEiEVknIn3c+dk6mg92HKW23pCZGmd1FLeI7x7KikcyiOvWialvbWTt7jKrIymlPJSIkJkWx/r9xyk7XWN1HKU6rNM1tTy0cCPr91fw6oRUHsxIsDqSR3BbcS4i/sBcYAyQDEwWkeRmu00HThpj+gC/A152HpsMTAIGAKOBP4mIfyvnfB2YYoxJA5YBv3TXZ+uIcovsXBcZxsC4LlZHcZueXULIfiSDpOjOzFpSyAfbj1gdSSnloTJTYzEG3t+m3xNKucPJKgdT3txA0cFTvDZ5MPcNibc6ksdwZ895OlBijPnCGOMAlgNZzfbJAt52Pn4HuEsaBxllAcuNMeeNMaVAifN8lzqnAS5Ull0BvdXeRUcraygoPU5mWmyHH+MVERbEspkjSInvxqPLtvDu5kNWR1JKeaA+PTszILYLOTb9VaJUWys7U8Ok+QXsOXaG+Q8N4XspMVZH8ijuLM7jgINNnh9ytrW4jzGmDqgEelzi2EudcwawSkQOAQ8C/9lSKBGZJSKFIlJYXl5+BR+r43l/mx1jGnuKfEGXkECWTE8n4/oePLnSxpKCL62OpJTyQJmpsdgOnuJARZXVUZTqMA6fOsfEN/I5eLKaRVOHcWe/aKsjeRx3FuctdcEaF/e53HaAfwfGGmPigbeA37YUyhgz3xgz1BgzNCrKexfaaUu5NjuD4rpyXVRnq6O0m9CgABY+PIzv9u/JM+/tYP5n+62OpJTyMOOdHRZ52nuuVJsorahi4hv5HK9ysGT6cG7qE2l1JI/kzuL8EHBNk+fxfHuoydf7iEgAjcNRTlzi2BbbRSQKSDXGbHC2ZwM3tc3H6NhKK6rYdqjSZ3rNmwoJ9Of1B4YwLiWGl1bt5ncf7cWY5v9+VEr5qthunUhPjCDHZtfvBqWu0t5jZ5g4L59ztfX8ZeYIhvTubnUkj+XO4nwTkCQiiSISROMNnrnN9skFHnY+vg/4p2n8BswFJjlnc0kEkoCNlzjnSaCriNzgPNdIYJcbP1uHkVtkRwTGpfrmeK9Afz/+MOlGJgyJ5w9r9vHi33fpL2Gl1NcyU2MpKTvLriO6yrBSV2r7oUrun5ePANmzRjAwrqvVkTxagLtObIypE5HHgNWAP/BnY0yxiPwKKDTG5AILgSUiUkJjj/kk57HFIrIC2AnUAY8aY+oBWjqns30m8K6INNBYrE9z12frKIwx5NgOMzwxgpiunayOYxl/P+Hle1MICw5gwbpSqmvr+Y+sgR1uvnel1OUbOyiG53OLybEdJjm2485mpZS7FB44wQ/f2kSXToEsmzmc3j3CrI7k8dxWnAMYY1YBq5q1PdvkcQ0w4SLHvgi86Mo5ne1/A/52lZF9SrH9NF+UVzHjluusjmI5Pz/hufHJhAb586dP9nPOUc8r96UQ4K/rdCnlyyLCgrg1KZK8Ijs/v7uf/qNdqcuwbl8FMxcXEtM1hKUzhhPbzXc7Ai+HVh4+LNdmJ9BfGDOwl9VRPIKI8NTofvzs7r78bethHlu2lfN19VbHUkpZLCstDntlDZu/Oml1FKW8xsc7jzFt0SZ69wgl+5EMLcwvgxbnPqqhwZBns3NbUhTdw4KsjuNRHr2jD8+OS+bD4qPMWryZcw4t0JXyZSOTowkJ9COn6LDVUZTyCnk2O7OXbqZ/TDjLZ40gKjzY6kheRYtzH7XpwAmOVNaQmeZ7s7S4Ytotibx87yA+21fO1Lc2cvZ8ndWRlFIWCQsO4Lv9o1m1/Si19Q1Wx1HKo60oPMi/Ld/K4Gu7s3TGcLqFagfg5dLi3Efl2Ox0CvRnZLJO/n8x9w+7lt/fn0bhlyeZsmADp6odVkdSSlkkKy2OE1UO1pVUWB1FKY+16PNSnnpnGzf3ieTtaemEhwRaHckraXHugxx1DazafoSRydGEBrn1nmCvl5UWx+tTBrPLfppJ8wuoOHve6khKKQvcdkMkXUICyC3SBYmUasnctSU8n7eTUcnRLHh4KJ2C/K2O5LW0OPdB60rKOVVdS5YOaXHJqAG9WDh1KAeOVzFxXj5HKs9ZHUkp1c6CA/wZOyiGfxQf1ftQlGrCGMMrq3fzyuo9ZKXFMnfKYIIDtDC/Glqc+6CcIjtdOwVya1KU1VG8xq1JUSyeNpyy0+eZ8EY+Xx2vtjqSUpYTkdEiskdESkRkTguv9xaRNSKyTUQ+EZF4Z3uaiOSLSLHztfvbP/3ly0yLpcpRz5rdx6yOopRHMMbwQt5O5q7dz+T0a/jtxDQCdQriq6b/BX1MtaOOj3YeY+ygGIIC9K//cqQnRrBs5nDOnq9jwrz1lJTpioHKd4mIPzAXGAMkA5NFJLnZbq8Ci40xKcCvgN8426uBh4wxA4DRwO9FpFv7JL9ywxN70DM8WIe2KAXUNxjmvLudResPMO3mRF66ZxD+ug5Am9DqzMd8vKuMake9Dmm5Qinx3cielUF9A0ycV0CxvdLqSEpZJR0oMcZ8YYxxAMuBrGb7JANrnI/XXnjdGLPXGLPP+dgOlAEefynP308YnxrLJ3vKqayutTqOUpaprW/gJ9lFZBce5PE7+/DMuP6IaGHeVrQ49zG5RXZ6dQkhPSHC6iheq2+vcFbOziAkwI/J8wvYoguTKN8UBxxs8vyQs60pG3Cv8/E9QLiI9Gi6g4ikA0HAfjflbFOZqbE46hv4sPiI1VGUskRNbT0/WrqFPJudOWP68cSovlqYtzEtzn3IqWoHn+4tY3xqjC5BfZUSI8NYMTuD7mFBPLBgA/n7j1sdSan21tKXiGn2/KfA7SKyFbgdOAx8vWiAiMQAS4AfGmNanEBcRGaJSKGIFJaXl7dN8quQEt+VhB6h5Np0aIvyPdWOOma8XcjHu47x66wBzL79eqsjdUhanPuQD3YcpbbekJnavHNLXYn47qGsfCSDuG6dmPrWRtbuLrM6klLt6RBwTZPn8cC/VKzGGLsx5vvGmBuBXzjbKgFEpAvwd+CXxpiCi72JMWa+MWaoMWZoVJT1I19EhMy0ONbvP07Z6Rqr4yjVbk7X1PLQwo2s31/BqxNSeTAjwepIHZYW5z4kt8jOdZFhDIzrYnWUDqNnlxCyH8kgKbozs5YU8sF2vdStfMYmIElEEkUkCJgE5DbdQUQiReTC75mngT8724OAv9F4s+jKdszcJjJTYzEG3t+mP+/KN5yscjDlzQ0UHTzFa5MHc9+QeKsjdWhanPuIo5U1FJQeJzMtVseGtbGIsCCWzRxBSnw3Hl22hXc3H7I6klJuZ4ypAx4DVgO7gBXGmGIR+ZWIZDp3+w6wR0T2AtHAi872icBtwFQRKXJuae37Ca5cn56dGRDbhRwd2qJ8QNmZGibNL2DPsTPMf2gI30uJsTpSh6fLQ/qI97fZMaaxx0e1vS4hgSyZns7MxYU8udJGdW09D47obXUspdzKGLMKWNWs7dkmj98B3mnhuKXAUrcHdKPM1Fh+88FuDlRUkRAZZnUcpdzi8KlzTHmzgLIz51k0dRg39Ym0OpJP0J5zH5FrszMorivXRXW2OkqHFRoUwMKHh3FXv548894O5n/mFZNPKKWuwHhnR0ee9p6rDqq0ooqJb+RzvMrBkunDtTBvR1qc+4DSiiq2HarUXvN2EBLozxsPNl72e2nVbn730V6MaT6BhVLK28V260R6YgQ5Nrv+jKsOZ++xM0ycl8+52nr+MnMEQ3p3tzqST9Hi3AfkFtkRgXGpOk6sPQT6+/HHSTcyYUg8f1izjxf/vkt/eSvVAWWmxlJSdpZdR3S1YNVxbD9Uyf3z8hEge9YIBsZ1tTqSz3G5OBcRHVTnhYwx5NgOMzwxgpiunayO4zP8/YSX701h6k0JLFhXyi/e20FDgxboSnUkYwfFEOAn5NgOWx1FqTZReOAEP3izgNCgAFbOziApOtzqSD6p1eJcRG4SkZ003o2PiKSKyJ/cnky1iWL7ab4or9K5zS3g5yc8Nz6ZH3/nepZt+IonV9qoq29xnRWllBeKCAvi1qRI8ors+o9v5fXW7avgwYUbiQoPZuXsDHr30D5Zq7jSc/474G7gOIAxxkbjFFjKC+Ta7AT6C2MG9rI6ik8SEZ4a3Y+f3d2Xv209zGPLtnK+rt7qWEqpNpKVFoe9sobNX520OopSV+zjnceYtmgTvXuEkv1IBrHd9Eq7lVwa1mKMOdisSasLL9DQYMiz2bktKYruYUFWx/Fpj97Rh2fHJfNh8VFmLd7MOYf+CCnVEYxMjiYk0I+cIh3aorxTns3O7KWb6R8TzvJZI4gKD7Y6ks9zpTg/KCI3AUZEgkTkpziHuCjPtunACY5U1pCZprO0eIJptyTy8r2D+GxfOVPf2sjZ83VWR1JKXaWw4AC+2z+aVduPUqvD1pSXWVF4kH9bvpXB13Zn6YzhdAvVjjxP4EpxPht4FIgDDgFpwI/dGUq1jRybnU6B/oxMjrY6inK6f9i1/P7+NAq/PMmUBRs4Ve2wOpJSAIjIUBH5m4hsEZFtIrJdRLZZncsbZKXFcaLKwbqSCqujKOWyRZ+X8tQ727i5TyRvT0snPCTQ6kjKyZUVQvsaY6Y0bRCRm4HP3RNJtQVHXQOrth9hZHI0oUG6EKwnyUqLo1OgP48t28qk+QUsnTGcyM56GVFZ7n+BnwHbAe0Cvgy33RBJl5AAcovs3NG3p9VxlGrV3LUlvLJ6D6OSo3ntBzcSHOBvdSTVhCs956+52KY8yLqSck5V15KlQ1o80qgBvVg4dSgHjlcxcV4+RyrPWR1JqXJjTK4xptQY8+WFzepQ3iA4wJ+xg2L4R/FRvZ9EeTRjDK+s3s0rq/eQlRbL3CmDtTD3QBctzkUkQ0SeBKJE5Ikm2/OA/k16uJwiO107BXJrUpTVUdRF3JoUxeJpwyk7fZ4Jb+Tz1fFqqyMp3/aciCwQkcki8v0Lm9WhvEVmWixVjnrW7D5mdRSlWmSM4YW8ncxdu5/J6dfw24lpBPrrWpSe6FJ/K0FAZxqHvoQ32U4D97k/mrpS1Y46Ptp5jLGDYggK0B88T5aeGMGymcM5e76OCfPWU1KmKw0qy/yQxnuKRgPjnds4SxN5keGJPegZHkxukd3qKEp9S32DYc6721m0/gDTbk7kpXsG4e8nVsdSF3HRwcjGmE+BT0VkkV7a9C71xNJyAAAgAElEQVQf7yqj2lGvQ1q8REp8N7JnZTBlwQYmzitgyfR0BsTqcsmq3aUaYwZZHcJb+fsJ41NjWZL/JZXVtXQN1ZvrlGeorW/giRU28mx2Hr+zD/8+8gZEtDD3ZK50q1aLyCsiskpE/nlhc3sydcVyi+z06hJCekKE1VGUi/r2Cmfl7AxCAvyYPL+ALbqgiWp/BSKSbHUIb5aZGoujvoEPi49YHUUpAGpq6/nR0i3k2ezMGdOPJ0b11cLcC7hSnP8vsBtIBF4ADgCb3JhJXYVT1Q4+3VvG+NQY/PSSlVdJjAxjxewMuocF8cCCDeTvP251JOVbbgGKRGSPTqV4ZVLiu5LQI5Rcmw5tUdardtQx4+1CPt51jF9nDWD27ddbHUm5yJXivIcxZiFQa4z51BgzDRjh5lzqCn2w4yi19YbM1Diro6grEN89lJWPZBDXrRNT39rI2t1lVkdSvmM0kASM4pvx5uMtTeRlRITMtDjW7z9O2ekaq+MoH3a6ppaHFm5k/f4KXp2QyoMZCVZHUpfBleK81vnnERH5nojcCMS7MZO6CrlFdq6LDGNgXBero6gr1LNLCNmPZJAU3ZlZSwr5YLteIlftwlxkU5chMzUWY+D9bfpzq6xxssrBlDc3UHTwFK9NHsx9Q7Rk8zauFOf/ISJdgSeBnwILgH93ayp1RY5W1lBQepzxqbE6pszLRYQFsWzmCFLiu/Hosi28u/mQ1ZFUx/d34H3nn2uAL4APLE3khfr07MyA2C7k6NAWZYGyMzVMml/AnmNnmP/QEL6XEmN1JHUFLlmci4g/kGSMqTTG7DDG3GGMGWKMyXXl5CIy2jl+sURE5rTwerCIZDtf3yAiCU1ee9rZvkdE7m7tnNLoRRHZKyK7RORxVzJ2JO9vs2NM43y7yvt1CQlkyfR0Mq7vwZMrbSwp0EmTlPsYYwYZY1KcfyYB6cA6q3N5o8zUWGwHT3GgosrqKMqHHD51jolv5HPwZDWLpg7jzn7RVkdSV+iSxbkxph7IvJITOwv7ucAYIBmY3MJMANOBk8aYPsDvgJedxyYDk4ABNI6D/JOI+LdyzqnANUA/Y0x/YPmV5PZmuTY7g+K6cn1UZ6ujqDYSGhTAwoeHcVe/njzz3g7mf7bf6kjKRxhjtgDDrM7hjcanNnaQ5GnvuWonpRVVTHwjn+NVDpZMH85NfSKtjqSuwkXnOW9ivYj8D5ANfN0N4PzivpR0oMQY8wWAiCwHsoCdTfbJAp53Pn4H+B9pHI+RBSw3xpwHSkWkxHk+LnHOHwE/MMY0OPP51J10pRVVbDtUyS/G9rc6impjIYH+vPHgEH6SXcRLq3ZTdb6en3w3SYcuqTYlIk80eeoHDAbKLYrj1WK7dSI9MYIcm53H7uyjP6vKrfYeO8OUBRuobzD8ZeYIBsbpOhnezpXi/Cbnn79q0maAO1s5Lg442OT5IWD4xfYxxtSJSCXQw9le0OzYC9OPXOyc1wP3i8g9NP5CedwYs6+VjB1GbpEdERiXquPLOqJAfz/+OOlGQgP9+cOafVSdr+MX3+uvv/RVWwpv8riOxrHn71qUxetlpsbyy/d2sOvIGZJj9QZ95R7bD1Xy0J83EOjvR/asESRFh7d+kPJ4rRbnxpg7rvDcLVUNze/8v9g+F2tvaRjOhXMGAzXGmKEi8n3gz8Ct3wolMguYBXDttde2nNzLGGPIsR0mPSGCmK6drI6j3MTfT3j53hTCggNYsK6U6tp6/iNroM5nr9rKTmPMyqYNIjIBWHmR/dUljB0Uw/O5xeTYDmtxrtyi8MAJfvjWJrp0CmTZzOH07hFmdSTVRlyZreVKHaJxDPgF8UDzAXhf7yMiAUBX4MQljr3UOQ/xTS/P34CUlkIZY+YbY4YaY4ZGRUVd5kfyTMX203xRXkVWms5t3tH5+QnPjU/mx9+5nmUbvuKnK23U1TdYHUt1DE+72KZcEBEWxK1JkeQV2Wlo0BkpVdtat6+CBxduJCo8mJWzM7Qw72DcWZxvApJEJFFEgmi8wbP5LC+5wMPOx/cB/zTGGGf7JOdsLok0LoyxsZVzvsc3Q21uB/a66XN5nFybnUB/YczAXlZHUe1ARHhqdD9+dndf/rr1MI8t28r5unqrYykvJSJjROQ1IE5E/thkW0Tj8BZ1hbLS4rBX1rD5q5NWR1EdyMc7jzFt0SZ69wgl+5EMYrvpFfOOxm3FuTGmDngMWA3sAlYYY4pF5FcicmEGmIVAD+cNn08Ac5zHFgMraLzR80PgUWNM/cXO6TzXfwL3ish24DfADHd9Nk/S0GDIs9m5LSmK7mFBVsdR7ejRO/rw7LhkPiw+yqzFmznn0AJdXRE7UAjUAJubbLnA3Zc4TrViZHI0IYF+5BQdtjqK6iDybHZmL91M/5hwls8aQVR4sNWRlBu0OubcOX67uUpge2szohhjVgGrmrU92+RxDTDhIse+CLzoyjmd7aeA710qT0e06cAJjlTWMGdMP6ujKAtMuyWRsGB/5vx1O1Pf2sjCqcPoHOzKfd5KNTLG2ACbiCwzxtS2eoByWVhwAN/tH82q7Ud5bvwAAv3debFadXQrCg8y591tDO0dwcKpQwkPCbQ6knITV74pptO4KugU5/Ymjb3cn4vIg27MplyQY7PTKdCfkcm62ICvun/Ytfz+/jQKvzzJlAUbqKzW+kpdkXQR+ci5kNsXIlIqIl9YHcrbZaXFcaLKwbqSCqujKC+26PNSnnpnGzf3ieTtaelamHdwrhTnDUB/Y8y9xph7aVz85zyNUxj+3J3h1KU56hpYtf0II5OjCQ3S3lJflpUWx+tTBrPLfppJbxZQcfa81ZGU91kI/Ba4hcbFh4aiixBdtdtuiKRLSAC5Rbogkboyc9eW8HzeTkYlR7Pg4aF0CvK3OpJyM1eK8wRjzLEmz8uAG4wxJwDtorPQupJyTlXXkpUWa3UU5QFGDejFwqlDKa04y8R5+RypPGd1JOVdKo0xHxhjyowxxy9srR0kIqNFZI+IlIjInBZe7y0ia0Rkm4h8IiLxTV57WET2ObeHmx/bEQQH+DN2UAz/KD6q94Woy2KM4ZXVu3ll9R6y0mKZO2UwwQFamPsCV4rz/yci7zu/RB8GcoDPRCQMOOXeeOpScorsdO0UyK1JHWNKSHX1bk2KYvG04ZSdPs+EN/L56ni11ZGU91grIq+ISIaIDL6wXeoAEfEH5gJjaLyqOllEkpvt9iqw2BiTQuNidr9xHhsBPEfjVdh04DkR6d62H8kzZKbGUuWoZ83uY63vrBSNhfkLeTuZu3Y/k9Ov4bcT0/SeBR/iyt/0o8AiIA24EVhM4+wpVVexQJG6StWOOj7aeYyxg2IICtAfWPWN9MQIls0cztnzdUyYt56SsjNWR1LeYTiNQ1leAv7bub3ayjHpQIkx5gtjjANYDmQ12ycZWON8vLbJ63cDHxljThhjTgIfAaOv+lN4oOHX9aBneLAObVEuqW8wzHl3O4vWH2DazYm8dM8g/HWxOZ/SalVnGr1jjPl3Y8xPnI91RQWLfbyrjGpHPZmpOqRFfVtKfDeyZ2VQ3wD3zyug2F5pdSTl4Ywxd7Sw3dnKYXHAwSbPDznbmrIB9zof3wOEi0gPF4/tEPz9hPGpsXyyp1xv2FaXVFvfwE+yi8guPMjjd/bhmXH9EdHC3Ne0WpyLyPed4wErReS0iJwRkdPtEU5dXG6RnV5dQkhPjLA6ivJQfXuFs3J2BsEBfkyeX8AWXQhFXYKIRIvIQhH5wPk8WUSmt3ZYC23NO29+CtwuIltpXCDuMI2LG7lyLCIyS0QKRaSwvLy81c/hqTJTY3HUN/Bh8RGroygPVVNbz4+WbiHPZmfOmH48MaqvFuY+ypXxEP8FZBpjuhpjuhhjwo0xXdwdTF3cqWoHn+4tY3xqjF7qUpeUGBnGitkZdA8L4oEFG8jf3+r9fcp3LaJxgbcLl+P2Aj9p5ZhDwDVNnsfTuKjR14wxdmPM940xNwK/cLZVunKsc9/5xpihxpihUVHee39NSnxXEnqEkmvToS3q26oddcx4u5CPdx3j11kDmH379VZHUhZypTg/ZozZ5fYkymUf7DhKbb0hM7VDXgFWbSy+eygrH8kgrlsnpr61kbW7L7l2mPJdkcaYFTROn3thlefWphfZBCSJSKKIBAGTaFxZ9GsiEikiF37XPA382fl4NTBKRLo7bwQd5WzrkESEzNRY1u8/TtnpGqvjKA9yuqaWhxZuZP3+Cl6dkMqDGQlWR1IWc6U4LxSRbBGZ7Bzi8v2LrBqq2klukZ3rIsMYGKcXMJRrenYJIfuRDJKiOzNrSSEfbNdL6+pbqpxjwQ2AiIygcTXoi3IW8I/RWFTvAlYYY4pF5Fcikunc7TvAHhHZC0TjXPnZOR3vr2ks8DcBv3K2dViZabEYA+9v058/1ehklYMpb26g6OApXps8mPuGxLd+kOrwXFm5pgtQTWOvxgUG+KtbEqlLOlpZQ0HpcR6/M0nHoqnLEhEWxLKZI/jhW5t4dNkWXrkvlXv1F4H6xhM09npfLyKfA1HAfa0dZIxZBaxq1vZsk8fvAO9c5Ng/801PeofXp2c4A2K7kGOzM+2WRKvjKIuVnanhwQUbKT1exfyHhnBnP13pWzVqtTg3xvywPYIo17y/zY4xjT0wSl2uLiGBLJmezszFhTy50sa52noeGNHb6ljKAxhjtojI7UBfGm/W3GOM0alF2lhmaiy/+WA3ByqqSIgMszqOssjhU+eY8mYBZWfOs2jqMG7qE2l1JOVBLjqsRUSecv75moj8sfnWfhFVU7k2O4PiunJ9VGeroygvFRoUwMKHh3FXv5788r0dzP9sv9WRlAdwLig0FriLxiul/1dEnrA2Vccz3jn9bZ7eGOqzSiuqmPhGPserHCyZPlwLc/UtlxpzfuEm0EJgcwubamelFVVsO1Spc5urqxYS6M8bDw7heykxvLRqN7/7aC+6fIHPywOmAj2A8CabakOx3TqRnhBBjs2uP3M+aO+xM0ycl8+52nr+MnMEQ3p3yEVx1VW66LAWY0ye88+32y+OupTcIjsiMC41xuooqgMI9Pfjj5NuJDTQnz+s2UfV+Tp+8T1d8MKHxRtjUqwO4Qsy02L55Xs72HXkDMmxemO/r9h+qJKH/ryBQH8/smeNICla/+2rWubKIkQ3iMh8EfmHiPzzwtYe4dQ3jDHk2A6TnhBBTNdOVsdRHYS/n/DyvSlMvSmBBetK+cV7O2ho0N48H/WBiIxqfTd1tcYOiiHAT8ixHbY6imonhQdO8IM3CwgNCmDl7AwtzNUluTJby0rgDWABrc95q9yk2H6aL8qrmHHLdVZHUR2Mn5/w3PhkOgX58/on+6lx1PNf96UQ4O/KTKuqAykA/uack7yWxptCjS461/YiwoK4NSmSvCI7P7+7H366mFyHtm5fBTMXFxLTNYSlM4YT20072NSluVKc1xljXnd7EnVJuTY7gf7CmIG9rI6iOiAR4eej+9E5OIBXVu+h2lHPHyanERzgb3U01X7+G8gAthsdDO12WWlx/CS7iM1fnWRYQoTVcZSbfLzzGD/+3y1cFxXGkunDiQoPtjqS8gKudI3liciPRSRGRCIubG5Ppr7W0GDIs9m5LSmK7mFBVsdRHdijd/Th2XHJfFh8lFmLN3POoRfLfMg+YIcW5u1jZHI0IYF+5BTp0JaOKs9mZ/bSzfSPCWf5rBFamCuXuVKcPwz8DFjPNzO1FLozlPpXmw6c4Ehljc5trtrFtFsSefneQXy2r5ypb23k7Pk6qyOp9nEE+EREnhaRJy5sVofqqMKCA/hu/2hWbT9KbX2D1XFUG1tReJB/W76Vwdd2Z+mM4XQL1Y415bpLFufOsYcPGGMSm2068Lkd5djsdAr0Z2Syrh6m2sf9w67l9/enUfjlSaYs2EBlta5F4wNKgTVAEDqVYrvISovjRJWDdSUVVkdRbWjR56U89c42bu4TydvT0gkPCbQ6kvIylxxzboxpEJFXaRyHqCzgqGtg1fYjjEyOJjTIlVsElGobWWlxdAr057FlW5n0ZgFLpqcT2Vkvy3ZUxpgXAEQkvPGpOWtxpA7vthsi6RISQG6RnTv69rQ6jmoDc9eW8MrqPYxKjua1H9yo9+2oK+LKsJZ/iMi9opMfW2JdSTmnqmvJ0iEtygKjBvRi4dShlFacZeK8fI5UnrM6knITERkoIluBHUCxiGwWkQFW5+rIggP8GTsohn8UH9X7O7ycMYZXVu/mldV7yEqLZe6UwVqYqyvmSnH+BI3TKZ4XkdMickZETrs5l3LKKbLTtVMgtyZFWR1F+ahbk6JYPG04ZafPM+GNfL46Xm11JOUe84EnjDG9jTG9gSeBNy3O1OFlpsZS5ahnze5jVkdRV8gYwwt5O5m7dj+T06/htxPTCNSpaNVVaPX/HmNMuDHGzxgTZIzp4nyu8962g2pHHR/tPMbYQTEEBegPurJOemIEy2YO5+z5OibMW09J2RmrI6m2F2aMWXvhiTHmEyDMuji+Yfh1PegZHkxukd3qKOoK1DcY5ry7nUXrDzDt5kReumcQ/jpvvbpKLlV8ItJdRNJF5LYLm7uDKfh4VxnVjnoyU3VIi7JeSnw3smdlUN8A988roNheaXUk1ba+EJFnRCTBuf2SxptElRv5+wnjU2P5ZE+53njtZWrrG/hJdhHZhQd5/M4+PDOuPzoCWLWFVotzEZkBfAasBl5w/vm8e2MpgNwiO726hJCeqNPKK8/Qt1c4K2dnEBzgx+T5BWz56qTVkVTbmQZEAe8CfwUigalWBvIVmamxOOob+LD4iNVRlItqauv50dIt5NnszBnTjydG9dXCXLUZV3rO/w0YBnxpjLkDuBEod2sqxalqB5/uLWN8aoxeIlMeJTEyjBWzM+geFsQDCzaQv/+41ZFU27geuIbG3wuBwF00dswoN0uJ70pCj1BybTq0xRtUO+qY8XYhH+86xq+zBjD79uutjqQ6GFeK8xpjTA2AiAQbY3YDfd0bS32w4yi19YbM1Diroyj1LfHdQ1n5SAZx3Tox9a2NrN1dZnUkdfX+F/gz8H1gnHMbb2kiHyEiZKbGsn7/ccpO11gdR13C6ZpaHlq4kfX7K3h1QioPZiRYHUl1QK4U54dEpBvwHvCRiOQA+s97N8stsnNdZBgD4/TeW+WZenYJIfuRDJKiOzNrSSEfbNdL8l6u3BiTZ4wpNcZ8eWGzOpSvyEyLxRh4f5v+HHmqk1UOpry5gaKDp3ht8mDuGxJvdSTVQbkyW8s9xphTxpjngWeAhcD/cXcwX3a0soaC0uOMT43VMWzKo0WEBbFs5ghS4rvx6LItvLv5kNWR1JV7TkQWiMhkEfn+hc3qUL6iT89wBsR2IUeHtniksjM1TJpfwJ5jZ5j/0BC+lxJjdSTVgbk6W8stIvJDY8ynQD6gYy3c6P1tdoxp7ElRytN1CQlkyfR0Mq7vwZMrbSwt0M5WL/VDIA0YTeNwlvE0Dm1R7SQzNRbbwVMcqKiyOopq4vCpc0x8I5+DJ6tZNHUYd/aLtjqS6uBcma3lOeDnwNPOpkBgqTtD+bpcm51BcV25Pqqz1VGUckloUAALHx7GXf168sv3djD/s/1WR1KXL9UYM9QY87Ax5ofObZrVoXzJeOe0uXnae+4xSiuqmPhGPserHCyZPpyb+kRaHUn5AFd6zu8BMoEqAGOMHQh3ZyhfVlpRxbZDlTq3ufI6IYH+vPFg4+Xel1bt5ncf7cUYY3Us5boCEUm2OoQvi+3WifSECHJsdv3Z8QB7j51h4rx8ztXW85eZIxjSu7vVkZSPcKU4d5jGbwkDICK6Ypwb5RbZEYFxqTqeTXmfQH8//jjpRiYMiecPa/bx4t93aZHhPW4BikRkj4hsE5HtIrLN6lC+JjMtlpKys+w6oqvwWmn7oUrun5ePANmzRjAwrqvVkZQPcaU4XyEi84BuIjIT+Bh405WTi8ho5xd9iYjMaeH1YBHJdr6+QUQSmrz2tLN9j4jcfRnnfE1EzrqSz9MYY8ixHSY9IYKYrp2sjqPUFfH3E16+N4WpNyWwYF0pv3hvBw0NWqB7gdFAEjCKb8ab61SK7WzsoBgC/IQc22Gro/iswgMn+MGbBYQGBbBydgZJ0TpYQLWvgNZ2MMa8KiIjgdM0zm/+rDHmo9aOExF/YC4wEjgEbBKRXGPMzia7TQdOGmP6iMgk4GXgfuel1UnAACAW+FhEbnAec9FzishQoJsrH9wTFdtP80V5FTNuuc7qKEpdFT8/4bnxyXQK8uf1T/ZT46jnv+5LIcDfpXvQlQV02kTPEBEWxK1JkeQV2fn53f3w00Xo2tW6fRXMXFxITNcQls4YTmw37ShT7c+l35TGmI+MMT8zxvzUlcLcKR0oMcZ8YYxxAMuBrGb7ZAFvOx+/A9wljXMHZgHLjTHnjTGlQInzfBc9p/MfA68AT7mYz+Pk2uwE+gtjBvayOopSV01E+Pnofvzs7r78dethHlu2lfN19VbHUsrjZaXFYa+sYfNXJ62O4lM+3nmMaYs20btHKNmPZGhhrixz0eJcRM6IyOkWtjMictqFc8cBB5s8P8S3p2D8eh9jTB1QCfS4xLGXOudjQK4xxitXcGhoMOTZ7NyWFEX3sCCr4yjVZh69ow/Pjkvmw+KjzFq8mXMOLdCVupSRydGEBPqRU6RDW9pLns3O7KWb6R8TzvJZI4gKD7Y6kvJhFy3OjTHhxpguLWzhxhhXlq1s6Vpc84GnF9vnstpFJBaYALzWaiiRWSJSKCKF5eXlre3ebjYdOMGRyhqd21x1SNNuSeTlewfx2b5ypr61kbPn66yOpJTHCgsO4Lv9o/n7tiPU1jdYHafDW1F4kH9bvpXB13Zn6YzhdAvVDjJlLXcOAD0EXNPkeTzQfPLWr/cRkQCgK3DiEsderP1GoA9QIiIHgFARKWkplDFmvnMu36FRUVFX9sncIMdmp1OgPyOTdXED1THdP+xafn9/GoVfnmTKgg1UVtdaHUkpj5WVFsfJ6lrWlVRYHaVDW/R5KU+9s42b+0Ty9rR0wkMCrY6klFuL801AkogkikgQjTd45jbbJxd42Pn4PuCfzmkbc4FJztlcEmmcQWDjxc5pjPm7MaaXMSbBGJMAVBtj+rjxs7UpR10Dq7YfYWRyNKFBrd6jq5TXykqL4/Upg9llP82kNwuoOHve6khKeaTbboikS0gAuUW6IJG7zF1bwvN5OxmVHM2Ch4fSKcjf6khKAW4szp1jyB8DVgO7gBXGmGIR+ZWIZDp3Wwj0cPZyPwHMcR5bDKwAdgIfAo8aY+ovdk53fYb2sq6knFPVtbrwkPIJowb0YuHUoZRWnGXivHyOVJ6zOpK6Ci5Mb3utiKwVka3O+dPHOtsDReRt53zqu0Tk6W+f3XcFB/gzdlAM/yg+qvdptDFjDK+s3s0rq/eQlRbL3CmDCQ7Qwlx5DrfOa2aMWWWMucEYc70x5kVn27PGmFzn4xpjzARjTB9jTLox5osmx77oPK6vMeaDS52zhff1qnXvc4rsdO0UyG03eM4wG6Xc6dakKBZPG07Z6fNMeCOfr45XWx1JXYEmU+aOAZKByS2sMvpLGjtSbqTxauefnO0TgGBjzCBgCPBI07UuFGSmxlLlqGfN7mNWR+kwjDG8kLeTuWv3Mzn9Gn47MY1AneJVeRj9P9Ji1Y46Ptp5jLGDYggK0L8O5TvSEyNYNnM4Z8/XMWHeekrKdEVEL+TKlLkGuDCJQFe+uffIAGHO+406AQ4a19NQTsOv60HP8GBydGhLm6hvMMx5dzuL1h9g2s2JvHTPIPx1HnnlgbQatNjHu8qodtTrkBblk1Liu5E9K4P6Brh/XgHF9kqrI6nL48qUuc8DD4jIIWAV8H+d7e8AVcAR4CvgVWPMCbem9TL+fsL41Fg+3VOuN1Bfpdr6Bn6SXUR24UEev7MPz4zrT+OyKkp5Hi3OLZZbZKdXlxDSEyOsjqKUJfr2Cmfl7AyCA/yYPL+ALbrwijdxZcrcycAiY0w8MBZYIiJ+NPa619O4CnQi8KSIfGt5ZE+d/ra9ZKbG4qhv4MNir1zCwyPU1Nbzo6VbyLPZmTOmH0+M6quFufJoWpxb6FS1g0/3ljEuJUYvrSmflhgZxorZGXQPC+KBBRvI33/c6kjKNa5MmTudxhv8McbkAyFAJPAD4ENjTK0xpgz4HBja/A08dfrb9pIS35WEHqHk2nRoy5WodtQx4+1CPt51jF9nDWD27ddbHUmpVmlxbqEPdhyltt6Qldb8KrBSvie+eygrH8kgrlsnpr61kbW7y6yOpFrnypS5XwF3AYhIfxqL83Jn+53SKAwYAexut+ReQkTITI1l/f7jlJ2usTqOVzldU8tDCzeyfn8Fr05I5cGMBKsjKeUSLc4tlFtk57rIMAbGubLgqlIdX88uIWQ/kkFSdGdmLSnkg+16Kd+TuThl7pPATBGxAX8BpjrXs5gLdAZ20Fjkv2WM2dbuH8ILZKbFYgzkbdOfB1edrHIw5c0NFB08xWuTB3PfkHirIynlMi3OLXK0soaC0uOMT43VsW9KNRERFsSymSNIie/Go8u28O7m/9/enUdXVd97H39/M0MMcwgJKIMgEIZEkEDqWAdUiuTxWqZShQcV8bG37e3gtU97vd7eVVd97Oq4aAGxTogi2ivBCYdy9aoBZEjCLCDIcIAQhAAJkOn3/HE2baQBE8jJ3if5vNY6K/v8zh4+J2x+fNn7t/fe43ckOYcG3DJ3o3PuSudclnMu2zn3ttd+3LuV7iDnXKZz7nE/v0eQ9e2awqCMdhra0kAlx04yae5ythw4xty7hvONoel+RxJpFBXnPnmtOIRz4SMiIvJl7ZLiee7uHHIv7cwPFxUxf/nnfkcS8dW4rAyKdh9hZ2m531ECbe+RE0yYXcDuwxU8PW0E1w9I8zuSSKOpOOp77nEAABuMSURBVPdJflGIwd3bcWlqVD0vSaTZtE2I48mpI7hhQFd+9up65n6w3e9IIr65zbvd7hIdPT+rHaXlTJhdwKHySp67eyRf69vF70gi50XFuQ92lJZTvKeMvCxdCCpyLknxscy+M3xa+tE3NvObdz4lPFxZpHXJ6NCGnF6deLVwr/4O1OPTA8eYMKeAE1U1vHDvKIb37Oh3JJHzpuLcB/mFIcxgbJbGwYl8lfjYGH4/6XLGD+/B797byi9e36TiRFqlcdkZbD9YzsZ9epBqXev2lDFxTgEGLJwxisHd2/sdSeSCqDhvZs45FhftJadXJ9Lbt/E7jkhUiI0xHrtjKNO+1ot5H+7gp6+up7ZWBbq0LmOGpBMXY7owtI5VO7/gW08sp21CHItm5tIvLcXvSCIXTMV5M9sQOspnB8t1b3ORRoqJMf79tkzuv+5SFqzYxY8WFVFdU+t3LJFm0yk5gav7dWFJYUj/OQU+3FrKnU+uJDUlkUUzc+nZOdnvSCJNQsV5M8svChEXY9w6uJvfUUSijpnxr7cM4Mc39+cva/fynQVrOVVd43cskWaTl92dUNlJVu867HcUX7278QDTn/6Enp3bsvC+XDI66Ey0tBwqzptRba1jSVGIay9LpWNygt9xRKLWA1/vy8NjM3lrw35mPLuaE5Uq0KV1uCkzjaT4GBYX7vU7im+WFIWYOX81A9NTeHHGKFJTEv2OJNKkVJw3o092fsG+spO6t7lIE5h+VW8eu2MIH2w9yLSnVnL8VLXfkUQiLjkxjhsHpvF68T6qWuGwrpdW7eZ7L65l2CUdmX/PSDq01YEuaXlUnDejxUUh2sTHclOmHoog0hQmjriE307MZtXnh5kybwVlFVV+RxKJuLzs7hyuqOLDbaV+R2lWT3+0gwdfLubKvl14ZnoOKUnxfkcSiQgV582ksrqWN9bt46bMNNomxPkdR6TFyMvuzp+mDGNT6CiTnlhO6fFTfkcSiahrLutCu6Q48gtbz11bZi3bxiNLNjI6M415U6+gTUKs35FEIkbFeTP5cNtBjlRUMS5LQ1pEmtroQd14ctoV7Cg9zoQ5BewrO+F3JJGISYyLZcyQdN7esL/FX2/hnOPxpZt5fOkW8rIzmDVlGIlxKsylZVNx3kwWF4Zo3yaeay5L9TuKSIt0db9Unp0+kpKjpxg/u4Bdhyr8jiQSMeOyMiivrOG9zQf8jhIxzjn+Y8lGZi3bzuSci/n1hGziY1W2SMunvbwZVFRW887GA4wZkk5CnH7lIpGS07sTC+4dyfFT1Yyf8zHbSo75HUkkIkb26UzXlEQWt9ChLTW1jodeWcfTH+9k+pW9efT2IcTGmN+xRJqFKsVm8O6mEioqazSkRaQZDO3RgYUzcqmphYlzlrMhVOZ3JJEmFxtj3JaVwftbDra4C6Gramr5/sJCFq7azXev78u/jR2ImQpzaT1UnDeD/MIQ3dolkdO7k99RRFqF/t1SWDQzl8S4GCbPXc6aVv7AFmmZxmVlUFlTy1sb9vkdpcmcrKrh/vlrWFIU4qFbB/CD0f1VmEuro+I8wo5UVPL+pyWMHZquU3Iizah3l2RemplLx+QEvj1vBQXbD/kdSaRJDe3Rnl6d25Jf1DKGtlRUVnPPM6t4d9MB/jNvEDOvvdTvSCK+UHEeYW+u309VjSMvu7vfUURanR4d27Lovly6d2jDtKdWsmxzid+RRJqMmTEuK4OPtx+i5OhJv+NckKMnq7jryZV8vL2UX43P4s7cXn5HEvGNivMIyy8M0adLMoO7t/M7ikir1LVdEgvvy6Vf2kXMeG4Vb65rOUMARMZlZ+AcLCmO3v36cHklU55YQeHuI/xh8jC+ObyH35FEfKXiPIL2l51k+Y5D3JaVoTFzIj7qlJzAgntHMbRHBx5YsIZXVu/xO5JIk+jbNYXM9HZRO7Sl5NhJJs1dzpYDx5h713C+MTTd70givlNxHkGvFYdwLnxkQ0T81S4pnmen5zCqT2d+uKiI+cs/9zuSSJPIy86gaPcRdpaW+x2lUfYeOcGE2QXsPlzB09NGcP2ANL8jiQSCivMIyi8KMbh7Oy5NvcjvKCICJCfG8edpI7hhQFd+9up65n6w3e9IIhfsNu82vUui6Oj5ztJyJswu4FB5Jc/dPZKv9e3idySRwFBxHiE7Sssp3lNGXpYuBBUJkqT4WGbfGT59/ugbm/nNO5/inPM7lsh5y+jQhpxenXi1cG9U7MufHjjG+DkFnKiq4YV7RzG8Z0e/I4kEiorzCMkvDGEGY7M0fk4kaOJjY/j9pMsZP7wHv3tvK794fVNUFDUiZzMuO4PtB8vZuO+o31HOad2eMibOKcCAhTNGMbh7e78jiQSOivMIcM6xuGgvOb06kd6+jd9xRKQesTHGY3cMZWpuT+Z9uIOfvrqe2loV6BKdxgxJJy7GAn1h6KqdX/CtJ5bTNiGORTNz6ZeW4nckkUBScR4BG0JH+exgue5tLhJwMTHGI+MGcf91l7JgxS5+tKiI6ppav2OJNFqn5ASu7teFJYWhQP4n88Otpdz55EpSUxJZNDOXnp2T/Y4kElgqziMgvyhEXIxx6+BufkcRka9gZvzrLQP48c39+cvavXxnwVpOVdf4HUuk0fKyuxMqO8nqXYf9jvIl7248wPRnPqFn57YsvC+XjA46oyxyLirOm1htrWNJUYhrL0ulY3KC33FEpIEe+HpfHh6byVsb9jPj2dWcqFSBLtHlpsw0kuJjWFy41+8of7OkKMTM+asZ2C2FF2eMIjUl0e9IIoEX0eLczG4xsy1mts3MHqrn80QzW+h9vsLMetX57Cde+xYzu/mr1mlmz3vt683sz2YWH8nvdjaf7PyCfWUndW9zkSg0/arePHbHED7YepBpT63k+KlqvyOJNFhyYhw3Dkzj9eJ9VAVgeNZLq3bzvRfXMuySjsy/ZyQd2uqAlUhDRKw4N7NYYBZwK5AJTDazzDNmuxs47JzrC/wGeMxbNhOYBAwCbgH+aGaxX7HO54EBwBCgDXBPpL7buSwuCtEmPpabMvUwBZFoNHHEJfx2YjarPj/MlHkrKKuo8juSSIONy8rgcEUVH24r9TXH0x/t4MGXi7mybxeemZ5DSpIvx8tEolIkj5znANucc5855yqBF4G8M+bJA57xpl8GbrDwc+7zgBedc6ecczuAbd76zrpO59wbzgOsBHpE8LvVq7K6ljfW7eOmzDTaJsQ19+ZFpInkZXfnT1OGsSl0lElPLKf0+Cm/IwVWA86QXmJmy8xsrZkVm9mYOp8NNbMCM9tgZuvMLKl507c81/ZPpV1SHPmF/t21ZdaybTyyZCOjM9OYN/UK2iTE+pZFJBpFsjjvDuyu836P11bvPM65aqAM6HyOZb9ynd5wljuBty74GzTSh9sOcqSiinFZGtIiEu1GD+rGk9OuYEfpcSbMKWBf2Qm/IwVOA8+Q/gx4yTl3OeEzon/0lo0D5gMznXODgOsAnaa4QIlxsYwZks7bG/Y3+3UTzjkeX7qZx5duIS87g1lThpEYp8JcpLEiWZxbPW1n3t/pbPM0tr2uPwIfOOf+p95QZjPMbJWZrTp48GB9s5y3xYUh2reJ55rLUpt0vSLij6v7pfLs9JGUHD3F+NkF7DpU4XekoGnIGVIHtPOm2wOnD+mOBoqdc0UAzrlDzjldhdsExmVlUF5Zw3ubDzTbNp1z/Py1jcxatp3JORfz6wnZxMfqnhMi5yOSf3P2ABfXed+Dv3fK/zCPdxSlPfDFOZY95zrN7N+BVOAHZwvlnJvrnLvCOXdFamrTFdEVldW8s/EAY4akkxCnDkmkpcjp3YkF947k+Klqxs/5mG0lx/2OFCQNOUP6CPBtM9sDvAH8s9d+GeDMbKmZrTGzByMdtrUY2aczXVMSWdxMQ1tqah0PvbKOpz7ayfQre/Po7UOIjanvWJqINEQkq8hPgH5m1tvMEgifzsw/Y558YKo3/U3gr96Y8Xxgknc3l95AP8LjyM+6TjO7B7gZmOyca/bL1N/dVEJFZY2GtIi0QEN7dODFGaOoqYWJcwrYECrzO1JQNORs5mTgaedcD2AM8JyZxQBxwFXAFO/n7WZ2wz9sIIJnO1uq2Bhj7NAM3t9yMOIXNFfV1PL9hYUsXLWb717fl38bO5DwpWMicr4iVpx7Y8i/AywFNhEec7jBzH5uZuO82Z4EOpvZNsJHux/ylt0AvARsJDx2/AHnXM3Z1umtazaQBhSYWaGZPRyp71af/MIQ3dolkdO7U3NuVkSayYBu7XjpvlEkxsUwee5y1gTsQS8+acgZ0rsJ9+c45wqAJKCLt+z7zrlS51wF4aPqw87cQKTOdrZ0edkZVNbU8taGfRHbxsmqGu6fv4YlRSEeunUAPxjdX4W5SBOI6PgL7w4qlznnLnXO/cJre9g5l+9Nn3TOjXfO9XXO5TjnPquz7C+85fo759481zq99jivLdt7/TyS362uIxWVvP9pCWOHputUnkgL1if1Il6amUvH5AS+PW8FBdsP+R3Jbw05Q7oLuAHAzAYSLs4PEj7IMtTM2nrDGq8lfEBGmsDQHu3p1bkt+UWRGdpSUVnNvc+u4t1NB/jPvEHMvPbSiGxHpDXS4Ogm8Ob6/VTVOPKyzxxqKSItTY+ObVl0Xy7dO7Rh2lMrWba5xO9IvmngGdIfAveaWRHwAjDNu+vtYeDXhAv8QmCNc+715v8WLZOZMS4rg4+3H6Lk6MkmXffRk1VM/fNKPtpWyq/GZ3Fnbq8mXb9Ia6fivAnkF4bo0yWZwd3bffXMIhL1urZLYuF9ufRLu4gZz63izXWRGzoQdA04Q7rROXelcy7LO6v5dp1l5zvnBjnnBjvndEFoExuXnYFzsKS46fbPw+WVTHliBWt3HeEPk4fxzeHN/kgRkRZPxfkF2l92kuU7DnFbVobG2om0Ip2SE1hw7yiG9ujAAwvW8Jc1e/yOJPIlfbumkJnersmGtpQcO8mkucvZcuAYc+8azjeGpjfJekXky1ScX6DXikM4Fz5CISKtS7ukeJ6dnsOoPp35wUtFzF/+ud+RRL4kLzuDot1H2FlafkHr2XvkBBNmF7D7cAVPTxvB9QPSmiihiJxJxfkFyi8KMbh7Oy5NvcjvKCLig+TEOP48bQQ3DOjKz15dz9wPtvsdSeRvbvNu77vkAo6e7ywtZ8LsAg6VV/Lc3SP5Wt8uTRVPROqh4vwC7Cgtp3hPGXlZuhBUpDVLio9l9p3h0/yPvrGZ37zzKeFHNoj4K6NDG3J6deLVwr3ntU9+euAY4+cUcKKqhhfuHcXwnh0jkFJE6lJxfgHyC0OYwdgsjbsTae3iY2P4/aTLGT+8B797byuPvrFJBboEwrjsDLYfLGfjvqONWm7dnjImzinAgIUzRjG4e/vIBBSRL1Fxfp6ccywu2ktOr06kt2/jdxwRCYDYGOOxO4YyNbcnT/zPDn726npqa1Wgi7/GDEknLsYadWHoqp1f8K0nltM2IY5FM3Ppl5YSwYQiUpeK8/O0IXSUzw6W697mIvIlMTHGI+MGcf91l/L8il38aFER1TW1fseSVqxTcgJX9+vCksJQg/6z+OHWUu58ciWpKYksmplLz87JzZBSRE5TcX6e8otCxMUYtw7u5ncUEQkYM+NfbxnAj2/uz1/W7uU7C9ZyqrrG71jSiuVldydUdpLVuw6fc753Nx5g+jOf0LNzWxbel0tGB50ZFmluKs7PQ22tY0lRiGsvS6VjcoLfcUQkoB74el8eHpvJWxv2M+PZ1ZyoVIEu/rgpM42k+BgWF+496zxLikLMnL+agd1SeHHGKFJTEpsxoYicpuL8PHyy8wv2lZ3Uvc1F5CtNv6o3j90xhA+2HmTaUys5fqra70jSCiUnxnHjwDReL95HVT3DrF5atZvvvbiWYZd0ZP49I+nQVgeeRPyi4vw8LC4K0SY+lhsH6iEMIvLVJo64hN9OzGbV54f59rwVlFVU+R1JWqFxWRkcrqjiw22lX2p/+qMdPPhyMVf27cIz03NISYr3KaGIgIrzRqusruWNdfu4KTON5MQ4v+OISJTIy+7On6YMY2PoKJOeWE7p8VN+R5JW5tr+qbRLiiO/8O93bZm1bBuPLNnI6Mw05k29gjYJsT4mFBFQcd5oH247yJGKKsZlaUiLiDTO6EHdeHLaFewoPc6EOQXsKzvhdyRpRRLjYhkzJJ23N+znRGUNjy/dzONLt5CXncGsKcNIjFNhLhIEKs4baXFhiPZt4rnmslS/o4hIFLq6XyrPTh9JydFTjJ9dwK5DFX5HklZkXFYG5ZU1XPv4MmYt287knIv59YRs4mNVDogEhf42NkJFZTXvbDzAmCHdSIjTr05Ezk9O704suHckx09VM37Ox3x+qNzvSNJKjOzTGYCSY6eYfmVvHr19CLEx5nMqEalLg6Yb4eiJam4YmMbtl/fwO4qIRLmhPTqwcEYuv39vK11TkvyOI61EbIwx987hlBw7xZSRl2CmwlwkaFScN0K39kn8YfLlfscQkRaif7cUZk0Z5ncMaWVGD9LD80SCTGMzREREREQCQsW5iIiIiEhAqDgXEREREQkIFeciIiIiIgGh4lxEREREJCBUnIuIiIiIBISKcxERERGRgFBxLiIiIiISEOac8zuDb8zsIPD5eSzaBSht4jiRpLyRFW15IfoyK+8/6umcS43wNgJFfXZgRVteiL7MyhtZgeqzW3Vxfr7MbJVz7gq/czSU8kZWtOWF6MusvHIhou3PQ3kjL9oyK29kBS2vhrWIiIiIiASEinMRERERkYBQcX5+5vodoJGUN7KiLS9EX2bllQsRbX8eyht50ZZZeSMrUHk15lxEREREJCB05FxEREREJCBUnDeCmd1iZlvMbJuZPeRjjj+bWYmZra/T1snM3jGzrd7Pjl67mdnvvczFZjaszjJTvfm3mtnUCOa92MyWmdkmM9tgZt+LgsxJZrbSzIq8zP/htfc2sxXe9heaWYLXnui93+Z93qvOun7itW8xs5sjldnbVqyZrTWz14Ke18x2mtk6Mys0s1VeW5D3iQ5m9rKZbfb25dwg55Xg9NleFvXbEcysPlt99lkyR2e/7ZzTqwEvIBbYDvQBEoAiINOnLNcAw4D1ddr+H/CQN/0Q8Jg3PQZ4EzBgFLDCa+8EfOb97OhNd4xQ3nRgmDedAnwKZAY8swEXedPxwAovy0vAJK99NnC/N/1/gNne9CRgoTed6e0riUBvbx+KjeC+8QNgAfCa9z6weYGdQJcz2oK8TzwD3ONNJwAdgpy3tb8IUJ/t5VG/HcHMqM9Wn11/5qjstyO24pb2AnKBpXXe/wT4iY95evHlTn4LkO5NpwNbvOk5wOQz5wMmA3PqtH9pvghnXwzcFC2ZgbbAGmAk4YcUxJ25TwBLgVxvOs6bz87cT+rOF4GcPYD3gOuB17ztBznvTv6xow/kPgG0A3bgXacT9Lx6Ba/P9jL0Qv12xDOjPrvV99neuqO239awlobrDuyu836P1xYUac65fQDez65e+9ly+/J9vFNxlxM+qhHozN7pxkKgBHiH8BGJI8656nq2/7ds3udlQOdmzvxb4EGg1nvfOeB5HfC2ma02sxleW1D3iT7AQeAp7xT0PDNLDnBeiY7fdVTsP9HSb6vPjnjeaOqzIYr7bRXnDWf1tLlmT9F4Z8vd7N/HzC4CXgG+75w7eq5Z62lr9szOuRrnXDbhoxs5wMBzbN/XzGY2Fihxzq2u23yObQfhd3ylc24YcCvwgJldc455/c4bR3hIwp+cc5cD5YRPh56N33klun/Xgdl/oqnfVp/9D8s0tWjqsyGK+20V5w23B7i4zvseQMinLPU5YGbpAN7PEq/9bLmb9fuYWTzhDv5559xfoiHzac65I8B/Ex6D1sHM4urZ/t+yeZ+3B75oxsxXAuPMbCfwIuHTpL8NcF6ccyHvZwnwX4T/MQ3qPrEH2OOcW+G9f5lwpx/UvBIdv+tA7z/R2m+rz1afXSdDVPbbKs4b7hOgn3cldQLhCzLyfc5UVz4w1ZueSnh84On2u7yrkEcBZd5pnKXAaDPr6F2pPNpra3JmZsCTwCbn3K+jJHOqmXXwptsANwKbgGXAN8+S+fR3+SbwVxcenJYPTPKutO8N9ANWNnVe59xPnHM9nHO9CO+bf3XOTQlqXjNLNrOU09OE/yzXE9B9wjm3H9htZv29phuAjUHNK0Dw+2wI8P4Tbf22+mz12WeK6n47kgPaW9qL8JW8nxIex/ZTH3O8AOwDqgj/j+5uwmPP3gO2ej87efMaMMvLvA64os56pgPbvNf/jmDeqwifAioGCr3XmIBnHgqs9TKvBx722vsQ7vi2AYuARK89yXu/zfu8T511/dT7LluAW5th/7iOv1/5H8i8Xq4i77Xh9N+ngO8T2cAqb594lfBV+4HNq1dw+mwvi/rtCGZGfbb67PpzR2W/rSeEioiIiIgEhIa1iIiIiIgEhIpzEREREZGAUHEuIiIiIhIQKs5FRERERAJCxbmIiIiISECoOJdWzcw+9n72MrNvNfG6/2992xIRkfOjPltaA91KUQQws+uAHznnxjZimVjnXM05Pj/unLuoKfKJiMjfqc+WlkxHzqVVM7Pj3uQvgavNrNDM/sXMYs3scTP7xMyKzew+b/7rzGyZmS0g/JACzOxVM1ttZhvMbIbX9kugjbe+5+tuy3v62ONmtt7M1pnZxDrr/m8ze9nMNpvZ895T+jCzX5rZRi/Lr5rzdyQiEhTqs6U1iPM7gEhAPESdozBeh13mnBthZonAR2b2tjdvDjDYObfDez/dOfeF98joT8zsFefcQ2b2Hedcdj3b+ifCTy3LArp4y3zgfXY5MAgIAR8BV5rZRuB2YIBzzp1+RLWISCumPltaLB05F6nfaOAuMysEVhB+3G8/77OVdTp5gO+aWRGwHLi4znxncxXwgnOuxjl3AHgfGFFn3Xucc7WEH5fdCzgKnATmmdk/ARUX/O1ERFoW9dnSYqg4F6mfAf/snMv2Xr2dc6ePwpT/babwuMcbgVznXBawFkhqwLrP5lSd6RogzjlXTfjIzyvA/wLeatQ3ERFp+dRnS4uh4lwk7BiQUuf9UuB+M4sHMLPLzCy5nuXaA4edcxVmNgAYVeezqtPLn+EDYKI3RjIVuAZYebZgZnYR0N459wbwfcKnV0VEWjP12dJiacy5SFgxUO2d6nwa+B3h05NrvAt8DhI+AnKmt4CZZlYMbCF8mvS0uUCxma1xzk2p0/5fQC5QBDjgQefcfu8fivqkAIvNLInwEZx/Ob+vKCLSYqjPlhZLt1IUEREREQkIDWsREREREQkIFeciIiIiIgGh4lxEREREJCBUnIuIiIiIBISKcxERERGRgFBxLiIiIiISECrORUREREQCQsW5iIiIiEhA/H9LypWf5DDDswAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 864x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "learn.sched.plot_lr()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iterations = learn.sched.iterations\n",
+    "lrs = learn.sched.lrs\n",
+    "momentums = learn.sched.momentums"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Shallow 3 layers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 135,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ShallowNet(nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        self.conv1 = nn.Conv2d(3,20,5,padding=2)\n",
+    "        self.conv2 = nn.Conv2d(20,50,5,padding=2)\n",
+    "        self.linear = nn.Linear(50*8*8, 500)\n",
+    "        self.out = nn.Linear(500,10)\n",
+    "    \n",
+    "    def forward(self,x):\n",
+    "        x = F.max_pool2d(F.relu(self.conv1(x)),2)\n",
+    "        x = F.max_pool2d(F.relu(self.conv2(x)),2)\n",
+    "        x = x.view(x.size(0),-1)\n",
+    "        x = F.relu(self.linear(x))\n",
+    "        return F.log_softmax(self.out(x))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 136,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn = ConvLearner.from_model_data(ShallowNet(), data)\n",
+    "learn.crit = F.nll_loss"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 137,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c26133731ae14309b445efe3ad09afae",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>HBox</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=1), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                                                                                                       \r"
+     ]
+    }
+   ],
+   "source": [
+    "learn.lr_find()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 138,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEOCAYAAABmVAtTAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzt3XmYXFWd//H3t6r3Pd3pJfu+NZiYDRLCGjAiiCggyE8RkJGJoqCiMyrqjOOMu8yMC2oEZVRc2EQEZHOSsIQsnZXsk3T2tTtJd3pfqs7vj6pum9DpdCd1+1ZVPq/nqaerbp2q+vRJp7997rn3XHPOISIiAhDwO4CIiMQPFQUREemkoiAiIp1UFEREpJOKgoiIdFJREBGRTioKIiLSSUVBREQ6qSiIiEgnFQUREemU4neAvho4cKAbOXKk3zFERBLKypUrq51zxadql3BFYeTIkVRUVPgdQ0QkoZjZrt600+4jERHppKIgIiKdVBRERKSTioKIiHRSURARkU4qCiIi0smzomBmw8xsoZltMrMNZnZPN22uNbN1ZrbGzCrM7EKv8hyua+aVrVUs2VbNtsP1NLeFvPooEZGE5eV5Cu3Avc65VWaWC6w0s5eccxu7tPkb8LRzzpnZZOBRYKIXYZbvOMqnfre683FuRgozRgxgRFE26akBxgzMYc+xRrYequNAbTM1jW3kpKfQ0h6iLeRobgsxpjiHwuw0ygfnkZ0WJDMtSEZqkPSUSG0NmDFyYDajBmbT3BZi15FGzCLbs9NSKMhOJRx2tLaHARiQnUbYOWoa26hrbiM1GMAwAgHISU8hJz2FlKAGcyLSfzwrCs65A8CB6P06M9sEDAE2dmlT3+Ul2YDzKs8FYwbyxCdm09Ie5mBtM69tq2bTgTqW7ThKY2tk1BAwGFuSQ0FmGuNL0wFITwmSEjRSAgHW76tlR3UDz755oMfPCgaMsHO4M/xuUgLG6OJsCjLTyE4Pkh0tFDnpKWSnp5CdHuRIfSsYpAcDpKVEb8EAqSkBMlKC5GakkJeZGvmakUpWWhAzIzM1SEZqADM7s5AiklT65YxmMxsJTAWWdfPcB4BvASXA1V5lKMxOozC7sPPxddOGdt6vbWrj0PFmCrJSKcnN6PF9nHM0tYVobgtHv4ZoaQtjBq3tYXZUN7DtcD3pKQHGleZgZoTDjvqWdmoa2wgGjPTUAGEHR+pbSAkYBVlp5GWm0toeJhx2YFDf3E5VfQvbDtdzvKmNqvoWdh5ppL6lnYaW9s5ClhYMRD47FO5zETKDzNQgWWlB0oIByvIzyE5PoaquhYAZGakBstNTSAsGCAaMYMBwDtpCYULOUZKbTll+JmV5GZTmpVOal0FpXgZF2WkEAio2IonI3Jn+OXuqDzDLARYD/+Gce7KHdhcDX3POXdHNc3cCdwIMHz58+q5dvTpbO6mFwo6G1nayUoOkBAM452iP7ppqbQ/TGgrT3Bairrmd481tHG+KfG1saSfsoLk9RFNr5NbQGqKlPcT+miYaW0PRwuhobgvT0NpOa3uYUNgRCjvMIDUYIGDGoePNVNW3vK0YpQSMwuw0HJCdFqQoJ53hhVkML8xiRFHk69ABWWSnBztHNhqxiHjLzFY652acsp2XRcHMUoFngBecc/f3ov0OYKZzrvpkbWbMmOG09lH8aAuFqa5v4WBtM4eOt3DoeDOHjjdzpL6VQADqW0JU1TWz52gT+2ubTjqayU1PYXRJDuNKchhbksPogdlkpkVGMSOLsinMTlPhEDkDvS0Knu0+ssj/4IeATScrCGY2FtgenWieBqQBR7zKJLGXGgwwKD+TQfmZp2zb0h5i77Emdh9pZG9NE82tIVpDYVraQtQ0tbG9qp7FW6t4fOXet702LyOFUcU5jBmYzciB2UwalMdF4waSkRr04tsSOWt5OacwB7gFeNPM1kS3fRkYDuCc+xlwPfBRM2sDmoCbnNf7s8Q36SlBxhTnMKY4p8d2tY1t7DjSQHsoTF1zOzuqG6isrmdHdQNLK4/w5Op90fcL8P53DuHySSWcP6qI/KzU/vg2RJKa53MKsabdR9LcFmLFzqM8vWY/T6/dT0t7ZKK/fFAes0YXMXt0ETNHFZKfqSIh0iEu5hS8oKIgXbW0h1i7p5Y3th9haeURVu4+Rmu0SEwozeWuy8ZyyYRi8jJUIOTspqIgZ6XmthCrd9dERhJr97PtcD0Bg/Glucw7p4xPXjpG8xByVlJRkLNeeyjM69uP8Oy6/VRWNVCx6xgji7K4btpQ5k4s4dwh+X5HFOk3KgoiJ3jt/6r592c3svlgHWZQmpuBwzGhLI+PXzSKC8cO1GGvkrRUFEROorapjQWvbGf74QbMoGLXMarqWpg0KI87Lx7FeycPJlVrTkmSUVEQ6aWW9hB/Xr2fBa9Wsu1wPYPyM5hXXkppfgZzJ5YwsSzP74giZ0xFQaSPwmHHoq2HWfBKJat21dAaCpMaNL5x7bl86LzhfscTOSO+n9EskmgCAWPuxFLmTizFOcfB48388xNv8qU/vcnOI43cefFoCrPT/I4p4intOBXphpkxKD+TBbdM54PTh/KzxduZ+4NF/GH5btpDYb/jiXhGRUGkBxmpQb57wxSe/tQchg7I5ItPvsl3nt/sdywRz6goiPTC5KEF/PmuC3n/Owfzi1d38Js3dvodScQTmlMQ6aVgwPjODZOpb2nna09voDg3gyvPLfM7lkhMaaQg0gfpKUH+86Z3Mqoom/m/Xckz6/b7HUkkplQURPooNyOVZ+6+kGnDC/j071fz1afWs3DLYRLt8G6R7qgoiJyGrLQUHvmHWVw3dSi/WbqL23+1gl+9vtPvWCJnTEVB5DRlpgX5wY1TWPsv87hkfDH/+dJWGlra/Y4lckZUFETOUH5mKp+5Yhx1Le184IHXeei1HX5HEjltKgoiMTB1+AC+/8EpBMz4xjMb+ciDyzhS3+J3LJE+U1EQiZEbpg/liU9cwNiSHF7bVs29j631O5IkCeccP1m4jc0Hj3v+WSoKIjGUnZ7Cy5+7hPuumsSiLVU8sXKv35EkCTz02g6+98IW/rR6n+efpaIg4oFbLxjJxLJc7n1sLZ9/bC0Ha5v9jiQJKhx2LHilkgvGFPHFKyd6/nkqCiIeSEsJ8NRdc/jYnFE8vnIv7/nvV1i9+5jfsSQB1be2c7iuhbkTS/rlyoAqCiIeyUgN8rVryvnDnbPISkvhQwuW8vvluwmHdZKb9F5LW2RV3vTUYL98noqCiMdmjS7iL5++kCnDCvjSk2/yi1cr/Y4kCaSlPQRAekr//LpWURDpB4XZafzxzllcMKaIH7y4laf6YcJQkkNLe3SkoKIgklzMjK9dU86Ykhw+88c1rN1T43ckSQDNbR0jBe0+Ekk6E8vyeGz+bAZkpfKVp9Z3/ocXOZnOkUKqRgoiSSknPYXvXD+ZN/fV8m/PbPQ7jsS5zolm7T4SSV7zzilj/iVj+N2y3TrBTXr094lm7T4SSWqfnzee6SMG8N0XNtMeCvsdR+KUJppFzhIpwQAfv2g0h463sGhLld9xJE51FIUMzSmIJL/LJ5VQnJvOTxdv16SzdKtFRx+JnD1SgwG+MG8CK3cd4+ElO/2OI3FIu49EzjI3zhzG+aMK+e3SXYS0BIac4O9FQSMFkbPGrReMZO+xJl7edMjvKBJnOo8+SvQ5BTMbZmYLzWyTmW0ws3u6afNhM1sXvS0xsyle5RGJZ+8qL2XUwGy++tR6Nuyv9TuOxJGO8xTSggleFIB24F7n3CRgFnCXmZWf0GYHcIlzbjLwDWCBh3lE4lZqMMAPbpxCKOz45COr2HO00e9IEida2sOkBQMEAt4vmw0eFgXn3AHn3Kro/TpgEzDkhDZLnHMdi8wvBYZ6lUck3k0bPoAf/79pVNe18LlH1+Cc5hcksvuovyaZoZ/mFMxsJDAVWNZDszuAv/ZHHpF4NXtMEV949wRW7DzGxgPeX49X4l91fSsDstP67fM8LwpmlgM8AXzGOdftT7mZXUakKPzzSZ6/08wqzKyiqkon+Uhye++UwZjBSxs16Syw+0gDI4qy+u3zPC0KZpZKpCA84px78iRtJgMPAtc6545018Y5t8A5N8M5N6O4uNi7wCJxYGBOOtOGD+CZdQdobdfyF2ezptYQa/fWMqwwCYqCRS4m+hCwyTl3/0naDAeeBG5xzm31KotIonlXeSnbDtdz+8PL/Y4iPnHOcctDkT3uQwdk9tvnejlSmAPcAsw1szXR21VmNt/M5kfbfA0oAh6IPl/hYR6RhHHzzOGU5Kbz+rYjLNxy2O844oNfvFpJxa7IcTjXTB7cb59riXaEw4wZM1xFhWqHJL+Glnau/+kSjjW28uo/zSWtH49AEX9tOVjH1T98lSsmlfKTD08jGIPDUc1spXNuxqna6adMJE5lp6fwxfdM5NDxFv6ydr/fcaSfNLWGuPexNeRmpPDN694Rk4LQFyoKInHskvHFTCjN5aeLt9Omay6cFX7+ynbW7zvO926YQmE/HoraQUVBJI6ZGV949wS2Ha7n98t3+x1HPNbcFuJXr+/kXeWlXFFe6ksGFQWROHdFeSnvHFbAzxdXavmLJHf/S1upbWrj1tkjfcugoiCSAG6fM5J9NU1c9N2F1DS2+h1HPLBoy2EWvFLJdVOHcMGYIt9yqCiIJID3nDuIUQOzAXhRZzonpTV7agD49vWT+23xu+6oKIgkgLSUAP977yWMHpjNt/+6mSvuX8zh481+x5IYamwNkZEa8P3QYxUFkQRhZnz2XeMJGGyvqueBRdv9jiQx1NjaTlZait8xVBREEsk1UwZT8ZV38aGZw3h4yU5W7jrqdySJkcbWEJmp/XPJzZ6oKIgkoPuuLic9JcDTa3RSW7Joag2RlaaiICKnISc9hcsmlPDc+oOEwom1VI10r1FFQUTOxNWTB1FV16KT2pKE5hRE5Iy8+5wypgwr4L9e/j9dujMJaKQgImckLSXADdOHUl3fwm6d6ZzwmlpDZKooiMiZOH9UIQAPLNThqYlOIwUROWPjS3P58PnDeXTlHg7pZLaEpjkFEYmJOy4chXPomgsJrlG7j0QkFkYX5zB5aD5/Wr3P7yhymlrbw7SHHdkqCiISCzdMH8qG/cdZVnnE7yhyGppaQwBkaveRiMTCjTOGMTAnjR8v3OZ3FDkNjW3tAJpoFpHYyEgNcseFo3n1/6p5SUtrJ5yGlshIQUVBRGLmI7OGMzAnjY//uoKP/nI51fUtfkeSXurcfaQF8UQkVnIzUnnu7ov49NyxvL6tmm8+t8nvSNJLja2R3UfZ6f7PKfifQERipiQvg3vnTaCqroVn1x2gLRQmNai//eJdY1vHRLNGCiLigUsnlFDX0s7KXcf8jiK90LH7SHMKIuKJOWOLSA0aC7cc9juK9EJDS/Too1T/d96oKIgkodyMVGaOLGTR5iq/o0gvNGn3kYh47bIJJWw5VMe+mia/o8gpNGr3kYh47bKJxQAs0i6kuNeoQ1JFxGtjinMYOiCThZtVFOJdVV0LuekpBALmdxQVBZFkZWZceU4Zi7ZU8ebeWr/jyEkcqG3i98t3c/7oQr+jACoKIkntjotGkZ4S4LZfLae1Pex3HDlBU2uImxcsBeC9kwf7nCZCRUEkiQ3Kz+S7N0zhSEMrS7ZX+x1HTvDbpbvYeaSRBz86g/dPHeJ3HEBFQSTpXT6pBIDbfrWC772w2ec00iEcdjy8ZCezRxdxRXmp33E6qSiIJLmM1CA3nzcMgJ8s3M6uIw0+JxKAxf9Xxb6aJj4U/beJF54VBTMbZmYLzWyTmW0ws3u6aTPRzN4wsxYz+7xXWUTOdv9yzTk8+o+zCQaMX7xa6XccAR5YuI3B+Rm859xBfkd5Cy9HCu3Avc65ScAs4C4zKz+hzVHgbuD7HuYQOetlpAY5b1Qht8wawW+X7mbroTq/I53VVuw8yoqdx7jz4tGkpcTXDhvP0jjnDjjnVkXv1wGbgCEntDnsnFsBtHmVQ0T+7u7Lx5EaNB5fudfvKGe1X7+xi7yMFG6aOdzvKG/TLyXKzEYCU4Flp/n6O82swswqqqq0lovI6SrMTuOyCSU8uWof7SEdouqH6voWnl9/gOunD42LtY5O5HlRMLMc4AngM86546fzHs65Bc65Gc65GcXFxbENKHKWuWnmMKrrW/jyn94kFHZ+xznrPFqxh7aQ48Pnj/A7Srd6VRTM7B4zy7OIh8xslZnN68XrUokUhEecc0+eaVgROXNzJ5Zw9+XjeLRiL48s2+V3nLOKc44/rtjDrNGFjC3J8TtOt3o7UvhY9K/8eUAxcDvw7Z5eYGYGPARscs7df0YpRSRmzIzPXjGO80YWsuCVSpzTaKG/bK9qYNeRRq6ZEh9nL3ent0WhY5Wmq4BfOefWdtl2MnOAW4C5ZrYmervKzOab2XwAMyszs73A54CvmNleM8s7je9DRPrAzLh26mD2Hmtie1W933HOGh0r1l4yPn53g/f2Mj8rzexFYBTwJTPLBXqcpXLOvcYpCodz7iAwtJcZRCSG5k6MnOn87LqD3HNFrs9pzg6Lt1YxtiSHoQOy/I5yUr0dKdwBfBGY6ZxrBFKJ7EISkQQ1KD+TC8YU8dSafX5HOSs0trazrPIol8bxKAF6XxRmA1ucczVm9hHgK4DW4hVJcO8+p4wd1Q1a+qIfLK08QmsozKUTSvyO0qPeFoWfAo1mNgX4J2AX8GvPUolIv7ho3EAAXt6kC/F47fn1B8lOCzJz1AC/o/Sot0Wh3UUOUbgW+G/n3H8D2gkpkuBGDcxm2vAC/mfJTh2F5KHmthDPrjvA1ZMHkZ4SfyesddXbolBnZl8icjTRs2YWJDKvICIJzMz44Ixh7D7aSGW1diF5ZcP+WhpaQ1w+KX6WyD6Z3haFm4AWIucrHCSyhtH3PEslIv1m9ugiAN7YfsTnJMlr5a5jAEwbHt+7jqCXRSFaCB4B8s3svUCzc05zCiJJYERRFmV5GSytVFHwyspdxxhemEVxbrrfUU6pt8tc3AgsBz4I3AgsM7MbvAwmIv3DzJg1upCllUe0FpIHnHOs2l3D9BHxP0qA3u8+uo/IOQq3Ouc+CpwHfNW7WCLSn648t4zq+lYWvKIL8MTa3mNNVNW1MG14gd9ReqW3RSHgnOt6zNqRPrxWROLcu88p4+p3DOK7L2xmz9FGv+MklVW7o/MJSTZSeN7MXjCz28zsNuBZ4DnvYolIfzIz/unKCTgHL2485HecpLJy1zGy04JMKE2Mo/h7O9H8BWABMBmYAixwzv2zl8FEpH+NKMpm0qA8HqvYo3MWYmjlrmNMGVZASjAxdq70OqVz7gnn3Oecc591zv3Jy1Ai4o+PzRnJ5oN1rNh5zO8oSaGhpZ3NB+sSZpIZTlEUzKzOzI53c6szs9O6ipqIxK8rzy0jNWi8tPGg31GSwtq9NYTCLiHOT+jQY1FwzuU65/K6ueU653TdA5Ekk5uRypyxA3lm3QFdwzkGVu+uAWBqghx5BDqCSERO8KGZwzhQ28zrOsP5jK3cdYyxJTkUZKX5HaXXVBRE5C0unVBCVlqQFzdoF9KZiJy0dixhzk/ooKIgIm+RkRrk0gnFvLTxEGGd4XzaKqsbqGlsS6hJZlBREJFuzCsv43BdCyt36yik05VIi+B1paIgIm9z+aQSCrPT+NZzmzRaOE2rdh0jLyOFMcU5fkfpExUFEXmb3IxU7rtqEqt213D3H1brZLbTsHznUaaNGEAgYH5H6RMVBRHp1nXThnD7nJE8s+4AP1tcqUNU+2DP0UYqqxq4aFyx31H6LMXvACISn8yML181iW2H6/nO85sJhcN8au44v2MlhMVbqwC4ZHziFQWNFETkpFKDAX79sfN4x5B8XttW7XechLF4axVDCjIZU5ztd5Q+U1EQkR6ZGVOHF/Dm3lpdhKcXWtvDLNlWzSUTijFLrPkEUFEQkV6YNnwADa0hNu7XkmenUrHrKA2toYTcdQQqCiLSCxeMLQLQLqReWLSlitSgccGYIr+jnBYVBRE5pZLcDCaW5fK6isIp/e/mw5w3qpDcjFS/o5wWFQUR6ZU5YweyfOdRmttCfkeJW3uONrLtcD2XTSjxO8ppU1EQkV6ZNbqI1vYwGzSvcFIdh6LOnaiiICJJbmJZ5BrD1/90CbuONPicJj5VVjWQlRZk1MDEOxS1g4qCiPTK0AGZnfe/98IWH5PErwO1TZTlZyTkoagdVBREpFfMjFtmjQDg5U2HON7c5nOi+HOgtpnB+ZmnbhjHVBREpNe+8f5zeeITF9DcFubj/1OhFVRPcKC2iUH5GX7HOCOeFQUzG2ZmC81sk5ltMLN7umljZvZDM9tmZuvMbJpXeUQkNqaPGMBXrp7Esh1H+a+Xt/odJ260h8JU1bVQpqJwUu3Avc65ScAs4C4zKz+hzXuAcdHbncBPPcwjIjHysTmjuGJSCT/83238bdMhv+PEhePN7YQdFGYnzvWYu+NZUXDOHXDOrYrerwM2AUNOaHYt8GsXsRQoMLNBXmUSkdgIBIybzxsOwB3/U8G2w/U+J/JfTWMrAAVZiXnSWod+mVMws5HAVGDZCU8NAfZ0ebyXtxcOEYlDM0YWdt7/44rdPiaJD7VNkYn3gkyNFHpkZjnAE8BnnHMnnvXS3XFbb5u5MrM7zazCzCqqqqq8iCkifZSfmcqmf7uSmSMHsGKnruVcEy0K+RopnJyZpRIpCI84557spsleYFiXx0OB/Sc2cs4tcM7NcM7NKC5OzJUHRZJRZlqQGSMLWb+vlmMNrX7H8VVtY8dIQUWhWxY5e+MhYJNz7v6TNHsa+Gj0KKRZQK1z7oBXmUQk9j4wdQjtYcevluz0O4qv/j6noN1HJzMHuAWYa2ZrorerzGy+mc2PtnkOqAS2Ab8APulhHhHxwPjSXOaVl/Lw6ztobG33O45vOnYf5WUk9lWOPUvvnHuN7ucMurZxwF1eZRCR/nHjjGG8uPEQG/YfZ2aXCeizye6jjQzMSSMlmNjnBCd2ehGJC+cMyQNg04GzdwXVFTuPMmNE4hdEFQUROWNleRkMyErlla1VRHYAnF321zSx52gT541SURARwcy47YJRvLzpMA++usPvOP1uxc6jACoKIiId7r58LDNGDODJ1fv8jtLvllYeJTc9hUmD8vyOcsZUFEQkJsyMaSMGsOnAcf7xNxXUnUVLay/fcYQZIwcQDCTudRQ6qCiISMwMi16I54UNh/jkI6t8TtM/qutb2F7VwHmjivyOEhMqCiISM5dPKqV8UB7vObeMJduP0NQa8juS51bsiMwnnD868ecTQEVBRGJocEEmz91zEddNG0oo7Nh4oNbvSJ5btuMomalBzh2c73eUmFBREJGYmzI08gvy9W1HfE7ivW2H6xlflktaSnL8Ok2O70JE4kpJXgazRxfx2Mo9SX/Jzur6Fopz0v2OETMqCiLiiZtmDmPP0SaWVib3aKG6vpXi3MReBK8rFQUR8cSV55aRl5HCHyv2nLpxggqFHUcbWijK1khBRKRHGalBPjB1CH998yA7qxv8juOJmsZWwg4G5mikICJySp+8bCxpKQEu/f4ifrt0l99xYq66PnINhSLNKYiInFppXgb/+r5zAPjOXzcTSrJJ5x3REdCQ6El7yUBFQUQ8dcP0ofzw5qnUtbSzdm+N33FiavXuY6QGjfIkWPOog4qCiHhu9ujIEhDLKo/6nCS2Vu+poXxwPhmpQb+jxIyKgoh4rjg3nfGlOfznS1s5UNvkd5yYcM6x+cBxzhmcPKMEUFEQkX5y39XltIbCLEmSs5wPHm/meHM7E8ty/Y4SUyoKItIv5owpIj0lwMYkuWTn5oN1AEws00hBRKTPUoIBJg3K49GKPRw63ux3nDO2+UCkKEwo1UhBROS0fH7eBOqa23lxw0G/o5yxLQePMyg/g/ysVL+jxJSKgoj0mzljiyjKTmPt3tqEXyhv66F6JiTZfAKoKIhIPzIzpg4fwOMr91L+L8+z4JXtfkc6bftqmhg2IMvvGDGnoiAi/epfrinn1tkjmD5iAN98bjOXfX8Rr2+r9jtWnzS1hqhtaqMsP8PvKDGnoiAi/WpYYRZfv/ZcHr79PMoH5bGjuoEPP7iMJ1ftxbnE2KV0MDpRPkhFQUQkNlKDAX738fP5+EWjKMhK5XOPruWpNfv8jtUrHSfgleWpKIiIxExBVhr3XV3Oyq+8i8lD8/mnx9ex7XCd37FOqeNw1MEFybMQXgcVBRHxXTBg3H/jO2kLuYS4rvPvlu9myrACRhRpollExBNjirMpyk5j/b5av6P0qC0UprKqnkvGDcTM/I4TcyoKIhIXzIzJQ/NZuuNIXJ/DcLC2mbBLrmsodKWiICJx4/1Th7DnaBNvVMbvLqR9NZFJ5iEFybfrCFQURCSOzCsvIzVovBbH5y3sOxYpCoMLku/II1BREJE4kpkW5B1D8lkaxyOF/TUdRUG7j0REPHfphBJW765hU5wusb2vpomBOelJdbW1rjwrCmb2SzM7bGbrT/L8ADP7k5mtM7PlZnauV1lEJHHcMH0omalBPvrL5dQ1t/kd52321TQl7SQzeDtSeBi4sofnvwyscc5NBj4K/LeHWUQkQQwuyOSXt82kqq6FPyzf43ect9lX08SQJJ1PAA+LgnPuFaCnq3SXA3+Ltt0MjDSzUq/yiEjimD2miIlluSzcctjvKG/hnGN/TROD8zVS8MJa4DoAMzsPGAEM9TGPiMSRi8cXU7HzGI2t7X5H6dTYGqK5LczA3HS/o3jGz6LwbWCAma0BPg2sBrr91zezO82swswqqqqq+jOjiPjkwrEDaQ2FWbajpx0O/etYYysAhVlpPifxjm9FwTl33Dl3u3PunUTmFIqBHSdpu8A5N8M5N6O4uLhfc4qIP84bVUh6SoCXNx7yO0qnmsbIxHdBkl2CsyvfioKZFZhZR7n9B+AV51x8HoMmIv0uIzXIVe8YxJ/X7O9cqtpvRxuiI4VsjRT6zMx+D7wBTDCzvWZ2h5nNN7P50SaTgA1mthl4D3CPV1lEJDHdddlYnHN867nN/fq5re1hmttC/GXtfkJd1mHq2H1UkMS7j1K8emPn3M2LredRAAAMCklEQVSneP4NYJxXny8iiW9sSQ7ve+dg/rL2AC3tIdJTvD9h7MFXK7n/pa28q7y0c5QyeWgBP120ncVbI3OayTxS8KwoiIjEwhWTSvn98j2s3HWMC8YM9PSzlu84yn88twnn4M9r9gPwzW5GKfmZmlMQEfHFzFGFBAx+triSJduqqW2M7VnOO6sb+MADr7Nwy2Fu/PkbOAdffW85OekpXD9tKBeOjRSiOy4cxZIvzuVXt88kGEi+6yh0sES5UHaHGTNmuIqKCr9jiEg/eu+PXmX9vr8fh7LjW1fF7AI383+zkuc3HOx8vOCW6cw7p4yO343JciEdM1vpnJtxqnYaKYhI3PvK1eVvebxmT2TBvD1HG/nZ4u00tYZO633X76t9S0G4ftpQ5p1TBkSKQbIUhL7QnIKIxL1Zo4tYcd8V3PLQMjYfrOMjDy6joUshqKyq5+7LxzF0QN8ufPPSxkMEDL593WS2V9fzqcvGxjp6wtHuIxFJKIu3VnHrL5d3+9xv7jiPi8b17gTXmsZWrvnxaxRmp/Pnu+bEMmJc0u4jEUlKl4wv5vnPXMRj82czsSyX2aOLOp+75aHlrN59rFfv89BrO9hztIm752p00JV2H4lIwplYlgfA85+5GICGlnYeem0H97+0la/+eT1PfOKCHs9pCIcdT67ax8Xji7l8khZn7kojBRFJeNnpKdx9+Th+9pFprN93nCdW7uux/RuVR9hX08QN07Uw84lUFEQkabz7nDIKslJ5c19tj+2+8/xminPTmVeuUcKJVBREJGmYGRPLctl88ORra1bVtbBuby0fv2hU0l5n+UyoKIhIUpk0KI9NB47T2h6mtqmN1vbwW57fdCBSMM4dku9HvLinoiAiSeX8UUU0t4VZu7eG9//kdT784NLOq7c55/jl65HLtkyKTlbLW+noIxFJKrNGR9ZKenjJTnZUN7CjuoHyr73A6IHZjC7OYdGWKj4yazgDknil0zOhoiAiSaUgK40ZIwt5dt0BAO6+fBxVdS08vnIPja0hrp48iK+/71yfU8YvFQURSTp3XTaWlMB2bj5vONdMGQzA1993Dmkp2mN+KioKIpJ0LhlfzCXj37rchQpC76iXRESkk4qCiIh0UlEQEZFOKgoiItJJRUFERDqpKIiISCcVBRER6aSiICIinRLuGs1mVgXsij7MB7ounN718UCgOsYff+LnxaJ9T226e64329Qv3W9Tv3S/revjE59L9H7py/be9ks89ElvXnPi8yOcc6e+gLVzLmFvwIKTPQYqvP68WLTvqU13z/Vmm/pF/XK6/dLNcwndL33Z3tt+iYc+6c1rTuc9nXMJv/voL6d47PXnxaJ9T226e64329Qv3W9Tv3S/7S89POeF/uyXvmz3s19O5/1P9ZrTypxwu496y8wqnHMz/M4Rb9Qv3VO/dE/98nbJ3ieJPlLoyQK/A8Qp9Uv31C/dU7+8XVL3SdKOFEREpO+SeaQgIiJ9pKIgIiKdVBRERKTTWVkUzOxSM3vVzH5mZpf6nSeemFm2ma00s/f6nSUemNmk6M/J42b2Cb/zxAsze7+Z/cLM/mxm8/zOEy/MbLSZPWRmj/ud5XQlXFEws1+a2WEzW3/C9ivNbIuZbTOzL57ibRxQD2QAe73K2p9i1C8A/ww86k3K/hWLPnHObXLOzQduBJLiMMQY9ctTzrmPA7cBN3kYt9/EqF8qnXN3eJvUWwl39JGZXUzkF/qvnXPnRrcFga3Au4j8kl8B3AwEgW+d8BYfA6qdc2EzKwXud859uL/yeyVG/TKZyCn8GUT66Jn+Se+NWPSJc+6wmb0P+CLwY+fc7/orv1di1S/R1/0AeMQ5t6qf4nsmxv3yuHPuhv7KHkspfgfoK+fcK2Y28oTN5wHbnHOVAGb2B+Ba59y3gJ52gxwD0r3I2d9i0S9mdhmQDZQDTWb2nHMu7GlwD8XqZ8U59zTwtJk9CyR8UYjRz4oB3wb+mgwFAWL+uyVhJVxROIkhwJ4uj/cC55+ssZldB7wbKAB+7G00X/WpX5xz9wGY2W1ER1OepvNHX39WLgWuI/LHw3OeJvNXn/oF+DRwBZBvZmOdcz/zMpyP+vrzUgT8BzDVzL4ULR4JJVmKgnWz7aT7xZxzTwJPehcnbvSpXzobOPdw7KPEjb7+rCwCFnkVJo70tV9+CPzQuzhxo6/9cgSY710c7yXcRPNJ7AWGdXk8FNjvU5Z4on55O/VJ99Qv3Tvr+iVZisIKYJyZjTKzNOBDwNM+Z4oH6pe3U590T/3SvbOuXxKuKJjZ74E3gAlmttfM7nDOtQOfAl4ANgGPOuc2+Jmzv6lf3k590j31S/fULxEJd0iqiIh4J+FGCiIi4h0VBRER6aSiICIinVQURESkk4qCiIh0UlEQEZFOKgriOTOr74fPeF8vlwaP5WdeamYXnMbrpprZg9H7t5lZXKy/ZWYjT1w2ups2xWb2fH9lkv6noiAJI7qMcbecc087577twWf2tD7YpUCfiwLwZeBHpxXIZ865KuCAmc3xO4t4Q0VB+pWZfcHMVpjZOjP7epftT1nkim8bzOzOLtvrzezfzGwZMNvMdprZ181slZm9aWYTo+06/+I2s4fN7IdmtsTMKs3shuj2gJk9EP2MZ8zsuY7nTsi4yMy+aWaLgXvM7BozW2Zmq83sZTMrjS6xPB/4rJmtMbOLon9FPxH9/lZ094vTzHKByc65td08N8LM/hbtm7+Z2fDo9jFmtjT6nv/W3cjLIlfMe9bM1prZejO7Kbp9ZrQf1prZcjPLjY4IXo324aruRjtmFjSz73X5t/rHLk8/BST8NUjkJJxzuunm6Q2oj36dBywgsvJkAHgGuDj6XGH0ayawHiiKPnbAjV3eayfw6ej9TwIPRu/fRuQiOAAPA49FP6OcyHr4ADcQWf46AJQRuZ7GDd3kXQQ80OXxAP5+9v8/AD+I3v9X4PNd2v0OuDB6fziwqZv3vgx4osvjrrn/Atwavf8x4Kno/WeAm6P353f05wnvez3wiy6P84E0oBKYGd2WR2Rl5CwgI7ptHFARvT8SWB+9fyfwlej9dKACGBV9PAR40++fK928uSXL0tmSGOZFb6ujj3OI/FJ6BbjbzD4Q3T4suv0IEAKeOOF9OpY9X0nkWgfdecpFrgex0SJX2AO4EHgsuv2gmS3sIesfu9wfCvzRzAYR+UW74ySvuQIoN+tcbTnPzHKdc3Vd2gwCqk7y+tldvp/fAN/tsv390fu/A77fzWvfBL5vZt8BnnHOvWpm7wAOOOdWADjnjkNkVAH82MzeSaR/x3fzfvOAyV1GUvlE/k12AIeBwSf5HiTBqShIfzLgW865n79lY+RCNlcAs51zjWa2iMglQQGanXOhE96nJfo1xMl/hlu63LcTvvZGQ5f7PyJy2dano1n/9SSvCRD5Hpp6eN8m/v69nUqvFyZzzm01s+nAVcC3zOxFIrt5unuPzwKHgCnRzM3dtDEiI7IXunkug8j3IUlIcwrSn14APmZmOQBmNsTMSoj8FXosWhAmArM8+vzXgOujcwulRCaKeyMf2Be9f2uX7XVAbpfHLxJZUROA6F/iJ9oEjD3J5ywhsjQzRPbZvxa9v5TI7iG6PP8WZjYYaHTO/ZbISGIasBkYbGYzo21yoxPn+URGEGHgFiLXGz7RC8AnzCw1+trx0REGREYWPR6lJIlLRUH6jXPuRSK7P94wszeBx4n8Un0eSDGzdcA3iPwS9MITRC6ash74ObAMqO3F6/4VeMzMXgWqu2z/C/CBjolm4G5gRnRidiPdXIHLObeZyCUsc098Lvr626P9cAtwT3T7Z4DPmdlyIrufusv8DmC5ma0B7gP+3TnXCtwE/MjM1gIvEfkr/wHgVjNbSuQXfEM37/cgsBFYFT1M9ef8fVR2GfBsN6+RJKCls+WsYmY5zrl6i1xLdzkwxzl3sJ8zfBaoc8492Mv2WUCTc86Z2YeITDpf62nInvO8QuTi9cf8yiDe0ZyCnG2eMbMCIhPG3+jvghD1U+CDfWg/ncjEsAE1RI5M8oWZFROZX1FBSFIaKYiISCfNKYiISCcVBRER6aSiICIinVQURESkk4qCiIh0UlEQEZFO/x+GE/66uI2yBgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "learn.sched.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 139,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x,y = next(iter(data.aug_dl))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 141,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([3, 32, 32])"
+      ]
+     },
+     "execution_count": 141,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x[0].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 144,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Clipping input data to the valid range for imshow with RGB data ([0..1] for floats or [0..255] for integers).\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.image.AxesImage at 0x2701c71c0b8>"
+      ]
+     },
+     "execution_count": 144,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAP8AAAD8CAYAAAC4nHJkAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAFEtJREFUeJzt3X+wlNV9x/H3FwRBwQgFlUEq6NCO5hcyK2PGxsYftcaxoraxOsVxJkxwOjojqe2U2ImQaZxRJ/76w7G5CiNpiGj9MdKMTXQoUdNk1CsqoDTBWIwUCjhqgCii3G//2If2Svec3Xv2eZ699HxeM8zd+5w9zzn37H7Z3ee75xxzd0QkPyN63QER6Q0Fv0imFPwimVLwi2RKwS+SKQW/SKYU/CKZUvCLZErBL5Kpw7qpbGbnA3cBI4H73P3m6P3HTHLGTU9oKKFzqV9cTGkrViflfN3Uq+t87Qwk1Ik9ZmV/EbWKL7amnjNUL2U83t+M73u7o0c7OfjNbCRwN/BHwBbgBTNb5e6vBSuNmw5z+4feWEovP06ok9pWrM6oGvuRer7UtmJjvDfhfB8ltpWi7PNB2t8M4b7E+hgqe7rRcbPdvO2fA7zu7m+4+z5gJTC3i/OJSI26Cf6pwFuDft9SHBORQ0A3wd/qc8X/+SRiZgvMrN/M+tm7s4vmRKRM3QT/FmDaoN+PB7YefCd373P3hrs3GDO5i+ZEpEzdBP8LwEwzm2Fmo4HLgVXldEtEqpZ8TdndPzaza4Ef00z1LXP3V6OVLNJi2VeOq7i6HVLFleNUYwLH6xyP2DljYxXLjKRc+Y5JfcxS+xEb49BjFnvel/Cc6+phd/cngCe674aI1E3f8BPJlIJfJFMKfpFMKfhFMqXgF8lUFUmesAFgT0K9lLRGvX9ZWGo/UlNzockxqROMYlIm4lSRYqs4Jdbx+Upva3+47LCRrY8PYWahXvlFMqXgF8mUgl8kUwp+kUwp+EUypeAXyZSCXyRTCn6RTCn4RTKl4BfJlIJfJFMKfpFM1Tv9ZQQwLlBW9oSJutesK7ut1Ik4da7hlzLZJnXyyweRsjp3dKpiDb9Q2d7A5B0Ij+8QtmXTK79IphT8IplS8ItkSsEvkikFv0imFPwimeoq6WVmm4HdwH7gY3dvRCs4aSmWUPoqpoqUTEqd1JRdFem3spWdno2tCRgzXFK3KdvKxepV/FiWMWxnufvbJZxHRGqkt/0imeo2+B140sxeNLMFZXRIROrR7dv+M9x9q5kdAzxlZv/u7s8MvkPxn0LzP4Yjf7fL5kSkLF298rv71uLnDuAxYE6L+/S5e8PdG4yZ3E1zIlKi5OA3syPNbPyB28B5wIayOiYi1ermbf+xwGNmduA8P3D3H0VrWKTFstNlKVtJtevH2IR+xAyXLcViUmcDhspSx77s9GzsfFWkHFO3GxuqIczqS376ufsbwOdT64tIbynVJ5IpBb9IphT8IplS8ItkSsEvkql6k02xVF8sFZKSYktd8DF1Fl5KW1WMfsr4lt1WTOpMwNT0W2hGaKyt2HMgtR9lpypDtICniLSj4BfJlIJfJFMKfpFMKfhFMlX/dl2hK/dlXw2NZQhSr8CH+lj25JdupEycqqKPockqKesxdlMvpIqxL3OCDqQ9LkN4Odcrv0imFPwimVLwi2RKwS+SKQW/SKYU/CKZGj4Te8ZF6qWkeWJplzpTMlWIjUeoL+MTz1fX2nMQfw6kTggKlZW91Rikj2OZ6x0q1Sci7Sj4RTKl4BfJlIJfJFMKfpFMKfhFMtU2SWVmy4ALgR3u/pni2ETgQWA6sBm4zN3fbdvaCMLpnD2Reimpl1idWEqpbKnpsNSZdqGU3qTE871Xcj9iqljDr+x0ZKyPRyfWS6kTKhvZ+ek7eeW/Hzj/oGOLgNXuPhNYXfwuIoeQtsHv7s8A7xx0eC6wvLi9HLi45H6JSMVSP/Mf6+7bAIqfx5TXJRGpQ+UX/MxsgZn1m1k/v91ZdXMi0qHU4N9uZlMAip87Qnd09z53b7h7gyMnJzYnImVLDf5VwFXF7auAx8vpjojUpZNU3wPAl4BJZrYFWAzcDDxkZvOBXwNf6ai1/YRTR7EZUWXP6oulr8pOA6bO9CpbbDxSZ7ilLHZat5TtumJSZ3Cm1IttG7Y7cHwIqb62XXL3KwJF53TejIgMN/qGn0imFPwimVLwi2RKwS+SKQW/SKbqXXrySOC0QNmmktuKpdg+Gy4aPSNcti80WrG+vxUpi0l9ZEIprNisyVSxPqak2KrYM7DslGPq+cqe1RcaD+v89HrlF8mUgl8kUwp+kUwp+EUypeAXyZSCXyRTtab6Jo2HuWe3Llu6MVIxpZeRNMn8QB8A7ktYcuCd2eGy2WvDZW+uj5y07L3kUmfgpabfQmVVPONSxqrOfQEhvgBpyn6CId75XfXKL5IpBb9IphT8IplS8ItkSsEvkilzH8LlwW4bm/JZZ/6q1oVHR2bUlHy1n/f+I1i08rpwtT+fHOljgq+/Fi67M9xF+K9IWejvrmLtudgV87Ifs+GyXmCdE3tSthr7+wa+ub+j6T165RfJlIJfJFMKfpFMKfhFMqXgF8mUgl8kU51s17UMuBDY4e6fKY4tAb4GHNh29wZ3f6Jta3Y4HBZIl8Um1JQ9kWVPOGV3+TmLg2UPXPphy+O3L7kpWOfEyP5Jd5wSLOIbkbK/WhcuWxFKEcbSg2VvlQZpKcfUtmLnHFvy+WLPxQ8S64X6GJsMFFqTcQjbdXXyyn8/cH6L43e4+6ziX/vAF5FhpW3wu/szwDs19EVEatTNZ/5rzWydmS0zswml9UhEapEa/PcAJwGzgG3AbaE7mtkCM+s3s37e3xm6m4jULCn43X27u+939wHgXmBO5L597t5w9wZHJCyTIyKVSAp+M5sy6NdLgA3ldEdE6tJ2Vp+ZPQB8CZgEbAcWF7/Porli2Gbganff1raxkxrOrf2tC2PbSaWkgGIzomKz0Z7cHy5bdnnr42PCubc/vO6LwbKffPu+SEfShHpy47vhOo//LHLCtyNlscclNMajInVi257tDhcdcVG47P3A82pEJPU2EJtRGSt7KfDcBnhpTbjs0nNbHj7hslODVd4MfYJe2MA3dTarr22e392vaHF4aScnF5HhS9/wE8mUgl8kUwp+kUwp+EUypeAXyVSt23XhhFNwZW9PFasTSwNOiEyLuvS7rY9Pmxis8vTShcEyuymc91ry9Mpg2eIz/zRY9rnA8b7IF7D/5QfLgmVnLf5qsGzN5vA5960I7EV2WOuZkQAsuyVcdvxvgkW/XfRksMzs0y2PDxBZPTXZheGiy8Irw44+rXVKb28kOkPfl4vVOZhe+UUypeAXyZSCXyRTCn6RTCn4RTKl4BfJVL179U1vON+MzHw6VB0dKYvNins+UrYsPDHrhIu+EK72eOvZY+dY2uqYsefH36wIpwi/M29+Unspvv+LtcGyeb8/e8jnO+ffwn/z6tjMw2nhoqOOC5cFs9IJe/Xtnddg/2vaq09EIhT8IplS8ItkSsEvkikFv0im6p3YY4ktptRJmQzUrq3QVf2+yGSVVbGr7JGJIBFvrvp5sCx4VT+WkXgvXGTW0YXjGvxesGTehS+Fq/1t6yv3d94crhI5W/z5Ebk6vyu29l9IbL3DUD8iS1AeTK/8IplS8ItkSsEvkikFv0imFPwimVLwi2SqbRLNzKYB3wOOAwaAPne/y8wmAg8C02lu2XWZu0c2haL5X03K/JLhkuoL5YBW/UliYz9MrJcgks6rwugvnNXy+As/+9dgndg8li+Gd0Rj31vhstXrt7Y8vmnpjcE6y0++JnzC9eEttJKe2zEpz/uPOr9rJ6/8HwPXu/vJwOnANWZ2CrAIWO3uM4HVxe8icohoG/zuvs3d1xa3dwMbganAXGB5cbflwMVVdVJEyjekz/xmNh04FXgOOPbAzrzFz2PK7pyIVKfj4DezccAjwEJ33zWEegvMrN/M+tkV2ldYROrWUfCb2Siagb/C3R8tDm83sylF+RRgR6u67t7n7g13b3BUYKcBEald2+C35syOpcBGd799UNEq4Kri9lXA4+V3T0Sq0kky4QzgSmC9mb1cHLsBuBl4yMzmA78GvtL2TEb56ZCQ1PmKYyNlewLHJ4WrjJgRXm9v4IXw7LxD3RWXtp6xGNpOrJ0PYxUja+dx4dSWh289dV64zvWRdF7ksQ4+PyCex0yJiVAqewhLcrYNEXf/Kc2wbeWczpsSkeFE3/ATyZSCXyRTCn6RTCn4RTKl4BfJVL3bdc1sOHcO8+26YosmhmZMPRtZwPOJ28NlYyL5q5mtZ8UBMOOIcNlNiwMFPwrXmXR1uOzt2LZb4UU14ZetD18UngLy/TvCM+3+4sRI+u2R8LZhu+7+55bHP7UmlmYNp2eZFMs5RpJnJ0fOedG5rY/HUpihVN83G/gb2q5LRCIU/CKZUvCLZErBL5IpBb9IphT8Ipmqd68+J31hzeEglAY87/BwnbO/kdZWbCHG8ZGyPd9qffyuyEN99VfDZVMiZbEZbqG96Z79cbDKvK8/Gy7bHU6Zfnr9mmDZl+9/uHXB3ruDdfj5U+GyvaeEy6adkFY2IXA8NtsvFEdD2FpRr/wimVLwi2RKwS+SKQW/SKYU/CKZ0sSeqsUmClUhlCWIrSEXyx7ExHJFKevSxVZ2D22VBrAxnEHgtD9ufTz2N4+LlE2JlMXGI5blCpUNYeut/7GwgW/SxB4RiVDwi2RKwS+SKQW/SKYU/CKZUvCLZKrtxB4zmwZ8DzgOGAD63P0uM1sCfI3/TdDc4O5PxE9GOPWVktZIFUu/lT3VKZbyKjs1FGsvltpK/ZtT6sX6HtvH9YJYWSCdB+E+xvoRS4vujpSlCvWl4ml3nZz+Y+B6d19rZuOBF83swLSnO9z9O9V1T0Sq0slefduAbcXt3Wa2EWi9+6GIHDKG9JnfzKYDpwLPFYeuNbN1ZrbMzEKzkkVkGOo4+M1sHPAIsNDddwH3ACcBs2i+M7gtUG+BmfWbWT+/iX1/U0Tq1FHwm9komoG/wt0fBXD37e6+390HgHuBOa3qunufuzfcvcGnYld0RKRObYPfzAxYCmx099sHHR88xeESYEP53RORqnRytf8M4EpgvZm9XBy7AbjCzGbRXJlvMxDZ86kwgnAqqs7VBOtMbVXRVtljlbquYqxeqI+x1GcsxbYnoa2Y1DGMXdlKTc+mKGENv06u9v80cMp4Tl9EhjV9w08kUwp+kUwp+EUypeAXyZSCXyRT9W7XFWux/p4MXZ0ppZSZe6lSZx5GHBWYOTkhcr53PwiX7YqlAcsWayv1cUlJA6akB7Vdl4i0o+AXyZSCXyRTCn6RTCn4RTKl4BfJVL0JttisvpiUlMdwmSWYMvOtXVnKGEbOd9TYcNnYksdxZySNlpzNK3vGXKrUWX2hPzzl7xrC1pt65RfJlIJfJFMKfpFMKfhFMqXgF8mUgl8kU/Wm+pz60jKp7ZS9/1wVf29sMcsEuyLn21VuU3GHQsoutV5KyjclhaxZfSLSjoJfJFMKfpFMKfhFMqXgF8lU22vbZjYGeAY4vLj/w+6+2MxmACuBicBa4Ep33xc/WScttjDcJ/bElL3e3qGi7PEvey3E1MlYsdlHqRO1ynx+l3y1/0PgbHf/PM3tuM83s9OBW4A73H0m8C4wv/NmRaTX2ga/Nx3IBI8q/jlwNvBwcXw5cHElPRSRSnT0md/MRhY79O4AngJ+Bbzn7gfesGwBplbTRRGpQkfB7+773X0WcDwwBzi51d1a1TWzBWbWb2b9vLszvaciUqohXe139/eAnwCnA0eb2YHLDscDWwN1+ty94e4NJkzupq8iUqK2wW9mk83s6OL2WOBcYCOwBviz4m5XAY9X1UkRKV8nCZQpwHIzG0nzP4uH3P2HZvYasNLMvg28BCxte6bUVN9wWY9vuKQPU1SxbVjEiMC6gNEdrT5K68ZApGx0oOK4yHhEM32RevtSJ/aUuV3XELR9Srj7OuDUFsffoPn5X0QOQfqGn0imFPwimVLwi2RKwS+SKQW/SKbMfQj7+3TbmNlO4M3i10nA27U1HqZ+fJL68UmHWj9OcPeOvk1Xa/B/omGzfndv9KRx9UP9UD/0tl8kVwp+kUz1Mvj7etj2YOrHJ6kfn/T/th89+8wvIr2lt/0imepJ8JvZ+Wb2CzN73cwW9aIPRT82m9l6M3vZzPprbHeZme0wsw2Djk00s6fMbFPxc0KP+rHEzP6zGJOXzeyCGvoxzczWmNlGM3vVzK4rjtc6JpF+1DomZjbGzJ43s1eKfnyrOD7DzJ4rxuNBMxvdVUPuXus/YCTNZcBOBEYDrwCn1N2Poi+bgUk9aPdMYDawYdCxW4FFxe1FwC096scS4K9rHo8pwOzi9njgl8ApdY9JpB+1jgnNye/jitujgOdoLqDzEHB5cfwfgL/spp1evPLPAV539ze8udT3SmBuD/rRM+7+DPDOQYfn0lwIFWpaEDXQj9q5+zZ3X1vc3k1zsZip1DwmkX7UypsqXzS3F8E/FXhr0O+9XPzTgSfN7EUzW9CjPhxwrLtvg+aTEDimh3251szWFR8LKv/4MZiZTae5fsRz9HBMDuoH1DwmdSya24vgb7WtQK9SDme4+2zgy8A1ZnZmj/oxnNwDnERzj4ZtwG11NWxm44BHgIXuXuvu4G36UfuYeBeL5naqF8G/BZg26Pfg4p9Vc/etxc8dwGP0dmWi7WY2BaD4uaMXnXD37cUTbwC4l5rGxMxG0Qy4Fe7+aHG49jFp1Y9ejUnR9pAXze1UL4L/BWBmceVyNHA5sKruTpjZkWY2/sBt4DxgQ7xWpVbRXAgVergg6oFgK1xCDWNiZkZzDciN7n77oKJaxyTUj7rHpLZFc+u6gnnQ1cwLaF5J/RXwdz3qw4k0Mw2vAK/W2Q/gAZpvHz+i+U5oPvA7wGpgU/FzYo/68Y/AemAdzeCbUkM//oDmW9h1wMvFvwvqHpNIP2odE+BzNBfFXUfzP5obBz1nnwdeB/4JOLybdvQNP5FM6Rt+IplS8ItkSsEvkikFv0imFPwimVLwi2RKwS+SKQW/SKb+GwmSAb1TohMzAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.imshow(np.transpose(x[1],(1,2,0)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e9ca326472f64c24aab45d3e05d7413a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>HBox</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=4), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch      trn_loss   val_loss   accuracy                                                                              \n",
+      "    0      1.166266   1.152554   0.596222  \n",
+      "    1      1.215572   1.166726   0.586432                                                                              \n",
+      "    2      1.1776     1.152374   0.592761                                                                              \n",
+      "    3      1.128169   1.08678    0.617385                                                                              \n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[1.086779915833775, 0.6173852848101266]"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "learn.fit(1e-2, 1, cycle_len=4, use_clr=(10,2,0.95,0.85), wds=3e-3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAuIAAAEKCAYAAABXHDBNAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzs3XeclIW1//HP2YWlSC/SIx2kLkqwYEtMBCwgSPN3c2OsaeYGUBE0UUHQJKJgLMk1MTcxJsKKGLEXQE2xgSxLhxUpCwqrFClKPb8/5hkc12UZlp19pnzfr9e8mH3mmd2ziMth5jnna+6OiIiIiIhUrqywCxARERERyURqxEVEREREQqBGXEREREQkBGrERURERERCoEZcRERERCQEasRFREREREKgRlxEREREJARqxEVEREREQqBGXEREREQkBFXCLqAyNGrUyFu3bh12GSIix2zBggWfuHvjsOuoTPqZLSKp6lh/ZmdEI966dWvmz58fdhkiIsfMzNaFXUNl089sEUlVx/ozW5emiIiIiIiEQI24iIiIiEgI1IiLiIiIiIRAjbiIiIiISAjUiIuIiIiIhCChjbiZ9TezlWZWaGbjSnm8mpnNCB5/x8xaB8cbmtk8M9tlZg+WeM6pZrY4eM5vzcwS+T2IiIiIiCRCwhpxM8sGHgIGAF2Ay82sS4nTrga2uXt7YCrw6+D4F8AvgRtL+dS/A64DOgS3/hVfvYiIiIhIYiXyFfE+QKG7r3H3fcB0YFCJcwYBfwnuzwTONzNz993u/i8iDflhZtYMqOPub7m7A48BlybwexAp02vLNlO4ZVfYZYhkvHkrtvDF/oNhlyEiaaBo2x7ufnF5pfxMSWQj3gLYEPNxUXCs1HPc/QCwA2h4lM9ZdJTPCYCZXWdm881sfnFx8TGWLnJ0/y78hGsem8/3H32HHZ/vD7sckYy18uOdXPnn9/jViyvCLkVEUtzBQ84NeYt4/K11FO/cm/Cvl8hGvLRrt70c55TrfHd/xN17u3vvxo0zKh1aKsGOPfu5IW8RLerVYPPOvdz+zJKwSxLJWJ2a1uYHZ7bmz/9Zyz9X64UXESm/P/5zDe98uJU7BnalVYOaCf96iWzEi4BWMR+3BDYd6RwzqwLUBbYe5XO2PMrnFEkod+fWfyzmk117+f33TuVn327PP/I3MXuR/iiKhGXcgM60P7EWNz65iO179oVdjoikoKWbdjDllZX079qUoae2PPoTKkAiG/H3gA5m1sbMcoCRwOwS58wGrgjuDwXmBtd+l8rdPwJ2mtnpwbaU7wPPVHzpIkf2TP4mniv4iNHf7Uj3lnW5/lvtyW1Vj188vZhN2z8PuzyRjFS9ajbTRuSydfc+bnl6MWX8VSIi8jVf7D/I6Bn51KuZw11DulNZS/kS1ogH13xfD7wMLAfy3H2pmU00s4HBaY8CDc2sEBgDHF5xaGZrgfuAH5hZUczGlR8DfwQKgQ+AFxP1PYiUVLRtD798Zgm9T6rPj85tB0CV7CymjcjlwCHnxicXceiQGgCRMHRrUZfR3+3IC4s/Ztb7G8MuR0RSyG9eWsmqzbu4Z2gPGpyQU2lft0oiP7m7vwC8UOLYbTH3vwCGHeG5rY9wfD7QreKqFIlPdIDj0CFn6ohcsrO+/Ndy60Yn8MuLuzB+1mL+9O8PuebstiFWKpK5fnhOO15fUczts5fSp02DSrnGU0RS279Wf8Kf/v0hV5xxEud1OrFSv7aSNUXiFB3guP0IAxwjv9mK75zchN+8tJIVH38WQoUikp1l3Du8JwA35C3ioN6hEpEybN+zjxuezKdd4xMYN+DkSv/6asRF4rBs02eHBziGHWGAw8z41WXdqVOjCqOm57P3gHYai4ShVYOaTBjYlXfXbuV/3/wg7HJEJElFli8s4dNd+7h/ZC9q5GRXeg1qxEWO4ov9Bxk1Y2FcAxyNalXjN0N7sOLjndz7yqpKrFJEYg05pQUXdm/K1FdXsWTjjrDLEZEk9I/8jTwfLF/o1qJuKDWoERc5imMd4Ph25yb8v9O+wR/+uYb/fPBJJVQoIiWZGZMv7U79mjmMmpGv1E0R+YqibXu47R9L+WbrL5cvhEGNuEgZyjvA8YuLTqZ1wxO4MW+RUjdFQlL/hBymDOtJ4ZZdSt0UkcMOHnLG5C3CgfuGf3X5QmVTIy5yBNv37OPGJxeVa4CjZk4Vpo7IZfPOvdym1E2R0JzTsfHh1M03Vyl1U0TgD/9cw7sfbuX2S7qEvllJjbhIKaIDHJ/s2lvuAY7cVvX4n2934Jn8TTyTr53GImEZN6AzHYLUzW27lbopksmWbtrBva+sZEC3ykvPLIsacZFSVNQAx0+/1Y5e36jHL/6xRKmbIiGpXjWbqSNy2bZHqZsimeyL/QcZNT2f+jVzuGtw5aVnlkWNuEgJ0QGO2PTM8qqSncXU4blfCQMSkcrXrUVdxny3Ey8u+ZinlLopkpF+/dIKVm/ZxT3DelK/EtMzy6JGXCRGtGF2+Fp6Znm1bnQCt13chbfWfMqf/v3h8RcpIuVy3Tlt6dO6AXfMXsqGrXvCLkdEKtE/Vxfzf/9eyw/ObM25HRuHXc5hasRFYvwhmp5ZwQMcI2JSN5d/pNRNSS1m1t/MVppZoZmNK+Xxk8xsjpkVmNnrZtayxON1zGyjmT1YeVV/XWzq5pi8fKVuimSI6PKF9ifWYtyAzmGX8xVqxEUCiRzgMDN+fVl36tSoymjtNJYUYmbZwEPAAKALcLmZdSlx2hTgMXfvAUwE7i7x+J3AG4muNR6tGtRk4qCuvLd2m1I3RTKAu3Pr05H0zGkjcqletfLTM8uiRlyEyADH6BmJHeBoWKsavxnaPUjdXFnhn18kQfoAhe6+xt33AdOBQSXO6QLMCe7Pi33czE4FmgCvVEKtcRncqwUXdW/Gfa8odVMk3T29cCPPLw43PbMsasRFiAxwrNqc+AGOb3duwn+d9g3++K8P+U+hUjclJbQANsR8XBQci7UIuCy4PxiobWYNzSwLuBe4KeFVHgMzY/LgbjSspdRNkXS2Yesebn8m/PTMsqgRl4wXHeC44oyTKmWA49YgdfOGJxexY49SNyXplfb2UMmLq28EzjWzhcC5wEbgAPAT4AV338BRmNl1ZjbfzOYXFyc+eKdeTaVuiqSz2OULYadnlkWNuGS0rw5wHFt6ZnnVzKnCtBG5bNm5l18qdVOSXxHQKubjlsCm2BPcfZO7D3H3XsCtwbEdwBnA9Wa2lsh15N83s1+V9kXc/RF37+3uvRs3rpyNBmd3aMyVfSOpm28odVMkrTzy5hreXbuVOwZ2DT09syxqxCVjlRzgKE96Znn1bFWPn5/fgdmLlLopSe89oIOZtTGzHGAkMDv2BDNrFFyGAjAe+BOAu/+Xu3/D3VsTedX8MXf/2taVMN3cP5K6eZNSN0XSxpKNO7jv1ZVc2L0pl51S8kq65KJGXDJW2AMcPznvy9TNjUrdlCTl7geA64GXgeVAnrsvNbOJZjYwOO08YKWZrSIymDk5lGLLoXrVbKaNVOqmSLr4Yv9BRgXLFyZfmhzpmWVRIy4ZqWhb+AMcVbKzmDYikrp5o1I3JYm5+wvu3tHd27n75ODYbe4+O7g/0907BOdc4+57S/kcf3b36yu79nh0bV6XGy5Q6qZIOvjViyso3LKLKUmUnlkWNeKScQ4ecsYkyQDHSQ1P4PZLIqmbj/5LqZsiYbn27Lb0aaPUTZFU9s/Vxfz5P5H0zHOSKD2zLGrEJeP84Z9rePfD5BngGN67FRd0acI9Lyt1UyQs2VnGfcN7YsDoGUrdFEk123Ynb3pmWdSIS0ZZsvHL9MxkGeAwM+4eEkndHDVdO41FwtKyfk0mDOrK/HXb+P0bSt0USRXuzq3/WMzW3cmZnlkWNeKSMSojPbO8Gtaqxj1De7By806mvKzUTZGwDO7Vgot6NGPqq6tYXKTUTZFUMOv9jbyw+OOkTc8sixpxyRi/fmkFq5N4gONbnU/ke6dHUjf/rdRNkVCYGZMv7UajWtUYNWMhn+/TO1QiyWzD1j3cPnspfVo34IfnJGd6ZlnUiEtGiKZnJvsAx60XdqFtoxO4IU+pmyJhiaZuflC8m1+9uDzsckTkCCLLF/IBuHd4z6RNzyyLGnFJe19Nz0zuAY4aOZGdxp/s2ssvlLopEpqzOjTiyr6t+ctb63h95ZawyxGRUvzvmx/w3tptTEiS5QvloUZc0lo0PTOVBjh6tIykbj6r1E2RUN3cvzMdm9TippkFbFXqpkhSWbJxB1NfXcWF3ZsyJEmWL5SHGnFJa2GnZ5bXj89rxylK3RQJVfWq2Uwb0Yvte/Zxyyylbooki2h6ZoMTUiM9syxqxCVtbdi6h9ueSc0BjirZWUwdkcuhQ84NeflK3RQJSZfmdbjhgk68tPRjZi4oCrscESH10jPLokZc0tLBQ84NeYuA1B3giKRuduXtNVv547/WhF2OSMa69uy2nBakbq7/VKmbImF6c9WX6Zlnd0je5QvxUiMuaemRN9fw7tqtKT3AATCsd0su6NKEKS+vYtkmpW6KhCE7y7h3eE+yzBiTp9RNkbBE0zM7pMDyhXipEZe0s2TjDu57dWXKD3BAidTNGQuVuikSkpb1azLxUqVuioTF3bnl6cVs27OPqSmyfCEeasQlrUQHOOrXTP0BjqiGtapxz7AerNq8i3uUuikSmktzlbopEpan3t/Ii0s+Zsx3O6XU8oWjUSMuaSWdBjhifavTifz36SfxqFI3RUITm7r5c6VuilSaDVv3cEeQnnndOW3DLqdCqRGXtBE7wJHM6ZnldcuFJ9O2sVI3RcJUr2YO9w7vyZri3dyt1E2RhIumZxqpu3yhLAltxM2sv5mtNLNCMxtXyuPVzGxG8Pg7ZtY65rHxwfGVZtYv5vhoM1tqZkvM7Akzq57I70FSQzoOcJRUIyebaSMiqZu3/kM7jUXC0rd9I67q24bHlLopknC/fyNIzxyU2ssXjiRhjbiZZQMPAQOALsDlZtalxGlXA9vcvT0wFfh18NwuwEigK9AfeNjMss2sBfA/QG937wZkB+dJBnN3bv1H+g1wlKZHy3qM+k4Hniv4iGfyN4VdjkjGGtu/k1I3RRIsmp55UfdmDO6V2ssXjiSRr4j3AQrdfY277wOmA4NKnDMI+EtwfyZwvkWm6wYB0919r7t/CBQGnw+gClDDzKoANQF1Ixlu1vsbeWFx+g1wHMmPzm3HqSfV55fPKHVTJCzR1M0de/YzflaB3qESqWDR5QsNa+UweXC3tFi+UJpENuItgA0xHxcFx0o9x90PADuAhkd6rrtvBKYA64GPgB3u/kppX9zMrjOz+WY2v7i4uAK+HUlGG7bu4fY0HeA4kirZWUwdHkndHDNDO41FwhJJ3ezIy0s386RSN0UqVOzyhXo102f5QkmJbMRL+6dLyY7hSOeUetzM6hN5tbwN0Bw4wcy+V9oXd/dH3L23u/du3Dj9BvfkywEOSM8BjrJ8o2FNbh/YlXc+3Mof/6nUTZGwXBOkbk5Q6qZIhXkjWL5wZd/0SM8sSyIb8SKgVczHLfn6ZSSHzwkuNakLbC3jud8BPnT3YnffD8wCzkxI9ZL0/vfNyADHxDQd4DiaYae2pF/XJkx5ZaVSN0VCkp1l3Dcil6wsY3RePgcOHgq7JJGUtm33Pm4Kli/c3D89ly/ESmQj/h7QwczamFkOkaHK2SXOmQ1cEdwfCsz1yIV2s4GRwVaVNkAH4F0il6ScbmY1g2vJzwe0PyoDZcIAx9FEUjd7UK9mjlI3RULUol4N7hzUjQVK3RQ5Lu7O+FmR5QvTRqb38oWohDXiwTXf1wMvE2mW89x9qZlNNLOBwWmPAg3NrBAYA4wLnrsUyAOWAS8BP3X3g+7+DpGhzveBxUH9jyTqe5DkFB3gaHBCeg9wxKPBCTn8ZmgkdfM3Lyl1UyQsg3Kbc3GPZkx7bTUFRdvDLkckJc1cUMRLSz/mhgs60bV5+i9fALBMmPTu3bu3z58/P+wypILcMXspf/7PWv56dZ+0v3YsXrc9s4TH3lrH41efxlkdGoVdjlQgM1vg7r3DrqMyperP7B179tP//jepkZPN8z87mxo56f9qnkhF2bB1DwPu/yddmtfhiWtPT9m5r2P9ma1kTUkpmTTAcSzGDziZdo1P4MYnF7F9j3Yai4Shbs2qTBkWSd286wVdNSkSr4OHnNEzIumZ92XY8gU14pIyMm2A41hEUjd7BambS7TTWCQkfds34uqz2vDXt9cxT6mbInH5/RsfMH/dNiZe2pWW9TNr+YIacUkJ7s4tT2fWAMex6t6yLqO/25HnCz7iH/kbwy5HJGPd1K8TnZrUZuzMAj7dtTfsckSS2uKiYPlCj2Zcmpt5yxfUiEtKeOr9jby4JLMGOMrjR+e2o/dJ9bntH0sp2qadxiJhqF41m6kjcoPUzcV6h0rkCD7fd5BRMxbSqFY1Jl+amcsX1IhL0tuwdQ93zF5KnzYNuPbszEjPLK/sLGPqiFwOuXND3iKlboqEpEvzOtzYryOvLNvMk/OVuilSml+9uJwPinenfXpmWdSIS1LL5AGO8mrV4MvUzT8odVMkNNec1ZbT2zZgwrNK3RQp6fWVW/jLW+u4qm+bjN72pUZcklomD3Acj2GntqR/16bc+8pKlm7aEXY5kuLMrL+ZrTSzQjMbV8rjJ5nZHDMrMLPXzaxlcDzXzN4ys6XBYyMqv/rwZGUZ9w5X6qZISVt37+OmmQV0bFKLsf07hV1OqNSIS9I6nJ6ZoQMcx8PMuGtId+rVzGH0jHylbkq5mVk28BAwAOgCXG5mXUqcNgV4zN17ABOBu4Pje4Dvu3tXoD8wzczqVU7lyaFFvRpMujSSuvm715W6KeLu3DJrMdv37GPaiF4Zv3xBjbgkpc/3HeTn0zN7gON4NTghh3uUuinHrw9Q6O5r3H0fMB0YVOKcLsCc4P686OPuvsrdVwf3NwFbgIwLABiU24JLejbn/jlK3RSJpmfeeEEnujSvE3Y5oVMjLklJAxwV47xOJ3LFGSfxp39/yD9XF4ddjqSmFsCGmI+LgmOxFgGXBfcHA7XNrGHsCWbWB8gBMvJl4UmDutG4djVGTc9nz74DYZcjEor1n0aWL5zWpgHXaPkCoEZcktAbq4o1wFGBxil1U45PaW9HlVzHcyNwrpktBM4FNgKHu00zawb8FbjS3Uu9UNrMrjOz+WY2v7g4/f7RWLdmVe4d1pM1nyh1UzLTwUPOmLx8ssy4V8sXDlMjLkll6+593PjkIg1wVKAaOdncP7IXn+7ax61PK3VTjlkR0Crm45bAptgT3H2Tuw9x917ArcGxHQBmVgd4HviFu799pC/i7o+4e2937924cXpevXJm+0Zcc1YbHn97PfNWKHVTMkt0+cKdl3bT8oUYasQlaWiAI3G6tQhSNxd/xNMLlbopx+Q9oIOZtTGzHGAkMDv2BDNrZGbRv0/GA38KjucATxMZ5HyyEmtOWjf260TnprW5SambkkEKirYz9dVVXNyjGYNym4ddTlJRIy5JIzrAcYMGOBIimrp5+zNK3ZT4ufsB4HrgZWA5kOfuS81sopkNDE47D1hpZquAJsDk4Phw4BzgB2aWH9xyK/c7SC7R1M3PPlfqpmSGSHpmfrB8obuWL5SgRlySQuwAh9IzEyOauunAGKVuyjFw9xfcvaO7t3P3ycGx29x9dnB/prt3CM65xt33Bscfd/eq7p4bc8sP83tJBic3q8NN/TrxyrLN5M3fcPQniKSwu19czpri3dw7vCd1a1YNu5yko0ZcQqcBjsrTqkFNbr+kC+8qdVMkVFef1YYz2jZkwrPLWPfp7rDLEUmIeSu38Nhb67j6rDb0ba/lC6VRIy6hU3pm5Rp6aksGdIukbi7ZqNRNkTBEUjcjLzyMnqHUTUk/W3fvY+zMAjo1qc1N/bR84UjUiEuoFhftODzAofTMymFm3DW4O/WVuikSquZB6ub767fzsFI3JY24O+NnFbBjz36mjsjV8oUyxN2Im9kJiSxEMk9kgGOhBjhCUP+EHO4Z1pPVW3bx65dWhF2OSMYalNuCgUHq5qINSt2U9PDkgiJeXrqZG/t11PKFozhqI25mZ5rZMiLT8phZTzN7OOGVSdq7O0jP1ABHOM7t2JgrzjiJ//v3WqVuioTozkHdOLF2NUbPUOqmpL71n+5hwuylnN62AdecpeULRxPPK+JTgX7ApwDuvojIOiqRcns9GOC4qq8GOMI0bsDJtD+xllI3RUKk1E1JFwcOHmJ0Xn4wA5FLlpYvHFVcl6a4e8n9SrqoVMpt6+593DSzQOmZSaBGTjbTRuQqdVMkZGe2b8S1Z0dSN+eu2Bx2OSLl8vs3PmDBum3cOagbLerVCLuclBBPI77BzM4E3MxyzOxGgstURI5V7ACH0jOTg1I3RZJDNHVz7MzFSt2UlFNQtJ1pr63mkp7NlZ55DOJpxH8E/BRoARQBucBPElmUpK/oAMcNF2iAI5n86Nx2fLN1fW57Zikbtip1M12ZWW8ze9rM3jezAjNbbGYFYdclEdWqZDNtZCR1c5xSNyWFRNMzG9euxqRB3bR84RjE04h3cvf/cvcm7n6iu38PODnRhUn6+coAh9Izk0p2lnHf8Ejy+A1K3UxnfwP+D7gMuAS4OPhVkkTnpnUY278Try7bzIz3lLopqeGuFyLpmVOGafnCsYqnEX8gzmMiR3Tg4KFIemYwwKH0zOTTqkFN7hjYlXfXbuWRN5W6maaK3X22u3/o7uuit7CLkq+6qm8bzmzXkInPLWPtJ0rdlOQ2b+UW/vr2Oq5Rema5VDnSA2Z2BnAm0NjMxsQ8VAfQhb1yTKLpmdNG5GqAI4lddkoL5izfzH2vruTsDo3o1qJu2CVJxbrdzP4IzAEOX4Ts7rPCK0lKysoypgzrSf9pbzI6L58nf3gGVbKVvyfJ59Ndexk7s4DOTWtzo9Izy6Ws/7NzgFpEmvXaMbfPgKGJL03SRXSA4+IezTTAkeRiUzdHKXUzHV1JZM6nP5FLUqKXp0iSaV6vBnde2o2FSt2UJBVZvrBY6ZnH6YiviLv7G8AbZvZnvXUp5RU7wKH0zNRQ/4Qcpgzryff/9C6/enEFdwzsGnZJUnF6unv3sIuQ+AzKbcHcFVu4f85qzunYmNxW9cIuSeSwJ+cX8cqyzdxyYWdObqblC+UVz3tde8zsHjN7wczmRm8Jr0zSggY4UtM5HRvzgzNb8+f/rOXNVUrdTCNvm1mXsIuQ+E0c1I0mSt2UJLPu091MeHYpZ7RtqPTM4xRPI/43YAXQBpgArAXeS2BNkiaiAxxXa4AjJY0b0Plw6ua23UrdTBNnAflmtlLrC1ND3RpVmTK8J2s/3c3k5xXhIeE7cPAQo2dEly/0VHrmcYqnEW/o7o8C+939DXe/Cjg9wXVJitu6ex9jZxbQqUltbtIAR0qqXjWSurltzz5u/Yd2GqeJ/kAH4AK0vjBlnNmuEdee3Za/vbOeOcuVuinh+t3rH/D++u1MurQbzbV84bjF04jvD379yMwuMrNeQMsE1iQpzt0Z91SQnjlSAxypLJq6+cLij5n1vlI304Af4SZJ7oYLOtK5aW1ufqqAT5S6KSEpKNrO/XNWM7Bncwbltgi7nLQQTyM+yczqAjcANwJ/BEYntCpJadEBjhv7ddQARxr44Tnt6NO6AbfPVupmGngeeC74dQ6wBngx1IokLl+mbh5g3FN6h0oq3559Bxg1PbJ84c5B3cIuJ22U2YibWTbQwd13uPsSd/+Wu5/q7rPj+eRm1j+4FrHQzMaV8ng1M5sRPP6OmbWOeWx8cHylmfWLOV7PzGaa2QozWx7sO5cksf7TPUx4NkjP1ABHWsgOrgMEGJOXr9TNFObu3d29R/BrB6AP8K+w65L4RFM3X1uu1E2pfHe9sJw1n+zmXi1fqFBlNuLufhAYWJ5PHDTxDwEDgC7A5aVM618NbHP39sBU4NfBc7sAI4GuRK5pfDj4fAD3Ay+5e2egJ6DplSRx4OAhRsekZ2qAI320alCTCQO78t7abfzvm9ppnC7c/X3gm2HXIfFT6qaEYd6KLTz+9nquOasNZ2r5QoWK59KU/5jZg2Z2tpmdEr3F8bw+QKG7r3H3fcB0YFCJcwYBfwnuzwTOt8ii6UHAdHff6+4fAoVAHzOrA5wDPArg7vvcfXsctUgl+N3rH7Bg3TYmXdpN6ZlpaMgpLbiwe1OmvrqKJRt3hF2OlIOZjYm53Whmfwe0nzKFRDdVVMkyRs3I58DBQ2GXJGnu0117uUnpmQkTTyN+JpFXpicC9wa3KXE8rwUQ+95ZUXCs1HPc/QCwA2hYxnPbEvlL4//MbKGZ/dHMToijFkmw6ADHJRrgSFtmxuRLlbqZ4mJTkqsRuVa85AskkuSa1a3BpMHdyd+wnYfm6R0qSRx3Z9ysxXz2uZYvJMpRG/HguvCSt2/H8blLuy6h5MWlRzrnSMerAKcAv3P3XsBu4GvXngOY2XVmNt/M5hcX6wWfRIpNz5ykAY60Fk3dLNyyi1+9uCLscuTYLXP3CcFtsrv/Da0vTEkDezbn0tzm/Hbuahau3xZ2OZKm8uZv4NVlm7mpXyc6N9XyhUSI5xXx8ioCWsV83BLYdKRzzKwKUBfYWsZzi4Aid38nOD6TSGP+Ne7+iLv3dvfejRs3Ps5vRcoSTc/UAEdmUOpmShsf5zFJAROC1M0xeYuUuikVLpKeuYwz2jbk6rPahF1O2kpkI/4e0MHM2phZDpHhy5LbVmYDVwT3hwJzPbKTaTYwMtiq0oZIAMW77v4xsMHMohcpnQ8sS+D3IEcxb0UkPVMDHJll3IDOdFDqZsowswFm9gDQwsx+G3P7M6AOLkXVrVGVe4fnsvbT3UxS6qZUoGh6ZhWlZyZcwhrx4Jrv64GXiWw2yXP3pWY20cyim1geBRqaWSEwhuAyE3dfCuQRabJfAn4abHAB+BnwtyCWORe4K1Hfg5RNAxyZq3rVbKYGqZu3PK2dxilgEzAf+AJYEHObDfQr43mS5M5o15Brz27L35W6KRXo4SA9806lZyacHe0vUDMbUsrhHcBid9+SkKoqWO/evX3+/PlA7JHWAAAgAElEQVRhl5FW3J0f/nUBr68s5pnr+yq4J0P97vUP+PVLK5gyrCdDT1XgbiKY2QJ3711Bn6uqu+8/+pnh0s/sY7P3wEEGPfhvPtm1l5dGnUOjWtXCLklS2KIN2xnyu/9wUfdm/PbyXmGXk3KO9Wd2PK+IX00kTfO/gtsfiLx6/W8z++9yVSkpL2/+Bl4JBjjUhGeu685pS5/WDbhDqZupoo+ZvWpmq8xsjZl9aGZrwi5Kjk+1KtncP7IXn31xgHFPFegdKim3PfsOMHpGPk2Unllp4mnEDwEnu/tl7n4ZkXCevcBpwM2JLE6SkwY4JCo2dXP0DKVupoBHgfuAs4gE+fRGgT5poVPT2ozt14nXlm9hulI3pZwmP7+cDz/dzZThWr5QWeJpxFu7e+yFZ1uAju6+FUj6tzilYkUHOLI1wCGBVg1qMnFQV+av28bv39BO4yS3w91fdPct7v5p9Ha0J5lZfzNbaWaFZva1lbFmdpKZzTGzAjN73cxaxjx2hZmtDm5XlHyuVJyr+rahb/uGTHx2GR8qdVOO0dwVm/nbO0F6ZjstX6gs8TTi/zSz54IfplcAzwBvBkE6SrXMML8LBjgmaYBDYgzu1YKLujdT6mbym2dm95jZGfEmJZtZNvAQMIDIO6KXm1mXEqdNAR5z9x5Ewt/uDp7bALidyDuofYDbzax+xX5LEpWVZUwZ1pOq2cZopW7KMfh0117Gzlys5QshiKcR/ynwZyIbSnoBjxHZYrLb3b+VwNokySzasJ1pc1YzUOmZUoKZMXlwNxrWyuHn0xfy+T6lbiap04hcjnIX8Scl9wEK3X2Nu+8DpvP1NM4uwJzg/ryYx/sBr7r7VnffBrwK9D/u70KOqFndGkwOUjcfnFcYdjmSAkqmZ1arovTMyhRPsqa7+0x3H+3uo4L7uhA0w0QHOE7UAIccQb2akdTND4p386sXtdM4GZUzKbkFEHvRcVFwLNYi4LLg/mCgtpk1jPO5UsEuCVI3H5hbqNRNOaoZ70XSM8f2V3pmGI7aiJvZkODavh1m9pmZ7TSzzyqjOEked70QGeC4VwMcUoazOzTmyr6t+ctb63hDqZtJx8yamNmjZvZi8HEXM7v6aE8r5VjJF2NuBM41s4XAucBGIkFB8Tw3Wtt1ZjbfzOYXF+vPzvGaMKgbTetUZ/SMfHbvVWaTlG7tJ7uZ+NwyzmzXkKv6avlCGOK5NOU3wEB3r+vuddy9trvrn0wZZN6KLTz+tgY4JD439/8ydXOrUjeTzZ+JhKw1Dz5eBYw6ynOKgFYxH7ckEhB0mLtvcvch7t4LuDU4tiOe58Z8jkfcvbe7927cuHF8340cUSR1syfrtu5R6qaU6sDBQ4zOi6RnThmm5QthiacR3+zu+r84Qyk9U45V9arZTBuZy/Y9+7hlllI3k0wjd88jspY2moB8tAv63wM6mFkbM8sBRhJJ5DzMzBqZWfTvk/HAn4L7LwMXmFn9YEjzguCYVILT2zbkurPb8sS763ltmVI35asemvcBC9dvZ9Lg7lq+EKJ4GvH5ZjbDzC4PLlMZcoS0TUkzGuCQ8uravC43XNCJl5Z+zMwFRWGXI1/aHVy77QBmdjqRpOQjCpr164k00MuBPHdfamYTzWxgcNp5wEozWwU0ASYHz90K3EmkmX8PmBgck0oy5oKOnNysDjc/VUDxzr1hlyNJIn/Ddn47dzWDcpszsGfzoz9BEqZKHOfUAfYQeSUjyoFZCalIkkbe/MgAxy8uOlkDHHLMrj27LXNXbGHCs8s4vW1DWjWoGXZJEklFng20M7N/A42BoUd7kru/ALxQ4thtMfdnAjOP8Nw/8eUr5FLJqlXJZtqIXC558F+Me6qAP17RGzNdgpDJYtMzJ2r5Quji2ZpyZSm3qyqjOAnP2k8i6Zka4JDyys4y7hveE0Opm8nC3d8nMkx5JvBDoKu7F4RblSRap6a1ubl/Z+as2MIT7yp1M9NNfn45az/dzb3Dc6lbQ8sXwnbERtzMxga/PmBmvy15q7wSpbJpgEMqSsv6NZl4qVI3k0UQznMhcD6Rdzl/ZmZjwq1KKsOVZ7amb/uG3PmcUjcz2ZzlkfTMa89uyxntGoZdjlD2K+LRAc35wIJSbpKmHn5dAxxScS7NbcFFPSKpm4uLlLoZsmeBHwANgdoxN0lz0dTNnCpZjJqRz36lbmacT3bt5eanIssXbrigY9jlSOCI14i7+7PBr3+pvHIkbPkbtnP/HA1wSMUxMyZf2o0Fa7cxasZCnvvZ2dTI0eBvSFoGMfSSgSKpm924/u8LeXBuIaO/q2YsU7g7455azGdfHODxa07T8oUkEk+gT0cze8TMXjGzudFbZRQnlUsDHJIoSt1MGi+a2QVHP03S1cU9mjO4VwsenFfI+0rdzBgz3tvAa8s3M7af0jOTTTzrC58EFgK/AG6KuUmaiQ5wTBneUwMcUuHO6tCIq/q24S9vreP1lVvCLidTvQ08bWafKyk5c00Y1FWpmxkkmp7Zt72WLySjeBrxA+7+O3d/190XRG8Jr0wq1dwVXw5wKD1TEmVs/050bFKLm2YWKHUzHPcCZwA1lZScuepUj6Rurt+6h0nPLwu7HEmgAwcPMWqGli8ks3ga8WfN7Cdm1szMGkRvCa9MKs0nu/YydqYGOCTxqlfNZtqIXkrdDM9qYInrNz7jnd62Ided05Yn3o3kRUh6emjeB+Rv2M7kwd1pVlfLF5JRPIE+VwS/xl6O4kDbii9HKtvhAY7PNcAhlaNL8zrceEEn7n5xBU8uKGJ471Zhl5RJPgJeN7MXgcMxi+5+X3glSVjGfLcjb676hHFPFZDb6hwa164WdklSgRau38Zv567m0tzmXKLlC0mrzFfEzSwL+J67tylxUxOeJg4PcPTXAIdUnmvObstpbRowYfZS1n+6J+xyMsmHwBwgB60vzHjVqmRz/8hcdu49wM1PFegdqjSyZ98BxuQtokntakzQ8oWkVmYj7u6HgCmVVItUMg1wSFiys4x7h/cky4wxeUrdrCzuPsHdJwD3AffGfCwZqmOT2ozr35m5K7bw93fXh12OVJBJSs9MGfFcI/6KmV1mZrrCP41ogEPCptTNymdm3cxsIbAEWGpmC8ysa9h1Sbh+cGZrzmrfiEnPLWdN8a6wy5HjNGf5Zv7+znquU3pmSoinER9DZIXhXq27Sh/RAY5JGuCQEF2a24KLg9TNgqLtYZeTCR4Bxrj7Se5+EnAD8IeQa5KQxaZujlbqZkqLpmee3KwOY7R8ISUctREP1ltluXuO1l2lh/wN2w8PcCg9U8IUSd3sTqNa1Rg1I5/P9x0Mu6R0d4K7z4t+4O6vAyeEV44ki6Z1q3PX4O4sKtrBA3MLwy5HyiGyfKGAz744wLQRuVq+kCLieUUcM6tvZn3M7JzoLdGFSWLEpmdqgEOSQd2akZ3Ga4p3c7dSNxNtjZn90sxaB7dfEBngFOGiHs0Y0qsFDyl1MyVNf28Dry3fws39O9OpqWawU0U8EffXAG8CLwMTgl/vSGxZkiga4JBk1Ld9I64+qw2PvbWOeUrdTKSrgMbAU8AsoBHwgzALkuRyh1I3U9KHn+xm4rOR5QtXntk67HLkGMTzivjPgW8C69z9W0AvoDihVUlCaIBDktlN/TrRqUltxip1M5HaAa2I/OyvCpxP5IUWESCSunlfkLp553NK3UwFBw4eYvSMfKpma/lCKoqnEf/C3b8AMLNq7r4C6JTYsqSiaYBDkl31qtlMHZHLjj37GT9LO40T5G/An4AhwMXB7ZJQK5Kkc1rbhvzwnHZMf0+pm6ngwXmF5G/Yzl1DtHwhFcXTiBeZWT3gH8CrZvYMsCmxZUlF0gCHpIouzetwwwUdeXnpZp5cUBR2Oemo2N2fdfcP3X1d9BZ2UZJ8xny3I12a1eHmpwrYsvOLsMuRI1i4fhsPzC1kcK8WXNxDyxdSUTxbUwa7+3Z3vwP4JfAocGmiC5OKEx3gGNuvkwY4JOldc3ZbTm+r1M0Eud3M/mhml5vZkOgt7KIk+eRUyWLayFx27T3AzTP1DlUy2r03snyhaZ3qTBikOIBUFe/WlLPM7Ep3fwN4C2iR2LKkosQOcCg9U1JBJHUzl6wsY3RePge007giXQnkAv2JXJJyCZHLU0S+pmOT2owf0Jl5K4v52ztK3Uw2k55fzrqte7h3eE/qVNfyhVQVz9aU24GbgfHBoarA44ksSiqGBjgkVbWoV4M7B3VjgVI3K1pPd+/t7le4+5XB7aqwi5LkdcUZrTm7QyMmP6/UzWTy2rLNPPHueq47py2nt9XyhVQWzyvig4GBwG4Ad98E6PqGFBAd4Jis9ExJQYNym3NJz+ZMe221Ujcrzttm1iXsIiR1ZGUZ9wxV6mYyKd4Zs3zhu1q+kOriacT3eeTiMAcwM6WwpYDYAY5LlJ4pKcjMmDSoG41rK3WzAp0F5JvZSjMrMLPFZlYQdlGS3L6SujlnddjlZLTo8oWdew9w/0gtX0gH8TTieWb2v0A9M7sWeA34Qzyf3Mz6Bz/wC81sXCmPVzOzGcHj75hZ65jHxgfHV5pZvxLPyzazhWb2XDx1ZBoNcEi6qFuzKlOGRVI373pBqZsVoD/QAbiAL68P1/pCOaqLejRjyCkteHBeIQvWKXUzLE+8u4E5K7Ywrn9nOjbRxQnpIJ6tKVOAmUSS2DoBt7n7A0d7npllAw8BA4AuwOWlvCV6NbDN3dsDU4FfB8/tAowEuhL5i+Ph4PNF/RzQ38pHoAEOSSfR1M2/vr2OeSuUunk8YlcWan2hHKs7BnalWd0ajMlT6mYYPvxkN3c+t4yz2jfiB0rPTBtxbU1x91fd/SZ3v9HdX43zc/cBCt19jbvvA6YDg0qcMwj4S3B/JnC+mVlwfLq773X3D4HC4PNhZi2Bi4A/xllHRjk8wHG2BjgkfURTN2+aWcCnu/aGXY5IRqpTvSpTR+QqdTME+w8eYtSMfHKqZGn5Qpo5YiNuZjvN7LNSbjvN7LM4PncLYEPMx0V8fe3h4XPc/QCwA2h4lOdOA8YCmhgp4SsDHErPlDRSvWo200bm8tnn+xk/a7F2GouEpE+bBvzo3Ejq5stLPw67nIzx4NxCFm3YzuTB3What3rY5UgFOmIj7u613b1OKbfa7l4njs9d2j/XSv7teaRzSj1uZhcDW9x9wVG/uNl1ZjbfzOYXFxcfvdoUpwEOSXcnN6vDjf068sqyzTw5X6mbImEZ/Z2OdG1eh/GzFit1sxK8v34bD84rZIjSM9NSXJemlFMR0Crm45bApiOdY2ZVgLrA1jKe2xcYaGZriVzq8m0zK3Wnubs/EuzL7d24cePj/26SXHSA42YNcEgau+astpzRtiF3PLuUdZ/uDrsckYyUUyWLaSNy2a3UzYSLXb5wh5YvpKVENuLvAR3MrI2Z5RAZvpxd4pzZwBXB/aHA3GBV4mxgZLBVpQ2RKf933X28u7d099bB55vr7t9L4PeQEqIDHH3bN+RKDXBIGsvKMu4d3pPsLGP0DKVuioSlQ5PajAtSNx9X6mbCTHp+Geu37uE+LV9IWwlrxINrvq8HXiay4STP3Zea2UQzGxic9ijQ0MwKgTHAuOC5S4E8YBnwEvBTd9cS4VJogEMyTfN6NZh0aTfeX7+d372u1M3KEMcq2m+Y2bxgrWyBmV0YHK9qZn8J9pUvN7PxX//skqq+TN1cxgdK3axwry7bzBPvbuCH57TjNC1fSFuJfEUcd3/B3Tu6ezt3nxwcu83dZwf3v3D3Ye7e3t37uPuamOdODp7Xyd1fLOVzv+7uFyey/lQQO8Ch9EzJFINyI0FV989ZzaINSt1MpDhX0f6CyIstvYi8W/lwcHwYUM3duwOnAj+MzYuQ1JaVZUwZ1pPqVbOVulnBinfuZdxTBXRRembaS2gjLom1MBjgGKwBDslA0dTN0TPy2bNPO40TKJ5VtA5Eh/jr8uU8kAMnBDNANYB9QDxbtyRFNKkTSd0sUOpmhXF3bg6WL0wbmUtOFbVq6Uz/dVOU0jMl09WtWZV7h/VkzSdK3UyweFbR3gF8z8yKgBeAnwXHZwK7gY+A9cAUd9+a0Gql0l3YvRmXndIySN3Uf97j9fd31zNX6ZkZQ414ipr0/DLWaYBDMtyZ7RtxzVltePzt9UrdTJx4VtFeDvzZ3VsCFwJ/NbMsIq+mHwSaA22AG8ysbalfJMNWzqabOwZ2oXm9GoyesYhdSt0stzXFu5j03HLO7qD0zEyhRjwFRQc4rjunrQY4JOPd2K8TnZsqdTOB4llFezWRAXvc/S2gOtAI+H/AS+6+3923AP8Gepf2RTJt5Wy6qV29KvcNz2XDtj3c+axSN8tj/8FDjM5bRE6VLO4ZquULmUKNeIqJDnCcrAEOEeCrqZvjlLqZCPGsol0PnA9gZicTacSLg+PftogTgNOBFZVWuVSqaOrmjPlK3SyPB4LlC3cN7q70zAyiRjyFKD1TpHSdm9bhpn6deHXZZvLmbzj6EyRuca6ivQG41swWAU8APwgyIR4CagFLiDT0/+fuBZX+TUilUepm+by/fhsPzStkyCktuKhHs7DLkUqkRjyF/P3d9czRAIdIqa4+qw1ntG3IhGeXKXWzgsWxinaZu/d1957unuvurwTHdwUraru6exd3vyfM70MSL6dKFvePjKRujlXqZly+kp45UMsXMo0a8RQRHeA4q70GOERKE5u6OUqpmyKhaX9ibcYP6MzrSt2My53PRdIzp47I1fKFDKRGPAXEDnAoPVPkyKKpmwvXb+dhpW6KhOb7Z7TmnI6Nlbp5FK8u28z09yLpmX3aNAi7HAmBGvEUoAEOkfgNym3BQKVuioQqK8u4Z2gPpW6WQemZAmrEk97hAY5eGuAQidedg7rRRKmbIqFqUqc6dwepm79V6uZXRNMzdwXLF5Sembn0Xz6JfWWAQ+mZInGrW7MqU4b35MNPdzP5eaVuioRlQJC6+ZBSN7/ib+8E6ZkDOtNByxcymhrxJDbp+cgAh9IzRY7dme0iqZuRv/A2h12OSMZS6uZXrSnexeTnI+mZV5zROuxyJGRqxJNUND3zh+e0U3qmSDlFUzfHzizgE6VuioSidvWqTB2RS9G2PUx8dmnY5YRq/8FDjJ6RT7WqWr4gEWrEk5AGOEQqRrUq0dTNA4x7SqmbImH5ZutI6mbe/CJeWpK5qZsPzFnNoqId3DW4O03qaPmCqBFPOhrgEKlYnZvWYWz/Try2fDMz3lPqpkhYRn2nI91a1GH8rAK2fJZ5qZsL1m3jwSA988LuWr4gEerykowGOEQq3lV923Bmu4ZMfG4Zaz9R6qZIGHKqZDFtRC579h1k7FOZlbq5e+8BxuTl07xeDSYoPVNiqBFPIhrgEEmMrCxjyrCeVMkyRucpdVMkLO1PrM0tF54cSd18e13Y5VSaaHrmfcNzqa3lCxJDjXiSiA5w5FTJ4p6hGuAQqWjN69Vg0uDuLFy/nYfmKXVTJCzfP+MkzunYmEnPL6dwS/qnbr689GOmv7eBH52r9Ez5OjXiSeKBuYUsKtrB3UOUnimSKAN7NmdQbnN+O3c1+UrdFAmFWSR1s2ZOJHVz34H0fYdqy84vGD9rMV2b12H0d7R8Qb5OjXgSWLBuGw/OXa0BDpFKMFGpmyKha1KnOncP6c7ijembuunu3DyzgN1aviBl0J+KkEUHOJrVrcEdGuAQSbi6NSKpm2s/3c0kpW6KhKZ/t2YMPbUlD79eyPy16Ze6+fg765m3spjxAzrT/kQtX5DSqREPWXSAY+qIXKVnilSSM9s14tqz2/L3d9YzZ7lSN0XCcvslQepmXj47v9gfdjkV5oPiXUx+fhlnd2jE97V8QcqgRjxEGuAQCc8NF3Skc9Pa3PyUUjdFwhJN3dy47XMmPrss7HIqRHT5QvWq2UrPlKNSIx4SDXCIhOtw6uYXSt0UCdM3Wzfgx+e148kFRby05KOwyzluD8xZTUHRDu5WeqbEQY14CGIHOKaN0ACHSFg6N63D2H6R1M3pSt0UCc3Pz4+mbi5O6dTNBeu28uC8Qi47pSUDtHxB4qAOMAR/ixngUHqmSLiu6tuGvu0bcqdSN0VCE0nd7MXn+w9y08zUTN3ctfcAo2csonm9GtwxsEvY5UiKUCNeyT4o3sUkDXCIJI3Y1M1RM5S6KRKW9ifW4pYLT+aNVcX8NQVTN+98dhlF2yLLF5SeKfFSI16JNMAhkpya1a3B5MHdyd+wnQfnFYZdjkjG+u/TT+Lcjo2Z/PxyCrfsDLucuL289GNmzI8sX/hmay1fkPipEa9E0QGOuzTAIZJ0LunZnEtzm/PA3EIWrt8WdjkiGSk2dXNUiqRuRpcvdGtRh1FaviDHSI14JVmwbtvhAQ6lZ4okpwlB6uaYvEVK3RQJyYlB6uaSjZ9x/5xVYZdTJndnrJYvyHHQn5hKEBngyNcAh0iSq1ujKvcOz1XqpkjI+ndrxrBTW/K71z/gvSRO3Xz8nfW8vrKYWy48WemZUi5qxCvBnc8uY8O2Pdw3XAMcIsnujHYNuS5I3XxtmVI3RcJy+8CutKhfg9EzkjN1M5qeeU7Hxnz/jJPCLkdSlBrxBIsOcPxY6ZkiKWPMBR05uVkdxs1S6qZIWGpVq8LU4bls2v45E5IsdTO6fKFG1WzuGdoDMy1fkPJRI55AGuAQSU3VqmQzbUQ0dTM1dxqLpIPerRvwk/PaMzPJUjd/G03PHKLlC3J8EtqIm1l/M1tpZoVmNq6Ux6uZ2Yzg8XfMrHXMY+OD4yvNrF9wrJWZzTOz5Wa21Mx+nsj6j4cGOERSW6emtbm5f2deW75FqZsiIfr5dzrQvUVdxs1azOYkSN1csG4rD80rZOipLenfTcsX5PgkrDs0s2zgIWAA0AW43MxKTipeDWxz9/bAVODXwXO7ACOBrkB/4OHg8x0AbnD3k4HTgZ+W8jmTQnSAY/yAzhrgEElRV57Zmr7tGzLx2WV8qNRNkVBUzc5i6ohcvkiC1M3Y9MzbL0nK9kNSTCJfpu0DFLr7GnffB0wHBpU4ZxDwl+D+TOB8i1xoNQiY7u573f1DoBDo4+4fufv7AO6+E1gOtEjg91AuXx3gaB12OSJSTtHUzarZxugMTt2M493NbwTvVi40swIzuzDmsR5m9lbwLuZiM9P7+HLM2p9Yi1svPJk3VxXz2FvhpW5OfHap0jOlQiWyEW8BxL6fW8TXm+bD57j7AWAH0DCe5waXsfQC3qnAmo9bbHrmPUN7KD1TJMVleupmnO9u/gLIc/deRN7NfDh4bhXgceBH7t4VOA9IvvUXkhK+d/pJnNepMXe9EE7q5ktLPiZvfhE/Pk/pmVJxEtmIl9aBlnw/6UjnlPlcM6sFPAWMcvfPSv3iZteZ2Xwzm19cXBxnycfv8ACH0jNF0sYlPZszuFeLTE3djOfdTQfqBPfrApuC+xcABe6+CMDdP3X3g5VQs6QhM+M3l0VSN38+vXJTN7d89gXjZxXQrUUdfn6+li9IxUlkI14EtIr5uCVf/nD+2jnBKyd1ga1lPdfMqhJpwv/m7rOO9MXd/RF37+3uvRs3bnyc30p8Ygc4Big9UyStTBjUlaZ1qjN6Rj6792ZU6mY8727eAXzPzIqAF4CfBcc7Am5mL5vZ+2Y2NtHFSnqLpG72YOmmz5j2WuWkbro7Y58qYM++g1q+IBUukX+a3gM6mFkbM8sh8nbl7BLnzAauCO4PBeZ6ZApjNjAy2KrSBugAvBtcP/4osNzd70tg7cdMAxwi6a1O9arcO7wn67buybTUzXje3bwc+LO7twQuBP5qZllAFeAs4L+CXweb2fmlfpGQ3sWU1NO/W1OG927J79+onNTNx99ex+sri7n1IqVnSsVLWCMeXPN9PfAykaHKPHdfamYTzWxgcNqjQEMzKwTGAOOC5y4F8oBlwEvAT4O3M/sC/w1828zyg9uFJAENcIikv9PbNuS6c9ryxLsZlboZz7ubVxP5mY27vwVUBxoFz33D3T9x9z1EXi0/pbQvEsa7mJK6brukKy3r10x46mbhll1MfmE553ZszH+frvRMqXgJfX/F3V9w947u3s7dJwfHbnP32cH9L9x9mLu3d/c+7r4m5rmTg+d1cvcXg2P/cndz9x7unhvcXkjk9xCPl5dGBjh+dK4GOETS3ZjvRlI3b36qgOKdGZG6Gc+7m+uB8wHM7GQijXgxkRdiephZzeDyw3OJvMAiclxqVavC1BE92bT9c+6YnZg/UvsOKD1TEk8XOh2nLZ99wbinCpSeKZIhqlXJ5v6Ruezcmxmpm3G+u3kDcK2ZLQKeAH7gEduA+4g08/nA++7+fOV/F5KOTj2pAT/9Vnueer+IFxdXfOrmb+esZvHGSHrmiVq+IAlSJewCUpkGOEQyU8cmkdTNO59bxhPvbuD/nfaNsEtKqOCdxxdKHLst5v4yIpcOlvbcx4msMBSpcP9zfgfeWFXM+KcXc8pJ9StsW9n8tVt5+PVChik9UxJMneNxiA5w3HKhBjhEMs2VZ7bmrPaNuPO5Zawp3hV2OSIZKTZ188YnF3Ho0PG/Q7Xzi/2MzsunRf0a3D6wawVUKXJkasTLKXaA4/tnaIBDJNNEUzdzqmQxOm8R+zM0dVMkbO0a1+LWi7rwz9Wf8Nhba4/78018dhkbt33O1OG51KqmCwcksdSIl4MGOEQEoGnd6kwe3I1FG7bz4NzMS90USRbfO+0bfKtTY+5+cQWrN5c/dfOlJR/x5IIifnJee3pr+YJUAjXi5aABDhGJurhHc4b0asGD8wp5P/NSN0WSgpnx66E9OKFaFUbNKF/qZiQ9czHdW9Tl59/pkIAqRb5OjfgxWrAuMsAxVAMcIhK4I3NTN0WSxom1q3P3kO4s3fQZU48xddPduWlmAZ/vP8jUEblUzVZ7JJVDf9KOwa69Bxg1IxjgUHqmiATqVK/KfcN7sq7D6kEAAAw2SURBVH7rHiY9rzXZImHp17UpI3q34vdvfMC7H8afuvnXt9fxxqpibr3wZNqfWCuBFYp8lRrxYzBh9tLDAxxKzxSRWKcdTt3cwKuZk7opknR+eUkXWgWpm5/FkbpZuGUnk59fznmdGvM9pWdKJVMjHqfoAMePz2unAQ4RKdWY73akS7M6jMuc1E2RpBNJ3czlox2fc8fspWWeu+/AIUbNyKdmTja/uUzLF6TyqRGPw1cGOM5XeqaIlK5alWymBambN2dA6qZIsjr1pPr89FvtmfX+Rl4oI3Xz/jmrWLLxM+4e0kPLFyQUasSPouQAh9IzRaQsHZvUZlz/zsxdsYW/v7s+7HJEMtb/nN+BHi3rcsvTi9n82Rdfe3z+2q387vUPGN67Jf27NQ2hQhE14kcVHeC4RQMcIhKnH5zZmrM7NGLSc8uVuikSkrJSN6PpmS3r1+S2S5SeKeFRI16Gwi27mPx8JD3zvzXAISJxysoy7hkapG7OyFfqpkhIYlM3//LW2sPHJ0TTM0f0VHqmhEqN+BFEBjgWUjNH6Zkicuya1q3OXYO7s6hoBw8odVMkNNHUzV8FqZsvLfmImQuK+Om32nPqSVq+IOFSI34EGuAQkeN1UY9mDOnVgofmFbJgnVI3RcIQm7r5sycWMn7WYnq0rMv/nK/0TAmfGvFSRAc4hp2qAQ4ROT7R1M0xefnsPXAw7HJEMtKJtavzqyHdWfHxTqVnSlLRhVGlyKmSxVkdGnP7QA1wiMjxqVO9KtNG5rJ9z36qVckOuxyRjHVB16ZMHNSVlvVr0K6xli9IclAjXooeLevx2FV9wi5DRNLENxUCJpIUvn9G67BLEPkKvS8jIiIiIhICNeIiIiIiIiFQIy4iIiIiEgI14iIiIiIiIVAjLiIiIiISAjXiIiIiIiIhUCMuIiIiIhICNeIiIiIiIiEwdw+7hoQzs2Jg3TE+rRHwSQLKKa9kqke1HFky1ZNMtUBy1ZNKtZzk7o0rq5hkoJ/ZFS6ZaoHkqke1HFky1ZNMtUDZ9RzTz+yMaMTLw8zmu3vvsOuISqZ6VMuRJVM9yVQLJFc9qiX9JNvvYzLVk0y1QHLVo1qOLJnqSaZaoGLr0aUpIiIiIiIhUCMuIiIiIhICNeJH9kjYBZSQTPWoliNLpnqSqRZIrnpUS/pJtt/HZKonmWqB5KpHtRxZMtWTTLVABdaja8RFREREREKgV8RFREREREKgRrwUZtbfzFaaWaGZjauEr9fKzOaZ2XIzW2pmPw+ONzCzV81sdfBr/eC4mdlvg/oKzOyUBNSUbWYLzey54OM2ZvZOUMsMM8sJjlcLPi4MHm+dgFrqmdlMM1sR/B6dEdbvjZmNDv4bLTGzJ8ysemX+3pjZn8xsi5ktiTl2zL8XZnZFcP5qM7uiAmu5J/jvVGBmT5tZvZjHxge1rDSzfjHHK+T/t9LqiXnsRjNzM2sUfFzpvzfB8Z8F3+tSM/tNzPGE/t6ku8r+fTL9zD5aLfqZ/eXX18/sY6gn5rHM+Znt7rrF3IBs4AOgLZADLAK6JPhrNgNOCe7XBlYBXYDfAOOC4+OAXwf3LwReBAw4HXgnATWNAf4OPBd8nAeMDO7/HvhxcP8nwO+D+yP5/+3dfawUVxnH8e8v3PJSqHAroihNLhiwURPAiAH7EqyI1hBsmya1krRajS+JmjbRWiQx8T9MG1P/MFpTo0av1QpIG9MUY61tUiMgCBfEokSIvW1paarUlmiAPv5xzt477N0LLOzO1NnfJ5ns7JnZnWcfZp57mDOzCz/vQiw/Aj6V5ycCM6rIDfAW4CAwpZCTj5eZG+BK4F3A3kJbW7kALgb+nh/783x/h2JZCfTl+W8UYnl7PpYmAXPzMTahk8dbq3hy+yXAFtL3Us+sMDfvA34DTMrPZ5WVmzpPVeQJ1+wzxeKaPRqDa3Yb8eT2nqrZHT346jABy4AthedrgbUlx/AA8AFgPzA7t80G9uf5e4AbC+uPrNeh7c8BHgGuAn6Vd/wXCgfrSI7ywbIsz/fl9dTBWF5HKqRqai89N6Si/lQ+4Ptybj5Ydm6AgaZi0VYugBuBewrtp6x3PrE0LbsWGMzzpxxHjdx0+nhrFQ+wAVgIHGK0qJeeG9If/xUt1islN3WdXgt5wjW7GItr9tg4mmuBa/Zp4qHHarYvTRmrceA2DOe2UuShsMXAVuCNEfEsQH6cVVKMdwO3A6/m568H/hURJ1psbySWvPxoXr9T5gFHgB/kYdd7JU2lgtxExNPAXcA/gGdJn3UH1eWmod1clLWP30I6g1FZLJJWA09HxO6mRVXEswC4Ig95PyZpSYWx1Ilrtmt2S67ZbXPNPlUpNdsd8bHUoi1K2bA0DdgI3BoRL51u1RZtHYlR0irg+YjYcZbb63a++kjDRd+JiMXAK6ShvPF0Mzf9wEdIQ1FvBqYCV59me5XtS2fYftfjkrQOOAEMVhWLpAuBdcDXWi0uOx7SvtxPGlb9MnC/JFUUS524Zrtmt35j1+yz37Brdiul1Gx3xMcaJl2f1DAHeKbbG5V0AamgD0bEptz8nKTZefls4PkSYrwMWC3pEPAz0lDn3cAMSX0ttjcSS14+HXixQ7E03n84Irbm5xtIRb6K3KwADkbEkYg4DmwC3kt1uWloNxdd3cfzzTKrgDWRx+cqiuWtpD/Au/P+PAfYKelNFcUzDGyKZBvp7OXMimKpE9ds1+zxuGafBdfscZVSs90RH2s7MF/pruqJpBs2HuzmBvP/sL4P/CUivllY9CBwc56/mXQdYqP9pnwX8VLgaGOY63xFxNqImBMRA6TP/tuIWAM8Clw/TiyNGK/P63fsf+oRcRh4StLbctP7gX1UkBvS8OZSSRfmf7NGLJXkpqDdXGwBVkrqz2eMVua28ybpQ8BXgNURcawpxo8qfSvBXGA+sI0uHm8RsSciZkXEQN6fh0k32B2mgtwAm0mdJCQtIN3M8wIV5KZmXLNds8fjmn0GrtmnVU7NPpcL2us+ke7O/Svp7td1JWzvctLwxRCwK08fJl2b9gjwt/x4cV5fwLdzfHuAd3cpruWM3oE/L+9oB4BfMHoX8eT8/EBePq8LcSwC/pjzs5k0VFRJboCvA08Ce4Efk+6aLi03wH2kax2Pk4rUJ88lF6RrAQ/k6RMdjOUA6Rq5xn783cL663Is+4GrO328tYqnafkhRm/8qSI3E4Gf5H1nJ3BVWbmp+1R2nnDNPlMcrtmj23fNbiOepuWH6IGa7V/WNDMzMzOrgC9NMTMzMzOrgDviZmZmZmYVcEfczMzMzKwC7oibmZmZmVXAHXEzMzMzswq4I249QdLv8+OApI91+L2/2mpbZmZ2blyzrVf46wutp0haDnwpIla18ZoJEXHyNMtfjohpnYjPzMxGuWZb3fmMuPUESS/n2fXAFZJ2SbpN0gRJd0raLmlI0mfy+sslPSrpp6QfD0DSZkk7JP1Z0qdz23pgSn6/weK28i+A3Slpr6Q9km4ovPfvJG2Q9KSkwfyrb0haL2lfjuWuMnNkZvZa4ZptvaKv6gDMSnYHhbMruTgfjYglkiYBT0j6dV73PcA7I+Jgfn5LRLwoaQqwXdLGiLhD0ucjYlGLbV1H+oW5hcDM/JrH87LFwDuAZ4AngMsk7QOuBS6NiJA0o+Of3szs/4trttWaz4hbr1sJ3CRpF7CV9NPD8/OybYWCDvBFSbuBPwCXFNYbz+XAfRFxMiKeAx4DlhTeezgiXiX9rPAA8BLwH+BeSdcBx87705mZ1YtrttWKO+LW6wR8ISIW5WluRDTOrrwyslK6TnEFsCwiFgJ/AiafxXuP57+F+ZNAX0ScIJ3R2QhcAzzc1icxM6s/12yrFXfErdf8G7io8HwL8DlJFwBIWiBpaovXTQf+GRHHJF0KLC0sO954fZPHgRvyNY1vAK4Eto0XmKRpwPSIeAi4lTREambWy1yzrdZ8jbj1miHgRB6u/CHwLdIQ4858880R0pmNZg8Dn5U0BOwnDXU2fA8YkrQzItYU2n8JLAN2AwHcHhGH8x+FVi4CHpA0mXRm5rZz+4hmZrXhmm215q8vNDMzMzOrgC9NMTMzMzOrgDviZmZmZmYVcEfczMzMzKwC7oibmZmZmVXAHXEzMzMzswq4I25mZmZmVgF3xM3MzMzMKuCOuJmZmZlZBf4HGjnDN7ZOp1oAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 864x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "learn.sched.plot_lr()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "947a5de65c32436ca75b8abd86eb83bf",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>HBox</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=10), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch      trn_loss   val_loss   accuracy                                                                              \n",
+      "    0      1.184064   1.160499   0.589992  \n",
+      "    1      1.225595   1.173991   0.581586                                                                              \n",
+      "    2      1.213392   1.152305   0.594541                                                                              \n",
+      "    3      1.143425   1.096187   0.61788                                                                               \n",
+      " 37%|█████████████████████████▏                                           | 143/391 [00:07<00:12, 20.40it/s, loss=1.11]"
+     ]
+    },
+    {
+     "ename": "KeyboardInterrupt",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-19-e783b2ab0511>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mlearn\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mfit\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;36m1e-2\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;36m1\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mcycle_len\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;36m10\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0muse_clr1\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;36m10\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;36m2\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;36m100\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;36m0.95\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;36m0.85\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mwds\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;36m3e-3\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;32mD:\\Work\\Deeplearning\\Notebooks\\fastai\\learner.py\u001b[0m in \u001b[0;36mfit\u001b[1;34m(self, lrs, n_cycle, wds, **kwargs)\u001b[0m\n\u001b[0;32m    231\u001b[0m         \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0msched\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;32mNone\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    232\u001b[0m         \u001b[0mlayer_opt\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mget_layer_opt\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mlrs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mwds\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 233\u001b[1;33m         \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mfit_gen\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mmodel\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mlayer_opt\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mn_cycle\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    234\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    235\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0mwarm_up\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mlr\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mwds\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;32mNone\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mD:\\Work\\Deeplearning\\Notebooks\\fastai\\learner.py\u001b[0m in \u001b[0;36mfit_gen\u001b[1;34m(self, model, data, layer_opt, n_cycle, cycle_len, cycle_mult, cycle_save_name, best_save_name, use_clr, use_clr1, metrics, callbacks, use_wd_sched, norm_wds, wds_sched_mult, **kwargs)\u001b[0m\n\u001b[0;32m    178\u001b[0m         \u001b[0mn_epoch\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0msum_geom\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mcycle_len\u001b[0m \u001b[1;32mif\u001b[0m \u001b[0mcycle_len\u001b[0m \u001b[1;32melse\u001b[0m \u001b[1;36m1\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mcycle_mult\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mn_cycle\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    179\u001b[0m         return fit(model, data, n_epoch, layer_opt.opt, self.crit,\n\u001b[1;32m--> 180\u001b[1;33m             metrics=metrics, callbacks=callbacks, reg_fn=self.reg_fn, clip=self.clip, **kwargs)\n\u001b[0m\u001b[0;32m    181\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    182\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0mget_layer_groups\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mmodels\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mget_layer_groups\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mD:\\Work\\Deeplearning\\Notebooks\\fastai\\model.py\u001b[0m in \u001b[0;36mfit\u001b[1;34m(model, data, epochs, opt, crit, metrics, callbacks, stepper, **kwargs)\u001b[0m\n\u001b[0;32m     97\u001b[0m             \u001b[0mavg_loss\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mavg_loss\u001b[0m \u001b[1;33m*\u001b[0m \u001b[0mavg_mom\u001b[0m \u001b[1;33m+\u001b[0m \u001b[0mloss\u001b[0m \u001b[1;33m*\u001b[0m \u001b[1;33m(\u001b[0m\u001b[1;36m1\u001b[0m\u001b[1;33m-\u001b[0m\u001b[0mavg_mom\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     98\u001b[0m             \u001b[0mdebias_loss\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mavg_loss\u001b[0m \u001b[1;33m/\u001b[0m \u001b[1;33m(\u001b[0m\u001b[1;36m1\u001b[0m \u001b[1;33m-\u001b[0m \u001b[0mavg_mom\u001b[0m\u001b[1;33m**\u001b[0m\u001b[0mbatch_num\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 99\u001b[1;33m             \u001b[0mt\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mset_postfix\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mloss\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mdebias_loss\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    100\u001b[0m             \u001b[0mstop\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;32mFalse\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    101\u001b[0m             \u001b[1;32mfor\u001b[0m \u001b[0mcb\u001b[0m \u001b[1;32min\u001b[0m \u001b[0mcallbacks\u001b[0m\u001b[1;33m:\u001b[0m \u001b[0mstop\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mstop\u001b[0m \u001b[1;32mor\u001b[0m \u001b[0mcb\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mon_batch_end\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mdebias_loss\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m~\\Anaconda3\\envs\\fastai\\lib\\site-packages\\tqdm\\_tqdm.py\u001b[0m in \u001b[0;36mset_postfix\u001b[1;34m(self, ordered_dict, refresh, **kwargs)\u001b[0m\n\u001b[0;32m   1206\u001b[0m                                  for key in postfix.keys())\n\u001b[0;32m   1207\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[0mrefresh\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 1208\u001b[1;33m             \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mrefresh\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   1209\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1210\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0mset_postfix_str\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0ms\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;34m''\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mrefresh\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;32mTrue\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m~\\Anaconda3\\envs\\fastai\\lib\\site-packages\\tqdm\\_tqdm.py\u001b[0m in \u001b[0;36mrefresh\u001b[1;34m(self, nolock)\u001b[0m\n\u001b[0;32m   1245\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[1;32mnot\u001b[0m \u001b[0mnolock\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1246\u001b[0m             \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_lock\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0macquire\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 1247\u001b[1;33m         \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mmoveto\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpos\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   1248\u001b[0m         \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0msp\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m__repr__\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1249\u001b[0m         \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mmoveto\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m-\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpos\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m~\\Anaconda3\\envs\\fastai\\lib\\site-packages\\tqdm\\_tqdm.py\u001b[0m in \u001b[0;36mmoveto\u001b[1;34m(self, n)\u001b[0m\n\u001b[0;32m   1218\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0mmoveto\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mn\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1219\u001b[0m         \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mfp\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mwrite\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0m_unicode\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'\\n'\u001b[0m \u001b[1;33m*\u001b[0m \u001b[0mn\u001b[0m \u001b[1;33m+\u001b[0m \u001b[0m_term_move_up\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;33m*\u001b[0m \u001b[1;33m-\u001b[0m\u001b[0mn\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 1220\u001b[1;33m         \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mfp\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mflush\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   1221\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1222\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0mclear\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mnolock\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;32mFalse\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m~\\Anaconda3\\envs\\fastai\\lib\\site-packages\\ipykernel\\iostream.py\u001b[0m in \u001b[0;36mflush\u001b[1;34m(self)\u001b[0m\n\u001b[0;32m    332\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpub_thread\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mthread\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mis_alive\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    333\u001b[0m             \u001b[1;31m# request flush on the background thread\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 334\u001b[1;33m             \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpub_thread\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mschedule\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_flush\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    335\u001b[0m             \u001b[1;31m# wait for flush to actually get through, if we can.\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    336\u001b[0m             \u001b[1;31m# waiting across threads during import can cause deadlocks\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m~\\Anaconda3\\envs\\fastai\\lib\\site-packages\\ipykernel\\iostream.py\u001b[0m in \u001b[0;36mschedule\u001b[1;34m(self, f)\u001b[0m\n\u001b[0;32m    201\u001b[0m             \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_events\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mappend\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mf\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    202\u001b[0m             \u001b[1;31m# wake event thread (message content is ignored)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 203\u001b[1;33m             \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_event_pipe\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0msend\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34mb''\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    204\u001b[0m         \u001b[1;32melse\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    205\u001b[0m             \u001b[0mf\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m~\\Anaconda3\\envs\\fastai\\lib\\site-packages\\zmq\\sugar\\socket.py\u001b[0m in \u001b[0;36msend\u001b[1;34m(self, data, flags, copy, track, routing_id, group)\u001b[0m\n\u001b[0;32m    389\u001b[0m                                  copy_threshold=self.copy_threshold)\n\u001b[0;32m    390\u001b[0m             \u001b[0mdata\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mgroup\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mgroup\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 391\u001b[1;33m         \u001b[1;32mreturn\u001b[0m \u001b[0msuper\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mSocket\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0msend\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mdata\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mflags\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mflags\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mcopy\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mcopy\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mtrack\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mtrack\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    392\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    393\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0msend_multipart\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mmsg_parts\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mflags\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;36m0\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mcopy\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;32mTrue\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mtrack\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;32mFalse\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mzmq/backend/cython/socket.pyx\u001b[0m in \u001b[0;36mzmq.backend.cython.socket.Socket.send\u001b[1;34m()\u001b[0m\n",
+      "\u001b[1;32mzmq/backend/cython/socket.pyx\u001b[0m in \u001b[0;36mzmq.backend.cython.socket.Socket.send\u001b[1;34m()\u001b[0m\n",
+      "\u001b[1;32mzmq/backend/cython/socket.pyx\u001b[0m in \u001b[0;36mzmq.backend.cython.socket._send_copy\u001b[1;34m()\u001b[0m\n",
+      "\u001b[1;32m~\\Anaconda3\\envs\\fastai\\lib\\site-packages\\zmq\\backend\\cython\\checkrc.pxd\u001b[0m in \u001b[0;36mzmq.backend.cython.checkrc._check_rc\u001b[1;34m()\u001b[0m\n",
+      "\u001b[1;31mKeyboardInterrupt\u001b[0m: "
+     ]
+    }
+   ],
+   "source": [
+    "learn.fit(1e-2, 1, cycle_len=10, use_clr1=(10,2,100,0.95,0.85), wds=3e-3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAuMAAAEKCAYAAAC43ltzAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzs3Xl4VOX5//H3nT2EEJawr4GwZcMFcV9RRJAt0W/111prtfqtdrUqQdlkEXCp9lu1rWtrN2sJCAiIiqjUHbdsEAhhC2vYEiB7cv/+yNCmGMiwTJ6Z5H5d17mYOXPOmc8Ak7kz5znPLaqKMcYYY4wxpukFuQ5gjDHGGGNMS2XFuDHGGGOMMY5YMW6MMcYYY4wjVowbY4wxxhjjiBXjxhhjjDHGOGLFuDHGGGOMMY5YMW6MMcYYY4wjVowbY4wxxhjjiBXjxhhjjDHGOBLiOkBTiI2N1T59+riOYYwxJ+2LL77Yq6odXedoSvYz2xgTqE7lZ3aLKMb79OnDmjVrXMcwxpiTJiJbXGdoavYz2xgTqE7lZ7YNUzHGGGOMMcYRK8aNMcYYY4xxxIpxY4wxxhhjHLFi3BhjjDHGGEesGDfGGGOMMcYRnxbjIjJSRPJEJF9E0ht4PFxE/uF5/FMR6eNZ30FEVonIYRF5+ph9zhWRLM8+/yci4svXYIwxxhhjjK/4rBgXkWDgGeA6IAG4WUQSjtnsduCAqsYDTwLzPOvLgSnAfQ0c+nfAnUB/zzLyzKc3xhhjjDHG93w5z/gwIF9VCwBE5FVgHJBbb5txwHTP7fnA0yIiqnoE+JeIxNc/oIh0Bdqo6see+68A44HlPnwdpgXZfrCMb7YdZFRyV9dRjDEnYVXeHi6I60BkWLDrKMaYJrCx6DCLvt4Bqj57jrsu70dUuO9b8vjyGboD2+rdLwTOP942qlotIsVAB2DvCY5ZeMwxuze0oYjcSd036PTq1etks5sWqLqmljtfWUPOjhJe+P5Qrk7o7DqSMcYLebsOcdvLn3PX5X2ZdN1g13GMMT5WWlnNrS99RuGBMnw5WPmWC/sEfDHe0F/Psb++eLPNKW2vqs8BzwEMHTrUd782mWbj+dWbyNlRQmzrMCa/ns2wvu1pExHqOpYxphEDu0Rz03k9eWH1JsakdCOpe4zrSMYYH/r1W+spPFDGa3ddyLC49q7jnDZfXsBZCPSsd78HsON424hICBAD7G/kmD0aOaYxJ62g6DBPvbOekYldePHW89hzqJx5y9e5jmWM8dKkUYNpHxXGA/MzqaqpdR3HGOMj32w7yEsfbuK75/dqFoU4+LYY/xzoLyJxIhIG3AQsPmabxcCtnts3AO+qHn/wj6ruBA6JyAWeWVS+Dyw689FNS1Jbq6QvyCI8JIgZ4xIZ0rMtP7w4jr9+upVPCva5jmeM8UJMZCgzxyWSu7OEF/+1yXUcY4wPVNXUMjEjk47R4Uy8bpDrOGeMz4pxVa0GfgKsANYCr6lqjojMEJGxns1eBDqISD5wL/Dv6Q9FZDPwa+AHIlJYbyaWHwMvAPnARuziTXOa/v75Vj7btJ/JoxPo1CYCgHtHDKBX+1ZMWpBFeVWN44TGGG+MTOrKtYmdefLt9Wzee8R1HGPMGfbcBwWs23WIWeOTm9UwUp/OM66qy1R1gKr2U9XZnnVTVXWx53a5qt6oqvGqOuzozCuex/qoantVba2qPVQ117N+jaomeY75kxN9k25MY3YWlzF32Touju/AjUP/MwKqVVgIc1KT2bT3CL9ZucFhQmPMyZgxLomwkCAmLcjCPh6MaT42Fh3mNys3MDq5K9c0swkWrAOnabFUlSmvZ1NVW8ucCSkc2z/q4vhY/mdoD577oIDs7cWOUhpjTkbnNhE8OGowHxfs47U12xrfwRjj92prlUkZWUSEBDFt7LEtawKfFeOmxXojcyfvrN3DfSMG0qtDqwa3eWhUAu2jwpiYkUm1XRRmTED4ztCenB/XntlL17KnpNx1HGPMafr751v5bLNnOGl0hOs4Z5wV46ZFOnCkkumLcxjSI4bbLo477nYxreouCsvZUcLzq+2iMGMCQVCQMCc1mfLqWqYvyXEdxxhzGnYVlzN32Tou6vffw0mbEyvGTYs0841cisuqmJuWQnDQiTsGjEzqysjELjz5znoKig43UUJjzOno27E1v7i6P8uydrEiZ5frOMaYU6CqTFmUTWVNLXNSk781nLS5sGLctDjv5e1hwVfbufuKfgzu2sarfWaMSyQiJIj0BVnU1tpFYcYEgh9d2pfBXdsw5fVsisuqXMcxxpyk5dm7eDt3N/deM4DeHaJcx/EZK8ZNi3K4opqHFmYT36k191wV7/V+ndpEMHl0Ap9t2s/fP9/qw4TGmDMlNDiIeWnJ7D1cwbw3rYmXMYGkuLSKqYtySOrehtsvOf5w0ubAinHTojy+Io8dxWXMS0smPCT4pPa9cWgPLo7vwJxl69hZXOajhMaYMymlR1tuvySOv326lU+tiZcxAeORZWs5UFrJ3NQUQoKbd7navF+dMfV8sWU/f/p4M7de2Idze598C10RYc6EFKpra5m8MNvmMDYmQNx7zUBr4mVMAPkofy//WLONH13al6TuMa7j+JwV46ZFqKiuYWJGFt1iIrn/2oGnfJxeHVpx34iBrFy3hyWZO89gQmOMr0SGBfPIhGQK9h7ht+9aEy9j/FlZZQ2TFmbRu0MrfnF1f9dxmoQV46ZFeObdfPL3HGb2hCSiwkNO61i3XRzHkB4xPLw4hwNHKs9QQmOML13SP5Ybzu3BH94vIHdHies4xpjjeGrlerbsK2VOajIRoSc3nDRQWTFumr21O0t49r2NpJ7dnSsGdjrt4wUHCfNuSKG4rIqZb+SegYTG+DcRGSkieSKSLyLpDTzeW0RWikimiLwnIj2OebyNiGwXkaebLvW3TR49mLatQklfkEmNzYpkjN/J3l7MC6s3cdN5PbmoX6zrOE3GinHTrNXUKukZmcREhjLl+jPXQndQlzbcfUU/Fny1nffy9pyx4xrjb0QkGHgGuA5IAG4WkWPfTI8Dr6hqCjADmHPM4zOB932dtTFtW4UxfWwimYXFvPyhNfEyxp9U19QyMSOT9lFhTLpusOs4TcqKcdOsvfzhJr4pLGba2ETaRYWd0WPfc1U88Z1a89DCbA5XVJ/RYxvjR4YB+apaoKqVwKvAuGO2SQBWem6vqv+4iJwLdAbeaoKsjRqd3JWrB3fi8bfy2Lqv1HUcY4zHC//aRM6OEmaMTSSmVajrOE3KinHTbG3dV8rjb+Vx9eBOjEnpesaPHx4SzLy0ZHYUl/H4irwzfnxj/ER3YFu9+4WedfV9A6R5bk8AokWkg4gEAU8A9/s8pZdEhJnjkwgJCuKh17NsViRj/MDmvUd48u31jEjozMikLq7jNDkrxk2zpKqkL8gkJCiImeOTfNZC99ze7bn1wj786ePNfLFlv0+ewxjHGnrzHFvB3gdcLiJfAZcD24Fq4G5gmapuoxEicqeIrBGRNUVFRaeb+YS6xkQyceRAVm/Yy4Ivt/v0uYwxJ6aqTFqQRViwbz+v/ZkV46ZZ+ueaQj7auI9JowbRNSbSp891/7UD6RYTycSMLCqqbQ5j0+wUAj3r3e8B7Ki/garuUNVUVT0beMizrhi4EPiJiGymblz590VkbkNPoqrPqepQVR3asWNHH7yM//bd83sztHc7Zi7NZe/hCp8/nzGmYf9cU8jHBfuYNGowndtEuI7jhBXjptnZU1LOrKW5DItrz83n9fL580WFhzB7QhL5ew7zzLv5Pn8+Y5rY50B/EYkTkTDgJmBx/Q1EJNYzJAVgEvASgKp+V1V7qWof6r49f0VVvzUbiwtBQcLctGRKK2p4eInNimSMC/U/r286r2fjOzRTVoybZmfqohzKq2uZm5pMUFDTnO66YmAnUs/uzrPvbWTtTpvD2DQfqloN/ARYAawFXlPVHBGZISJjPZtdAeSJyHrqLtac7STsSYrvFM1PropnyTc7WLl2t+s4xrQ405c0/ee1P7Ji3DQrb2bv5M2cXfzy6gH07di6SZ97yvUJxESGkp5hcxib5kVVl6nqAFXtp6qzPeumqupiz+35qtrfs80dqvqtcR+q+kdV/UlTZ2/M/17ej4Gdo5n8ejaHyqtcxzGmxViRs4tlWbv4+fD+Tf557W+sGDfNRnFpFVMW5ZDYrQ0/ujSuyZ+/XVTdHMbf2BzGxgSMsJAg5qYls6uknMdsViRjmkRJeRVTF2UzqEs0d17W13Uc56wYN83G7GW57D9Syby0FEKC3fzXvj7lP3MYb9l3xEkGY8zJObtXO35wUR/+/MkW1my2WZGM8bW5y9dRdKiCR29IIdTR57U/sb8B0yx8mL+X19YUcudlfUnqHuMsR/05jCctsDmMjQkU942omxUpfYHNimSML31asI+/fbqV2y+JI6VHW9dx/IIV4ybglVZWk74gk7jYKH4+vL/rOHSNiWTSqEF8tHEf/1xT6DqOMcYL/zUr0qqNruMY0yyVV9UwaUEWPdtH8strBriO4zesGDcB79dvrWfb/jLmpiYTERrsOg4AN5/Xi2Fx7Zm5NJc9JeWu4xhjvHDFwE5MOLs7v3svn7xdh1zHMabZefrdfAr2HuGRCcm0CgtxHcdvWDFuAtrX2w7y0oeb+O75vTi/bwfXcf4tKEiYm5pMZXUtUxfluI5jjPHSlOsTiI4IZaLNimTMGbV2Zwm/f38jaef04NL+vm/sFUisGDcBq7K6lonzM+kUHUH6dYNcx/mWvh1b84urB/Bmzi6WZ+10HccY44X2UWFMvT6Br7cd5M8fb3Ydx5hmoaZWmZiRSdtWoUwePdh1HL9jxbgJWL9/fyN5uw8xa3wS0RGhruM06EeXxpHYrQ1TF+dQXGpzGBsTCMad1Y0rBnbk0RV5FB4odR3HmID38oebyCwsZtqYRNpFhbmO43esGDcBacPuQzz9bj5jhnTj6oTOruMcV0hwEPPSUth/pJLZy6zltjGBQESYNT4JgMmvZ9usSMachm37S3nirfUMH9SJ61O6uo7jl6wYNwHn6OmuVuHBTBuT4DpOo5K6x3DnZX15bU0hH+bvdR3HGOOFHu1acf+1A3kvr4jF3+xwHceYgKSqPLgwi+Cguml/RVpuy/sTsWLcBJw/f7yZL7ceZOr1CcS2Dncdxys/H96fuNgo0hdkUlpZ7TqOMcYL37+wD2f1bMvDS+oaihljTs6CL7ezesNeJo4cSLe2ka7j+C0rxk1AKTxQyqMr8rh8QEcmnN3ddRyvRYQGMzc1mW37y/j1W+tdxzHGeCE4SJiXlsKh8ipmvmHDzIw5GXsPVzBzaS7n9m7Hd8/v7TqOX7Ni3ASMutNd2QDMnhB4p7vO79uB757fi5c+3MTX2w66jmOM8cLALtH8+Ip4Fn61nffy9riOY0zAeHhJLqUVNcxNTSYoKLA+r5uaFeMmYCz8ajsfrC/igWsH0qNdK9dxTkn6dYPoFB3BxPmZVFbXuo5jjPHCPVf2o1/HKB5amM2RChtmZkxjVq7dzZJvdnDPlfH07xztOo7fs2LcBIS9hyuY8Ubd6a5bLuzjOs4pi44IZdb4JPJ2H+L371vLbWMCQXhIMPPSUth+sIwnbJiZMSd0uKKaya9nM6Bza358RT/XcQKCT4txERkpInkiki8i6Q08Hi4i//A8/qmI9Kn32CTP+jwRubbe+l+KSI6IZIvI30UkwpevwfiH6YtzKK2oYV5aMsEBfrrr6oTOjBnSjd++u4ENu63ltjGBYGif9txyQW9e/mgTX2094DqOMX7rsTfXsauknLlpKYSF2He+3vDZ35KIBAPPANcBCcDNInLsPHS3AwdUNR54Epjn2TcBuAlIBEYCz4pIsIh0B34GDFXVJCDYs51pxt7J3c0bmTv56VXxxHdqHqe7po1JICo8xFpuGxNAHhg5kC5tIkjPyLJhZsY04Ist+3nlky3cemEfzunVznWcgOHLX1mGAfmqWqCqlcCrwLhjthkH/Mlzez4wXOquyhsHvKqqFaq6Ccj3HA8gBIgUkRCgFWATwDZjJeVVTH49m0Fdornr8uZzuiu2dTjTxiTw5VZruW1MoKg/zOwPNszMmP9SUV3DxIwsusVEcv+1A13HCSi+LMa7A9vq3S/0rGtwG1WtBoqBDsfbV1W3A48DW4GdQLGqvuWT9MYvzF2+jj2HypnXDE93jT+ru7XcNibADB/cmetTuvLbd/PJ33PYdRxj/MazqzaSv+cwsyYkERUe4jpOQPFlddPQwN5jz8cfb5sG14tIO+q+NY8DugFRIvK9Bp9c5E4RWSMia4qKik4itvEXnxTs42+fbuX2S+IY0rOt6zhnXP2W2w8utJbbxgSKaWMSiQwLZtKCTGptmJkxrN99iGffy2f8Wd24cmAn13ECji+L8UKgZ737Pfj2kJJ/b+MZdhID7D/BvlcDm1S1SFWrgAXARQ09uao+p6pDVXVox44dz8DLMU2pvKqG9IxMerVvxb3XNN/TXT3atWLiyEF8sL6IhV9tdx3HGOOFjtHhTLk+gc83H+Cvn211HccYp2pqlYkZmbQOD2HK9cdeGmi84cti/HOgv4jEiUgYdRdaLj5mm8XArZ7bNwDvat3Xg4uBmzyzrcQB/YHPqBuecoGItPKMLR8OrPXhazCOPPXOBjbvK2VOajKRYcGu4/jULRf05tze7ZjxRi57D1e4jmOM8ULaOd25JD6WecvXsbO4zHUcY5z588eb+WrrQaaOSaBD63DXcQKSz4pxzxjwnwArqCuYX1PVHBGZISJjPZu9CHQQkXzgXiDds28O8BqQC7wJ3KOqNar6KXUXen4JZHnyP+er12DcyN5ezPOrC/jO0J5cHB/rOo7PBQUJ89KSKa2oYfriHNdxjDFeEBEemZBMTa0y5XUbZmZapu0Hy3h0RR6XD+jI+LOOvSzQeMunV8Sp6jJVHaCq/VR1tmfdVFVd7Lldrqo3qmq8qg5T1YJ6+8727DdQVZfXWz9NVQepapKq3qKq9lViM1JVU8sD8zNpHxXGg6MGu47TZOI7RfPTq+J5I3Mnb+fudh3HGOOFXh1a8asRA3hn7R6WZu10HceYJqWqTF6YBcDsCUnUDVgwp6J5TU9hAt7zqwvI3VnCzHGJxLQKdR2nSd11eT8GdYlm8utZlJRXuY5jjPHCDy7qQ0qPGKYvzuFgaaXrOMY0mcXf7GBVXhH3jRhIj3atXMcJaFaMG79RUHSYp97ZwHVJXRiZ1NV1nCYXFhLEvLQUig5VMHf5OtdxjDFeCAkOYm5qCgdKq5i91C5hMi3D/iOVPLwkl7N6tuXWi/q4jhPwrBg3fqG2VknPyCIiJIiHxyW6juPMkJ5tuf2SOP726VY+KdjnOo4xxgsJ3dpw12V9+ecXhfxrw17XcYzxuVlv5FJSVsW8tBSCg2x4yumyYtz4hb99tpXPNu9n8ugEOkVHuI7j1L3XDKRX+1akZ2RSXlXjOo4xxgs/G96fvrFRTFqYSVmlvW9N8/X++iIWfLWdu6/ox8Au0a7jNAtWjBvndhaXMXf5Oi6O78CNQ3u4juNcZFgwc1KT2byvlKfe2eA6jjHGCxGhwTySmsy2/WU8+c5613GM8YkjFdU8uCCLfh2juOeqeNdxmg0rxo1TdVdjZ1NTq8yZkGJXY3tcHB/Ld4b25PnVBWRvL3YdxxjjhQv6duDmYb14YXUBWYX2vjXNzxNvrWf7wTLmpaUQHtK8e4A0JSvGjVNLMneyct0efjViAL062NXY9T04ajDto8J4YH4mVTW1ruMYY7yQft0gYluH80CGvW9N8/LV1gO8/NEmbrmgN0P7tHcdp1mxYtw4s/9IJQ8vzmFIz7bcdnGc6zh+J6ZVKDPHJZG7s4TnVxc0voMxPiIiI0UkT0TyRSS9gcd7i8hKEckUkfdEpIdn/Vki8rGI5Hge+07Tp29aMZGhzByfxFp735pmpLK6lkkLsugcHcEDIwe6jtPsWDFunJn5Ri7FZVXMS0u2q7GPY2RSF65L6sJT72ygoOiw6zimBRKRYOAZ4DogAbhZRBKO2exx4BVVTQFmAHM860uB76tqIjASeEpE2jZNcneuTfzP+3bT3iOu4xhz2v7w/kbW7TrErPFJREe0rB4gTcGKcePEe3l7WPjVdu6+Mp5BXdq4juPXHh6XSERIEOkZWdTWWstt0+SGAfmqWqCqlcCrwLhjtkkAVnpurzr6uKquV9UNnts7gD1AxyZJ7djDYxMJDwkiPSPT3rcmoOXvOcxv383n+pSuXJ3Q2XWcZsmKcdPkDldU89DCbOI7teaeK/u5juP3OkVHMPn6BD7bvJ+/fbbVdRzT8nQHttW7X+hZV983QJrn9gQgWkQ61N9ARIYBYcBGH+X0K53aRPDQqMF8umk//1izrfEdjPFDtbXKpAWZRIYFM21My+0B4mtWjJsm99ib69hRbFdjn4wbz+3BJfGxzF2+jp3FZa7jmJaloTFkx37Vex9wuYh8BVwObAeq/30Aka7An4HbVLXBqxpF5E4RWSMia4qKis5Mcse+c15PLuzbgUeWrWV3SbnrOMactL99tpXPNx9g8ujBdIwOdx2n2bJi3DSpNZv388onW7j1wj6c27ud6zgBQ0R4ZEIyNbV1U0Gq2mlv02QKgZ717vcAdtTfQFV3qGqqqp4NPORZVwwgIm2ApcBkVf3keE+iqs+p6lBVHdqxY/MYySIiPJKaTGV1LdMW5biOY8xJOdoD5JL4WG4413qA+JIV46bJlFfVMDEjk24xkdx/rV2NfbJ6dWjFr0YMYOW6PSzJ3Ok6jmk5Pgf6i0iciIQBNwGL628gIrEicvTzZBLwkmd9GLCQuos7/9mEmf1GXGwUv7h6AG/m7OLNbHvfmsCgqkx5PZvq2loemZBsPUB8zIpx02SeWZXPxqIjPJKaTFR4iOs4Aem2i+MY0rMt0xfnsP9Ipes4pgVQ1WrgJ8AKYC3wmqrmiMgMERnr2ewKIE9E1gOdgdme9f8DXAb8QES+9ixnNe0rcO+OS+NI6NqGqYtyKC6rch3HmEYty9rFO2v38KtrBloPkCZgxbhpEmt3lvC79zaSek53Lh/QPE5BuxAcJMxLS6akrIqZb+S6jmNaCFVdpqoDVLWfqs72rJuqqos9t+eran/PNneoaoVn/V9UNVRVz6q3fO3ytbgQGhzEozeksO9IJXOXr3Udx5gTOlhaybTF2SR3j+G2i/u4jtMiWDFufK66ppaJGZnERIYyZfSx0xObkzWoSxvuvjKehV9tZ1XeHtdxjDFeSOoewx2XxPH3z7bx8cZ9ruMYc1yzl67lQGkVc9OSCQm2MrEp2N+y8bmXP9xMZmEx08cm0i4qzHWcZuGeK/sR36k1Dy3I4nBFdeM7GGOc+8XVA+jVvhUPLsyivKrGdRxjvuVfG/byzy8KueuyviR2i3Edp8WwYtz41JZ9R3ji7TyuHtyZ61O6uo7TbISHBDMvLYWdJeU89uY613GMMV6IDAtmTmoym/Ye4TcrN7iOY8x/Kaus4cGFWcTFRvGz4f1dx2lRvC7GRSTKl0FM86OqTFqQRWhQELPGJ9nV2GfYub3bceuFfXjlky2s2bzfdRxjjBcujo/lf4b24LkPCsjZUew6jjH/9tQ769m6v5Q5qclEhFoPkKbUaDEuIheJSC51V9EjIkNE5FmfJzMB77U12/ho4z7SRw2iS0yE6zjN0v3XDqRbTCQTMzLttLcxAeLBUYNp1yqM9Iwsqmsa7IFkTJPKKizm+dUF3DysJxf07dD4DuaM8uab8SeBa4F9AKr6DXVTVRlzXLtLypm1dC3nx7Xn5vN6uY7TbEWFh/BIajIbi47wzKp813GMMV5o2yqMh8cmkrW9mJc/3Ow6jmnhqjyTLMS2Dif9usGu47RIXg1TUdVtx6yyr+DMCU1dlE1ldS1z01IICrLhKb50+YCOpJ7Tnd+9t5G1O0tcxzHGeGFUcheuHtyZJ97OY8u+I67jmBbshdWbyN1ZwoxxScREhrqO0yJ5U4xvE5GLABWRMBG5D8+QFWMasjxrJytydvOLqwcQF2uXGjSFKaMTiIkMZWJGpp32NiYAiAizxicRGhTEgwuzUFXXkUwLtGnvEZ56Zz0jE7swMqmL6zgtljfF+P8C9wDdgULgLOBuX4Yygau4tIopi3JI6t6GH10a5zpOi9EuKozpYxPJLLTT3ub4RGSoiCwUkS9FJFNEskQk03WulqpLTAQTrxvEh/n7mP9Foes4poWpm2Qhk7CQIB4el+g6TovmTTE+UFW/q6qdVbWTqn4PsEFFpkGzluZyoLSSeWkp1iygiV2f0tVOe5vG/BV4GUgDxgDXe/40jvy/Yb04r087Zi1dS9GhCtdxTAvyj8+38UnBfh4aNZjObWySBZe8qZZ+6+U608IdbRZwpzULcKL+ae9JC+y0t2lQkaouVtVNqrrl6OI6VEsWFCTMSU2hrLKG6UtyXMcxLcSeknJmL1vLBX3b853zerqO0+KFHO8BEbkQuAjoKCL31nuoDWATUJr/UlpZzaSFmfSNjeLn1izAmS4xEaSPGsRDC7N5bc02vmMz2Zj/Nk1EXgBWAv/+GlZVF7iLZOI7teZnw+N5/K31jD9rN9ckdHYdyTRz0xbnUFFdy5zUFOsB4gdO9M14GNCauoI9ut5SAtzg+2gmkDzx1nq27S+zZgF+4ObzenF+XHtmLV3L7pJy13GMf7mNuut+RlI3POXoUBXj2J2X9WNQl2imvJ7NofIq13FMM/Zm9i6WZ+/iF1f3t0kW/MRxvxlX1feB90Xkj3Ya05zIV1sP8PKHm/jeBb0435oFOBcUJMxNS2HkUx8wdVE2f7hlqOtIxn8MUdVk1yHMt4WFBDE3LYUJz37IvDfXMWu8/TOZM6+4rIqpi7JJ6NqGH13a13Uc4+HNmPFSEXlMRJaJyLtHF58nMwGhsrqW9IwsOreJYOLIQa7jGI+42Ch+cfUAVuTsZnnWTtdxjP/4REQSXIcwDTurZ1tuuyiOv3yylc8373cdxzRDc5evY+/hCualpRBqkyz4DW/+Jf4KrAPigIeBzcDnPsxkAsjv3ttI3u5DzBqfRHSENQvwJz8XnNXOAAAgAElEQVS6NI6k7m2YsiiH4lI77W0AuAT4WkTybGpD/3TftQPo0S6S9IxMyqusv545cz4p2MffP9vKHZf2JbmHTbLgT7wpxjuo6otAlaq+r6o/BC7wcS4TADbsPsTTqzYwdkg3hg+2C478TUhwEPPSUjhQWsmspbmu4xj/MBLoD4zApjb0S63CQpg9IZmNRUd4dlW+6zimmSivqmHSgix6tW/FL68e4DqOOYY3xfjRr9R2ishoETkb6OHDTCYA1NQqD2Rk0jo8hGlj7Ky3v0rsFsNdl/Xln18U8q8Ne13HMe7pcRbjRy4f0JHUs7vz7HsbWberxHUc0wz838oNbNp7hDmpyUSG2SQL/sabYnyWiMQAvwLuA14AfunTVMbvvfLxZr7aepCpYxLo0DrcdRxzAj8b3p++sVGkL8iktLLadRzj1lLgDc+fK4ECYLnTRKZBk69PoE1kKBMzsqiptd+XzKnL3VHCHz4o4MZze3BxfKzrOKYBJyzGRSQY6K+qxaqarapXquq5qrrYm4OLyEjP2MR8EUlv4PFwEfmH5/FPRaRPvccmedbnici19da3FZH5IrJORNZ65kM3TWjb/lIeW5HHFQM7Mv6s7q7jmEZEhAYzJzWZwgNlPPHWetdxjEOqmqyqKZ4/+wPDgH+5zmW+rX1UGNPGJPDNtoP86aPNruOYAFVdU8vEjEzatQrjodHWPN1fnbAYV9UaYOypHNhTyD8DXAckADc3cBX/7cABVY0HngTmefZNAG4CEqkb4/is53gAvwHeVNVBwBBg7ankM6dGVXlwYRYCzJ6QbM0CAsT5fTvwvQt68fKHm/hq6wHXcYyfUNUvgfNc5zANGzukG1cO7Mjjb+WxbX+p6zgmAL384Waythfz8NhE2rYKcx3HHIc3w1Q+EpGnReRSETnn6OLFfsOAfFUtUNVK4FVg3DHbjAP+5Lk9HxguddXdOOBVVa1Q1U1APjBMRNoAlwEvAqhqpaoe9CKLOUMWfLmd1Rv28sDIQXRvG+k6jjkJE0cOonObCNIzsqisrnUdxzggIvfWW+4Tkb8BRa5zmYaJCLMm1M03/tDr2ajacBXjva37Snni7TyuHtyZUcldXMcxJ+BNMX4Rdd9QzwCe8CyPe7Ffd2BbvfuFnnUNbqOq1UAx0OEE+/al7oPjZRH5SkReEBFrH9VEig5VMHNpLkN7t+OWC3q7jmNOUnREKLPGJ5G3+xC/e2+j6zjGjfrdlMOpGzt+7Jckxo90bxvJA9cO5IP1Rbz+9XbXcUyAOHoWOyQoiJnjE+0stp87bgfOo1T1ylM8dkP/8sf+Wn+8bY63PgQ4B/ipqn4qIr8B0oEp33pykTuBOwF69ep1ErHN8UxfkkNpRQ1z01IICrI3diAaPrgzY4d04+lVGxiV3IX+naNdRzJNK1dV/1l/hYjcCPzzONsbP3DLhX1Y/M0OZizJ5bL+He2iedOo+V8U8q/8vcwcn0TXGDuL7e982X6pEOhZ734PYMfxthGRECAG2H+CfQuBQlX91LN+PnXF+beo6nOqOlRVh3bs2PE0X4p5O3c3SzN38tOr4onv1Np1HHMapo1JoHV4CA9kZNosDS3PJC/XGT8SHCTMTUvhcEU1M9+wngHmxIoOVTBr6VrO69OO7w6zLyMDgS+L8c+B/iISJyJh1F2QeewsLIuBWz23bwDe1bpBcYuBmzyzrcRR16TiM1XdBWwTkYGefYYD9pPJx0rKq5j8ehaDukRz1+X9XMcxp6lD63Cmjkngq60HeeXjza7jmCYgIteJyG+B7iLyf/WWPwI232UAGNA5mruviOf1r3ewKm+P6zjGjz28JIeyyhrmpNpZ7EDhs2LcMwb8J8AK6mY8eU1Vc0RkhogcnaHlRaCDiOQD91I35ARVzQFeo67QfhO4xzOzC8BPgb96WjifBTziq9dg6sxZto6iQxU8ekMKYSG+/P3NNJXxZ3XnioEdeWyFzdLQQuwA1gDlwBf1lsXAtSfYz/iRu6/sR/9OrXloQRaHK+x3KPNt7+Tu5g07ix1wpLGrs0UktYHVxUCWqgbEr+dDhw7VNWvWuI4RkD7euI+bn/+EH10ax0OjrdNmc7L9YBkjfv0+5/Ruxys/HGYX+PgpEflCVYeeoWOFqmpV41u6ZT+zj++LLQe44fcfceuFfZg+NtF1HONHDpVXMeLJD2gTEcqSn15iX545cio/s735l7qduq6b3/Usz1P3LfaHInLLSac0AaO8qoZJCzLp1b4V914zsPEdTEDp3jaSB0YOYvWGvSz40mZpaCGGicjbIrJeRApEZJOIFLgOZbx3bu92fP+C3vzp4818aT0DTD2PvpnHrpJy5tlZ7IDjzb9WLTBYVdNUNY26Bj4VwPnARF+GM249+c56Nu8rZW5qMpFhwY3vYALOLRf0ZmjvdsxcmkvRoQrXcYzvvQj8GriEumY/Q7GmPwHn/pGD6NomgvSMTOsZYABYs3k/f/5kC7ddFMdZPdu6jmNOkjfFeB9V3V3v/h5ggKruB/z+dKc5NVmFxbywehPfGdqTi+JjXccxPhLkmaWhtKKG6UtyXMcxvlesqstVdY+q7ju6NLaTiIwUkTwRyReR9AYe7y0iK0UkU0TeE5Ee9R67VUQ2eJZbj93XnLzW4SHMmpDE+t2HrWeAoaK6hokZmXRvG8mvRgxwHcecAm+K8dUi8obnB+qtwCLgA0+zHet+2QxV1dTyQEYmHaLCeHD0YNdxjI/Fd2rNT6+KZ2nmTt7O3d34DiaQrRKRx0TkQm87KotIMPAMcB11Z0ZvFpFjLyB5HHhFVVOoaxA3x7Nve2AadWdShwHTRKTdmX1JLdNVg/7TM2DD7kOu4xiHnnk3n41FR3gkNZmo8Ebbxxg/5E0xfg/wR+pmLjkbeIW62U2OnEZDIOPHnvuggLU7S5gxLomYyFDXcUwTuOvyfgzqEs3k17MoKbcTXs3Y+dQNTXkE7zsqDwPyVbVAVSuBV/l2184EYKXn9qp6j18LvK2q+1X1APA2MPK0X4UBYOqYBKLCQ0hfkEWt9QxokdbtKuHZ9zaSenZ3Lh9gPVUCVaPFuNaZr6q/VNVfeG7bu76Z2lh0mN+srOvOODKpi+s4pomEhQTx6A0pFB2qYM6yda7jGB9R1SsbWK5qZLfuwLZ69ws96+r7Bkjz3J4ARItIBy/3NacotnU4U0Yn8MWWA/zl0y2u45gmVlOrpGdk0SYylMnX22xngazRYlxEUj1j/YpFpEREDolISVOEM02rtlZJz8gkMjTYpsxqgVJ6tOX2S+L4+2db+aSg0WHEJgCJSGcReVFElnvuJ4jI7Y3t1sC6Y7+QuQ+4XES+Ai4HtlPXTMibfY9mu1NE1ojImqKiokYimaNSz+nOpf1jmbd8HTsOlrmOY5rQKx9v5uttB5k2JoH2UWGu45jT4M0wlUeBsaoao6ptVDVaVdv4Ophpen/9bCufbz7AQ6MH0yk6wnUc48C91wykV/tWpGdkUl5V0/gOJtD8kbpGbN0899cDv2hkn0KgZ737PahrIvRvqrpDVVNV9WzgIc+6Ym/2rXeM51R1qKoO7djRTrd7S0R4ZEIytQpTXs/GTly3DIUHSnlsRR5XDOzI2CHdGt/B+DVvivHdqrrW50mMUzsOljFv+TouiY/lxnN7NL6DaZYiw4KZm5rM5n2lPPnOetdxzJkXq6qvUTdl7dFOyY391vU50F9E4kQkDLiJus6d/yYisSJy9PNkEvCS5/YKYISItPNcuDnCs86cQT3bt+JXIwawct0e3sjc6TqO8TFV5cGF2QDMnpBsDduaAW+K8TUi8g8RudkzZCX1OF05TYBSVSa/nk1NrTIn1d7YLd1F8bF8Z2hPXli9ieztxa7jmDPriGcstwKIyAXUdVQ+Lk/B/hPqiui1wGuqmiMiM0RkrGezK4A8EVkPdAZme/bdD8ykrqD/HJjhWWfOsNsujmNIjximL87hwJFK13GMDy36egcfrC/igWsH0r1tpOs45gzwphhvA5RS943GGM9yvS9Dmaa1+JsdvLtuD78aMYCe7Vu5jmP8wIOjB9MhKowH5mdSVWNNRZqRe6n7VrufiHxI3exYP21sJ1VdpqoDVLWfqh4ttKeq6mLP7fmq2t+zzR2qWlFv35dUNd6zvOybl2WCPT0DisuqmLXUTmY3V/sOV/DwkhzO7tWWWy7s4zqOOUManZBSVW9riiDGjf1HKnl4SS5DerbltovjXMcxfiImMpQZ45L43798wXMfFHDPlfGuI5kzQFW/FJHLgYHUXVyZp6o2l2UzMbhrG/738n48vSqf8Wd349L+Nva+uZn5Ri6HK6qZl5ZCcJCdxW4ujvvNuIg84PnztyLyf8cuTRfR+NKMJTkcKq/iUXtjm2OMTOrCdUld+M3KDWwsOuw6jjkDPA18RgHDqTvb+VMRuddtKnMm/eSqePrGRjFpQRalldWu45gzaFXeHl7/egd3XxHPgM7RruOYM+hEw1SOnudaA3zRwGIC3NE39o+viGdgF3tjm297eFwiESFBpGdkWlOR5mEJ8AOgAxBdbzHNRERoMHNSkyk8UMav37KLsJuLIxXVTF6YTXyn1tx9ZT/XccwZdtxhKqq6xPPnn5oujmkqhyuqeWhBFv07teYee2Ob4+gUHcHk6xN4YH4mf/1sK7dc0Nt1JHN6enha1ptm7Py+Hfju+b146cNNjBnSjSE927qOZE7T42/lsaO4jPn/eyHhIcGu45gzzJumPwNE5DkReUtE3j26NEU44zuPvrmOnSXlzE1LsTe2OaEbz+3BJfHWVKSZWC4iI1yHML438bpBdIwOZ2KGXYQd6L7ceoA/frSZ71/Qm3N7t3cdx/iAN7Op/BP4CpgM3F9vMQHq8837+fMnW7j1wj6c27ud6zjGzx1tKlJTWzcFpjUVCWifAAtFpMw6KjdvbSJCmTkuiXW7DvHcBwWu45hTVFldS3pGJl3aRHD/yEGu4xgf8aYYr1bV36nqZ6r6xdHF58mMT5RX1TAxI5NuMZHcf+1A13FMgOjVoa6pyLvr9rD4mwYbKJrA8ARwIdDKOio3fyMSuzAq2S7CDmS/f38j63cfZtb4JFqHNzoBnglQ3hTjS0TkbhHpKiLtjy4+T2Z84ul38ykoOsKc1GSi7I1tTsJtF8cxpGdbHl6Sy35rKhKoNgDZaqc3WozpY+suwp60IMsuwg4w+XsO8fS7+YwZ0o3hgzu7jmN8yJti/FbqhqV8xH9mUlnjy1DGN3J3lPD79zeSek53Lhtg88+akxMcJDyalsKh8ipmLMlxHcecmp3AeyIySUTuPbq4DmV8p1N0BJNHJ/DZpv28+vk213GMl2prlfSMLFqFBzNtTILrOMbHTliMi0gQ8D1VjTtm6dtE+cwZUl1Ty8SMTNq2CmXKaHtjm1MzsEs0P74inte/3sGqvD2u45iTtwlYCYRhUxu2GDcO7cFF/TowZ9ladhWXu45jvPDXT7ewZssBpoxOILZ1uOs4xsdOWIyrai3weBNlMT700oebyNpezPSxibSLCnMdxwSwe67sR/9OrXloQRaHK6ypSCBR1YdV9WHg18AT9e6bZuzoRdiVNbVMWWQXYfu7HQfLmPdmHpf2jyX1nO6u45gm4M0wlbdEJE1ErD1jgNq89wi/fns91yR0ZnRyV9dxTIALDwlmbloKO0vKefTNda7jmJMgIkki8hWQDeSIyBcikug6l/G9PrFR3HvNAN7O3c2b2btcxzHHoapMeT2bmlrlkQnJWOnVMnhTjN9L3fSGFTYVVuBRVSYtyCI0KIiZ45LsjW3OiHN7t+PWC/vw50+2sGbzftdxjPeeA+5V1d6q2hv4FfC840ymidx+SRyJ3dowdXEOxaVVruOYBryRuZOV6/bwqxED6Nm+les4pok0Wox7pr4KUtUwmwor8Pzj8218XLCPSaMG0yUmwnUc04zcf+1AusVEMjEjk/KqGtdxjHeiVHXV0Tuq+h4Q5S6OaUohwUHMS0th/5FKHlm21nUcc4wDRyqZvjiHIT1iuO3iONdxTBPy5ptxRKSdiAwTkcuOLr4OZk7f7pJyZi9bywV923PTeT1dxzHNTFR4CHNSk9lYdISn3813Hcd4p0BEpohIH88ymbqLOk0LkdQ9hjsujeMfa7bxUf5e13FMPbOXraW4rIo5qSkEB9lZ7Jak0WJcRO4APgBWAA97/pzu21jmdB0dd1ZZXcvc1BSC7I1tfOCyAR1JPac7v39/I2t32ui1APBDoCOQASwAYoEfuAxkmt4vrx5A7w6tmLQwy85q+Yl/bdjL/C8KuevyviR0s8EHLY0334z/HDgP2KKqVwJnA0U+TWVO2/LsXbyVu5tfXjOAPrF2Ftr4zpTRCbRtFcrEjEyqa2pdxzEn1g/oSd3P/lBgOHVftpgWJCI0mDmpyWzZV8pT72xwHafFK62sZtLCTPrGRvHTq/q7jmMc8KYYL1fVcgARCVfVdYD1UfdjB0srmbooh6TubbjjEht3ZnyrXVQY08cmkllYzEsf2ogHP/dX4CUgFbjes4xxmsg4cVG/WL4ztCfPry4ge3ux6zgt2pNvr2fb/jLmpCYTERrsOo5xwJtivFBE2gKvA2+LyCJgh29jmdMxa+laDpRWMi8thZBgry4LMOa0jE7uytWDO/Prt9ezZd8R13HM8RWp6hJV3aSqW44urkMZNx4cNZj2UWF2VsuhzMKDvPivTfy/83txft8OruMYR7yZTWWCqh5U1enAFOBFYLyvg5lTs3pDUd24s8v6ktgtxnUc00KICLPGJxEaFER6RpY1FfFf00TkBRG5WURSjy6uQxk3YlqFMmNsIjk7SnjxX3ZWq6lV1dQyMSOLjtHhpF83yHUc45C3s6lcIiK3qer7wMeAtYTyQ6WV1UxakEXf2Ch+NtzGnZmm1SUmgkmjBvNxwT7+8fk213FMw24DzgJGUjc8ZQx1Q1VMCzUyqQsjEurOam3ea2e1mtJzHxSwdmcJM8cl0SYi1HUc45A3s6lMAyYCkzyrQoG/+DKUOTWPr1hP4YEy5qal2Lgz48RN5/Xk/Lj2zF62lt0l5a7jmG8boqpDVfVWVb3Ns/zQdSjjjogwY1wSYcFBPLjQzmo1lYKiw/xm5QZGJXdhRGIX13GMY958Mz4BGAscAVDVHUC0L0OZk/fl1gO8/NEmvndBL4bFtXcdx7RQQUHC3LQUKqtrmfJ6tn2w+59PRCTBdQjjX7rERJA+ahAfbdzHP9cUuo7T7NXW1nXGjggJYvrYRNdxjB/wphiv1LpPVAUQEa/nyRORkSKSJyL5IpLewOPhIvIPz+Ofikifeo9N8qzPE5Frj9kvWES+EpE3vM3SnFVW15KekUmXNhFMHGnjzoxbcbFR/PKaAbyVu5vl2btcxzH/7RLga8/P1UwRyRKRTNehjHs3n1f3Rc6spbnsOWRntXzp1c+38emm/Tw0ejCdoq0ztvGuGH9NRP4AtBWRHwHvAM83tpOIBAPPANcBCcDNDXwjcztwQFXjgSeBeZ59E4CbgETqxjY+6zneUT8HrJevx7Pv5bN+92FmT0gi2sadGT9wxyVxJHVvw9RFORwsrXQdx/zHSKA/MIL/jBe3qQ0NQUHCnNRkyqtrmb44x3WcZmt3STlzlq3lon4d+J+h1hnb1PFmNpXHgfnUdWwbCExV1d96cexhQL6qFqhqJfAqMO6YbcYBf/Lcng8MFxHxrH9VVStUdROQ7zkeItIDGA284EWGZm/97kM8syqfsUO6cdWgzq7jGANASHAQ89JSOFBayayl9nuzv6g/naFNbWiO1a9ja34+vD/LsnaxIsfOavnC1EXZVNbU8siEZOrKHWO8nE1FVd9W1ftV9T5VfdvLY3cH6k+pUMi3Z2H59zaqWg0UAx0a2fcp4AGgxU+KWlOrPDA/k9bhIUwbY8NAjX9J7BbDXZf1Zf4XhazeYE17jQkEd17Wl0Fdopm6KJuS8irXcZqVN7N3siLHOmObbztuMS4ih0SkpIHlkIiUeHHshn7lO/ZqruNt0+B6Ebke2KOqXzT65CJ3isgaEVlTVNQ8C4E/fbSZr7cdZNqYRDq0Dncdx5hv+dnw/vSNjWLSgixKK6tdxzHGNCLUc1ar6FAF85avcx2n2SgurWLKohwSu1lnbPNtxy3GVTVaVds0sESrahsvjl0I1B8Q1YNvd+789zYiEgLEAPtPsO/FwFgR2UzdsJerRKTBaRZV9TnPFF5DO3bs6EXcwLJtfymPrcjjioEdGXdWN9dxjGlQRGgwc9NSKDxQxuMr1ruOY4zxwpCebfnhxXH89dOtfFqwz3WcZmHO8rXsP2KdsU3DfPk/4nOgv4jEiUgYdRdkLj5mm8XArZ7bNwDvemZuWQzc5JltJY66C44+U9VJqtpDVft4jveuqn7Ph6/BL6kqDy7MIkhgto07M35uWFx7vndBL17+aBNfbT3gOo4xxgv3jhhAz/aRTFqQRXlVjes4Ae2jjXt59fNt3HFpHEndrTO2+TafFeOeMeA/AVZQN/PJa6qaIyIzRGSsZ7MXgQ4ikg/cC6R79s0BXgNygTeBe1TVfhp4ZHy5ndUb9jLxukF0bxvpOo4xjZo4clDd1JsZmVRWt/jLPYzxe63CQnhkQjIFe4/w9Lv5ruMErPKqGh5ckEXvDq34xfABruMYP+XTcyWqukxVB6hqP1Wd7Vk3VVUXe26Xq+qNqhqvqsNUtaDevrM9+w1U1eUNHPs9VW1xbZyLDlUw841chvZux/fO7+06jjFeiY4IZfaEJNbvPsyz79kHe6DxomdELxFZ5en/kCkiozzrQ0XkT575zNeKyKRvH934q0v7dyTtnB78/v2NrN3pzaVi5lhPvbOBzftKmZOaTGSYdcY2DbOBSwFm+uIcyiprmJuWQlCQDU8xgeOqQZ0ZO6Qbz6zKZ/3uQ67jGC952TNiMnVnP8+mbgjhs571NwLhqpoMnAvcVb+5m/F/k0cPJiYylPSMTGpqraPuycjeXszzqwv4ztCeXNQv1nUc48esGA8gb+XsYmnWTn42PJ74Tq1dxzHmpE0bk0Dr8BAm2gd7IPGmZ4QCRy/sj+E/F+srEOW5QD8SqATsK9YA0i4qjGljE/mmsJiXP9zkOk7AqK6pJX1BJu1ahfHgqMGu4xg/Z8V4gCguq2LKomwGdYnmrsv7uY5jzCnp0DqcaWMS+WrrQf700WbXcYx3vOkZMR34nogUAsuAn3rWzweOADuBrcDjqrrfp2nNGTcmpSvDB3XiibfWs21/qes4AeGlDzeRvb2EGeMSiWllnbHNiVkxHiDmLl9L0aEKHr0hhVCbFskEsHFndeOKgR15bEWefbAHBm96RtwM/FFVewCjgD+LSBB136rXAN2AOOBXItK3wSdpAb0hApWIMHN8EkECDy7Mom7SM3M8W/Yd4ddvr2dEQmeuS+riOo4JAFbVBYCPN+7j759t445L+5LSo63rOMacFhFh9oRk+2APHN70jLiduhmwUNWPgQggFvh/wJuqWqWqe4APgaENPUlz7w0R6Lq1jWTidYNYvWEvC77c7jqO31JVJi3IIjQoiBnjkmzqYeMVK8b9XFllDZMWZNK7Qyt+ebVNi2Sah+71Ptgz7IPd33nTM2IrMBxARAZTV4wXedZfJXWigAsAa+sYoL53fm/O7d2OmUtz2Xu4wnUcv/TPLwr5aOM+0kcNoktMhOs4JkBYMe7nnnpnvU2LZJql753fm6G92zHzjVyKDtkHu7/ysmfEr4Aficg3wN+BH3gauD0DtAayqSvqX1bVzCZ/EeaMCAoS5qYmU1pRw4wlua7j+J09h8qZvXQtw+Lac/N5vVzHMQHEinE/lll4kOdXF3DTeTYtkml+goKEuWkplFXWMH1Jjus45gS86BmRq6oXq+oQVT1LVd/yrD/s6SWRqKoJqvqYy9dhTl//ztHcc2U8i7/ZwbvrdruO41ceXpxLWVUNc1KTbephc1KsGPdTVTW1PDA/k9jW4UyyaZFMMxXfqTU/Gx7P0sydvJWzy3UcY4wXfnxFPwZ0bs3khdkcrqh2HccvHJ16+OfD+9Ovo009bE6OFeN+6rkPCli36xAzxycRE2nTIpnm667L+zGoSzRTFmVTUl7lOo4xphFhIUHMSU1hZ0k5j71plwCUlP9n6uE7L2twsiBjTsiKcT+Uv+cwv1m5gVHJXbg20aZFMs1baHAQj96QQtGhCuYssw92YwLBub3bceuFfXjlky18saVlTx3/6JvrKDpUwbw0m3rYnBr7X+NnamuVSQsyiQwNZvrYRNdxjGkSKT3acselffn7Z1v5eOM+13GMMV6479qBdIuJZGJGFhXVNa7jOPHZpv385ZOt/PDiOIb0tKmHzamxYtzP/PXTLXy++QCTRw+mU7RNi2Rajl9ePYDeHVoxaUEmZZUt84PdmEDSOjyEWROSyN9zmGdXbXQdp8mVV9WQviCTHu0iuXeETT1sTp0V435k+8Ey5i5fx6X9Y7nh3B6u4xjTpCLDgpmTmszmfaU89c5613GMMV64cmAnxp3VjWffy2f97kOu4zSpZ1blU1B0hEcmJNMqLMR1HBPArBj3E6rK5IVZ1Co8MiHZunaZFumifrHcdF5Pnl9dQFZhses4xhgvTL0+gdbhIUzMyKSmtmV01F23q4TfvbeR1HO6c9kA6xhrTo8V435i8Tc7WJVXxH3XDqRn+1au4xjjzKRRg4ltHc4DGZlU1dS6jmOMaUSH1uFMHZPAV1sP8pdPtriO43M1tcrEjCxiIkOZMjrBdRzTDFgx7gf2Ha7g4SW5nNWzLT+4qI/rOMY4FRMZyszxSazdWcJzHxS4jmOM8cL4s+q+IX70zXVsP1jmOo5P/fGjzXyz7SDTxibSLirMdRzTDFgx7gdmvJHLofIq5qWlEGxdu4zh2sQujEruwm9WbmBj0WHXcYwxjRARZo9PQoHJC7NQbZ7DVbbtL5H+mFQAABm5SURBVOXxFXlcNagTY1K6uo5jmgkrxh17d91uFn29g7uviGdgl2jXcYzxG9PHJhIZGkx6xv9v787Do6rvvo+/v1lIgASQVfawr4mIirjWFREXFNpHvbXVuz5aW+2jtV4C7hYXaNUud+vTettW21qXW0Cp4kLdcBdFTMIeAdk32cKa7Xv/MSc6YghZZuZMks/ruuaamTPnzHzmTOaX75zzO+eXT0UT6Ycq0pB1b9uCm0YN4I0lm5n52bqw48Scu3Prc4WkGEy+YKiO7ZKYUTEeouJ9pdw2o5D+nbL4yal9wo4jklQ6Zmdy2zmDmLtyG0982Pj7oYo0Bpcfn8MR3dtw978WsnV3SdhxYmrGp2uZs3QzE84eSNc2zcOOI42IivEQ/fLlJazfuY8p4/PISEsNO45I0vnuUd04qV97pry0mHWNvB+qSGOQmmJMHZ/Lzr2l3PPCwrDjxMyWXfv5xQsLGd6jDZcd2zPsONLIqBgPydyVW/n7B19wxfE5DO9xWNhxRJKSmXHfhblUONz2XGGj7Ycq0pgMPLwVPz6lD9M/XctbSzeHHScmJr+wkD37y5k6Po8UHdslMaZiPAT7SsuZMC0yatdNowaEHUckqXVv24KbzhrA64s3Ncp+qCKN0XWn9aVPh5bcMr2A3fvLwo5TL28s3sTz89dx7al96ddJx3ZJ7KkYD8F/vb7sq1G7WmZo1C6RQ7ni+ByGNdJ+qCKNUUZaKlPG57F2+14efLXhjqi7a38Zt84ooH+nLH58io7tkvhQMZ5gC9bt4E9vLWf88G4atUukhiL9UPMo3lfKL/61IOw4IlIDx+S05bKRPfjreyv4dNW2sOPUyQOvRI7tun9cHs3SVDJJfOgvK4HKyiuYMC2fNi3Suf3cQWHHEWlQBhyezU9O6ctz89fx+uKNYccRkRqYMHognbIzmTS9gJKyhjWi7idfbOPx91dy+XE5HNVTx3ZJ/KgYT6A/v7OCwrU7ufv8obRpoVG7RGrrJ6f2oV/HLG6bUciuBt4PVaQpyM6MjKi7eEMxj8z5POw4NVZSVsHEafl0ad2cm87SsV0SXyrGE2Tllt08NHspZw7uxJjcw8OOI9IgZaSlMvW7eazfuY9fvrw47DgiUgNnDu7EOXmd+d1rRRRtahgj6j78ZhHLNu3inguHkqVjuyTOVIwngLszcXo+zdJSuEejdonUy/Aeh3HF8Tn87f0vmLtya9hxRKQG7jpvCM2bpTJpevKPqLtsYzF/eKOIscO6cOqAjmHHkSZAxXgCPDV3NR8s38otYwbRqVVm2HFEGrybRg2ga5vmTJiWz77S8rDjiMghdMjO4NZgRN1/frQq7DgHVVHhTJiWT1ZGGnecOzjsONJEqBiPsw079nHfi4sY2bstFx/TPew4Io1Cy4w07h+Xy/LNu/n960VhxxGRGvjeUd04oW87pry0mA079oUdp0r/+PAL5q3azh3nDaZdVkbYcaSJUDEeR+7O7c8XUlJewZRxeeqeIhJDJ/fvwPjh3fjjW5+zcN3OsOOIyCFUjqhbVlGRlCPqrt2+l6kvLebk/h24YFjXsONIE6JiPI5mFWxg9sKN3Hhmf3Latww7jkijc/u5g2jTIp0J0/IpK29Yp00TaYp6tmvJjWf259+LNjKrYEPYcb7i7tw2o4AKh3t1bJckmIrxONm+p4Q7ZxaS27U1V57YK+w4Io1SmxbNuPv8oRSs3cFf3l0RdhwRqYEfntCL3K6tuXNmIdv3JMeIuv/KX88bSzZz01kD6N62RdhxpIlRMR4nk19YxPY9pUwdn0daqlazSLyMyT2cMwd34sFXl7Jyy+6w44jIIaSlpjBlfC7b9pRy36xFYcdh2+4S7p65gCO6t+GK43PCjiNNUFyrRDMbbWZLzKzIzCZW8XiGmT0dPP6hmeVEPTYpmL7EzM4KpnU3szfMbJGZLTCz6+OZv67mLN3MtHlr+NF3ejO4S6uw44g0ambG5LFDaZaawsTp+UnXD1VEvm1Il9ZcfXJvnvl4De8WbQk1y+QXF7JjbylTx+eSmqLuKZJ4cSvGzSwV+ANwNjAYuMTMDjxP0JXANnfvC/wamBosOxi4GBgCjAYeDp6vDPi5uw8CRgLXVvGcodq9v4xbZhTQu0NLfnpav7DjiDQJh7fO5JZzBvHB8q08NXd12HFEpAauP70fOe1aMGl6AXtLwjlF6Zylm5k+by0/PqUPAw/XxjMJRzy3jI8Aitx9ubuXAE8BYw+YZyzweHD7WeB0ixw1MRZ4yt33u/sKoAgY4e7r3X0egLsXA4uApDrk+YFXl7Bm216mjs8jMz017DgiTcbFx3RnZO+23DdrERt3Judp00Tka5npqdw/Lo9VW/fwm38vTfjr7yn5euPZtaf2Tfjri1SKZzHeFYjeRLWGbxfOX83j7mXADqBdTZYNurQcCXwYw8z1Mm/VNh57byXfH9mTY3Lahh1HpEkxM6aMy6OkLDlPm9aQ1aDLYY+gC+GnZpZvZmOiHsszs/eDroUFZqaRz+Qrx/VpxyUjuvPfby+ncO2OhL72g68u1cYzSQrxLMar6nh14H/Hg81T7bJmlgVMA25w9ypPMGxmV5vZx2b28ebNm2sYue72l5Uz4dl8OrfK5ObRA+L+eiLybTntI6dNm70wuU6b1pDVsMvhbcAz7n4kkS6GDwfLpgH/AK5x9yHAKUBpgqJLAzHx7EG0y8rg5mfzKU3QKUrnr97OX99dwWUje2jjmYQunsX4GiB6yMluwLqDzRM02q2BrdUta2bpRArxJ9x9+sFe3N0fcfej3f3oDh061POtHNrDb3zOsk27uPfCXLIz0+P+eiJStStPTL7TpjVwNely6EBlh9vWfN3WjwLy3f0zAHf/0t3D6RwsSat183Qmjx3CwvU7efTt+J+itLS8gonT8umYncnNowfG/fVEDiWexfhcoJ+Z9TKzZkS2lsw8YJ6ZwOXB7e8Cr3tk3/JM4OLgbCu9gH7AR0F/8j8Di9z9oThmr5UlG4p5+M0ixg7rwqkDO4YdR6RJiz5t2j0vhn/atEagJl0O7wIuM7M1wCzgp8H0/oCb2StmNs/Mbo53WGmYRg/tzOghh/Obfy9lRZxPUfrInOUs3lDM5AuG0kobzyQJxK0YD/qAXwe8QuRAy2fcfYGZ/cLMzg9m+zPQzsyKgBuBicGyC4BngIXAy8C1wdaUE4DvA6eZ2fzgMoYQlVc4E6blk52Zzh3nJtWJXUSarCFdWnPNd3rz7CdrmLM0/t3UGrmadDm8BHjM3bsBY4C/m1kKkAacCFwaXF9oZqdX+SIJ7looyefusUNolpbCpDieovTzzbv47WvLOCevM2cO7hSX1xCprbieZ9zdZ7l7f3fv4+73BtPucPeZwe197v49d+/r7iPcfXnUsvcGyw1w95eCae+4u7l7nrsPCy6z4vkeDuWx91Yyf/V27jxvMO2yMsKMIiJRfnpaP3p3aMktMwrYvb8s7DgNWU26HF5JZAMK7v4+kAm0D5Z9y923uPseIlvNh1f1IonuWijJp1OrTG4ZEzlF6dNxOEVpRYUzaVoBzdNTueu8ITF/fpG60tCQ9bB66x4eeGUJpw7owPlHdAk7johEyUxPZcq4PNZs28uDryb+tGmNSE26HK4CTgcws0FEivHNRPaM5plZi+C4oO8Q2eMpUqWLju7Osb3acu+sRWyK8SlKn5y7io9WbuXWcwbRIVsbzyR5qBivI3dn0vQCUgzuvTCXSHd2EUkmI3q15fsje/LX91Ywb9W2sOM0SDXscvhz4Coz+wx4ErjCI7YBDxEp6OcD89z9xcS/C2koUlKMKePz2F9WwZ0zF8TseTfs2MeUWYs5oW87vndUt5g9r0gsqBivo2c/WcM7RVuYePZAurRpHnYcETmIm0cP4PBWmUyclk9JWWJOm9bY1KDL4UJ3P8Hdjwi6D74atew/3H2Iuw91dx3AKYfUq31LbjijHy8VbuDlwvqfotTduf35QkorKrhPG88kCakYr4NNxfu458VFHJNzGJce2zPsOCJSjezMdO69cChLN+7i4TeLwo4jIjVw1Um9GdS5FXc8X8iOvfU7Nf1LhRuYvXAjN57Zn57tWsYooUjsqBivg7tmLmBvaTlTxueRkqJf2CLJ7rSBnRg7rAt/eKOIpRuLw44jIoeQnprC1PG5bNm1nykvLa7z8+zYU8odzy8gt2trfnhCrxgmFIkdFeO19MqCDcwq2MD1p/ejT4essOOISA3dce5gsjLSuPnZfMor4nPaNBGJnbxubfi/J/XmyY9W8cHyL+v0HPfNWsS2PSVMGZ9LWqpKHklO+sushR17S7n9uUIGdW7F1Sf3DjuOiNRCu6wM7jxvCPNXb+fx91aGHUdEauBnZ/SnR9sWTJpewL7S2g3e+l7RFp7+eDVXn9ybIV1axymhSP2pGK+F+2ctYsuu/fxyfB7p+oUt0uCMHdaFUwd04FevLGH11j1hxxGRQ2jeLJX7LsxlxZbd/O61ZTVebm9JOZNmFJDTrgXXn94vjglF6k8VZQ299/kWnpq7mqtO6k1uN/3CFmmIzIx7LswlxeCWGQVxG+VPRGLnxH7t+e5R3fjTnOUsXLezRsv85rWlfPHlHu4fl0dmemqcE4rUj4rxGthbUs6k6QX0bNeCG87oH3YcEamHrm2aM+Hsgby9bAvT5q0NO46I1MBt5wzisBbpTJyeT1l59acoLVy7g0ffXsElI7pzXJ92CUooUncqxmvg1/+u/IWdS/Nm+oUt0tBddmxPju55GJNfWMjm4v1hxxGRQ2jTohl3nT+E/DU7+Ou7Kw86X1l5BROm5dO2ZTMmnj0ocQFF6kHF+CHkr9nOo28v55IR3Tm+T/uw44hIDFSO8re3pJy7YjjKn4jEzzm5nTljUEcenL2EVV9WfczHo++sYMG6nUweO4TWzdMTnFCkblSMV6O0vIKbn82nQ3aGfmGLNDJ9O2Zx/Rn9eLFgPa8sqP8ofyISX2bG5AuGkpaSUuUxHyu37ObXs5dy1pBOjB7aOaSUIrWnYrwaf3rrcxZvKGby2KH6hS3SCF19cmSUv9ufq/8ofyISf51bR475eKfom8d8uDuTphfQLC2FX4wdGmJCkdpTMX4QRZt28bvXijgntzOjhhwedhwRiYNvjvK3KOw4IlIDl47o8a1jPp75eDXvL/+SW8YMolOrzJATitSOivEqVFQ4E6fl07xZKnedPyTsOCISR3nd2nDVSb158qPVzF64kR17SzVCp0gSixzzkcveknLu/tcCNu3cx70vLuLYXm256OjuYccTqbW0sAMko//5ZDUff7GNB753BB2yM8KOIyJxdsMZ/Xl5wQau+tvHX01r2SyVrMw0sjPTyc5MIysjjVaZ6WRlpEXuVz52wP3IfJH7zdNTMbMQ35lI49S3YzbXndaXh2YvZdnGXewrq+D+cbmkpOj7Jg2PivEqnJvXhZJyZ/zwrmFHEZEEaN4slWd+dBxvLtlE8b4yiveVsWt/GcX7SoPryGXd9r1f3d9TcuihuVNT7KvivW/HLB77zxEJeDciTcM13+nDi/nrWbKxmJtHD6B3h6ywI4nUiYrxKrTMSOP7I3uGHUNEEqhTq0wuOqZHjecvK69g9/5yiveXfqN4/1YxH9xvpYPARWKqWVoKv/+PI5n52TquOql32HFE6kzFuIhIHaSlptC6RQqtW6jIFglLv07Z/HzUgLBjiNSLDuAUEREREQmJinERERERkZCoGBcRERERCYmKcRERERGRkKgYFxEREREJiYpxEREREZGQqBgXEREREQmJinERERERkZCYu4edIe7MbDPwRS0Xaw9siUOcWEr2jMmeD5I/Y7LnA2WMhery9XT3DokMEza12aFK9ozJng+SP2Oy54PkzxjTNrtJFON1YWYfu/vRYeeoTrJnTPZ8kPwZkz0fKGMsJHu+hqAhrENlrL9kzwfJnzHZ80HyZ4x1PnVTEREREREJiYpxEREREZGQqBg/uEfCDlADyZ4x2fNB8mdM9nygjLGQ7PkagoawDpWx/pI9HyR/xmTPB8mfMab51GdcRERERCQk2jIuIiIiIhISFeNVMLPRZrbEzIrMbGJIGbqb2RtmtsjMFpjZ9cH0u8xsrZnNDy5jopaZFGReYmZnJSjnSjMrCLJ8HExra2azzWxZcH1YMN3M7HdBxnwzGx7nbAOi1tN8M9tpZjeEvQ7N7C9mtsnMCqOm1XqdmdnlwfzLzOzyOOf7lZktDjLMMLM2wfQcM9sbtS7/GLXMUcHfRlHwHizOGWv9ucbzu36QjE9H5VtpZvOD6aGsx8ZCbXatcqrNrn2upG6zq8mYNO222uxDcHddoi5AKvA50BtoBnwGDA4hR2dgeHA7G1gKDAbuAm6qYv7BQdYMoFfwHlITkHMl0P6Aab8EJga3JwJTg9tjgJcAA0YCHyb4c90A9Ax7HQInA8OBwrquM6AtsDy4Piy4fVgc840C0oLbU6Py5UTPd8DzfAQcF2R/CTg7zuuwVp9rvL/rVWU84PEHgTvCXI+N4RLvz7EWOdRmx/5zVZtdv4xJ024fJF+tPtd4f9erynjA43Frs7Vl/NtGAEXuvtzdS4CngLGJDuHu6919XnC7GFgEdK1mkbHAU+6+391XAEVE3ksYxgKPB7cfBy6Imv43j/gAaGNmnROU6XTgc3evbiCRhKxDd58DbK3itWuzzs4CZrv7VnffBswGRscrn7u/6u5lwd0PgG7VPUeQsZW7v++R1ulvUe8pLhmrcbDPNa7f9eoyBltK/g/wZHXPEe/12Eioza4/tdnVSPY2+2AZk6ndVptdPRXj39YVWB11fw3VN6hxZ2Y5wJHAh8Gk64LdTn+p3DVGeLkdeNXMPjGzq4Npndx9PUT+QQEdQ84IcDHf/BIl0zqE2q+zMLP+kMiv/Uq9zOxTM3vLzE4KpnUNMiU6X20+1zDX4UnARndfFjUtmdZjQ6I2u3bUZsdGQ2qzIXnbbbXZqBivSlV9e0I75YyZZQHTgBvcfSfw/4E+wDBgPZHdJhBe7hPcfThwNnCtmZ1czbyhZDSzZsD5wP8Ek5JtHVbnYJnCWpe3AmXAE8Gk9UAPdz8SuBH4p5m1CilfbT/XMD/vS/hmoZFM67GhSap1pDa7/tRmx1YSt9tqswMqxr9tDdA96n43YF0YQcwsnUij/oS7Twdw943uXu7uFcB/8/UuuVByu/u64HoTMCPIs7FyV2ZwvSnMjET+6cxz941B1qRah4HarrOEZ7XIAUfnApcGu98IdiN+Gdz+hEh/vv5BvuhdonHPV4fPNZTP28zSgHHA05XTkmk9NkBqs2tBbXbMJH2bHWRL2nZbbfbXVIx/21ygn5n1Cn6dXwzMTHSIoH/Sn4FF7v5Q1PTo/noXApVH/c4ELjazDDPrBfQjchBBPDO2NLPsyttEDhYpDLJUHil+OfB8VMYfWMRIYEflbr44+8Yv2mRah1Fqu85eAUaZ2WHBrr1RwbS4MLPRwATgfHffEzW9g5mlBrd7E1lny4OMxWY2Mvhb/kHUe4pXxtp+rmF9188AFrv7V7syk2k9NkBqs2ueUW127CR1mw3J326rzY7iMT7quDFciBwNvZTIL51bQ8pwIpFdG/nA/OAyBvg7UBBMnwl0jlrm1iDzEhJwxgUiRzR/FlwWVK4roB3wGrAsuG4bTDfgD0HGAuDoBGRsAXwJtI6aFuo6JPJPZj1QSuRX9JV1WWdE+gAWBZf/jHO+IiJ99Sr/Fv8YzDs++Ow/A+YB50U9z9FEGtfPgd9DZJCxOGas9ecaz+96VRmD6Y8B1xwwbyjrsbFc4vk51iKD2uzYZFSbHbuMSdNuHySf2uzgohE4RURERERCom4qIiIiIiIhUTEuIiIiIhISFeMiIiIiIiFRMS4iIiIiEhIV4yIiIiIiIVExLk2Cmb0XXOeY2X/E+Llvqeq1RESkbtRmS1OiUxtKk2JmpwA3ufu5tVgm1d3Lq3l8l7tnxSKfiIh8TW22NAXaMi5NgpntCm5OAU4ys/lm9jMzSzWzX5nZXDPLN7MfBfOfYmZvmNk/iQxKgJk9Z2afmNkCM7s6mDYFaB483xPRrxWMwPYrMys0swIzuyjqud80s2fNbLGZPRGM1IWZTTGzhUGWBxK5jkREkoXabGlK0sIOIJJgE4nayhI00Dvc/RgzywDeNbNXg3lHAEPdfUVw/4fuvtXMmgNzzWyau080s+vcfVgVrzUOGAYcAbQPlpkTPHYkMARYB7wLnGBmC4kMCTzQ3d3M2sT83YuINCxqs6XR05ZxaepGAT8ws/nAh0SGOO4XPPZRVKMO8P/M7DPgA6B71HwHcyLwpLuXu/tG4C3gmKjnXuPuFUSGKc4BdgL7gEfNbBywp97vTkSkcVGbLY2OinFp6gz4qbsPCy693L1yK8vur2aK9Fs8AzjO3Y8APgUya/DcB7M/6nY5kObuZUS27EwDLgBertU7ERFp/NRmS6OjYlyammIgO+r+K8CPzSwdwMz6m1nLKpZrDWxz9z1mNhAYGfVYaeXyB5gDXBT0cewAnAx8dLBgZpYFtHb3WcANRHaXiog0ZWqzpdFTn3FpavKBsmDX5WPAb4nsbpwXHJCzmcgWjgO9DFxjZvnAEiK7PSs9AuSb2Tx3vzRq+gzgOOAzwIGb3X1D8I+hKtnA82aWSWQLzc/q9hZFRBoNtdnS6OnUhiIiIiIiIVE3FRERERGRkKgYFxEREREJiYpxEREREZGQqBgXEREREQmJinERERERkZCoGBcRERERCYmKcRERERGRkKgYFxEREREJyf8CeuLFm7mIDxIAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 864x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "learn.sched.plot_lr()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 3 conv layers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ConvBN(nn.Module):\n",
+    "    def __init__(self, n_in, n_out, stride):\n",
+    "        super().__init__()\n",
+    "        self.conv = nn.Conv2d(n_in,n_out,3,stride=stride,padding=1)\n",
+    "        self.bn = nn.BatchNorm2d(n_out)\n",
+    "        \n",
+    "    def forward(self,x):\n",
+    "        return self.bn(self.conv(x))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ShallowConvNet(nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        self.conv1 = ConvBN(3,64,2)\n",
+    "        self.conv2 = ConvBN(64,128,2)\n",
+    "        self.out = nn.Linear(128,10)\n",
+    "    \n",
+    "    def forward(self,x):\n",
+    "        x = self.conv1(x)\n",
+    "        x = self.conv2(x)\n",
+    "        x = F.adaptive_avg_pool2d(x,1)\n",
+    "        x = x.view(x.size(0),-1)\n",
+    "        return F.log_softmax(self.out(x))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn = ConvLearner.from_model_data(ShallowNet(), data)\n",
+    "learn.crit = F.nll_loss"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OrderedDict([('Linear-1',\n",
+       "              OrderedDict([('input_shape', [-1, 3072]),\n",
+       "                           ('output_shape', [-1, 1024]),\n",
+       "                           ('trainable', True),\n",
+       "                           ('nb_params', 3146752)])),\n",
+       "             ('Linear-2',\n",
+       "              OrderedDict([('input_shape', [-1, 1024]),\n",
+       "                           ('output_shape', [-1, 1024]),\n",
+       "                           ('trainable', True),\n",
+       "                           ('nb_params', 1049600)])),\n",
+       "             ('Linear-3',\n",
+       "              OrderedDict([('input_shape', [-1, 1024]),\n",
+       "                           ('output_shape', [-1, 10]),\n",
+       "                           ('trainable', True),\n",
+       "                           ('nb_params', 10250)]))])"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "learn.summary()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bdfd6dc509c9474cbdf8cab1f31083fd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>HBox</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=1), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 79%|██████████████████████████████████████████████████████▏              | 307/391 [00:09<00:02, 32.07it/s, loss=45.7]\n",
+      "                                                                                                                       \r"
+     ]
+    }
+   ],
+   "source": [
+    "learn.lr_find()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYwAAAEOCAYAAACaQSCZAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzt3XmcXFWd9/HPr6r3JUl3urOQpOkEwmaARJogBhUcJiKj4A6Ow4Dik9EZZ9wen3GZBwV11HHGGR0fhbiMOoIoe9iEuDCAmkASkkAWIASTNJ2kO0unu9N71e/5494klaY6qUjf2vJ9v171qnvPPffeX9906tfnnlvnmLsjIiJyNLFcByAiIoVBCUNERDKihCEiIhlRwhARkYwoYYiISEaUMEREJCNKGCIikhElDBERyYgShoiIZEQJQ0REMlKS6wDGUkNDgzc3N+c6DBGRgrFy5cpd7t6YSd2iShjNzc2sWLEi12GIiBQMM9uSaV3dkhIRkYwoYYiISEaUMEREJCNKGCIikhElDBERyYgShoiIZEQJQ0SkgD27o5uVW/Zk5VxKGCIiBexL96/ngz9eQf9QIvJzKWGIiBSoP7ywm8ee38XfXngyFaXxyM+nhCEiUqBuW7GNuqpSrjr/xKycTwlDRKRAte3rY1ZjTVZaF6CEISJSsDq6B5hUW5618ylhiIgUqHYlDBEROZr+oQTd/cNMGleRtXNGNry5mVUAjwLl4Xlud/fPj6jz78BF4WoVMMndJ4TbEsDT4bat7n5ZVLGKiBSa9q4BABqz2MKIcj6MAeCN7t5jZqXA42b2oLsvO1DB3T9+YNnM/h6Yl7J/n7vPjTA+EZGC1d7dD1Act6Q80BOuloYvP8Iu7wV+FlU8IiLFpL07aGFMqs3eLalI+zDMLG5mq4F2YKm7Lx+l3onATOA3KcUVZrbCzJaZ2duijFNEpNC0d4UtjHFF0MIAcPdEeFtpOjDfzOaMUvVKgj6O1O+2N7l7C/CXwH+Y2UnpdjSzRWFiWdHR0TGm8YuI5Kv27gFKYkZ9VVnWzpmVp6TcvRN4BLhklCpXMuJ2lLu3he+bw33nvXw3cPfF7t7i7i2NjRnNYy4iUvA6ugdoqCknFrOsnTOyhGFmjWZ24ImnSuBiYGOaeqcCdcAfUsrqzKw8XG4AFgDro4pVRKTQdPcPM64yyueWXi7Ks00FfmxmcYLE9At3v8/MbgBWuPuSsN57gVvdPbVD/HTgJjNLhvt+1d2VMEREQkl3Ypa91gVEmDDcfS1pbiO5+3Uj1r+Qps7vgTOjik1EpNAlHSzLCUPf9BYRKUDuTha7LwAlDBGRguSQ9VtSShgiIgUoqRaGiIhkQn0YIiKSEXcny/lCCUNEpBC5qw9DREQyoD4MERHJSNJdfRgiInJ0SYcsNzCUMERECpL6MEREJBNJd2JZ/gRXwhARKUC5GHxQCUNEpAAljzThdUSUMERECpDGkhIRkYxotFoREcmI+jBERCQjySQaS0pERI7OKaLRas2swsyeMLM1ZrbOzK5PU+caM+sws9Xh64Mp2642s+fD19VRxSkiUohy0YcR2ZzewADwRnfvMbNS4HEze9Ddl42o93N3/0hqgZnVA58HWggS6UozW+LueyOMV0SkYBRVH4YHesLV0vCV6ZPDbwKWuvueMEksBS6JIEwRkYIUTKCU3XNG2odhZnEzWw20EySA5WmqvdPM1prZ7WY2IyybBmxLqdMalomICAcmUCqSFgaAuyfcfS4wHZhvZnNGVLkXaHb3s4BfAT8Oy9NdhbStEzNbZGYrzGxFR0fHWIUuIpLXinYCJXfvBB5hxG0ld9/t7gPh6veAc8LlVmBGStXpQNsox17s7i3u3tLY2DimcYuI5KuimkDJzBrNbEK4XAlcDGwcUWdqyuplwIZw+SFgoZnVmVkdsDAsExERcjMfRpRPSU0FfmxmcYLE9At3v8/MbgBWuPsS4B/M7DJgGNgDXAPg7nvM7IvAk+GxbnD3PRHGKiJSUJzsPyUVWcJw97XAvDTl16Usfwb4zCj7/xD4YVTxiYgUsuCb3kXYhyEiImNLgw+KiEhGiu57GCIiEo1c9GEoYYiIFKCghaGEISIiR6E+DBERyYj6MEREJCNeTKPViohIdJLFOpaUiIiMraS7bkmJiMjRuYNleTQpJQwRkQKkp6RERCQjSYdYljOGEoaISAFSH4aIiGREfRgiIpKRYCyp7J5TCUNEpADpexgiIpKRYpvTu8LMnjCzNWa2zsyuT1PnE2a23szWmtmvzezElG0JM1sdvpZEFaeISCFyJ+uDSUU5p/cA8EZ37zGzUuBxM3vQ3Zel1HkKaHH3XjP7MPAvwBXhtj53nxthfCIiBcndAYqnheGBnnC1NHz5iDq/dffecHUZMD2qeEREikUy/CQtqj4MM4ub2WqgHVjq7suPUP1a4MGU9QozW2Fmy8zsbVHGKSJSSJI5amFEeUsKd08Ac81sAnCXmc1x92dG1jOzvwJagDekFDe5e5uZzQJ+Y2ZPu/sLafZdBCwCaGpqiuTnEBHJJwcSRlHOuOfuncAjwCUjt5nZxcDngMvcfSBln7bwfXO477xRjr3Y3VvcvaWxsXHsgxcRyTNhviieb3qbWWPYssDMKoGLgY0j6swDbiJIFu0p5XVmVh4uNwALgPVRxSoiUkg8R30YUd6Smgr82MziBInpF+5+n5ndAKxw9yXA14Ea4LawabXV3S8DTgduMrNkuO9X3V0JQ0SEIuzDcPe1pLmN5O7XpSxfPMq+vwfOjCo2EZFCdrAPQ2NJiYjIkSSLrQ9DREQiUozfwxARkbGXqz4MJQwRkQJT1N/DEBGRsXNoaJDsnlcJQ0SkwDhqYYiISAZy9cU9JQwRkQJzqA8ju+dVwhARKTDqwxARkYy4npISEZFMqA9DREQycmgsqexSwhARKTAH+zCy/AmuhCEiUmD84NAguiUlIiJHcGi0WiUMERE5AtfggyIikomDLYximUDJzCrM7AkzW2Nm68zs+jR1ys3s52a2ycyWm1lzyrbPhOXPmtmboopTRKTQHBhLqphaGAPAG939bGAucImZvWZEnWuBve5+MvDvwNcAzOwM4ErgVcAlwHfCucFFRI57yWTwXjR9GB7oCVdLw5ePqHY58ONw+Xbgzyy4ApcDt7r7gLu/CGwC5kcVq4hIISnKCZTMLG5mq4F2YKm7Lx9RZRqwDcDdh4F9wMTU8lBrWCYictzzYnxKyt0T7j4XmA7MN7M5I6qk+2n9COUvY2aLzGyFma3o6Oh4ZQGLiBSAYuzDOMjdO4FHCPojUrUCMwDMrAQYD+xJLQ9NB9pGOfZid29x95bGxsYxjlxEJP8k83ksKTP7qJmNs8APzGyVmS08yj6NZjYhXK4ELgY2jqi2BLg6XH4X8BsPHjBeAlwZPkU1E5gNPJH5jyUiUrzyfT6MD7h7F7AQaATeD3z1KPtMBX5rZmuBJwn6MO4zsxvM7LKwzg+AiWa2CfgE8GkAd18H/AJYD/wS+Dt3TxzDzyUiUrRyNbx5SYb1DkR1KfBf7r7GjhKpu68F5qUpvy5luR949yj7fxn4cobxiYgcNzzPJ1BaaWYPEySMh8ysFkhGF5aIiIwmV30YmbYwriX48t1md+81s3qC21IiIpJl+d6HcT7wrLt3mtlfAf9E8J0JERHJskMTKOXhU1LAd4FeMzsb+D/AFuAnkUUlIiKjy/M+jOHwcdfLgW+6+zeB2ujCEhGR0RyacS8/+zC6zewzwFXA68KBAEujC0tEREaT72NJXUEw+uwH3H0HwbhOX48sKhERGdWBhJF+FKXoZJQwwiRxMzDezN4C9Lu7+jBERHLgQLrIyxaGmb2HYGiOdwPvAZab2buiDExERNI7NEVrfvZhfA44193bIRgnCvgVwRwWIiKSRQcmUMrLwQeB2IFkEdp9DPuKiMgYytUX9zJtYfzSzB4CfhauXwE8EE1IIiJyJAe7vPMxYbj7p8zsncACgm75xe5+V6SRiYhIWvneh4G73wHcEWEsIiKSgbwcfNDMukk/NaoB7u7jIolKRERGlZd9GO6u4T9ERPJMvs+HISIieSKZoxn3lDBERAqM52MfxithZjMIhkCfQjA73+JwlNvUOp8C3pcSy+lAo7vvMbM/At1AgmC03JaoYhURKSSH5sPIrsgSBjAMfNLdV4VTuq40s6Xuvv5ABXf/OuEghmb2VuDj7r4n5RgXufuuCGMUESk4uWphRHZLyt23u/uqcLkb2EAwyu1o3suhLwaKiMgo8n2K1lfEzJqBecDyUbZXAZdw+Pc8HHjYzFaa2aKoYxQRKRSe5xMo/cnMrIYgEXzM3btGqfZW4HcjbkctcPc2M5sELDWzje7+aJrjLwIWATQ1NY1x9CIi+SdXfRiRtjDMrJQgWdzs7nceoeqVjLgd5e5t4Xs7cBcwP92O7r7Y3VvcvaWxsXFsAhcRyWOH5sMokj4MCx4Q/gGwwd2/cYR644E3APeklFWHHeWYWTWwEHgmqlhFRApJrqZojfKW1AKCOcCfNrPVYdlngSYAd78xLHs78LC770/ZdzJwV/illBLgFnf/ZYSxiogUjANjSWX7i3uRJQx3f5wMbrG5+4+AH40o2wycHUlgIiIFzov5KSkRERk7Rfc9DBERiUau+jCUMERECkyu+jCUMERECoz6MEREJCPJHE3RqoQhIlJgNIGSiIhkJFdzeithiIgUmAO3pLJNCUNEpMC4+jBERCQT6sMQEZGMqA9DREQyUtQz7omIyNg59MU9tTBEROQInOz3X4AShohIwUm6Z73/ApQwREQKTtKz338BShgiIgUn6Z71/guIdk7vGWb2WzPbYGbrzOyjaepcaGb7zGx1+LouZdslZvasmW0ys09HFaeISMHx3PRhRDmn9zDwSXdfZWa1wEozW+ru60fUe8zd35JaYGZx4P8Bfw60Ak+a2ZI0+4qIHHeKrg/D3be7+6pwuRvYAEzLcPf5wCZ33+zug8CtwOXRRCoiUliSDjloYGSnD8PMmoF5wPI0m883szVm9qCZvSosmwZsS6nTSubJRkSkqOWqhRHlLSkAzKwGuAP4mLt3jdi8CjjR3XvM7FLgbmA26ZNn2uEZzWwRsAigqalpzOIWEclXXoxPSZlZKUGyuNnd7xy53d273L0nXH4AKDWzBoIWxYyUqtOBtnTncPfF7t7i7i2NjY1j/jOIiOQbdyeWg17vKJ+SMuAHwAZ3/8YodaaE9TCz+WE8u4EngdlmNtPMyoArgSVRxSoiUkhy1YcR5S2pBcBVwNNmtjos+yzQBODuNwLvAj5sZsNAH3ClB4OkDJvZR4CHgDjwQ3dfF2GsIiIFo+j6MNz9cY6SBN3928C3R9n2APBABKGJiBQ0J/sDD4K+6S0iUnDcXYMPiojI0SWT2Z88CZQwREQKTjCWVPbPq4QhIlJggvkw1MIQEZGjUAtDREQy4q4WhoiIZEAtDBERyYhaGCIikhG1MEREJCNqYYiISEaS7sU7gZKIiIwdtTBERCQj6sMQEZGMJHPUwoh8itZCcP2964iZUVNeQk15CdXlJSTdcXd6BhL0Dg5TWRZnaNgZTiYZTCQZGnaGEsnwFZQPJ4Ky4aQznHSSSSfpwauyNE51ePzSeIx4zDCDuBnxcNhJJxiFMulBk9Px4N093JZSBiQSTsKdRDIYG780HhyrJGaUxGOUxA5fH21bPHzFzIjFLIwp+IUsLYlRHo9RWhKjLB6jrCRGeUmMitL4wfeK0vjBn0FEouc5amEoYQAPr9tJZ+8g+wcTabebBR/WwMEP2bLwQ7Q0bpTEwvfwg7gkbsRjMeIW1DeMXT2DbNndS8/AMEOJJEmHZPLQB/6B88TMMIKx7s1IvxzWDWKJEYsFo1cOJ5Mkks5QIjhm6nrUSuNGRUmc8tIY5SVxKsviVJamvJfGqSqLU1EWp+plyyUvLy+LU1VaQkVZjKqyEqrL4jkZ/18kH+VqLCklDOB3n34jAImks39wmP0Dw8TDT+jK8ANtKJE82DIoNAdaLQdaQcPJMKGEraFE+DrQGkokCd+dwUSSweGgJTU4HLwGhpP0DyXoH0qEy0n6hxNhWZKBoQT9wwn6BhP0DSXo7Bti+74+egeDOn2DCXqHEgeTcCZKYsaEqlImVJVRN+J9QlUpdeH6xJpyJtWWM6m2gsqyeHQXVSSHEskia2GY2QzgJ8AUIAksdvdvjqjzPuAfw9Ue4MPuvibc9kegG0gAw+7eElWsB8RjxriKUsZVlKbZVrgfPmYWtnbilOfJnwjuzsBw8mDy6Bscpm8wSe/gML1DCfoHE/SG23oHhtnXN8Te3iE6ewfZ2zvItj29rG0dZG/vEIPDybTnqC0voXFckEAaaoJXY205k8dVMGVcBZPHlTN5fAW15SVqvUhB2dnVz7QJlVk/b5QfH8PAJ919lZnVAivNbKm7r0+p8yLwBnffa2ZvBhYD56Vsv8jdd0UYo+SImR3s/6h7Bcdxd/qGEuztHWLv/kF27x+kvauf9u4BOroHaO/up6N7gHVtXXR0D9AzMPyyY1SWxpkyvoJJteVMGV/B5HHBa1ZDNadOqWXq+AolFMkb7s6W3b0sOLkh6+eOck7v7cD2cLnbzDYA04D1KXV+n7LLMmB6VPFIcTIzqspKqCoryegvrr7BBDu7+oNX9wA79wXLO7r6ae8a4Kmtnezs6mcgpdVSVhJj8rhyZtRVMbOhmlmNNcxqqGZmQzXT6yopiethQ8me9u4B+oYSNE+syvq5s3KDwsyagXnA8iNUuxZ4MGXdgYfNzIGb3H1xZAHKcaOyLE5zQzXNDdWj1nF3OnuH2NTRw8Yd3bTu7WV7Zz9b9/Ry75o2uvoPtVJK48ZJjTXMa6rjnBPrmDtjAjMbqguyr0sKwx937QfgxImj/w5HJfKEYWY1wB3Ax9y9a5Q6FxEkjAtSihe4e5uZTQKWmtlGd380zb6LgEUATU1NYx6/HH/MjLrqMs6trufc5vrDtrk7e3uH2NzRw+Zd+3lx137WtXVx39o2fvbEViBokcyeVMNpU8Zx+tRaTpsyjtOm1tJQU56LH0eKzJbdvQA0F1vCMLNSgmRxs7vfOUqds4DvA292990Hyt29LXxvN7O7gPnAyxJG2PJYDNDS0hL986NyXDMz6qvLqK+upyUlmSSTzqaOHtZs6+S5nd1s3NHNo893cMeq1oN1GmrKmFZXxZwTxjGvqY5XNwWtEfWPyLH44+79lMSMEyZUZP3cUT4lZcAPgA3u/o1R6jQBdwJXuftzKeXVQCzs+6gGFgI3RBWryCsVixmnTK7llMm1h5Xv6hng2R3dbNjexXM7u9m2p497Vrdx8/KgNVJXVcq8pjrmzZhAS3M985omUFFauE/kSfQ2tffQVF+Vk76zKFsYC4CrgKfNbHVY9lmgCcDdbwSuAyYC3wn/yjrw+Oxk4K6wrAS4xd1/GWGsIpFoqCmn4eTyw55oSSSdTe09PLV1L6u27mXV1k5+s7EdCPpEzp4+gQtmN7DwjCmcPrVWLRABgtuhtz65jYfX7+SvXpOb2+/mx/LtqTzX0tLiK1asyHUYIsdsX+8QK7fuYfnmPSx7cQ9rWztxh+l1lSw8YwqvO6WBV00dR2NtuRLIcWjbnl7+7z3P8MizHVxwcgPfv7plzFqiZrYy0++5KWGI5KGO7gF+vWEnD6/fyeObdh38cuKk2nLOba7nNbPqufDUScyoz/6jlZJ9l37zMbbs3s8nFp7K1eefOKa3o44lYeTJ935FJFVjbTlXzm/iyvlN7B8YZm3rPjZs72JNaydPvriH+5/eDqxjVkM1c5smcPncaZw3s179H0UomXSeb+/mAxfM5NoLZuY0FiUMkTxXXV7C+SdN5PyTJh4s29zRw2+f7eAPL+zi1xvauXPVS1SWxvmLs6Zy6ZlTeO1JDUoeRWLX/gGGEp6ToUBGUsIQKUCzGmuY1VjDtRfMpH8owePP7+JXG3Zy75o2bl/ZSmVpnCvOncHfvGEWU8fn/oNG/nTbO/sBOCEP/h2VMEQKXEVpnIvPmMzFZ0zm+stfxfLNe7hndRs/XbaFm5dvYf7Met47v4k3z5mqb6AXoLbOPgCm5uB7FyMpYYgUkfKSOK8/pZHXn9LIxy6ezX8v28LD63bwkVueorF2PWdPH8/rT2nkz06fzAkaVLEgtO1TC0NEIjajvorPXno6/3jJaSxdv5P71raxfnsXv9rQznX3rKO2ooTzZ03kbfOm8cbTJqnPI09t7+yjsjTOhKqXT7uQbUoYIkUuHjMumTOFS+ZMAeCZl/bx1LZO1rd1HXx0t6GmnHe3TOeSV03h7BkTchyxpGrb18fUCfnRGlTCEDnOzJk2njnTxgOQSM7hd5t28f3HX+R7j27mu4+8wMIzJvO62Q3MmTaeuTMm5MUH1fGsrbM/L25HgRKGyHEtHrODfR7d/UN895EXuG1lKw+v3wnA7Ek1XDm/iXfMm0ZddVmOoz3+dPcHIyO/ec7UXIcC6JveIjKCu7Ojq5/HntvFLU9sZfW2TspKYlw6Zwp//dpm5qnVkTWfv+cZfrJsC3f/7YLIbhXqm94i8iczM6aOr+Q9587gPefOYMP2Lm59Yit3rnqJu1e3ccbUcbxm1kTmNU3gz06fRFWZPkbG2oo/7uGW8Jr/9fkn5k2/kloYIpKR/QPD3LmqlXtWt/FM2z76h5LUlpfw9ldP4y/Pa+K0KeNyHWJR6Oof4tU3LMUMPrBgJp9606mRDmWuFoaIjLnq8hKuOr+Zq85vZjiRZNXWTn72xFZufXIbP/nDFs45sY6/nN/ExWdMZnxl7h8BLVTPtO5jOOn86P3ncuGpk3IdzmGUMETkmJXEY8yfWc/8mfVc95YzuGNVKzcv38onb1tDzIInsS47+wQuOm0SzRM1x/mxWNO6D4Czp+fHbahUShgi8orUVZfxwdfN4toLZrJiy14ef34X//NcB1+6fwNfun8Dk2rLef+CmXzwdTMpzcEscYVmbWsnTfVVeflUmhKGiIwJM+Pc5nrOba7n439+Cs/u6GZNayf3r93O1365kf/63Ytcee4Mrlkwk/o8/DDMF2tb9zGvKf9aF6CEISIROXVKLadOqeU9LTN45Nl2frpsC9/6zSa+9ZtNzKivpLqshHEVpZw1fTwLTm7gDac0EjvOb139esNOXursy/m8F6OJ7CkpM5sB/ASYAiSBxe7+zRF1DPgmcCnQC1zj7qvCbVcD/xRW/ZK7//ho59RTUiL5beOOLpau28mmjh56BxPs7hngmbYuBoeT1FeXMam2nJbmOhac1MBFx9n4Vht3dPHuG/9AU30Vd3z4tVn72fPlKalh4JPuvsrMaoGVZrbU3den1HkzMDt8nQd8FzjPzOqBzwMtgIf7LnH3vRHGKyIRO23KuJc9fjs4nOTBZ7bz+0272dHVz12rXuKny7YyvrKUvzhrKmdNG8/Jk2o4cWI1AOMrSykrKZ6+kL7BBDcv38KN//MCVWVxbrrqnLxNlJElDHffDmwPl7vNbAMwDUhNGJcDP/GgmbPMzCaY2VTgQmCpu+8BMLOlwCXAz6KKV0Ryo6wkxuVzp3H53GkADCeSLNu8h9tWbuOuVS9xy/Kth9WPGVwwuxGA1r29nNxYQ11VGTMbq3n97EYaasuoLI1TW5Hfj/Ymk85dT73Evz78LNv39XPOiXV87Z1nMr0uf+dpz0ofhpk1A/OA5SM2TQO2pay3hmWjlYtIkSuJx7hgdgMXzG4gmXRe6uzj+fZutu7uJRYztu3p5eH1O6mtKOHkxhrWb++ifyjJrhUDfPXBjQePU1tRwqtOGMeCkxo4aVINk8eVEwuHNKkuD/bNVZ/J7zft4kv3b2D99i7Onj6e/7hiLufNmnj0HXMs8oRhZjXAHcDH3L1r5OY0u/gRytMdfxGwCKCpqekVRCoi+SYWM2bUVzGj/vC/uj/3F2e8rO7Orn4ef34XvUMJ+gaHad3bx7LNu/m3pc+lPXY8ZlSXxZnZWMPJjTWcPKmGmQ3VjKsoYWA4Se9ggr7wWH1DCUpiMcpKYuzs6mdzx35K4sYJEyp57UkTOXVyLZ19Q5SXxCgviVNXXUp5SXBbadXWvdyyfCt9gwkGhhNs29PHszu7mTahkm9eOZe3nnVCwXT2Rzo0iJmVAvcBD7n7N9Jsvwl4xN1/Fq4/S3A76kLgQnf/m3T1RqNObxEZaf/AMC/u2s+unoHgr06HPfsH2dTRQ3f/EC+07+eFjh7auwcyOl48ZjTVVzGcTLJjXz9DiZd/htZWlPD62Y0MJ5P89tkOKkvjNNaWUxaPMaGqlDfPmcK7W2bkRV9FXnR6h09A/QDYkC5ZhJYAHzGzWwk6vfe5+3Yzewj4ZzOrC+stBD4TVawiUryqy0sOzv9xJPv6hti6u5f9g8OUl8SoLItTVVpCZVmcitIYiaQzMJykrqrsYKf7wHCC+9Zsp6t/iMbacgaGkvQPJ1i2eQ9Pt3ZSXhLnjadO4p/fcWZRfPckyltSC4CrgKfNbHVY9lmgCcDdbwQeIHikdhPBY7XvD7ftMbMvAk+G+91woANcRCQK4ytLOXP60RNLqvKSOO88Z/rLyt933oljFVZeifIpqcdJ3xeRWseBvxtl2w+BH0YQmoiI/AmK52FmERGJlBKGiIhkRAlDREQyooQhIiIZUcIQEZGMKGGIiEhGlDBERCQjkQ4Nkm1m1gF0AvvCogZg1xifZnzK8cei/pG2p9uWSVnqeuryWF+Psb4WR6qTafmxrBfb9cin343R4nkl9Qv5/8po8bySumP1f+VEd2/MKCp3L6oXwURNB5ZXRHn8sah/pO3ptmVSNuIaRHY9xvpaHKlOpuXHsl5s1yOffjeiuB6F/H/lWK9HLv6vZPIqxltS9+bZ8Y9W/0jb023LpOzeI2wbS2N9LY5UJ9PyY10fS7m+Hvn0u/GnHL+Y/68c6/Fz8X/lqIrqltRIZrbCMxyF8Xig63E4XY9DdC0Op+uRXjG2MFItznUAeUbX43C6HofoWhxO1yONom5hiIjI2Cn2FoaIiIwRJQwREcmIEoaIiGTkuE0YZnahmT1mZjea2YW5jicfmFm1ma00s7fkOpZcMrPTw9+L283pYjj+AAAHaklEQVTsw7mOJ9fM7G1m9j0zu8fMFuY6nlwzs1lm9gMzuz3XsWRbQSYMM/uhmbWb2TMjyi8xs2fNbJOZffooh3GgB6gAWqOKNRvG6HoA/CPwi2iizI6xuBbuvsHdPwS8ByjoRyvH6Hrc7e7/C7gGuCLCcCM3Rtdjs7tfG22k+akgn5Iys9cTfNj/xN3nhGVx4DngzwkSwJPAe4E48JURh/gAsMvdk2Y2GfiGu78vW/GPtTG6HmcRDIdQQXBt7stO9GNrLK6Fu7eb2WXAp4Fvu/st2Yp/rI3V9Qj3+zfgZndflaXwx9wYX4/b3f1d2Yo9H0Q2p3eU3P1RM2seUTwf2OTumwHM7Fbgcnf/CnCkWyx7gfIo4syWsbgeZnYRUA2cAfSZ2QPunow08AiM1e+Guy8BlpjZ/UDBJowx+t0w4KvAg4WcLGDMPzuOOwWZMEYxDdiWst4KnDdaZTN7B/AmYALw7WhDy4ljuh7u/jkAM7uGsPUVaXTZday/GxcC7yD4Q+KBSCPLjWO6HsDfAxcD483sZHe/McrgcuBYfz8mAl8G5pnZZ8LEclwopoRhacpGvd/m7ncCd0YXTs4d0/U4WMH9R2MfSs4d6+/GI8AjUQWTB471enwL+FZ04eTcsV6P3cCHogsnfxVkp/coWoEZKevTgbYcxZIPdD0O0bU4nK7H4XQ9MlRMCeNJYLaZzTSzMuBKYEmOY8olXY9DdC0Op+txOF2PDBVkwjCznwF/AE41s1Yzu9bdh4GPAA8BG4BfuPu6XMaZLboeh+haHE7X43C6Hq9MQT5WKyIi2VeQLQwREck+JQwREcmIEoaIiGRECUNERDKihCEiIhlRwhARkYwoYUjOmFlPFs5xWYZDu4/lOS80s9f+CfvNM7Pvh8vXmFlejHFmZs0jhwNPU6fRzH6ZrZgkN5QwpOCFw1On5e5L3P2rEZzzSOOwXQgcc8IAPgv8558UUI65ewew3cwW5DoWiY4ShuQFM/uUmT1pZmvN7PqU8rstmAVwnZktSinvMbMbzGw5cL6Z/dHMrjezVWb2tJmdFtY7+Je6mf3IzL5lZr83s81m9q6wPGZm3wnPcZ+ZPXBg24gYHzGzfzaz/wE+amZvNbPlZvaUmf3KzCaHQ2d/CPi4ma02s9eFf33fEf58T6b7UDWzWuAsd1+TZtuJZvbr8Nr82syawvKTzGxZeMwb0rXYLJhF8X4zW2Nmz5jZFWH5ueF1WGNmT5hZbdiSeCy8hqvStZLMLG5mX0/5t/qblM13AwU7r4xkwN310isnL6AnfF8ILCYYNTQG3Ae8PtxWH75XAs8AE8N1B96Tcqw/An8fLv8t8P1w+RqCSZAAfgTcFp7jDII5EADeRTCMeQyYQjBHyrvSxPsI8J2U9ToOjZbwQeDfwuUvAP87pd4twAXhchOwIc2xLwLuSFlPjfte4Opw+QPA3eHyfcB7w+UPHbieI477TuB7KevjgTJgM3BuWDaOYOTqKqAiLJsNrAiXm4FnwuVFwD+Fy+XACmBmuD4NeDrXv1d6RfcqpuHNpXAtDF9Phes1BB9YjwL/YGZvD8tnhOW7gQRwx4jjHBiufiXBfBbp3O3BXB/rLZhtEeAC4LawfIeZ/fYIsf48ZXk68HMzm0rwIfziKPtcDJxhdnAU7XFmVuvu3Sl1pgIdo+x/fsrP89/Av6SUvy1cvgX41zT7Pg38q5l9DbjP3R8zszOB7e7+JIC7d0HQGgG+bWZzCa7vKWmOtxA4K6UFNp7g3+RFoB04YZSfQYqAEobkAwO+4u43HVYYTGR0MXC+u/ea2SMEU8gC9Lt7YsRxBsL3BKP/bg+kLNuI90zsT1n+T4LpfZeEsX5hlH1iBD9D3xGO28ehn+1oMh4Azt2fM7NzgEuBr5jZwwS3jtId4+PATuDsMOb+NHWMoCX3UJptFQQ/hxQp9WFIPngI+ICZ1QCY2TQzm0Tw1+veMFmcBrwmovM/Drwz7MuYTNBpnYnxwEvh8tUp5d1Abcr6wwSjoQIQ/gU/0gbg5FHO83uCIbch6CN4PFxeRnDLiZTthzGzE4Bed/8pQQvk1cBG4AQzOzesUxt24o8naHkkgasI5rQe6SHgw2ZWGu57StgygaBFcsSnqaSwKWFIzrn7wwS3VP5gZk8DtxN84P4SKDGztcAXCT4go3AHwSQ6zwA3AcuBfRns9wXgNjN7DNiVUn4v8PYDnd7APwAtYSfxetLM1ubuGwmmQK0duS3c//3hdbgK+GhY/jHgE2b2BMEtrXQxnwk8YWargc8BX3L3QeAK4D/NbA2wlKB18B3gajNbRvDhvz/N8b4PrAdWhY/a3sSh1txFwP1p9pEioeHNRQAzq3H3Hgvma34CWODuO7Icw8eBbnf/fob1q4A+d3czu5KgA/zySIM8cjyPApe7+95cxSDRUh+GSOA+M5tA0Hn9xWwni9B3gXcfQ/1zCDqpDegkeIIqJ8yskaA/R8miiKmFISIiGVEfhoiIZEQJQ0REMqKEISIiGVHCEBGRjChhiIhIRpQwREQkI/8fkY+Vl5pBMCwAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "learn.sched.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b453ab9cfbce4b81ad6393ad452f9465",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>HBox</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=25), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch      trn_loss   val_loss   accuracy                                                                              \n",
+      "    0      1.660267   1.582494   0.43839   \n",
+      "    1      1.560502   1.490084   0.46697                                                                               \n",
+      "    2      1.533817   1.448728   0.483287                                                                              \n",
+      "    3      1.474159   1.410726   0.505142                                                                              \n",
+      "    4      1.475201   1.373148   0.513449                                                                              \n",
+      "    5      1.475229   1.368782   0.510779                                                                              \n",
+      "    6      1.482839   1.404723   0.50178                                                                               \n",
+      " 38%|██████████████████████████▍                                          | 150/391 [00:04<00:07, 30.21it/s, loss=1.47]\n"
+     ]
+    },
+    {
+     "ename": "KeyboardInterrupt",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-49-0108a29950d4>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mlearn\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mfit\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;36m5e-2\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;36m1\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mcycle_len\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;36m25\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0muse_clr\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;36m10\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;36m25\u001b[0m\u001b[1;33m/\u001b[0m\u001b[1;36m11\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;36m0.95\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;36m0.85\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;32mD:\\Work\\Deeplearning\\Notebooks\\fastai\\learner.py\u001b[0m in \u001b[0;36mfit\u001b[1;34m(self, lrs, n_cycle, wds, **kwargs)\u001b[0m\n\u001b[0;32m    225\u001b[0m         \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0msched\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;32mNone\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    226\u001b[0m         \u001b[0mlayer_opt\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mget_layer_opt\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mlrs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mwds\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 227\u001b[1;33m         \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mfit_gen\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mmodel\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mlayer_opt\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mn_cycle\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    228\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    229\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0mwarm_up\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mlr\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mwds\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;32mNone\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mD:\\Work\\Deeplearning\\Notebooks\\fastai\\learner.py\u001b[0m in \u001b[0;36mfit_gen\u001b[1;34m(self, model, data, layer_opt, n_cycle, cycle_len, cycle_mult, cycle_save_name, best_save_name, use_clr, metrics, callbacks, use_wd_sched, norm_wds, wds_sched_mult, **kwargs)\u001b[0m\n\u001b[0;32m    172\u001b[0m         \u001b[0mn_epoch\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0msum_geom\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mcycle_len\u001b[0m \u001b[1;32mif\u001b[0m \u001b[0mcycle_len\u001b[0m \u001b[1;32melse\u001b[0m \u001b[1;36m1\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mcycle_mult\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mn_cycle\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    173\u001b[0m         return fit(model, data, n_epoch, layer_opt.opt, self.crit,\n\u001b[1;32m--> 174\u001b[1;33m             metrics=metrics, callbacks=callbacks, reg_fn=self.reg_fn, clip=self.clip, **kwargs)\n\u001b[0m\u001b[0;32m    175\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    176\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0mget_layer_groups\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mmodels\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mget_layer_groups\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mD:\\Work\\Deeplearning\\Notebooks\\fastai\\model.py\u001b[0m in \u001b[0;36mfit\u001b[1;34m(model, data, epochs, opt, crit, metrics, callbacks, stepper, **kwargs)\u001b[0m\n\u001b[0;32m     91\u001b[0m         \u001b[0mt\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mtqdm\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0miter\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mdata\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mtrn_dl\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mleave\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;32mFalse\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mtotal\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mnum_batch\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     92\u001b[0m         \u001b[0mi\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;36m0\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 93\u001b[1;33m         \u001b[1;32mfor\u001b[0m \u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0mx\u001b[0m\u001b[1;33m,\u001b[0m\u001b[0my\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;32min\u001b[0m \u001b[0mt\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     94\u001b[0m             \u001b[0mbatch_num\u001b[0m \u001b[1;33m+=\u001b[0m \u001b[1;36m1\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     95\u001b[0m             \u001b[1;32mfor\u001b[0m \u001b[0mcb\u001b[0m \u001b[1;32min\u001b[0m \u001b[0mcallbacks\u001b[0m\u001b[1;33m:\u001b[0m \u001b[0mcb\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mon_batch_begin\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m~\\Anaconda3\\envs\\fastai\\lib\\site-packages\\tqdm\\_tqdm.py\u001b[0m in \u001b[0;36m__iter__\u001b[1;34m(self)\u001b[0m\n\u001b[0;32m    953\u001b[0m \"\"\", fp_write=getattr(self.fp, 'write', sys.stderr.write))\n\u001b[0;32m    954\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 955\u001b[1;33m             \u001b[1;32mfor\u001b[0m \u001b[0mobj\u001b[0m \u001b[1;32min\u001b[0m \u001b[0miterable\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    956\u001b[0m                 \u001b[1;32myield\u001b[0m \u001b[0mobj\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    957\u001b[0m                 \u001b[1;31m# Update and possibly print the progressbar.\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mD:\\Work\\Deeplearning\\Notebooks\\fastai\\dataloader.py\u001b[0m in \u001b[0;36m__iter__\u001b[1;34m(self)\u001b[0m\n\u001b[0;32m     82\u001b[0m                 \u001b[1;31m# avoid py3.6 issue where queue is infinite and can result in memory exhaustion\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     83\u001b[0m                 \u001b[1;32mfor\u001b[0m \u001b[0mc\u001b[0m \u001b[1;32min\u001b[0m \u001b[0mchunk_iter\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0miter\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mbatch_sampler\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mnum_workers\u001b[0m\u001b[1;33m*\u001b[0m\u001b[1;36m10\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 84\u001b[1;33m                     \u001b[1;32mfor\u001b[0m \u001b[0mbatch\u001b[0m \u001b[1;32min\u001b[0m \u001b[0me\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mmap\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mget_batch\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mc\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m \u001b[1;32myield\u001b[0m \u001b[0mget_tensor\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mbatch\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpin_memory\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     85\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m~\\Anaconda3\\envs\\fastai\\lib\\concurrent\\futures\\_base.py\u001b[0m in \u001b[0;36mresult_iterator\u001b[1;34m()\u001b[0m\n\u001b[0;32m    584\u001b[0m                     \u001b[1;31m# Careful not to keep a reference to the popped future\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    585\u001b[0m                     \u001b[1;32mif\u001b[0m \u001b[0mtimeout\u001b[0m \u001b[1;32mis\u001b[0m \u001b[1;32mNone\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 586\u001b[1;33m                         \u001b[1;32myield\u001b[0m \u001b[0mfs\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpop\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mresult\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    587\u001b[0m                     \u001b[1;32melse\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    588\u001b[0m                         \u001b[1;32myield\u001b[0m \u001b[0mfs\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpop\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mresult\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mend_time\u001b[0m \u001b[1;33m-\u001b[0m \u001b[0mtime\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mtime\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m~\\Anaconda3\\envs\\fastai\\lib\\concurrent\\futures\\_base.py\u001b[0m in \u001b[0;36mresult\u001b[1;34m(self, timeout)\u001b[0m\n\u001b[0;32m    425\u001b[0m                 \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m__get_result\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    426\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 427\u001b[1;33m             \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_condition\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mwait\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mtimeout\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    428\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    429\u001b[0m             \u001b[1;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_state\u001b[0m \u001b[1;32min\u001b[0m \u001b[1;33m[\u001b[0m\u001b[0mCANCELLED\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mCANCELLED_AND_NOTIFIED\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m~\\Anaconda3\\envs\\fastai\\lib\\threading.py\u001b[0m in \u001b[0;36mwait\u001b[1;34m(self, timeout)\u001b[0m\n\u001b[0;32m    293\u001b[0m         \u001b[1;32mtry\u001b[0m\u001b[1;33m:\u001b[0m    \u001b[1;31m# restore state no matter what (e.g., KeyboardInterrupt)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    294\u001b[0m             \u001b[1;32mif\u001b[0m \u001b[0mtimeout\u001b[0m \u001b[1;32mis\u001b[0m \u001b[1;32mNone\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 295\u001b[1;33m                 \u001b[0mwaiter\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0macquire\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    296\u001b[0m                 \u001b[0mgotit\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;32mTrue\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    297\u001b[0m             \u001b[1;32melse\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;31mKeyboardInterrupt\u001b[0m: "
+     ]
+    }
+   ],
+   "source": [
+    "learn.fit(5e-2, 1, cycle_len=25, use_clr=(10,25/11,0.95,0.85))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Resnet 56"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 147,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "size = 32\n",
+    "batch_size = 64\n",
+    "data = get_data(size,batch_size)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class BasicBlock(nn.Module):\n",
+    "    expansion = 1\n",
+    "\n",
+    "    def __init__(self, in_planes, planes, stride=1):\n",
+    "        super().__init__()\n",
+    "        self.bn1 = nn.BatchNorm2d(planes)\n",
+    "        self.conv1 = nn.Conv2d(in_planes, planes, kernel_size=3, stride=stride, padding=1, bias=False)\n",
+    "        self.bn2 = nn.BatchNorm2d(planes)\n",
+    "        self.conv2 = nn.Conv2d(planes, planes, kernel_size=3, stride=1, padding=1, bias=False)\n",
+    "\n",
+    "        if stride != 1 or in_planes != self.expansion*planes:\n",
+    "            self.shortcut = nn.Sequential(\n",
+    "                nn.Conv2d(in_planes, self.expansion*planes, kernel_size=1, stride=stride, bias=False),\n",
+    "                nn.BatchNorm2d(self.expansion*planes)\n",
+    "            )\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        out = F.relu(x)\n",
+    "        shortcut = self.shortcut(out) if hasattr(self, 'shortcut') else x\n",
+    "        out = self.conv1(out)\n",
+    "        out = self.bn2(self.conv2(F.relu(self.bn1(out))))\n",
+    "        out += shortcut\n",
+    "        return out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ResNet(nn.Module):\n",
+    "    def __init__(self, block, num_blocks, num_classes=10):\n",
+    "        super().__init__()\n",
+    "        self.in_planes = 16\n",
+    "        self.conv1 = nn.Conv2d(3, 16, kernel_size=3, stride=1, padding=1, bias=False)\n",
+    "        self.bn1 = nn.BatchNorm2d(16)\n",
+    "        self.layer1 = self._make_layer(block, 16, num_blocks[0], stride=1)\n",
+    "        self.layer2 = self._make_layer(block, 32, num_blocks[1], stride=2)\n",
+    "        self.layer3 = self._make_layer(block, 64, num_blocks[2], stride=2)\n",
+    "        self.linear = nn.Linear(64*block.expansion, num_classes)\n",
+    "\n",
+    "    def _make_layer(self, block, planes, num_blocks, stride):\n",
+    "        strides = [stride] + [1]*(num_blocks-1)\n",
+    "        layers = []\n",
+    "        for stride in strides:\n",
+    "            layers.append(block(self.in_planes, planes, stride))\n",
+    "            self.in_planes = planes * block.expansion\n",
+    "        return nn.Sequential(*layers)\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        out = self.bn1(self.conv1(x))\n",
+    "        out = self.layer1(out)\n",
+    "        out = self.layer2(out)\n",
+    "        out = self.layer3(out)\n",
+    "        out = F.adaptive_max_pool2d(out, 1)\n",
+    "        out = out.view(out.size(0), -1)\n",
+    "        return F.log_softmax(self.linear(out))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn = ConvLearner.from_model_data(ResNet(BasicBlock,[9,9,9]), data)\n",
+    "learn.crit = F.nll_loss"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8c5dabd1a6e34738a9861314c652f75a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>HBox</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=1), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 78%|█████████████████████████████████████████████████████▋               | 609/782 [01:09<00:19,  8.76it/s, loss=12.4]\n",
+      "                                                                                                                       \r"
+     ]
+    }
+   ],
+   "source": [
+    "learn.lr_find()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEOCAYAAABmVAtTAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzt3Xl8lfWZ9/HPlT0hK2QhhEDYBFQ2ARFxQWvd6taxVWdaq9aW6tNObTtLl5naZTozneeZmT52+rSW2mlt1XGtimjdalGUigRkXwpCWAOBEMhG9uv54xxCjCEkmHPunOT7fr3Oi/vc516u/Iznm9+9/G5zd0RERADigi5ARET6D4WCiIi0UyiIiEg7hYKIiLRTKIiISDuFgoiItFMoiIhIO4WCiIi0UyiIiEg7hYKIiLRLCLqA3srNzfWSkpKgyxARiSkrV6485O55p1ou5kKhpKSE0tLSoMsQEYkpZrazJ8vp8JGIiLRTKIiISDuFgoiItFMoiIhIO4WCiIi0UyiIiEi7QRMKFdUN/H5dOceaWoMuRUSk3xo0obCirIq7H15FWWVd0KWIiPRbgyYUCrNTACg/eizgSkRE+q9BEwojslIB2HekIeBKRET6r0ETCnkZyQD84zPrOVCtYBAR6cqgCYX4OGufXr37SICViIj0X4MmFAC+fOl4ACpqGgOuRESkfxpUofCVy84gMd7Yd0Qnm0VEujKoQiEuzijMSmVvlUJBRKQrgyoUAEYPS2NbRW3QZYiI9EuDLhTOLMxkW0Utza1tQZciItLvDL5QGJFJU2sbWw+otyAi0tmgC4VZJUMBeHPbwYArERHpfwZdKBRlpzKxIIPXNlcEXYqISL8T0VAwszIzW2dmq82stIvPzcx+bGbbzGytmZ0TyXqOu3RyPqVlVRw91hyN3YmIxIxo9BQucffp7j6ri8+uAiaEXwuAn0WhHi6dlE9Lm7N0qw4hiYh0FPTho+uB33jI20C2mRVGeqczirPJSk3UISQRkU4iHQoOvGxmK81sQRefFwG7O7zfE54XUQnxcVwwIZdl2ypx90jvTkQkZkQ6FOa5+zmEDhN90cwu6vS5dbHOB76lzWyBmZWaWenBg31zyOe8scPYX93Azsr6PtmeiMhAENFQcPd94X8rgKeBczstsgco7vB+JLCvi+0sdPdZ7j4rLy+vT2qbOzZ0aeryHZV9sj0RkYEgYqFgZkPMLOP4NHA5sL7TYouAz4SvQjoPOOru5ZGqqaNxeenkpiexfPvhaOxORCQmJERw2wXA02Z2fD+PuPuLZnYXgLvfD7wAXA1sA+qBOyJYz/uYGTNH57BqV1W0diki0u9FLBTcfTswrYv593eYduCLkarhVM4akcXLGw9Q29hCenIk81FEJDYEfUlqoM4szMQdtuyvDroUEZF+YXCHwohMADbuUyiIiMAgD4XCrBSy0xLZWK5QEBGBQR4KZsaZhZms3n006FJERPqFQR0KEBoHaVN5NVsP1ARdiohI4AZ9KNwwo4iEOOPJVXuCLkVEJHCDPhRy05O5ZFI+T5buoaG5NehyREQCNehDAeDOC8ZQWdfE46W7T72wiMgAplAA5owZyrSRWdz77AZe/7OesSAig5dCgdBVSD/5q9BD317asD/gakREgqNQCCsemsalk/J5fctBGlt0bkFEBieFQgefmTuavUeO8USprkQSkcFJodDB/In5FA9N1XkFERm0FAqdXDA+j7ffq6SltS3oUkREok6h0MmFE3KpaWxhzZ4jQZciIhJ1CoVOzh83DDNYuvVQ0KWIiESdQqGT7LQkphRl8dY2hYKIDD4KhS5cMD6Xd3cdoa6xJehSRESiSqHQhbnjhtHS5qzcqec3i8jgolDowszROSTEGW9vrwy6FBGRqFIodCEtKYFpxdkKBREZdCIeCmYWb2bvmtniLj673cwOmtnq8Otzka6np+aNz2X17iPsqaoPuhQRkaiJRk/hHmBTN58/5u7Tw68HolBPj9w8uxgHfrdqb9CliIhETURDwcxGAh8D+s2XfU8VZacysSBDJ5tFZFCJdE/h/wJ/D3Q3ZsSNZrbWzJ40s+KuFjCzBWZWamalBw9Gb1yiGaOyWb37CG1tHrV9iogEKWKhYGbXABXuvrKbxZ4DStx9KvAq8GBXC7n7Qnef5e6z8vLyIlBt12YU53D0WDM7Kuuitk8RkSBFsqcwD7jOzMqAR4FLzeyhjgu4e6W7N4bf/gKYGcF6em3GqGwA3t2lcZBEZHCIWCi4+zfdfaS7lwC3AK+5+6c7LmNmhR3eXkf3J6SjblxeOjlpiby5VUNpi8jgkBDtHZrZ94FSd18EfNnMrgNagMPA7dGupztxccalkwp4ZeN+WlrbSIjXbR0iMrBF5VvO3Ze4+zXh6XvDgXC8N3GWu09z90vcfXM06umNi87Ipbqhhc37a4IuRUQk4vSn7ymcO2YoACvKDgdciYhI5CkUTqEwK5Wi7FRKy3S/gogMfAqFHphdksOKssO4634FERnYFAo9cP64XCpqGlmz52jQpYiIRJRCoQeumjKc1MR4HluxO+hSREQiSqHQAxkpiVw9pZDn1uzjWFNr0OWIiESMQqGHrps+gtrGFt7eoWcsiMjApVDooTljhpKSGMfrW3R3s4gMXAqFHkpJjGfu2GEs2VIRdCkiIhGjUOiF+RPzKausp+yQRk0VkYFJodAL8yeGhu1+/c86hCQiA5NCoRdGDxtCybA0HUISkQFLodBL8yfm86ftlTQ069JUERl4FAq9dPHEPBqa21i+QwPkicjAo1Dopbljh5GcEMcfN+sQkogMPAqFXkpJjOeC8bm8svGABsgTkQFHoXAarppSyN4jx1irAfJEZIBRKJyGj04uICHOeGFdedCliIj0KYXCachKS2TuuGG8uulA0KWIiPQphcJpumRiPu8drGNTeXXQpYiI9JmIh4KZxZvZu2a2uIvPks3sMTPbZmbLzawk0vX0leunjyAnLZF/eWFT0KWIiPSZaPQU7gFO9s15J1Dl7uOBHwH/FoV6+sSw9GQ+d+FYlm49xLaK2qDLERHpExENBTMbCXwMeOAki1wPPBiefhL4iJlZJGvqS5+cORIzeH6tTjiLyMAQ6Z7C/wX+Hmg7yedFwG4Ad28BjgLDIlxTn8nPTOHckqE8XrqbppaT/YgiIrEjYqFgZtcAFe6+srvFupj3gTvCzGyBmZWaWenBg/1rhNK7Lh7H3iPH+N2qPUGXIiLyoUWypzAPuM7MyoBHgUvN7KFOy+wBigHMLAHIAj4wqJC7L3T3We4+Ky8vL4Il9978iXmcXZTJr5eVBV2KiMiHFrFQcPdvuvtIdy8BbgFec/dPd1psEXBbePoT4WViauwIM+OG6UVs3l/Drsr6oMsREflQon6fgpl938yuC7/9JTDMzLYBXwO+Ee16+sIVZw0H4KUN+wOuRETkw0mIxk7cfQmwJDx9b4f5DcAno1FDJBUPTePMwkxe2rCfz180NuhyREROm+5o7iNXnDWclbuqqKhpCLoUEZHTplDoI1dPGY47PPvuvqBLERE5bQqFPjKhIIPZJTk8tHwnbW0xda5cRKSdQqEP3Tq3hJ2V9by+tX/dSyEi0lMKhT505VnDyU1P5qE/7Qy6FBGR06JQ6ENJCXHcPHskf9xSwYFqnXAWkdijUOhjn5xZjAO/fHNH0KWIiPSaQqGPleQO4fppI3j47Z0ca2oNuhwRkV5RKETAzbNHUdfUyssbdYeziMQWhUIEzBkzlBFZKTz97t6gSxER6RWFQgTExRnXThvBm1sPUd3QHHQ5IiI91qNQMLN7zCzTQn5pZqvM7PJIFxfLLj+rgJY2Z8kW3bMgIrGjpz2Fz7p7NXA5kAfcAfwwYlUNANOLc8hNT+KVjQeCLkVEpMd6GgrHn5B2NfArd19D109Nk7D4OOMjkwpYsrlCj+oUkZjR01BYaWYvEwqFl8wsg5M/d1nCLjuzgJrGFt7eXhl0KSIiPdLTULiT0ANwZrt7PZBI6BCSdOPCCblkpSby0Nsa9kJEYkNPQ2EusMXdj5jZp4F/BI5GrqyBISUxntvOL+HljQfYeqAm6HJERE6pp6HwM6DezKYBfw/sBH4TsaoGkNvPLyE5IY5fLysLuhQRkVPqaSi0uLsD1wP3uft9QEbkyho4hg5J4mNTC3l29T7qGluCLkdEpFs9DYUaM/smcCvwvJnFEzqvID3wqTmjqW1sYdEaPZVNRPq3nobCzUAjofsV9gNFwP/pbgUzSzGzd8xsjZltMLPvdbHM7WZ20MxWh1+f6/VPEAPOGZXNpOEZPLx8J6EOl4hI/9SjUAgHwcNAlpldAzS4+6nOKTQCl7r7NGA6cKWZndfFco+5+/Tw64HeFB8rzIxPnTea9XurWbWrKuhyREROqqfDXNwEvAN8ErgJWG5mn+huHQ+pDb9NDL8G7Z/JN55TRGZKAv/9ZlnQpYiInFRPDx/9A6F7FG5z988A5wLfPtVKZhZvZquBCuAVd1/exWI3mtlaM3vSzIp7XHmMSUtK4C/njOL368vZU1UfdDkiIl3qaSjEuXtFh/eVPVnX3VvdfTowEjjXzM7utMhzQIm7TwVeBR7sajtmtsDMSs2s9ODB2B1g7jNzSzAzfqtnOItIP9XTUHjRzF4Knxi+HXgeeKGnO3H3I8AS4MpO8yvdvTH89hfAzJOsv9DdZ7n7rLy8vJ7utt8pyk7lyrOH88g7u3R5qoj0Sz090fx3wEJgKjANWOjuX+9uHTPLM7Ps8HQqcBmwudMyhR3eXgds6nnpsemz88ZQ09DCU6v2BF2KiMgHJPR0QXd/CniqF9suBB4M39MQBzzu7ovN7PtAqbsvAr5sZtcBLcBh4PZebD8mnTMqm2nF2fzqrTI+PWc0cXEabFZE+o9uQ8HMauj6iiEjdIFR5snWdfe1wIwu5t/bYfqbwDd7XO0AYGZ8dl4J9zy6mj9uqeAjkwuCLklEpF23h4/cPcPdM7t4ZXQXCNK9q6cUUpSdyvee20h9k84tiEj/oWc0ByAxPo5//+Q0dh2u51dvlQVdjohIO4VCQOaOG8bFZ+Txq7fKaGxpDbocERFAoRCoOy8Yw6HaRp5fWx50KSIigEIhUBdOyGV8fjr//dYODZQnIv2CQiFAZsYd80pYv7ea0p0aKE9EgqdQCNhfzBhJVmoiv1y6I+hSREQUCkFLTYrn0+eN4qWN+9lZWRd0OSIyyCkU+oHb5paQGBfHL99Ub0FEgqVQ6AfyM1O4fvoInijdw6HaxlOvICISIQqFfuKu+eNoaWvjO4s2BF2KiAxiCoV+YlxeOl+57AyeX1vOC+t034KIBEOh0I984aKxTB2ZxbefWU+lDiOJSAAUCv1IQnhMpJqGFu59VoeRRCT6FAr9zBkFGdxz2QSeX1eu4S9EJOoUCv3QFy4ay7SRWXz72fW6GklEokqh0A8dP4xU29DCd3QYSUSiSKHQT00oyOCvLx3P8+vKeWXjgaDLEZFBQqHQj33+orGcXZTJ3zy+mgPVDUGXIyKDgEKhH0tJjOe//vIcGlva+Nbv1ml4bRGJOIVCPzcmdwh/d8VE/rC5gqff3Rt0OSIywEUsFMwsxczeMbM1ZrbBzL7XxTLJZvaYmW0zs+VmVhKpemLZHfPGMGt0Dt9dtIEKHUYSkQiKZE+hEbjU3acB04Erzey8TsvcCVS5+3jgR8C/RbCemBUfZ/zvT0wNHUZ6WoeRRCRyIhYKHlIbfpsYfnX+NrseeDA8/STwETOzSNUUy8bmpfN3V0zk1U0VPLVKh5FEJDIiek7BzOLNbDVQAbzi7ss7LVIE7AZw9xbgKDAskjXFsjvmjWHOmKHc++x6tlXUnnoFEZFeimgouHuru08HRgLnmtnZnRbpqlfwgWMjZrbAzErNrPTgwYORKDUmxMcZ990yg5TEeL70yCoamluDLklEBpioXH3k7keAJcCVnT7aAxQDmFkCkAUc7mL9he4+y91n5eXlRbja/m14Vgr/cdM0Nu+v4Z8Wbwy6HBEZYCJ59VGemWWHp1OBy4DNnRZbBNwWnv4E8JrrLOopXTIxny9cPJaHl+/iidLdQZcjIgNIQgS3XQg8aGbxhMLncXdfbGbfB0rdfRHwS+C3ZraNUA/hlgjWM6D87eUTWbfnKF9/ai0FmSlcdMbg7kGJSN+wWPvDfNasWV5aWhp0Gf1CXWMLN/5sGfuOHOOZL85jbF560CWJSD9lZivdfdapltMdzTFsSHICv/jMLBLi4/jcg6UcrW8OuiQRiXEKhRhXPDSNn33qHHZX1fOl/1lFS2tb0CWJSAxTKAwAc8YO4wc3nM3SrYf4wfObdMeziJy2SJ5olii6efYotuyv5b/f2kH50WP86ObppCXpP6+I9I56CgPIP35sMt+6ehKvbDzALQvfpqJGg+eJSO8oFAaQuDhjwUXjWHjrLLYeqOXj/28Zfz5QE3RZIhJDFAoD0GVnFvDEXXNpbm3jxp8u440/D96hQUSkdxQKA9TZRVk888V5FOWkcsevV/DgsrKgSxKRGKBQGMBGZKfy5N3nc8nEPL6zaAPffma9LlkVkW4pFAa49OQEfn7rLBZcNJbfvr2T72sQPRHphq5ZHATi44xvXT0Zd+cXS3ewfu9R7r32LKYXZwddmoj0M+opDCLfuGoy/3D1ZPYfbeCWhX/iqZV7dKObiLyPQmEQiY8zPn/RWJ790gVMKcrib55Yw+d/s5I9VfVBlyYi/YRCYRDKy0jm0QVz+eZVk1j23iE+9uM3eXF9uXoNIqJQGKzi44wvXDyOF758ISOyU7nroVV88ZFVHKlvCro0EQmQTjQPciW5Q3jmi+fzsyXv8eM/bOWtbZVccVYB04tzuGnWSBLi9XeDyGCi/+OF5IR4vnLZGbxwz4WcN3Yor22u4FtPr+OOX6/gQLXGTxIZTPTkNenSYyt2ce+zG0iKj+Pvr5rELbOLSVSvQSRm6clr8qHcPHsUL33lIqaMzOLbz6xn3g9f45Hlu4IuS0QiTKEgJ1WSO4SHPzeHX90+mzG5Q/jW0+v46mOrNfKqyAAWsVAws2Iz+6OZbTKzDWZ2TxfLzDezo2a2Ovy6N1L1yOkxMy6ZlM8jnz+Pu+eP4/fry7n8R2/whd+WsqLscNDliUgfi9g5BTMrBArdfZWZZQArgRvcfWOHZeYDf+vu1/R0uzqnEKyquiZ+tayM+5e8R0tbG5+ZW8L/umQc+RkpQZcmIt3o6TmFiF2S6u7lQHl4usbMNgFFgEZki2E5Q5L42kfP4M55Y/jhi5v47ds7eXTFLi4/czhXTynkkkl5JCfEB12miJymqFx9ZGYlwBvA2e5e3WH+fOApYA+wj1CvYUN321JPoX8pO1THz9/Yzksb9nO4ronstEQ+d8EYbppVTH6meg8i/UVPewoRDwUzSwdeB/7Z3X/X6bNMoM3da83sauA+d5/QxTYWAAsARo0aNXPnzp0RrVl6r6W1jbfeq+T+Je/xp+2VJMYbV51dyPnjhjFzdA7j8tKJi7OgyxQZtPpFKJhZIrAYeMnd/7MHy5cBs9z90MmWUU+hf3N3Nu+v4dF3dvHc2nIO14WGzchMSeCc0TnMPyOP+RPzKR6aRrxCQiRqAg8FMzPgQeCwu3/lJMsMBw64u5vZucCTwGjvpiiFQuxwd8oq61m5s4qVO6tYUXaYbRW1ABRlp/LJWSO5cEIu54zKIfTrIiKR0h9C4QJgKbAOOP4MyG8BowDc/X4z+xJwN9ACHAO+5u7LutuuQiG2bd5fzepdR3j63b28U3YYd/jIpHwWXDSWGaNySErQrTMikRB4KESKQmHgOFLfxMPLd7Hwje0cPdZMbnoS104bwTVTRzBzdE7Q5YkMKAoFiRn1TS28vOEAi9bs481th2hqaePaaSO49bzRzC7RoSWRvqBQkJhU19jCz9/Yzv1L3qOptY3ZJTl8dt4YrjhruK5eEvkQFAoS047WN7No7T5+8tpWDlQ3Mrkwk5tnjeTqKYW6/0EGpV+8sZ0pI7M4b+yw01pfo6RKTMtKS+TW80az7Bsf4b5bptPQ3Mp3n9vIR/7zdR5Yup26xpagSxSJGnfnhy9uZunWgxHfl0JB+rX4OOP66UW89jcX88pXL2LqyCx+8Pwm5v3bazywdDtNLW2n3ohIjKtuaKG1zclJS4r4vhQKEhPMjAkFGTz8ufN46u7zmToymx88v4mP/uh1XlxfTqwdBhXpjePPTs+OQijoGc0Sc2aOzuE3nz2X1/98kH9+fiN3PbSK6cXZTCzIYMrILGaOzmF8frqeFCcDRlV9MwA5aYkR35dCQWLWxWfkMW/chTxeuocHl5XxyqYDPFa6G4DstEQ+PqOIm2cXM2l4ZsCVinw4VeopiPRMQnwcfzVnFH81Z1T7sBprdh/hlU0HeOjtnfzqrTKmjszi6imhwfmmFGXpvgeJOccPH6mnINILZsaY3CGMyR3CDTOKOFzXxNPv7uV3q/bww99vBiArNZErziogLyOZoUOSuWxyPqOHDQm4cpHuVdUdP3yknoLIaRs6JIk7LxjDnReMoaKmgSWbD/LqpgM8/e5emltDJ6b/afFGJhZkMGNUNpdOyufiiXpIkPQ/5UePkZQQR2aqegoifSI/I4WbZhdz0+ximlraONbUypFjTby6qYLn1uxj8dpyHl2xm8yUBK6eUsj104s4b+xQHWqSfmHz/hom5KdHZbh5hYIMOkkJcSQlxJGVltjek2hubeOtbYd4dvU+Fq3Zx6MrQies8zKSmZCfTlpSAnkZSYzPz2BMbhozinPYWF7NxOEZ5KYnB/wTyUC3ZX8NF0zIjcq+FAoiQGJ8HPMn5jN/Yj7Hmlp5dMUudhyqo7G5jTV7jnC4roll7x2ivqn1fevFx4XOY5wzKpvLJhcwY1QOeRkKCek7VXVNVNQ0Mml4RlT2p1AQ6SQ1KZ475o35wPy2NqemoYW3d1SyraKWcXlDWLf3KOv3VvPcmnIeL90DwKzROVw7bQTTirOZXJihcxTyoWzeXwPAxChdWq1QEOmhuDgjKy2RK84azhVnheZdeXYhAEePNfPm1kOs3XuEF9fv5zuLNrSvNyE/nbF5QzizMIsJBemcO2aoDjlJj23ZXw3AZPUURGJHVmoiH5tayMemFvKNKyex/VAdq3ZWsbvqGMu3V7Jlfw0vbTjQvvy5JUP5zPmjufiMPDJSIn9FicSu1buPkJeRHLXDkgoFkT5mZozLS2dcXvr75tc3tfDOjsNs2FfNg8vK+NIj75KSGMdlkwu4dtoIZhRnk5eRrCuepJ27886Ow5xbEr0r4RQKIlGSlpTQfjL71rmjWbmzij9sOsAL6/azeG05AMOGJDE+P53kxHhumD6CKUVZFGSlkKnexKD03sFa9h1t4O5xp/cMhdOhUBAJQGZKIpdMzOeSifl899qzeGfHYbZW1LJ2z1F2VtZRdqiOrz2+JrxsAmPz0ikZlsZ100cwbEgy+ZnJpCbGkxJ+HdfU0saqXVUkxhvJCfFs2V/DwdpGZpfksPdIA+Pz0hmXP4Tdh+tJTohn6dZDVNQ0kJ6cwIjsVDJTEmlobuXVTQcoP9pAc2sbuenJnDMqm9rGFoYOSWb+xDxGZKcG1XSDyssbQ4ccPzq5IGr7VCiIBCwhPo7zx+dy/vgT16G3tTkrd1Xxzo7DbCyv5kh9E69truCZ1fs+sP7Y3CFMHpHJtJFZPLx8Fzsr67vdX5xB2ylGGk9NjKcwO4V4M9buOcqiNe/f79jcIdxybjE3zx5FZkoCTa1t4W2bRqftQ396r5JJwzMYnhW9pw1GLBTMrBj4DTAcaAMWuvt9nZYx4D7gaqAeuN3dV0WqJpFYERdnzC4ZyuySoe3zGppbWbWzirqmVt47WEu8GdUNzWzZX8MfN1fw/NpyMlIS+MlfzaC1zUmIi2N8fjppSfFsO1hLY3Mb7+6uIjk+jjF5Q6htbGVkdirnjM7B3dl+qI4j9U2kJMQzZWRW+wnwtjbnUF0jKYnxrNpZxYqyw5SWVfEvL2zmX17YTEKc0RJOmTiDwqxURg1NoyQ3javOLmRCQTr5GSmnvBu3uqGZo/XNjMhOjcqdu/1dc2sbq3ZWcePMkVHdb8Se0WxmhUChu68yswxgJXCDu2/ssMzVwF8TCoU5wH3uPqe77eoZzSIf1NTSxpH6JtKSE0hPjvwBAHfnT9srKS2rYlN5NY3hoUPOLsrkYE0juw7Xs2V/DXXhm/0KMpO5ZGI+Hz2zgPkT89u/9OsaW1j4xnZe3XSArRW1NLW0ER9nZKcmMmfsUD45q5js1EQKMlNCd6GnJg6ansjv15Vz98Or+OVts/hIHxw+6ukzmiMWCh/YkdmzwE/c/ZUO834OLHH3/wm/3wLMd/fyk21HoSASG6obmtsvy/39unJKy6poam2jKDuV88cNY9TQNB5avpMD1Y2cO2YoeenJzBydw+G6JsqPNvDyhv3UdHoW95CkeLLTkqhvaqEoJ5XxeelcNaWw/UR8UkLoCX2xfmJ+W0UtN/y/t0hPTmDp1y/pkyDsaShE5ZyCmZUAM4DlnT4qAnZ3eL8nPO99oWBmC4AFAKNGjYpUmSLShzJTEpk/MR+AW88b3X4C+8mVe3hxw35qGlqYUpTFTz91DjNHD/3A+gdrJrGpvJq6xhYOVDfQ5rD9UC1V9c0crg09X+DFDfu7PM8yMieVyYWZfPTMAj46uYDstMSYuNR3T1U9z67ex2MrdpOUEMdjXzgv6j2jiIeCmaUDTwFfcffqzh93scoHui7uvhBYCKGeQp8XKSIRl5IYzzVTR3DN1BG0tTm1TS1kJCec9Ms6dMNWXrfbPFLfxHsH62hobqWhOXSoavP+GjaVV7Nu71FeCV+9Mz4/nY/PKKK2sYU/bDrA0CFJTBqeyYjsFOoaW2lpa+OiCXlMH5UdyLAk9U2hw2gPLiujqr6Z/Ixk7rtleiDP+ojo4SMzSwQWAy+5+3928bkOH4lIRLg7r2w8wLaDtTy1cg/vHawDYM6YoZRV1nGguvED62SnJTKjOJsbZ44MPaUP4+ixZvYeqaessp6SYUM4XNdEQWYyZ47IpDDr9C/N3XfkGKt2VfHWtkqeeXcvDS2tnD9uGN+59iworEi9AAAKK0lEQVTOKOj7IS0CP6cQvrLoQeCwu3/lJMt8DPgSJ040/9jdz+1uuwoFEektd6ehuQ2zUI/leM/CPTQAYk1DC6//+SDLt1eyfMdhdh3u/rJegLSkeP728omMyE7lggm57zvBv3l/NU+U7qGltY2E+DjSkxMYPSyNhPg4nl61hx2H6thddYzW8FVb04qz+foVE993WXJf6w+hcAGwFFhH6JJUgG8BowDc/f5wcPwEuJLQJal3uHu33/gKBRGJpNY2Z/Hafbx3sI6M5ASKclIpyk6leGgauw/Xk5maSPmRY/z7y1tYtesIACmJcZxRkEFqYjybyqupbmghKT6OhHjjWPiw1vGv2tz0ZOaMHUpGcgLXTRtBUU5qVA4TBR4KkaJQEJH+oK0tdG9HRU0DT63cy45DtRxrbuOsEZmcUZDOX5wzkmFDkmhpc9rc2X34GDUNzUwpyiIhgMtq+9XVRyIiA01cnDE+P53x+emcP+7kh30S40Mn0sfnp590mf5kcNwFIiIiPaJQEBGRdgoFERFpp1AQEZF2CgUREWmnUBARkXYKBRERaadQEBGRdjF3R7OZHQW2dpiVBRztYjoXONSHu+647b5a/mTLdDW/J/NitS26+1xt0f1np5rXXbuoLQZPW2QB2e7e/bCzEBooKpZehB7r2eX7TtOlkdxvXyx/smW6mt+TebHaFt19rrb4cG1xinZRWwyStuhNPbF4+Oi5bt53/iyS++2L5U+2TFfzezIvVtuiu8/VFt1/dqp53bVLX1NbnP62I90WPa4n5g4f9ZSZlXoPBn8aDNQWJ6gtTlBbnKC2OCEWewo9tTDoAvoRtcUJaosT1BYnqC3CBmxPQUREem8g9xRERKSXFAoiItJOoSAiIu0GZSiY2XwzW2pm95vZ/KDrCZqZDTGzlWZ2TdC1BMnMJod/J540s7uDridIZnaDmf3CzJ41s8uDridIZjbWzH5pZk8GXUs0xFwomNl/m1mFma3vNP9KM9tiZtvM7Bun2IwDtUAKsCdStUZaH7UFwNeBxyNTZXT0RVu4+yZ3vwu4CYjZyxP7qC2ecffPA7cDN0ew3Ijqo7bY7u53RrbS/iPmrj4ys4sIfaH/xt3PDs+LB/4MfJTQl/wK4C+BeOBfO23is8Ahd28zswLgP939U9Gqvy/1UVtMJXSLfwqhdlkcner7Vl+0hbtXmNl1wDeAn7j7I9Gqvy/1VVuE1/sP4GF3XxWl8vtUH7fFk+7+iWjVHpSEoAvoLXd/w8xKOs0+F9jm7tsBzOxR4Hp3/1egu0MiVUByJOqMhr5oCzO7BBgCnAkcM7MX3L0tooVHQF/9Xrj7ImCRmT0PxGQo9NHvhQE/BH4fq4EAff59MSjEXCicRBGwu8P7PcCcky1sZn8BXAFkAz+JbGlR16u2cPd/ADCz2wn3oCJaXXT19vdiPvAXhP5QeCGilUVfr9oC+GvgMiDLzMa7+/2RLC7Kevt7MQz4Z2CGmX0zHB4D1kAJBeti3kmPi7n774DfRa6cQPWqLdoXcP9135cSuN7+XiwBlkSqmID1ti1+DPw4cuUEqrdtUQncFbly+peYO9F8EnuA4g7vRwL7AqolaGqLE9QWJ6gtTlBbdGOghMIKYIKZjTGzJOAWYFHANQVFbXGC2uIEtcUJaotuxFwomNn/AH8CJprZHjO7091bgC8BLwGbgMfdfUOQdUaD2uIEtcUJaosT1Ba9F3OXpIqISOTEXE9BREQiR6EgIiLtFAoiItJOoSAiIu0UCiIi0k6hICIi7RQKEnFmVhuFfVzXw2HC+3Kf883s/NNYb4aZPRCevt3M+sX4W2ZW0nmI6S6WyTOzF6NVk0SfQkFiRnjI4y65+yJ3/2EE9tnd+GDzgV6HAvAt4L9Oq6CAuftBoNzM5gVdi0SGQkGiysz+zsxWmNlaM/teh/nPWOjpbxvMbEGH+bVm9n0zWw7MNbMyM/uema0ys3VmNim8XPtf3Gb2azP7sZktM7PtZvaJ8Pw4M/tpeB+LzeyF4591qnGJmf2Lmb0O3GNm15rZcjN718xeNbOC8HDMdwFfNbPVZnZh+K/op8I/34quvjjNLAOY6u5ruvhstJn9Idw2fzCzUeH548zs7fA2v99Vz8tCT8973szWmNl6M7s5PH92uB3WmNk7ZpYR7hEsDbfhqq56O2YWb2b/p8N/qy90+PgZICafQSI94O566RXRF1Ab/vdyYCGhUSrjgMXAReHPhob/TQXWA8PC7x24qcO2yoC/Dk//L+CB8PTthB6MA/Br4InwPs4kNHY+wCcIDYkdBwwn9DyNT3RR7xLgpx3e53Di7v/PAf8Rnv4u8LcdlnsEuCA8PQrY1MW2LwGe6vC+Y93PAbeFpz8LPBOeXgz8ZXj6ruPt2Wm7NwK/6PA+C0gCtgOzw/MyCY2MnAakhOdNAErD0yXA+vD0AuAfw9PJQCkwJvy+CFgX9O+VXpF5DZShsyU2XB5+vRt+n07oS+kN4Mtm9vHw/OLw/EqgFXiq03aOD3u+ktDzD7ryjIeeDbHRQk/YA7gAeCI8f7+Z/bGbWh/rMD0SeMzMCgl90e44yTqXAWeatY/MnGlmGe5e02GZQuDgSdaf2+Hn+S3wvzvMvyE8/Qjw712suw74dzP7N2Cxuy81sylAubuvAHD3agj1KoCfmNl0Qu17RhfbuxyY2qEnlUXov8kOoAIYcZKfQWKcQkGiyYB/dfefv29m6OE2lwFz3b3ezJYQejwoQIO7t3baTmP431ZO/jvc2GHaOv3bE3Udpv+L0GNbF4Vr/e5J1okj9DMc62a7xzjxs51Kjwcmc/c/m9lM4GrgX83sZUKHebraxleBA8C0cM0NXSxjhHpkL3XxWQqhn0MGIJ1TkGh6CfismaUDmFmRmeUT+iu0KhwIk4DzIrT/N4Ebw+cWCgidKO6JLGBvePq2DvNrgIwO718mNPomAOG/xDvbBIw/yX6WERrGGULH7N8MT79N6PAQHT5/HzMbAdS7+0OEehLnAJuBEWY2O7xMRvjEeRahHkQbcCuhZxN39hJwt5klhtc9I9zDgFDPoturlCR2KRQkatz9ZUKHP/5kZuuAJwl9qb4IJJjZWuCfCH0JRsJThB6wsh74ObAcONqD9b4LPGFmS4FDHeY/B3z8+Ilm4MvArPCJ2Y108bQud99M6BGXGZ0/C69/R7gdbgXuCc//CvA1M3uH0OGnrmqeArxjZquBfwB+4O5NwM3Af5nZGuAVQn/l/xS4zczeJvQFX9fF9h4ANgKrwpep/pwTvbJLgOe7WEcGAA2dLYOKmaW7e62Fnrv7DjDP3fdHuYavAjXu/kAPl08Djrm7m9kthE46Xx/RIruv5w1CD7qvCqoGiRydU5DBZrGZZRM6YfxP0Q6EsJ8Bn+zF8jMJnRg24AihK5MCYWZ5hM6vKBAGKPUURESknc4piIhIO4WCiIi0UyiIiEg7hYKIiLRTKIiISDuFgoiItPv/m85xP35H7XAAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "learn.sched.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "95de70729bec4f2ba5077160a93fb376",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>HBox</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=5), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch      trn_loss   val_loss   accuracy                                                                              \n",
+      "    0      0.775708   0.931436   0.689092  \n",
+      "    1      0.675417   0.696961   0.764132                                                                              \n",
+      "    2      0.607041   1.670062   0.779459                                                                              \n",
+      "    3      0.595804   0.63958    0.792994                                                                              \n",
+      "    4      0.522924   0.633957   0.784236                                                                              \n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[0.6339573553365887, 0.7842356687898089]"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "learn.fit(0.01, 1, cycle_len=5, use_clr_beta=(1,0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 92,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d7a5455b21174f3596e9f747f9cd2ab5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>HBox</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=1), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 11%|███████▌                                                              | 84/782 [00:46<06:29,  1.79it/s, loss=12.3]\n",
+      "                                                                                                                       \r"
+     ]
+    }
+   ],
+   "source": [
+    "learn = ConvLearner.from_model_data(ResNet(BasicBlock,[9,9,9]), data)\n",
+    "learn.crit = F.nll_loss\n",
+    "learn.lr_find_beta(num_it=100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZ4AAAK9CAYAAAAUrAoKAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzs3XmcXFWZ//HP03t3ek86e5oECEsImwYEcRx2grLp4AyOjsAww6ioOO7OqAjqb0YdccUFZXNBVFAJiERklS2QsCSEAAlJSEIg6aSz9JJeqvv5/XFvJZWml6qu5Xalvu/Xq15169S59z7XSD19zj33HHN3REREcqUo6gBERKSwKPGIiEhOKfGIiEhOKfGIiEhOKfGIiEhOKfGIiEhOKfGIiEhOKfGIiEhOKfGIiEhOlUQdwFgxYcIEnzlzZtRhiIjklSVLlmxx96ZU9lHiCc2cOZPFixdHHYaISF4xs1dS3UddbSIiklNKPCIiklNKPCIiklN5l3jMrMLMnjCzZ81suZldOUidD5rZMjN7xsweNrM5UcQqIiJvlHeJB+gGTnb3I4GjgPlmdtyAOje7++HufhTwDeDqXAcpIiKDy7tRbR6sXNcefiwNXz6gzs6Ej+MGfi8iItHJxxYPZlZsZs8Am4F73H3RIHUuM7OXCVo8HxviOJea2WIzW9zS0jKqWO5+7jWu/suLo9pXRKQQ5WXicfe+sBttOnCsmc0dpM417n4A8FngC0Mc51p3n+fu85qaUnr+abdHVm3ll4vWjWpfEZFClJeJJ87dtwMPAPOHqXYLcF5OAhIRkRHlXeIxsyYzqw+3K4FTgRcG1Jmd8PGdwMrcRSgiIsPJu8EFwBTgJjMrJkicv3X3O83sKmCxuy8APmJmpwK9wDbgwujCFRGRRHmXeNx9KXD0IOVfSti+PKdBiYhI0vKuq01ERPJb3rV4xprfLVlPV29/1GGIiOQNtXjSpKQjIpIaJZ40XXj8ftRXlUYdhohI3lDiERGRnFLiERGRnFLiyQDXFKQiIklT4kmTmUUdgohIXlHiERGRnFLiERGRnFLiERGRnFLiyQDX6AIRkaQp8YiISE4p8YiISE4p8YiISE4p8YiISE7lXeIxswoze8LMnjWz5WZ25SB1PmFmz5vZUjO718z2iyJWERF5o7xLPEA3cLK7HwkcBcw3s+MG1HkamOfuRwC3At/IZkAa0yYikry8SzweaA8/loYvH1DnfnfvDD8+DkzPVjyaMUdEJDV5l3gAzKzYzJ4BNgP3uPuiYapfAvw5qwGpySMikrS8TDzu3ufuRxG0ZI41s7mD1TOz9wPzgG8O8f2lZrbYzBa3tLSMKhZDTR4RkVTkZeKJc/ftwAPA/IHfmdmpwH8D57h79xD7X+vu89x9XlNTU1ZjFRGRQN4lHjNrMrP6cLsSOBV4YUCdo4GfECSdzdmOST1tIiLJK4k6gFGYAtxkZsUEifO37n6nmV0FLHb3BQRda9XA78L1cta5+znZCEaDC0REUpN3icfdlwJHD1L+pYTtU3MalIiIJC3vutpERCS/KfGIiEhOKfGIiEhOKfFkgBaCExFJnhJPmjSoTUQkNUo8IiKSU0o8GaCONhGR5CnxpEkPkIqIpEaJR0REckqJJwM0qE1EJHlKPGky9bWJiKREiUdERHJKiScDXOPaRESSpsSTJkP3eEREUqHEky7d4hERSYkSTwaowSMikjwlnjSZmjwiIinJu8RjZhVm9oSZPWtmy83sykHqvN3MnjKzmJmdn/Wg1OQREUla3iUeoBs42d2PBI4C5pvZcQPqrAMuAm7OdjB6jEdEJDUlUQeQKg8Wv2kPP5aGLx9QZy2AmfXnJCY1eUREkpaPLR7MrNjMngE2A/e4+6LIYonqxCIieSovE4+797n7UcB04Fgzmzua45jZpWa22MwWt7S0pBHPqHcVESk4eZl44tx9O/AAMH+U+1/r7vPcfV5TU9OoYtA9HhGR1ORd4jGzJjOrD7crgVOBF6KNSkREkpV3iQeYAtxvZkuBJwnu8dxpZleZ2TkAZnaMmW0A3gP8xMyWZzMg9bSJiCQvH0e1LQWOHqT8SwnbTxLc/8k6PUAqIpKafGzxjDmu0QUiIklT4kmTBheIiKQmssRjZt8ws1ozKzWze81si5m9P6p40qH2johI8qJs8Zzu7juBs4ANwEHApyOMZ1S0Ho+ISGqiTDyl4fs7gF+7e2uEsYye+tpERFIS5ai2O8zsBWAX8GEzawK6IoxnVOJpx90xJSERkRFF1uJx988BxwPz3L0X6ADOjSqe0YrnGnW3iYgkJ8rBBe8BYu7eZ2ZfAH4JTI0qntHSczwiIqmJ8h7PF929zczeBpwB3AT8KMJ40qIGj4hIcqJMPH3h+zuBH7n77UBZhPGMyp6uNqUeEZFkRJl4XjWznwD/CNxlZuURxzMquwcXRBqFiEj+iPKH/h+BhcD8cHmDRvLxOR4NLhARSUmUo9o6gZeBM8zsI8BEd/9LVPGMVnwItZa/FhFJTpSj2i4HfgVMDF+/NLOPRhVPutTiERFJTpQPkF4CvMXdOwDM7OvAY8D3I4wpZXpmVEQkNVHe4zH2jGwj3M67n/H4czxq8YiIJCfKFs8NwCIz+0P4+TzgupF2MrMK4CGgnCD+W939igF1yoGfA28GtgL/5O5rMxd64rmycVQRkX1XZInH3a82sweAtxG0dC5296eT2LUbONnd282sFHjYzP7s7o8n1LkE2ObuB5rZBcDXgX/K8CXsRYMLRESSk/PEY2aNCR/Xhq/d3400S7UHT2q2hx9Lw9fAX/1zgS+H27cCPzAz8yw85blnktBMH1lEZN8URYtnCUGiGPjspYXb+490ADMrDo9zIHCNuy8aUGUasB7A3WNmtgMYD2xJO/o3xBK8K++IiCQn54nH3Wdl4Bh9wFFmVg/8wczmuvtzCVUGu/PyhtxgZpcClwI0NzePKhZNEioikpq8m6ImUTjjwQPA/AFfbQBmAJhZCVAHvKELz92vdfd57j6vqakp3VjS2l9EpFDkXeIxs6awpYOZVQKnAi8MqLYAuDDcPh+4Lxv3d4IYgnelHRGR5EQ5nHq0pgA3hfd5ioDfuvudZnYVsNjdFxAMy/6Fma0iaOlcEF24IiKSKLLEM2B0W1xbuBrpkNx9KXD0IOVfStjuAt6TdpApUE+biEhyouxqewpoAV4CVobba8zsKTN7c4RxpcTU1yYikpIoE8/dwDvcfYK7jwfOBH4LfBj4YYRxpaQozDv9avKIiCQlysQzz90Xxj+ESyK8PZyBoDy6sFJTHGYeJR4RkeREObig1cw+C9wSfv4nYFs4aKA/urBSE+9q61PiERFJSpQtnn8GpgN/BG4HmsOyYoLVSfPC7sdHlXdERJIS5SShW4ChFn5blctY0qGxBSIiqYlyOPVBwKeAmYlxuPvJUcU0GlqPR0QkNVHe4/kd8GPgZ+y9IFxe2dPiUeYREUlGlIkn5u4/ivD8GaFlEUREUhPl4II7zOzDZjbFzBrjrwjjGRXd4xERSU2ULZ74JJ6fTihLaj2esWTPPR6lHhGRZEQ5qi3tdXnGgt0tHuUdEZGkRLH09cnufp+ZvXuw793997mOKR1FplFtIiKpiKLF8/fAfcDZg3znQH4lnvAumabMERFJThRLX18Rvl+c63NnQ7zFo8QjIpKcKB8gLQf+gTc+QHpVVDGNhinxiIikJMpRbbcDO4AlQHeEcaSlJJydui9vpjUVEYlWlIlnurvPT3UnM5sB/ByYTDCL9bXu/t0BdRqA64EDgC7gX939ufRDfqN4V1tfv1o8IiLJiPIB0kfN7PBR7BcDPunuhwLHAZeZ2ZwBdf4LeMbdjwA+AHyXLNnT4lHiERFJRpSJ523AEjN70cyWmtkyM1s60k7u/pq7PxVutwErgGkDqs0B7g3rvADMNLNJmQ0/EF8ITuvxiIgkJ8qutjPTPYCZzQSOBhYN+OpZ4N3Aw2Z2LLAfwdo/m9I95xtjCN7V4hERSU7OWzxmVhtutg3xSvY41cBtwMfdfeeAr/8XaDCzZwjW/HmaoItu4DEuNbPFZra4paUl5WsBLX0tIpKqKFo8NwNnEYxmcxIW8STJudrMrJQg6fxqsJkOwkR0cVjXgDXha2C9a4FrAebNmzeqzBFPPLE+JR4RkWRE8QDpWeH7qOZqCxPJdcAKd796iDr1QKe79wD/Bjw0SKsoI+Kj2rZ25O2IcBGRnIryHk982PNsoCJe5u4PjbDbCcC/AMvCrjQIRrE1h/v/GDgU+LmZ9QHPA5dkOPTdHn15KwBfun05Zx0xNVunERHZZ0Q5c8G/AZcT3PR/hmBo9GPAsEtfu/vD7N09N1idxwgSWtYdMrkGgMOm1o5QU0REINrh1JcDxwCvuPtJBKPTRneHP0LHzgrWrjttTlZGa4uI7HOiTDxd7t4Fwbxt4fM2B0cYz6iUhtNT92pwgYhIUqK8x7MhHATwR+AeM9sGbIwwnlEpKY6PatNkbSIiyYhyBdJ3hZtfNrP7gTrg7qjiGa3diUcPkIqIJCWSxGNmRcBSd58L4O4PRhFHJuzpalOLR0QkGZHc43H3fuBZM2uO4vyZVFRkFBeZHiAVEUlSlPd4pgDLzewJoCNe6O7nRBfS6JQWm1o8IiJJijLxXBnhuTOqtLiIHiUeEZGkRJl43uHun00sMLOvA3l3v6esuIiemBKPiEgyonyO57RBytJeKiEKpcVF6moTEUlSzls8ZvYh4MPA/gMWfqsBHsl1PJlQVqIWj4hIsqJaFuHPwP8An0sob3P31gjiSVtZie7xiIgkK4plEXYAO4D35vrc2aJ7PCIiyYvyHs8+I2jx6DkeEZFkKPFkQFlxEb1q8YiIJEWJJwNKS/QAqYhIsvIu8ZjZDDO738xWmNlyM7t8kDp1ZnaHmT0b1rk4mzFpOLWISPIiXfp6lGLAJ939KTOrAZaY2T3u/nxCncuA5939bDNrAl40s1+5e082AiotLqJbXW0iIknJuxaPu7/m7k+F223ACmDawGpAjZkZUA20EiSsrCjXczwiIknLxxbPbmY2k2DJ7EUDvvoBsIBgYbka4J/CGbGzoqK0mK7evmwdXkRkn5J3LZ44M6sGbgM+7u47B3x9BvAMMBU4CviBmdUOcoxLzWyxmS1uaWkZdSzlJepqExFJVl4mHjMrJUg6v3L33w9S5WLg9x5YBawBDhlYyd2vdfd57j6vqalp1PFUlBazSy0eEZGk5F3iCe/bXAescPerh6i2DjglrD8JOBhYna2YGqpK6ezpozum5CMiMpJ8vMdzAvAvwDIzeyYs+y+gGcDdfwx8BbjRzJYBBnzW3bdkK6DGceUAtHb0MKWuMlunERHZJ+Rd4nH3hwmSyXB1NgKn5yYiaBxXCsC2jl4lHhGREeRdV9tY1FBVBgQtHhERGZ4STwbUh4lnx67eiCMRERn7lHgyoLYy6LHc2aXEIyIyEiWeDKitCO7xqMUjIjIyJZ4MqCorprykiK3t3VGHIiIy5inxZICZMam2gk07lXhEREaixJMh0xsqeWVrR9RhiIiMeUo8GTJnSi0rXm+jv19LYIuIDEeJJ0Mm11XQE+unrTtrqy+IiOwTlHgyZPezPJ0a2SYiMhwlngyprwyGVG/fpdkLRESGo8STIfVV4XxtavGIiAxLiSdDmmqCGao37eyKOBIRkbFNiSdDptRVYgYbtu2KOhQRkTFNiSdDykqKmFJbwfrWzqhDEREZ05R4MuiQKbU8u2F71GGIiIxpSjwZdMzMRla3dGjONhGRYeRd4jGzGWZ2v5mtMLPlZnb5IHU+bWbPhK/nzKzPzBqzHdtRM+oBWPrqjmyfSkQkb+Vd4gFiwCfd/VDgOOAyM5uTWMHdv+nuR7n7UcDngQfdvTXbgR0+vQ4zWLpeiUdEZCh5l3jc/TV3fyrcbgNWANOG2eW9wK9zEVt1eQmzJ1bzzPptuThdTu3Y1cuqzW10x/qiDkVE8lxJ1AGkw8xmAkcDi4b4vgqYD3wkVzEdPaOBhc+/jrtjZrk6bVb0xPp58KUW/vD0Bv66YjM9sX6KDJobqzigqZoDJlZzQNO4YLupmoZxZVGHLCJ5IG8Tj5lVA7cBH3f3nUNUOxt4ZKhuNjO7FLgUoLm5OSNxHTurkd8sXs+sz9/FjRcfw4kHT8zIcVMR6+vn+kfWcMMja6kuL2FyXQWTayuYUlfBpLoKptZVMqOxkmn1VVSWFe+1r7vzzPrt/OHpV7nj2Y1s6+xl/Lgy/vnYZg6fVscrWzt4uaWDl1va+duqLfTE+nfvO35cGcfOauTUQydx8iETlYhEZFDmnn/T+JtZKXAnsNDdrx6m3h+A37n7zSMdc968eb548eK0Y+vq7eOQL94NwDsPn8I173tT2sdMxQuv7+Qzty5l6YYdvPWA8VSXl7BpZxev7+yipa2bgas2TKguZ0ZjJdMbqhg/royHXmph9ZYOykuKOG3OJN519DTeflATpcVv7JXt63de3baLl1vaebmlnRdfb+PBl1rY3NZNcZExb78GTpszidPmTGK/8eNy9L+AiOSSmS1x93kp7ZNviceC/qubgFZ3//gw9eqANcAMdx9xhbZMJR6AlZvauOzmp+iO9fPgp0/KyDFH0hPr55r7V/HDB1ZRW1HKl885jLOOmLJXd1+sr5+W9m42bt/Fhm27WN/ayfrWXWzYHry/vrOLNzXX8+6jpzP/8MnUVpSmHEd/v7Ps1R38dcUm7nl+Ey+83gbA7InVnDZnEqfOmcRR0+spKsrvbkgRCRRK4nkb8DdgGRDv5/kvoBnA3X8c1rsImO/uFyRz3EwmHoCf/W01X/3TCi5660z++52HDtpiSFdHd4xn1m/nybWt/Gnpa6zc3M65R03lirMPo3GMdHOt29q5Owk9sbaVvn6nqaacUw+dxOmHTeKtB4ynvKR45AOJyJhUEIknWzKdeNZu6eDE/3sAgBsuPoaTMnivZ+Hy17nm/lUs37iTvn7HLFgB9ROnHcQph07K2HkybUdnL/e/uJl7nt/EAy9upqOnj5ryEk48ZCJnHDaJEw+eSHV53t52FClISjxpyHTiAejsiXHEl//Cv799fz47/5CMHPNXi17hC398jtkTqzl9zmTmzWzgTfs1jKpbLEpdvX08+vIWFj63ib+u2MTWjh7Kios44cDxnHHYZE45dNLuGb9FZOwaTeLRn5dZVFVWwuHT63hiTfrPrro7P3zgZb658EVOOriJH77vzW8YkZZPKkqLOfmQSZx8yCT6+p0lr2xj4fLXWbj8de5/cRlmy5i3XwOnz5nM8QeM54Cm6ry+XhHZQ4kny46d1cj1D69hV09fyj+cHd0xtu/qZXtnD7cu2cANj6zlXUdP4xvnH5GVe0ZRKS4yjp3VyLGzGvnCOw9lxWttu5PQ1+5aAYAZzGioYvbEag6cVM3siTUcNCl4fmicuudE8or+i82y42aN5ycPrmbxK6383eympPf78YMv879/fmGvsoveOpMvnTVnnx4RZmbMmVrLnKm1/OdpB7G+tZOlG3awcnMbKze3s2pTOw+tbKG3b08X8bT6SmZPqmb2xCAhHRhu1+RZ96NIoVDiybLj9h9PZWkxC5e/zgkHTKCjJzbiD+K2jh6+d+9Kjt9/POceNZX6qlIm11Vy5PS6vJ8NIVUzGquY0VgFTNldFuvr55XWTlZuamdVmJBWbmrnsZe30p3wQOuUugoOnFjNQZOC1tGBE2uYPak67+6HiexrlHiyrLKsmJMPmcjdz21i885unlq3jfs+deKwP37XP7KGzp4+rjz3MA6aVJPDaPNDSXHR7ml6YPLu8r5+Z8O2Tl7a1B60kDa189KmNn75+CtKSCJjiBJPDpx5+GT+tOw1/vL8JgB+/uhaPnLy7EHr7tjVy42PrOXMuZOVdFJUXGTsN34c+40fx2lz9gwrTzUhzZ5YE7xPquZAzUEnknFKPDlw0sETqako4e2zm9jV28fPHl7DRSfMGvSZlRsfWUtbd4yPnHxgBJHum0ZKSCs3tfNSQkK6+YlX6Ordew66AyZWh0kpeD9wYjWTaysKrutTJBP0HE8oG8/xJGpp66ahqpRlr+7gXT98lDPnTuZTZxwcdhcF2rp6edvX7+eYmQ387MJjshaLDK+/33l1+y5WtQSDGVZtbg+2N7ezY1fv7nrV5SUc0DSOA8MWUvzV3FhF8T48AEQkkR4gTUO2E0+iby58gZ/+bQ09sX7eecQUPnnaQazd2sH/3PUCKze388fLTti9mqmMHe5OS3s3qza38/LmPQlp5aZ2NrftWe68rLiIqfUVNIwro6Eq/iqlYVwZjePC7aqy3d/XV5XuU8PjpbAo8aQhl4kHYEt7Nzc+snb3QAKAWRPG8V/vOHSv7iDJDzt29fJy2Cp6eXM7G3d0sa2jh22dPeF7L7t6h15Er6aihMZxZdRXldEYJqmGqrKwrJTGMFGNHxe811eWUqJkJWOAEk8acp144lrauvnFY2tpqq3ggmNm6C/ffVhXbx/bOnto7ehhW0dvkJQ692y3xhNVQln8j5LB1FWW7m5BNSYkqoZxZbsTVeO4oHU1flw5NRUl+/QzYDK0WF8/W9p72NzWxaad3Wza2cXmtm427+xi084uPnXGwRw2tW5Ux9aUOXmoqaacT5x+cNRhSA5UlBYzpa6SKXWVSe8TT1YDk1OQvHpo7exlW0cPG7d3sXzjTrZ29Oy1OF+i4iLbq5uvsaqMCTVlzGioojl8Xmq/8VV68DaPxPr62drREySSnd1sChNLy4AEs6W9m4FtDLNgPa6JNeXD/oGTDUo8ImNYqsnK3dnV20drR8/uV5CoesNEFSasjh5Wb2nn8TXdbO/s3esYDVWlNDdW0Tx+HM2NlcF24ziax1cxubZCAydyIJ5QNofJY1NbkFg2t+2dYLa2v3FxRzMYP66cSbXlTKqt4PBpdUysrWBSbTkTayp2l48fVxZZd60Sj8g+xMyoKiuhqqyE6Q1VSe2zs6uXdVs7Wd/aybrWTl5p7QynKtrOn5e9Rizhl62suIjpDZXMaAxaSfuNr9q93dxYpXnzRtDX72xt72ZTmETe0O0VJpYtwySUiTVBUpk7tY6JNeVhUqkIyyuYUB1dQkmW/l8iUuBqK0qZO62OudPe2Mcf6+vntR1drIsnpYQE9fS6bezsiu1Vf0J12Z6k1LgnKTXVlBPrd3pi/XTH+umJ9dPTF77H+unp69u93T3wuwGfu4f5Lr4dnKOPfgcDMCgyw+LvBD/klrC9p9zC78AwigbUi2/Hj0fC9qDHAXr6+odMKPH/3SbWVDCxtpzDptQxqbacptoKJoXJZGJtOROqy/eZe8BKPCIypJLiot3z5Z0wyPc7Onv3JKXWjt1J6al127jj2Y2D/simdP4io6ykKHgVF+21XR5uV5QWUVtREn5XvLteeUkRRWY4vvv+Rr8H247T7wTbg5WF+7g7DmF5sL27vofHg73quofHSahbW2zMmVIbJpE9rZNJ+1hCSVbeJR4zmwH8nGCSrn7gWnf/7iD1TgS+A5QCW9z973MZp0ghqKsq5fCqOg6f/sbWUm9fPxu372Jdaydb23soHZA44smhrKRoz3eJ5cVFGoW3j8q7xAPEgE+6+1NmVgMsMbN73P35eAUzqwd+CMx393Vmlrl1p0UkKaXFRbunKhJJlHftO3d/zd2fCrfbgBXAtAHV/hn4vbuvC+ttzm2UIiIylLxLPInMbCZwNLBowFcHAQ1m9oCZLTGzDwyx/6VmttjMFre0tGQ3WBERAfI48ZhZNXAb8HF33zng6xLgzcA7gTOAL5rZQQOP4e7Xuvs8d5/X1JT86qAiIjJ6+XiPBzMrJUg6v3L33w9SZQPBgIIOoMPMHgKOBF7KYZgiIjKIvGvxWLAAynXACne/eohqtwN/Z2YlZlYFvIXgXpCIiEQsH1s8JwD/Aiwzs2fCsv8CmgHc/cfuvsLM7gaWEgy5/pm7PxdJtCIishfNTh0ysxbglVHuPgHYksFw8k0hX38hXzvo+gv5+uPXvp+7p3STXIknA8xscarTgu9LCvn6C/naQddfyNefzrXn3T0eERHJb0o8IiKSU0o8mXFt1AFErJCvv5CvHXT9hXz9o7523eMREZGcUotHRERySolHRERySoknBWY238xeNLNVZva5Qb4vN7PfhN8vCicx3Sckce1vN7OnzCxmZudHEWM2JXH9nzCz581sqZnda2b7RRFntiRx/R80s2Vm9oyZPWxmc6KIMxtGuvaEeuebmZvZPjW8Ool/+4vMrCX8t3/GzP5txIMGK+TpNdILKAZeBvYHyoBngTkD6nwY+HG4fQHwm6jjzuG1zwSOIFik7/yoY47g+k8CqsLtD+0r//YpXH9twvY5wN1Rx52raw/r1QAPAY8D86KOO8f/9hcBP0jluGrxJO9YYJW7r3b3HuAW4NwBdc4Fbgq3bwVOCeeWy3cjXru7r3X3+BRF+5pkrv9+d+8MPz4OTM9xjNmUzPUnzhA/jmDl531BMv/dA3wF+AbQlcvgciDZ60+JEk/ypgHrEz5v4I0L0O2u4+4xYAcwPifRZVcy174vS/X6LwH+nNWIciup6zezy8zsZYIf4I/lKLZsG/HazexoYIa735nLwHIk2f/v/0PYzXyrmc0Y6aBKPMkbrOUy8K+6ZOrko331upKV9PWb2fuBecA3sxpRbiV1/e5+jbsfAHwW+ELWo8qNYa/dzIqAbwOfzFlEuZXMv/0dwEx3PwL4K3t6fYakxJO8DUBiJp8ObByqjpmVAHVAa06iy65krn1fltT1m9mpwH8D57h7d45iy4VU//1vAc7LakS5M9K11wBzgQfMbC1wHLBgHxpgMOK/vbtvTfj/+08JFuEclhJP8p4EZpvZLDMrIxg8sGBAnQXAheH2+cB9Ht59y3PJXPu+bMTrD7tbfkKQdDZHEGM2JXP9sxM+vhNYmcP4smnYa3f3He4+wd1nuvtMgvt757j74mjCzbhk/u2nJHw8hyTWPsvH9Xgi4e4xM/sIsJBgpMf17r7czK4CFrv7AoIF6n5hZqsIWjoXRBdx5iRz7WZ2DPAHoAE428yudPfDIgw7Y5L8t/8mUA38LhzyVgjjAAAgAElEQVRPss7dz4ks6AxK8vo/Erb4eoFt7PkDLK8lee37rCSv/2Nmdg4QI/jdu2ik42rKHBERySl1tYmISE4p8YiISE4p8YiISE4p8YiISE4p8YiISE4p8Ygkwczac3COc4ab/ThL5zzRzN6ay3OK6DkekRwys2J37xvsu/CZiIw/F2JmJeHcgYM5EWgHHs30eUWGohaPSIrM7NNm9mQ4KeKVCeV/NLMlZrbczC5NKG83s6vMbBFwvJmtNbMrw/WLlpnZIWG9i8zsB+H2jWb2PTN71MxWx9c4MrMiM/theI47zeyuwdY/MrMHzOz/mdmDwOVmdrYFa0Q9bWZ/NbNJFqwX9UHgP8N1VP7OzJrM7Lbw+p40sxOy+b+lFCa1eERSYGanA7MJpos3gnm53u7uDwH/6u6tZlYJPGlmt7n7VoJlAp5z9y+FxwDY4u5vMrMPA58CBls8awrwNuAQgpbQrcC7CdY+OhyYSDA9yfVDhFvv7n8fnrMBOM7dPVyo6zPu/kkz+zHQ7u7/F9a7Gfi2uz9sZs0ET6wfOur/wUQGocQjkprTw9fT4edqgkT0EMHUIe8Ky2eE5VuBPuC2Acf5ffi+hCCZDOaP7t4PPG9mk8KytwG/C8tfN7P7h4n1Nwnb04HfhPNqlQFrhtjnVGBOwjJStWZW4+5tw5xHJCVKPCKpMeB/3P0nexWanUjwo328u3ea2QNARfh11yD3deKz+fYx9H+HiTNc24D3ZHQkbH8fuDqcV+9E4MtD7FNEcA27UjiPSEp0j0ckNQuBfzWzagAzm2ZmEwmWwNgWJp1DCKbHz4aHCRbdKgpbQScmuV8d8Gq4nTiBZxvB1P5xfwE+Ev9gZkeNPlSRwSnxiKTA3f8C3Aw8ZmbLCO671AB3AyVmtpRgGeTHsxTCbQRrpDxHsAzDIoKVbkfyZYKZs/8GbEkovwN4V3xwAcHKofPCgRPPEww+EMkozU4tkmfMrNrd281sPPAEcIK7vx51XCLJ0j0ekfxzp5nVEwwS+IqSjuQbtXhERCSndI9HRERySolHRERySolHRERySolHRERySolHRERySolHRERySs/xhCZMmOAzZ86MOgwRkbyyZMmSLe7elMo+SjyhmTNnsnjx4qjDEBHJK2b2Sqr7qKtNRERySolHRERySolHRERySolHRERySolHRERySomnwOzo7GXNlo6RK4qIZIkST4H59l9f4uRvPcD//vkFemL9UYcjIgVIiafAvL6ji2Izfvzgy5x3zSOs3NQWdUgiUmCUeApMW3cvR0yv46cfmMemnV2c9f2HufGRNfT3a0FAEckNJZ4C094Vo6ailNPmTOLuj7+dEw6cwJfveJ4Lb3iCTTu7og5PRAqAEk+BaeuKUV0RzJTUVFPOdRfO46vnzeXJta2c8Z2HeEldbyKSZUo8BWZnV4zaij1T9JkZ7z9uP+786NvY3tnLX1dsijA6ESkESjwFpr27l5qK0jeUHzixhoaqUjZu3xVBVCJSSJR4CkhvXz9dvf1Ulw8+KfmUuko2btd9HhHJLiWeAtLeFQOgpmLwxDO1vlItHhHJOiWeAtK2O/G8sasNYFp9Ba8q8YhIlinxFJCdXb0AQ3a1Ta2vpK0rRltYT0QkG5R4Ckh7d9DiqR2mqw3gtR26zyMi2aPEU0DiXW3VIyQedbeJSDZlLfGY2fVmttnMnkso+6aZvWBmS83sD2ZWn/Dd581slZm9aGZnJJTPD8tWmdnnEspnmdkiM1tpZr8xs7KwvDz8vCr8fma2rjHfxLvQhr7HEyQeDTAQkWzKZovnRmD+gLJ7gLnufgTwEvB5ADObA1wAHBbu80MzKzazYuAa4ExgDvDesC7A14Fvu/tsYBtwSVh+CbDN3Q8Evh3WE/Z0tQ01qq2pppySIlPiEZGsylricfeHgNYBZX9x91j48XFgerh9LnCLu3e7+xpgFXBs+Frl7qvdvQe4BTjXzAw4Gbg13P8m4LyEY90Ubt8KnBLWL3i7u9qGGFxQXGRMqq3QszwiklVR3uP5V+DP4fY0YH3CdxvCsqHKxwPbE5JYvHyvY4Xf7wjrF7y2rhhlxUVUlBYPWWdafaXu8YhIVkWSeMzsv4EY8Kt40SDVfBTlwx1rsDguNbPFZra4paVl+KD3AW1dvUN2s8VNra/gtR1KPCKSPTlPPGZ2IXAW8D53jyeEDcCMhGrTgY3DlG8B6s2sZED5XscKv69jQJdfnLtf6+7z3H1eU1NTupc25iXOTD2UqfWVvL6jiz6tzyMiWZLTxGNm84HPAue4e2fCVwuAC8IRabOA2cATwJPA7HAEWxnBAIQFYcK6Hzg/3P9C4PaEY10Ybp8P3JeQ4Apae3csiRZPJb19zpb27hxFJSKFJpvDqX8NPAYcbGYbzOwS4AdADXCPmT1jZj8GcPflwG+B54G7gcvcvS+8R/MRYCGwAvhtWBeCBPYJM1tFcA/nurD8OmB8WP4JYPcQ7ELX1tU75MCCuGl6lkdEsmz4X6E0uPt7Bym+bpCyeP2vAV8bpPwu4K5BylcTjHobWN4FvCelYAtEW1eMGY1Vw9aZUl8BBM/yvKm5IRdhiUiB0cwFBaStK7muNtBDpCKSPUo8BaStq5eaEbraaitKqSkv0bM8IpI1SjwFwt3DwQWDT5eTSOvyiEg2KfEUiM6ePvp96OlyEk2tr2CjnuURkSxR4ikQI81MnSho8airTUSyQ4mnQLR3Dz8zdaKp9ZW0dvSwq6cv22GJSAFS4ikQO+PLXo8wuACCrjZA3W0ikhVKPAWivWv4JRESTa3TkGoRyR4lngLRtjvxJNfVBko8IpIdSjwFIr76aDKDCybXVWAGr2qAgYhkgRJPgRhp9dFEpcVFTKqp4DW1eEQkC5R4CkR8cEF1WXLT8+lZHhHJFiWeAhGfmbqoKLlVwPUsj4hkixJPgWhPYoLQRFPDJbC1lJGIZJoST4FIZmbqRFPrKuiJ9bO1oyeLUYlIIVLiKRDt3bERF4FLpCHVIpItSjwFoq2rN6lneOKUeEQkW7K59PX1ZrbZzJ5LKGs0s3vMbGX43hCWm5l9z8xWmdlSM3tTwj4XhvVXmtmFCeVvNrNl4T7fMzMb7hyFrq0rltQzPHHTdiceDTAQkczKZovnRmD+gLLPAfe6+2zg3vAzwJnA7PB1KfAjCJIIcAXwFoJlrq9ISCQ/CuvG95s/wjkKWlt3jNoUEk99VSmVpcVq8YhIxmUt8bj7Q0DrgOJzgZvC7ZuA8xLKf+6Bx4F6M5sCnAHc4+6t7r4NuAeYH35X6+6PeTDs6ucDjjXYOQpaql1tZqZneUQkK3J9j2eSu78GEL5PDMunAesT6m0Iy4Yr3zBI+XDnKFi9ff109fanNLgA4kOq1dUmIpk1VgYXDPZUo4+iPLWTml1qZovNbHFLS0uqu+eNVGamTjS1Tktgi0jm5TrxbAq7yQjfN4flG4AZCfWmAxtHKJ8+SPlw53gDd7/W3ee5+7ympqZRX9RYl8rM1Imm1lfS0tZNd0wLwolI5uQ68SwA4iPTLgRuTyj/QDi67ThgR9hNthA43cwawkEFpwMLw+/azOy4cDTbBwYca7BzFKy2cPXR1LvaggXhXt+h7jYRyZzUfolSYGa/Bk4EJpjZBoLRaf8L/NbMLgHWAe8Jq98FvANYBXQCFwO4e6uZfQV4Mqx3lbvHByx8iGDkXCXw5/DFMOcoWPEWTyqj2mDPkOpXt+9iv/HjMh6XiBSmrCUed3/vEF+dMkhdBy4b4jjXA9cPUr4YmDtI+dbBzlHI4oknled4YM9DpK9pgIGIZNBYGVwgWdQedrWleo9ncl3Q1aYBBiKSSUo8BaBtlKPaKkqLmVBdrmd5RCSjlHgKwO6uthQHF0AwwEDP8ohIJinxFIC2rhhlxUVUlBanvK+e5RGRTFPiKQDBdDmjG0cSrESqBeFEJHNGTDxmNs7MisLtg8zsHDNL7S61RKq9O7WZqRNNra+gs6ePHbt6MxyViBSqZFo8DwEVZjaNYLbniwmen5E8kerqo4m0PIKIZFoyicfcvRN4N/B9d38XMCe7YUkmtXX1jmpgAWhBOBHJvKQSj5kdD7wP+FNYlrUHTyXzghbP6HpHdyceDakWkQxJJvF8HPg88Ad3X25m+wP3ZzcsyaR0utrGjyujrLiIV9XiEZEMGfHXyN0fBB4ECAcZbHH3j2U7MMmctq5eakbZ1VZUZEypr9A9HhHJmGRGtd1sZrVmNg54HnjRzD6d/dAkE9yd9u7Rd7WBnuURkcxKpqttjrvvJFhC+i6gGfiXrEYlGdPZ00e/pz5dTqL4szwiIpmQTOIpDZ/bOQ+43d17GcVqnxKN9u7RzUydaFp9BZt2dhHr689UWCJSwJJJPD8B1gLjgIfMbD9gZzaDksxp6xrdzNSJptZX0u+wqa07U2GJSAEbMfG4+/fcfZq7v8MDrwAn5SA2yYCdo5yZOpGe5RGRTEpmcEGdmV1tZovD17cIWj+SB9rjiWeUo9pgzxLYSjwikgnJdLVdD7QB/xi+dgI3ZDMoyZw9a/GMvqttSt2eJbBFRNKVTOI5wN2vcPfV4etKYP90Tmpm/2lmy83sOTP7tZlVmNksM1tkZivN7DdmVhbWLQ8/rwq/n5lwnM+H5S+a2RkJ5fPDslVm9rl0Ys138dVH0xlcMK68hPqqUrV4RCQjkkk8u8zsbfEPZnYCMOpfoHCy0Y8B89x9LlAMXAB8Hfi2u88GtgGXhLtcAmxz9wOBb4f1MLM54X6HAfOBH5pZsZkVA9cAZxLMKffesG5BGu3qowMFz/LoIVIRSV8yiedDwDVmttbMXgF+AHwwzfOWAJVmVgJUAa8BJwO3ht/fRDB8G+Dc8DPh96eYmYXlt7h7t7uvAVYBx4avVWHrrAe4JaxbkOKDC6rL0kw8epZHRDIkmSlzngGONLPa8HNaQ6nd/VUz+z9gHUHL6S/AEmC7u8fCahuAaeH2NGB9uG/MzHYA48PyxxMOnbjP+gHlbxksFjO7FLgUoLm5OZ3LGrPau2JUl5dQVGRpHWd6QyWPr96KuxPkfRGR0Rky8ZjZJ4YoB8Ddrx7NCc2sgaAFMgvYDvyOoFtsoPhDqoP9yvkw5YO14gZ94NXdrwWuBZg3b94++VBsOquPJpreUEl7d4ztnb00jCvLQGQiUqiG+0WqydI5TwXWuHsLgJn9HngrUG9mJWGrZzqwMay/AZgBbAi75uqA1oTyuMR9hiovOOnMTJ2oubEKgHWtnUo8IpKWIX+RwtFr2bAOOM7Mqgi62k4BFhMstXA+wT2ZC4Hbw/oLws+Phd/f5+5uZguAm83samAqMBt4gqAlNNvMZgGvEgxA+OcsXcuY194dG/UicImax+9JPEfOqE/7eCJSuHK+oJu7LzKzW4GngBjwNEF315+AW8zsq2HZdeEu1wG/MLNVBC2dC8LjLDez3xLMmB0DLnP3PgAz+wiwkGDE3PXuvjxX1zfWtHX1Ul+VfgtlRsOexCMiko5IVhJ19yuAKwYUryYYkTawbhfwniGO8zXga4OU30Uwk3bBa+uOMT3sJkvHuPISJlSXsWGbEo+IpCeZ4dSSx9q6YtRm4B4PwIzGKrV4RCRtI/4imVk58A/AzMT67n5V9sKSTAlGtY1+upxEzY1VPLVuW0aOJSKFK5kWz+0Ew59jQEfCS8a43r5+unr7MzK4AIL7PBu3d9GrdXlEJA3J/CJNd/f5WY9EMq49Q9PlxDU3VtHX77y2vWv3KDcRkVQl0+J51MwOz3okknGZmJk60YxGjWwTkfQl86fw24CLzGwN0E3wnIy7+xFZjUzS1hafmTpDXW3xVs56jWwTkTQk84s02HQ2kgfiLZ5MjWqbXFtBabGpxSMiaUlm6etXgHrg7PBVH5bJGBe/x5POWjyJiouM6Q0aUi0i6Ulm6evLgV8BE8PXL83so9kOTNIX72rL1D0eCO7zrFfiEZE0JPOn8CXAW9y9A8DMvk4wb9r3sxmYpC9Ti8AlmtFQydIN2zN2PBEpPMmMajOgL+FzH4MvSSBjTDzxZGpwAQRDqrd39rJjV2/GjikihSWZX6QbgEVm9ofw83nsmcBTxrC2rhhlxUVUlBZn7Jjx5RHWt3ZSN60uY8cVkcKRzOCCq4GLCWaG3gZc7O7fyXZgkr5MLQKXKP4sjyYLFdk3xCKYiWTIxBNf6trMGoG1wC+BXwCvhGUyxrV3xzI2oi0ucV0eEclv61s7+ftvPsBjL2/N6XmH+1W6GTgLWMLeS0db+Hn/LMYlGZCp1UcT1VaUUl9VqsQjkufcnSsWLGdbZw8zJ+R2CqzhViA9K3yflbtwJJPauzKz+uhAzY1VrGvdlfHjikju3PP8Ju57YTP//Y5DmVJXmdNzJ/Mcz73JlMnYszODSyIkmtGgZ3lE8llnT4wr73iegyfVcNEJM3N+/uHu8VSE93ImmFmDmTWGr5nA1HROamb1Znarmb1gZivM7Pjw2PeY2crwvSGsa2b2PTNbZWZLzexNCce5MKy/0swuTCh/s5ktC/f5npkV5PDvbHS1QTDAYMO2Tvr6feTKIjLmfP++Vby6fRdffddcSotzvx7ocGf8D4L7O4eE7/HX7cA1aZ73u8Dd7n4IcCSwAvgccK+7zwbuDT9DMFfc7PB1KfAj2D3o4QrgLQRLZl8RT1ZhnUsT9ivIZR3au2PUZKmrrbfPeX1nV8aPLSLZtXJTGz99aDXnv3k6x8yMZpzYkInH3b8b3t/5lLvv7+6zwteR7v6D0Z4wHC33dsJngdy9x923Eyw2d1NY7SaC54UIy3/ugceBejObApwB3OPure6+DbgHmB9+V+vuj7m7Az9PONY+KdbXz4JnN9LZE9td5u5B4slCV1viszwikj/cnS/e/hzjykv4/JmHRBZHMs/xfN/M5prZP5rZB+KvNM65P9AC3GBmT5vZz8xsHDDJ3V8Lz/kawbxwANOA9Qn7bwjLhivfMEj5PuuZ9dv52K+f5n0/W8S2jh4AOnv66Ov3rHS1NWtdHpG8dPszG3l8dSufnX8I46vLI4sjmcEFVxDMy/Z94CTgG8A5aZyzBHgT8CN3P5pgGe3PDVN/sPszPoryNx7Y7FIzW2xmi1taWoaPOgfaunq5a9lrKe+3vTOYvubpddt5z08eY+P2XbR3Z3Zm6kRT6isoLjK1eETyyI5dvXz1T89z5Ix6LjhmRqSxJHNX6XzgFOB1d7+Y4J5MOqlyA7DB3ReFn28lSESbwm4ywvfNCfUT/1eaDmwcoXz6IOVv4O7Xuvs8d5/X1NSUxiVlxh3PvsaHf/UUm9tSu3fSEXax/b93Hc6mHV38w48e5alXtgGZnZk6rrS4iCl1FWrxiOSRb/3lRVo7evjaeXMpKop2vFUyiWeXu/cDsfD+zGbSeHjU3V8H1pvZwWHRKcDzwAIgPjLtQoJBDITlHwhHtx0H7Ai74hYCp4cj7hqA04GF4XdtZnZcOJrtAwnHGtPi92g6uvtGqLm3+GSgpx46kd/8x/HE+p2P/vppILMzUycKnuVR4hHJB8s27OAXj7/CB46fydwxMMdiMr9Ki82sHvgpwai2duCJNM/7UeBXZlYGrCaYC64I+K2ZXQKsA94T1r0LeAewCugM6+LurWb2FeDJsN5V7t4abn8IuBGoBP4cvsa87lgwZ1JXb2qJJ7FbbWJtBbd98K184PpFrN3ambHVRwdqbqzirys2ZeXYIpI5ff3OF/64jPHjyvnE6QdFHQ6QROJx9w+Hmz82s7sJRowtTeek7v4MMG+Qr04ZpK4Dlw1xnOuB6wcpXwzMTSfGKHSHCSflxNMVo8igMpyFunl8Fbd+6K38/qkNHD6tPuNxQvAsz5b2Hjp7YlSVZSe5iUj6fv3EOp7dsIPvXnAUtVnoeh+NIX8xEh/UHOw7d38qOyEVrniLZ9coWjzV5SUkPic7obqcS99+QEbjS7RnSPUuDp5ck7XziMjobWnv5ht3v8Dx+4/nnCPTeu4/o4b7U/Vb4XsFQevkWYIRY0cAi4C3ZTe0whNv6XT3pjZNeTBDQW7/kkkcUq3EIzI2/c9dL7Crt4+vnHfYXn+YRm24B0hPcveTgFeAN4Wjv94MHE1wv0UybPQtnt6sTAY6HD3LIzK2LVq9ldue2sC//93+HDhxbP1xmMyotkPcfVn8g7s/BxyVvZAKVzqDC8aVZ26V0WTUV5VSXV6iZ3lExqDevn6+ePtzTKuv5KMnz446nDdI5s/kFWb2M4KF4Bx4P8HcapJh3bH44ILUutrau/uoq8xtV5uZMUNDqkXGpBseWcNLm9r56QfmUVmW2z9Kk5FMi+diYDlwOfBxgmduLs5mUIUqfm8n5a62rt6sTAY6kubGSiUekTFm4/ZdfOevKzn10ImcNmdS1OEMKpnh1F3At8OXZFE6XW25vscDwX2eB15swd3H1I1LkUL2lTufp9+dK84+LOpQhjTccOrfuvs/mtkyBpnrzN2PyGpkBagrjed4sjEn20iaG6vojvXT0tbNxNqKnJ9fRPZ2/4ub+fNzr/PpMw5mRmNul7NOxXC/VpeH72flIhAZXYunr9/p6OmLpMUzI2FkmxKPSLS6evu44vblHNA0jn//u1HPapYTQ/5aJSxR8EruwilsoxlcEJ8gNFtzsg0ncUj1vIgWlBKRwI8eeJl1rZ3c/G9voawk96uKpmK4rrY2Bl9OwAhmsqnNWlQFajTP8bSHE4RG0eKZ1lCJmZ7lEYnami0d/OjBlzn3qKm89cAJUYczouFaPGPriaMCEB/VlkpXW0c4Qei4CBJPeUkxk2u1PIJIlNydL93+HOXFRfz3Ow6NOpykJP1rZWYTCabPAcDd12UlogLWFUt9cEFbFhd8S8aMxio9RCoSobuWvc7fVm7hy2fPyZt7rcmsQHqOma0E1gAPAmvJk2UG8s2eFk/y93jiXW1RPMcDwX2e9a27Ijm3SKFr745x1Z3LOWxqLe8/br+ow0laMnegvgIcB7zk7rMIli54JKtRFSB3TxhckMI9nohbPM2NVby+syvlIeAikr7v3PMSm9u6+ep5cykpHtsDChIlE2mvu28FisysyN3vR3O1ZVys3+kPh3Lky+AC2DOybcM2tXpEcmnFazu54dG1XHBMM0c3N0QdTkqS+bXabmbVwEMEq4ZuBmLZDavwxEe0weju8dSUR7PA04zd6/J0cuDE6khiECk0/f3OF/74HHWVpXzmjIOjDidlybR4ziVYcvo/gbuBl4Gz0z2xmRWb2dNmdmf4eZaZLTKzlWb2m3BZbMysPPy8Kvx+ZsIxPh+Wv2hmZySUzw/LVpnZ59KNNRe6E5LNaO7x5Hp26rgZjZWAhlSL5NKtT21gySvb+NyZh9AwrizqcFKWTOK5FJjq7jF3v8ndvxd2vaXrcvae5frrwLfdfTawDbgkLL8E2ObuBxLMF/d1ADObA1wAHAbMB34YJrNi4BrgTGAO8N6w7pjWFbZ4SostxXs8vVSUFkXWv9tUXU5FaZESj0iObOvo4X/uWsExMxs4/03Tow5nVJL5taoFFprZ38zsMjNLe7pTM5sOvBP4WfjZgJOBW8MqNwHnhdvnhp8Jvz8lrH8ucIu7d7v7GoLF6Y4NX6vcfbW79wC3hHXHtHiLp66yLMXE00d1RN1sECyP0KzlEURy5hsLX2RnV4yvnDeXoqL8nJx3xMTj7le6+2HAZcBU4EEz+2ua5/0O8Bkg3qc0Htju7vF7RxuAaeH2NGB9GEsM2BHW310+YJ+hyse0+D2eusoSdvX24T7YpBFv1N4di2S6nETNepZHJCeeWreNW55cx7+eMJNDJufv5DGp9M9sBl4HtgITR3tCMzsL2OzuSxKLB6nqI3yXavlgsVxqZovNbHFLS8swUWdfPPHUV5XR79Dbl2Ti6cr9stcDxR8iTTZZikjqYn39fPGPzzGppoLLTz0o6nDSkswDpB8ysweAe4EJwL+nuSTCCcA5ZraWoBvsZIIWUL2ZxX9BpwMbw+0NwIwwlhKgDmhNLB+wz1Dlb+Du17r7PHef19TUlMYlpW9PV1vQbZbskOqo1uJJ1NxYRUdPH60dPZHGIbIv++Xjr7B8406+dPacyP+bT1cyLZ79gI+7+2HufoW7P5/OCd398+4+3d1nEgwOuM/d3wfcD5wfVrsQuD3cXhB+Jvz+Pg/+tF4AXBCOepsFzAaeAJ4EZoej5MrCcyxIJ+ZciA8uqA8TT3eSiactorV4Es1o2DNLtYhk3uadXXzrLy/x9oOaOHPu5KjDSVsyK5DmajjyZ4FbzOyrwNPAdWH5dcAvzGwVQUvngjCu5Wb2W4KluGPAZe7eB2BmHwEWAsXA9e6+PEfXMGq7WzxVQeJJdkh1e3cssuly4prH70k8+fYgm0g++NpdK+ju6+eqcw7bJ1b7jfQXy90fAB4It1cTjEgbWKcLeM8Q+38N+Nog5XcBd2Uw1KzbM7gg9a62KGamThRv8WiAgUjmPbpqC7c/s5HLT5nNzAnjog4nI/Jncp99XPeArrZkhlS7Ox3d0Xe1VZYV01RTrslCRTKsO9bHF25/jv3GV/GhEw+IOpyMye87VPuQ+AShe7raRk483bF+evt8TNxo1LM8Ipn3s7+tYXVLBzdcfAwVpdHMTpINavGMEfElEeorg+kvkulqi89MHfVzPKDEI5Jp61s7+d69Kzlz7mROOnjUT7CMSUo8Y0R8EbjayuQHF0Q9M3WiGY1VvLZjFz2x5OeZE5GhXXnHcoqLjC+eNeZn/EqZEs8YEW/x1KVwj2f3WjxjIfE0VNLvsHG77vOIpOue5zfx1xWb+fips5laXxl1OBmnxDNGdMf6KSspoqos6MdNJvG0dUW7CFyi+Lo86m4TSU9nT4wvL1jOwZNquPiEWVGHkxXR/2IJEAwuKC8p2n0DMZUWT1Rr8SRKfJZHREbvB/et4tXtu/jdB4+nNI9WFU3FvnlVeag71q/JlcsAACAASURBVE95STGVYeLZlcw9nu5eILq1eBJNqqmgoaqURWtaow5FhP5+57YlG7jhkTV09uTPupWrNrfx07+t5vw3T+eYmY1Rh5M1avGMEd29/ZSXFFFeEvwtkFyLJ6gzFrraioqMdx4xhVuXbKBjDDzUKoVr3dZOPnvbUh5bHSwb9sMHXuZjp8zmgmNmjOkWhLvzxT8up6qshM+feUjU4WTV2P1XKDBdsT7KS4soKjLKSoqSSzxdY6erDeDco6bR1dvPPc9vijoUKUD9/c6Nj6zhjO88xHOv7uB/3304t37weGaNH8cX//gcp179IAue3Uh//9icRX3Bsxt5bPVWPjP/YMZXl0cdTlYp8YwRQYsn6DKrLC1OssXTS3GRUVE6Nv4Z39zcwLT6Sm5/5tWoQ5ECs3ZLBxf89HG+fMfzvGX/Rhb+59u54Nhm5s1s5Df/cRw3XHQMlaXFfOzXT3PW9x/mgRc3j6llPHZ29fKVO1dw5Ix6LjimOepwsk79IWNEfHABQEVpUdLP8VSXl4yZSQOLioyzj5zKT/+2mq3t3fv8X20Svb5+58ZH1/LNhS9QWlzEN88/gvPfPH2v/ybMjJMOmcjfH9TEgmc38q17XuSiG57kuP0b+cz8Q3jTGJjY9uq/vERrRzc3XHQMxXm6quj/b+++49sqr8ePf45kO86eznI2CUmcMAIGwg4FQlgJ9EspfEsLbWm+baGT0vGlpRT67f6VlhYKtKWMDmaBQAOBUEbDTEIGGQRCyHL2nh7SPb8/7pV8JUu2ZDR8nfN+vfyydHUlPTeOdfw8z3nOk4228afyIeaDrfvYfaAh4VhdxIn3XDqWhjOqXLC3DezFk2za0QOJOsrMJZuK3RTTzn2wdR+X3vU6tzy9jJMP68Pz3zidT1QPTvuHWCgkXDShkhe+OYmbp41j5ZZ9fPyO15h+/zze37y3wK1vtKRmN/e/vppPTxzKEYO6F60dhWSBpwiu+NOb/OzZ5QnHYlltAOWZDrXVFn/b62Rj+nfl8H5deHKBDbeZ/Ig6yt2vfMB5v/0PK7fs49ZPHsWfrqymf/fyjJ5fVhLiMycO4+Xrz+C6sw/ntQ+2c85vXuH6RxZRU+AF0I6j3PDEEnp17sA3J48u6HsXU9v61DpEbN9Xz5urEtOO6xqidOjqDk11yLDH0xa2REgmIkw7upJfzlrBuh0HGOwtLDUmF1Zu2cu3HlnMwnW7mFzVjx9fNJ6+3TILOMk6dyjhK2eO4lMTh3LHiyu5/401PLlwA58+cSjXnDGSXp3Lctz6ph6cu45F63bxm08eHa9aciiwHk+B1Ucc6qMOq7btZ/u+uvjxuohDh9JYckEoXkKnOfvb4FAbwNSjBgLw1OKUO44bk7VI1OGOl1Zy3m1zWLN9P7ddPoG7Pn1sq4OOX6/OZXz/gipe/NYkLpowkL+8+iGn/eJFbnvhffbX5W8N0PZ9dfz82XeZOKIX044emLf3aYss8BTYwfrGnszba3fFb9c1+JMLwvGioc3Z2wb24kllcK9OHDOkBzMWWuAxH92KTXv5+B9e4xfPruDMMX157hunM/WogTlPqqns0ZFfXHIUz33jNE4e2ZtfP/8ep//yRe57bXVeit/+9Jl3OVAf4ccXjW8zCUKFYoGnwPb5VlHPW9M43ObO8fiSC+oznONpgz0ecNf0vLtpL+9u2lPsppiAaog6/O6F97ngd/9h/c6D3P7fx/CHK46lomt+syVH9u3KXZ+u5vEvn8TIvl344YylnPnrl3h8wfqcrQF668MdPDp/PV84dQQj+3bNyWsGScEDj4gMFpEXRWS5iCwVka95x3uJyPMi8r73vad3XETkNhFZKSKLReQY32td6Z3/vohc6Tt+rIi84z3nNmlDf04c8HXd56/eGb/tZrX5kgsy6PHsa6NDbQDnHzmAcEis12NaZfnGPVx0+6v8v+ff45xx/Xn+G6dx/pEDCtqGCUN68o8vTOS+zx1Pt/JSvvHQIs677T/8+93NH2kNUEPU4QdPLKGyR0e+8rFROWxxcBSjxxMBrlPVscBE4BoRqQK+C7ygqqOAF7z7AOcCo7yv6cAfwA1UwA+BE4DjgR/GgpV3znTf86YU4Loyst/ryYzs24XFNbvjO48mr+M5WN981z7qKAfqo21yqA2gT5cOnDKyD08u3NCmFuqZtq0+4vCb2e9x4e/msHlPLXdecQy//+9jirYmTEQ4/fAKnrr2FH53+QRqG6J87t55XHrX68xb3bq6hPe+upoVm/dy09RxdCwrfp3FYih44FHVjar6tnd7L7AcqASmAfd5p90HXOTdngbcr643gB4iMgA4B3heVXeo6k7geWCK91g3VX1d3U+8+32vVXSxHs9poyqojzgsqdlD1FEaopqQTl3XQlZbW9qLJ51pRw+kZtdB3l67s+WTzSFvSc1upv5+Dr+Z/T4XHDmA579xOlPGF7aXk05scfTz3zydH180ntXbD3DJna9z9X1zsxpO3rj7ILfOfo+zxvbl7Kp+eWxx21bUTy0RGQZMAN4E+qnqRnCDk4jE9nqtBNb5nrbeO9bc8fUpjrcJsR7PqYf34Z5XP2Thul2MHeCO8XYozTy5oC1te53O5HH96VDyDk8u3MCxQ9tvpd1cOVAfYd2Og6zdcYB1Ow7Ev9fsOoiq2xPuUBKmQ6m7fUZsG43y0hDlseMl4fix1Oc2PlZeGqJbeWnRU/LrIlF+/++V3PHSB/TqXMYfP1PdZj+US8Mhrpg4lI8fU8lfXl3NnS9/wLm//Q8XT6jkG2cd3uLygVueXoajyg8vHFegFrdNRfsfJyJdgMeAr6vqnmamYVI9oK04nqoN03GH5BgypDD1kWIl2of06kRZOMSWPbXx1Gl/ckFDVIlEHUrSVNONFQgt9odGc7p0KOGsqn78a/FGfnBBVZuuDFwIUUfZuPsg63YcbAwsOxsDzLZ99Qnndy4LM7hXJwb17Eg4JNQ2ONQ2RNlTG2Hr3jrqIu792Pfahiitmfse1rsT4yu7c4T3Na6ye8HWlCxev4tvPbKI9zbv4+PHVHLjBVX06JT/9TMfVaeyEq45YySfOmEIf3j5A+59dTVPLdrAp04YyrUfG0mfFEODL63Ywsx3NnH9OaMP+fVtRfnUEpFS3KDzN1X9p3d4s4gM8Ho7A4At3vH1wGDf0wcBG7zjk5KOv+QdH5Ti/CZU9W7gboDq6uqCTET4h8h6dS5j+/566iKxwBMbavO2Rog4dEkXeAIw1AYw7aiB/GvxRl5duY1Jo/u2/IR2oGbXQRat28VaX68l1nNpiDb+NwuHhIE9yhncsxNnje3H4F6dGNyrE0O8r56dSrNKs1VVIo56QcihLhKNB6u6iENdQ5TaSJS6Boda77Ht++pYUrOHBWt38fTijfHXGuoFoyPzFIxqG6L89oX3ufuVVVR06cA9V1XzsTFts5fTnB6dyvjeuWO56qRh3PbC+zzwxhoembeOq08dwdWnDqdreeNW9j+csZQRFZ25+tT2uatoNgr+qeVlmP0ZWK6qv/Y9NAO4EviZ9/1J3/FrReRB3ESC3V5wmgX8xJdQMBn4nqruEJG9IjIRdwjvM8Dv8n5hGTrg7aHTqSxMr85l7NhfH08wKPcNtYG75iddYAnCUBvA6aMr6FZewoyFG9p14HEc5eX3t/LX19fw7xVbiOVT9OxUypBe7of4uUcMiAeVwT07MaBHeU57gSJCaVgoDYfo2op1lTv217OkZjfv1OxmSc1uFq3bxb9SBKNYz2j8wO5075R9MHp77U6+/ehiVm7Zx6XVg7jh/KrAr9of0L0jP/34kVx96gj+33Mr+K0XhK45YyRXTBzCnS9/wJrtB/jb1SfE/8A8lBXjU+tk4NPAOyKy0Dv2v7gB52ER+TywFviE99hM4DxgJXAA+CyAF2BuAeZ6592sqrE0ky8B9wIdgWe8rzZhvzfU1qmshN5d0vV4Wt7+OjbU1qWN7MWTToeSMOcdMYCnFm3gYH203WXx7NxfzyPz1/HXN9aydscB+nQp45pJI5kyvj9De3eK/8UbBL06l3Ha4RWcdnhF/NjO/fW800wwGtKrkxuEfAEpXTCqbYjy6+ff40//WUX/buXc97njOd33Xu3BYRVduONTx7Jo3S5+Metdbnl6GffM+ZCt++qYetRATh7Zp9hNbBMKHnhUdQ6p52EAzkxxvgLXpHmte4B7UhyfB4z/CM3MmwP1UTqWhgmHhF6dy1i9fX88wPgrFwDxnlAqsW2v22o6td/Uowfy4Nx1zF6+mQuPCn5pEFVl0frdPPD6Gp5avIH6iMPxw3rxrXNGM2Vcf8pK2s9cVs80wWjJhsZgtLhmF/96J30wGl/ZjQ+27uP6Rxazatt+Lj9+CP973phABeVsHTW4B3+7eiJz3t/Gz599l4MNUb5//thiN6vNaPufWu2Muy20G1h6d+7Ajn2+Ho9vWwSg2bU8e2uDMccDcMLw3vTr1oEnF24IdOA5WB/lqUUbeOCNNbxTs5vOZWEurR7EFROHMqZ/t2I3r2B6di7j1FEVnDqqMRjtOlDPkpo9LK7ZlTIYgVuS5q+fP4FTRh06f/WfMqoPJ488mfqoY0NsPm3/U6udOVAfpVOZ+8/eu0sZ++uj7Dno9l6aJhc01+MJTuAJh4QLjxzIfa+vZteB+kBkLfl9uG0/f/UmjffURhjVtwu3TBvHRRMq2/Vf7dno0amMU0b1SQgqsWD0Ts1uoo7DVScPD8T/11wTEQs6SQ69/wVFtq8uQidvniNWdn3D7lqg6VBbc/Xa9tVG4kN2QXDRhEr+NOdDnlmyicuPb/tb+0aiDv9+dwsPvLGG/7y/jZKQcM74/nxm4lCOH97rkCvq2BqpgpExYIGn4A7UN+6hEws8G73Np8rj2yK0nFywv75tVqZOZ9zAboyo6MyTC2vadODZureOh+au5e9vrmXD7lr6dyvnm2cfzmXHDc5JCX5jjAWegttfF6WblzraOxZ4mvR4GtfxpLO3DVemTkVEmHZUJb954T027j7IgO4di92kBLUNUf4850Nuf3ElB+qjnDKyDzdeOI6zxvZNu4jXGNM6wfnkaicO1EcY4G3RG+vxxLbb7ZC0jqe2uaG2NroXT3OmHj2QW2e/x9OLNvKF00YUuzmAm6H2/LLN/Phfy1m74wDnjOvH9eeMYWTfLsVumjHtVrA+udqB/XW+5ILOblmNjbu9wJO8jqe55ILatrslQjrD+3TmqEHdeXJRTZsIPCu37OVHTy3jP+9v4/B+Xfjb1SfYOgtjCiBYn1ztgDvH4waWbh1LKAkJm9IkFzS7gLQuwpDOwav3NPXoSm55ehnLN+5h7IDipCDvPtjAb2e/z/2vr6ZTWZibLqziiolDbUjNmAKx37QC8/d4RISencvi9bvigcf73tI6nqANtQFMPWog3cpLuPKet1i2obC7k0Yd5R9vreVjv3qJv7z2IZceN5gXvzWJq04ebkHHmAKy37YCqo841EcdOvvKxsQSDEpCEv/wKwmHKA1Li+t4gjbUBlDRtQOPfPEkQiJcetfrvLpyW0Hed97qHUy7fQ7f++c7jKjozFPXnsJPLj6iaBuMGXMos8BTQLF1Of6tDGIJBh2SyqyUl4bTruNRVfYHNPAAjO7flcevOYnKHh256i9v8eTCmry916bdtXz9wQVccufrbNtbz22XT+Dh/zmR8ZXd8/aexpjmBfOTK6BiBUJjczzgCzyliSuby0vDaWu11UUcIo4GcqgtZkD3jjz8xROZfv88vvbgQjbtrmX6aSNytjDTnx4dcZSvfGwkX5p0WHyY0xhTPPZbWEAHfJWpY3qn7fGEqG1IPccTq9MWpHU8qXTvWMr9nz+ebz68iJ8+8y4bd9fygwuqPlI1hrpIlFlLN/OrWSvi6dHfP7/qkN94y5i2JNifXAGzvy421Obv8bhzDMmBp2MzQ23xOm0B7vHEdCgJ87vLJtC/Wzl/nvMhW/bW8utLj45n9mVq2YY9PDxvHU8srGHXgQZG9e1yyBWkNCYogv/JFSD765r2eHp1ifV4mg61pUsuCMpePJkKhYQfXFDFgO7l/Phfy9m29y3++JnqFjcZ23WgnicXbuDheetYumEPZeEQZ4/rx6XVgzllZJ/A1LEz5lBjgaeA9seSC1IMtcXK5MQ0l1ywN7YXT8CH2pJdfeoI+nYr57qHF3LJna9x3+eOZ2CPxNI6UUeZs3Ibj8xbx3NLN1MfdRg3sBs/mjqOaUcPDFzla2MORe3rk6uNi8/xpEouSNHj2e1tl5As1uNp69tet8bUowbSp0sZ/3P/fC6+41Xu/ezxjB3QjTXb9/Po/PU8On89G3fX0qNTKf99whA+UT2IcQMtQ82YIGl/n1weEZkC/BYIA39S1Z8VuUnxOR5/TyWeXJDc4ykJsSVN5YLYHE/ndtbjiTnpsD488qUTufKet7j0ztcZO7Abb324g5DAaYdX8IMLqjhzbF/b48SYgGqXn1wiEgZuB84G1gNzRWSGqi4rZrsas9pS9XiSkgvKwhxME3j2B2gTuNYa078b//zyyXz+3rls3VvH9eeM5r+OGUT/7rY1gTFB114/uY4HVqrqKgAReRCYBuQ98EQdZd2OA/HKAkN6dSLkTXLHejz+5IIencoQSTHUVhJOW6ttb137HWrzq+zRkWe+dqptumZMO9NeP7kqgXW+++uBE/LxRj975l0enb8eUBqiyt7aBhxtfLxrhxLKy8Kouj2V8tJQQrZVOCT06lTWZKitY1mYLXvrOO7/Zjd5z/11EUpC0qSX1B5Z0DGm/WmvgSfVp5U2OUlkOjAdYMiQ1u2KOXZAV86u6ocIlIaE7h1LqehWTu/OZeytbWBJzR4iXiQqCQnjK5tWZL552niGJC1wvLR6MA1RJyGIJb+vfSgbY4JIVNN8sgWYiJwI3KSq53j3vwegqj9N95zq6mqdN29egVpojDHtg4jMV9XqbJ7TXsdq5gKjRGS4iJQBlwEzitwmY4wxtNOhNlWNiMi1wCzcdOp7VHVpkZtljDGGdhp4AFR1JjCz2O0wxhiTqL0OtRljjGmjLPAYY4wpKAs8xhhjCsoCjzHGmIJql+t4WkNEtgJrWvn0PsC2HDYnaA7l6z+Urx3s+g/l649d+1BVrcjmiRZ4ckBE5mW7gKo9OZSv/1C+drDrP5Sv/6Ncuw21GWOMKSgLPMYYYwrKAk9u3F3sBhTZoXz9h/K1g13/oXz9rb52m+MxxhhTUNbjMcYYU1AWeLIgIlNEZIWIrBSR76Z4vIOIPOQ9/qaIDCt8K/Mjg2s/TUTeFpGIiFxSjDbmUwbX/00RWSYii0XkBREZWox25ksG1/9FEXlHRBaKyBwRqSpGO/OhpWv3nXeJiKiItKsstwx+9leJyFbvZ79QRK5u8UVV1b4y+MKtcv0BMAIoAxYBVUnnfBm407t9GfBQsdtdwGsfBhwJ3A9cUuw2F+H6zwA6ebe/1F5+9llcfzff7anAs8Vud6Gu3TuvK/AK8AZQXex2F/hnfxXw+2xe13o8mTseWKmqq1S1HngQmJZ0zjTgPu/2o8CZ0j62CW3x2lV1taouBpxiNDDPMrn+F1X1gHf3DWBQgduYT5lc/x7f3c6k2PE3oDL5vQe4BfgFUFvIxhVAptefFQs8masE1vnur/eOpTxHVSPAbqB3QVqXX5lce3uW7fV/Hngmry0qrIyuX0SuEZEPcD+Av1qgtuVbi9cuIhOAwar6dCEbViCZ/t//L2+Y+VERGdzSi1rgyVyqnkvyX3WZnBNE7fW6MpXx9YvIFUA18Mu8tqiwMrp+Vb1dVQ8DvgN8P++tKoxmr11EQsCtwHUFa1FhZfKzfwoYpqpHArNpHPVJywJP5tYD/kg+CNiQ7hwRKQG6AzsK0rr8yuTa27OMrl9EzgJuAKaqal2B2lYI2f78HwQuymuLCqela+8KjAdeEpHVwERgRjtKMGjxZ6+q233/3/8IHNvSi1rgydxcYJSIDBeRMtzkgRlJ58wArvRuXwL8W73Zt4DL5Nrbsxav3xtuuQs36GwpQhvzKZPrH+W7ez7wfgHbl0/NXruq7lbVPqo6TFWH4c7vTVXVecVpbs5l8rMf4Ls7FVje0ou2262vc01VIyJyLTALN9PjHlVdKiI3A/NUdQbwZ+ABEVmJ29O5rHgtzp1Mrl1EjgMeB3oCF4rIj1R1XBGbnTMZ/ux/CXQBHvHySdaq6tSiNTqHMrz+a70eXwOwk8Y/wAItw2tvtzK8/q+KyFQggvu5d1VLr2uVC4wxxhSUDbUZY4wpKAs8xhhjCsoCjzHGmIKywGOMMaagLPAYY4wpKAs8xmRARPYV4D2mNlf9OE/vOUlETirkexpj63iMKSARCatqNNVj3pqInK8LEZESr3ZgKpOAfcBruX5fY9KxHo8xWRKR60VkrlcU8Ue+40+IyHwRWSoi033H94nIzSLyJnCiiKwWkR95+xe9IyJjvPOuEpHfe7fvFZHbROQ1EVkV2+NIREIicof3Hk+LyMxU+x+JyEsi8hMReRn4mohcKO4eUQtEZLaI9BN3v6gvAt/w9lE5VUQqROQx7/rmisjJ+fy3NIcm6/EYkwURmQyMwi0XL7h1uU5T1VeAz6nqDhHpCMwVkcdUdTvuNgFLVPVG7zUAtqnqMSLyZeBbQKrNswYApwBjcHtCjwIfx9376AigL255knvSNLeHqp7uvWdPYKKqqrdR17dV9ToRuRPYp6q/8s77O3Crqs4RkSG4K9bHtvofzJgULPAYk53J3tcC734X3ED0Cm7pkIu944O949uBKPBY0uv80/s+HzeYpPKEqjrAMhHp5x07BXjEO75JRF5spq0P+W4PAh7y6mqVAR+mec5ZQJVvG6luItJVVfc28z7GZMUCjzHZEeCnqnpXwkGRSbgf2ieq6gEReQko9x6uTTGvE6vmGyX976G/wrUkfc/Eft/t3wG/9urqTQJuSvOcEO41HMzifYzJis3xGJOdWcDnRKQLgIhUikhf3C0wdnpBZwxuefx8mIO76VbI6wVNyvB53YEa77a/gOde3NL+Mc8B18buiMjRrW+qMalZ4DEmC6r6HPB34HUReQd33qUr8CxQIiKLcbdBfiNPTXgMd4+UJbjbMLyJu9NtS27CrZz9H2Cb7/hTwMWx5ALcnUOrvcSJZbjJB8bklFWnNiZgRKSLqu4Tkd7AW8DJqrqp2O0yJlM2x2NM8DwtIj1wkwRusaBjgsZ6PMYYYwrK5niMMcYUlAUeY4wxBWWBxxhjTEFZ4DHGGFNQFniMMcYUlAUeY4wxBWXreDx9+vTRYcOGFbsZxhgTKPPnz9+mqhXZPMcCj2fYsGHMmzev2M0wxphAEZE12T7HhtqMMcYUlAUeY4wxBWWBxxhjTEEFLvCIyD0iskVElqR5XLy96ld6pd2PKXQbjTHGpBe4wAPcC0xp5vFzcbccHgVMB/5QgDYZY4zJUOCy2lT1FREZ1swp04D71S27/YaI9BCRAaq6sSANTLL7YAP1EYeQQO8uHTJ+nqqyfX896YqHdy0vobw0nKNWGmNM4QQu8GSgEljnu7/eO1bwwLNw3S4uvuPVePC46cIqrjp5eJPzPnnX65x4WG++ftbh8WN//M8qfjLz3bSvPbR3J16+/oyct9kYY/KtPQYeSXEsZb9BRKbjDscxZMiQnDdk855aVOHLkw7jgdfXsHLrvpTnrd6+n8oeHROObdhVS3lpiBvOr2py/uxlm3l15bYmx40xJgjaY+BZDwz23R8EbEh1oqreDdwNUF1dnfMd8WI9nQuOHMhzyzazY399yvOiDkSTxtQijkPnshI+PXFok/O376vj5fe24jhKKJQqzhpjTNsVxOSClswAPuNlt00Edhdrfie2u6sI9OpUxvZ9qQOPo0rESQo8USWcJqiUlbg/tvqok8PWGmNMYQSuxyMi/wAmAX1EZD3wQ6AUQFXvBGYC5wErgQPAZ4vT0sbxPRHo1bmMVdtSD7VFHSUaTe7xKCXpAk/YDTwNUccSDIwxgRO4wKOql7fwuALXFKg5zXK8Hk9IhJ6dy9ixJk2Px9EmQ21RRykJp+6QlsYDT85HB40xJu/a41BbmxGLJQL07lzGzgMNOE7TYBFVJZo81NZcjyc21BaxoTZjTPBY4MmjxqE2oVfnMqKOsqe2ocl5EafpHE/UcdLO8ZT6htqMMSZoLPDkUUJyQecyALanyGxzHG3SE2ouuaA07B635AJjTBBZ4Mkj/1BbLPDsTBF4oqpEnMQgEnGUknDzyQU21GaMCSILPHmkNCYXpOvxqCqqkBR3iDhKOJT6xxOb47GhNmNMEFngyaNYMPEPtSUvIo0lFST3eKKOQ6nN8Rhj2iELPHkUm7Xx93iaBB5vPK5JVluzczzuj63OhtqMMQFkgSePHN/anPLSMJ3Kwml7PKnX8TSfTm3reIwxQWSBJ59iyQVe/OjVuSz9UFtSEGlobo4nNtRmPR5jTABZ4Mkjf3IBpA48samd5KG2qOOkXUBaWmLp1MaY4LLAk0dOJj0eTT3U1myRUEsuMMYEmAWePGpcx+P1eDqlH2pr2uPR+ELRZKW2jscYE2AWePKocajNvd+9Uyl7DiaWzIklICTP8UQzWMdjQ23GmCCywJNH8U6MF3hKQtJ03x3vvtNkI7gMtkWwHo8xJoAs8OSTJiYXhELSZC7HiS8gTZ7jaaZIqKVTG2MCzAJPHsWTC7z7IZF44dCY2NxOkyKhzfR4rEioMSbILPDkUWN1ajdQhEWaJhFo6h5PswtILbnAGBNgFnjyqLFkjvc9JDhKQq/HSZPV5vZ4Uv94RITSsFg6tTEmkCzw5JGTlE4dC0D+0bZ0tdrcrLbUPR5wU6ot8BhjgsgCTx6pJk7yhL0hN3+CQSyNOjnwNETTVy4AN6XahtqMMUFkgecjikQd9tdFUj4Wiy/+oTZIDDLxdTxNtkVoucdTb1ltznx2JwAAIABJREFUxpgAssDzEX3xr28z7oezUj4WW0AaSy6IpVUnDLXF1/E09pBUtdmsNnATDGyozRgTRBZ4PqLZyzenfSy5x+MloyUMtfkXjvqDEEBJOP2Px4bajDFBZYEnj5omFzQdavN3WqJJw27ND7VZVpsxJpgs8ORR41Cbe79xqK1pL8d/O/a9uaE2y2ozxgSVBZ48iie1xYfaUvV4fBlu3u1YKZzmejxlJSHb+toYE0iBDDwiMkVEVojIShH5borHh4jIiyKyQEQWi8h5xWhnvHIBjbXaIHGOJ9rMYlLr8Rhj2qPABR4RCQO3A+cCVcDlIlKVdNr3gYdVdQJwGXBHYVvpapJckCKrzUnR44nN8TSbXBAOWZFQY0wgBS7wAMcDK1V1larWAw8C05LOUaCbd7s7sKGA7Ytr3IE0sXJBuqG2bOZ4LKvNGBNUJcVuQCtUAut899cDJySdcxPwnIh8BegMnFWYpiWKJxd491MtII2mSDSIZDDHY1ltxpigCmKPJ9WncfKY0+XAvao6CDgPeEBEmlyriEwXkXkiMm/r1q05b2iT5IIWhtrigSfW40lTnRpilQss8BhjgieIgWc9MNh3fxBNh9I+DzwMoKqvA+VAn+QXUtW7VbVaVasrKipy3tDkbRFCKRaQRlLM8UTj63ian+OxoTZjTBAFMfDMBUaJyHARKcNNHpiRdM5a4EwAERmLG3hy36VpgdLY24HUC0hTVS6IZDjHY0NtxpggClzgUdUIcC0wC1iOm722VERuFpGp3mnXAV8QkUXAP4CrNHnrz4K0tTHYQOOcTUsLSGNzPC2nU1tWmzEmeIKYXICqzgRmJh270Xd7GXByoduVzFFNmJAKpdgWodmstpbmeGyozRgTQIHr8QSJktjjyXaordk5nhJLLjDGBJMFnjxyVBNy8BqH2hqP+WNHbOFoxDvY/LYIbjp1EUYQjTHmI7HAk0+JcSfNAtLGyBPr/UTjPZ7mh9pUE7PijDEmCCzw5FGTobZUtdr86dTRxKG20mbmeMpK3B+dZbYZY4LGAk8eOY4mpFOHU22LkGI30mgGczylXh23hoj1eIwxwWKBJ4/SJxc0nuOkKJ+TyTqeUq/HUxeN5qq5xhhTEBZ48qhJOnWsckGaWm3x6tTRlncg7RDr8dhaHmNMwFjgySNVErPaWtiB1MmickFpiftYg63lMcYEjAWePMsquaDJHE/zWW2AreUxxgSOBZ48clRbrNWWsmROPKut+SKhgFUvMMYEjgWePEpaP5pyAWmqygWN1albTi6wdGpjTNBY4MkjRZOy2tzvmfZ4mq9cYMkFxphgssCTR46m2RZBW8pqa3mOJ7aA1IbajDFBY4Enj1QbN4GD1NsiOM1mtWWwgNSG2owxAWOBJ4803bYICYVB0+9A2vy2CO5jltVmjAkaCzx5pElDbbEktWiaHk8s4EQySKfuYENtxpiAssCTR02TC9zbyWVyJCnpIJrhDqRgQ23GmOCxwJNHTpNtEbzAk5BC3ZihFuvpNGSxgNQCjzEmaCzw5FG65ILkMjmxDLXG/XgcwiFJeG4yy2ozxgSVBZ48UpIqF4RS9HhU4/M1EV9WW3O9HfCXzLF1PMaYYLHAk0fJyQWxWOLfNDTqaHyoLTa3E40qpS0EnjIbajPGBJQFnjxSTUwuCKep1RYrf+Pfj6elHo8NtRljgsoCTx41SS5IM9QWDgkhSdyBtKSZAqFA/DnW4zHGBI0FnjxSEpMLUqVTO45SEhLCIfHN8Tgt9njAneexBaTGmKCxwJNHmrQtQnyoLWmOJyRu4HF8tdqaW8MTUxYO2VCbMSZwLPDkUfK2CLHSawk9Hm+orSQUStgILpMeT1lJyIbajDGBE8jAIyJTRGSFiKwUke+mOedSEVkmIktF5O+FbiM0U7kgqSJ18hxPxNFmN4GLKQ2HaIhYOrUxJliKGnhE5DEROV9EMm6HiISB24FzgSrgchGpSjpnFPA94GRVHQd8PYfNzpjjJNdqS731dUiEknAoIbkgozmeErE5HmNM4BS7x/MH4L+B90XkZyIyJoPnHA+sVNVVqloPPAhMSzrnC8DtqroTQFW35LLRmVIUoYXkgnhWW2NyQUPUyXyOxwKPMSZgihp4VHW2qn4KOAZYDTwvIq+JyGdFpDTN0yqBdb77671jfocDh4vIqyLyhohMSfVCIjJdROaJyLytW7d+tItJIdMFpO4cT2NyQcY9nnCIBksuMMYETLF7PIhIb+Aq4GpgAfBb3ED0fLqnpDiWPNFRAowCJgGXA38SkR5NnqR6t6pWq2p1RUVFq9rfHCejWm1utltiOnWGWW0l1uMxxgRPSTHfXET+CYwBHgAuVNWN3kMPici8NE9bDwz23R8EbEhxzhuq2gB8KCIrcAPR3Jw1PiOJG8GJCCJNF5CWhUKEQxLfjyeTBaTgDrVZVpsxJmiK3eP5vapWqepPfUEHAFWtTvOcucAoERkuImXAZcCMpHOeAM4AEJE+uENvq3Lb9JapNqZQx4REmmS1hbyhttj6nmwWkFpWmzEmaIodeMb6h8BEpKeIfLm5J6hqBLgWmAUsBx5W1aUicrOITPVOmwVsF5FlwIvA9aq6PT+XkJ6jickF4A6r+TspjqOEhaY9noyy2kLUWY/HGBMwRR1qA76gqrfH7qjqThH5AnBHc09S1ZnAzKRjN/puK/BN76tolMaEgphQKHkjODeRIBwSItFYVptSXppZVpslFxhjgqbYPZ6Q+GbfvTU6ZUVsT045brG2hGNhkZTp1OGQ+DaCyzS5QGyOxxgTOMXu8cwCHhaRO3E7CF8Eni1uk3JHVZuk4IVEmiwgjaVTJ24El1nlAstqM8YETbEDz3eA/wG+hJsm/Rzwp6K2KMeaDrUl9nii3p49oZD4Khc4lIZtqM0Y0z4VNfCoqoNbveAPxWxHvjiqCet4AG9IrfG+v8cTTejxZJZcYFtfG2OCptjreEYBP8WtuVYeO66qI4rWqBxKrk4Nbg+oyVCbJJbMyWZbBJvjMcYETbGTC/6C29uJ4K67uR93MWm74CRtfQ3eOp6kjeBCIaEknFwyJ4MFpCW2H48xJniKHXg6quoLgKjqGlW9CfhYkduUM6o06fL4s9fA7f24O5CGEnYgzWgdT9iy2owxwVPs5IJab0uE90XkWqAG6FvkNuVMynU8SQtIo46bcBD27cfjlszJrHJBxNF4r8kYY4Kg2D2erwOdgK8CxwJXAFcWtUU5pCkqFyQvIHVUvSKhoYTkgkyLhAKWUm2MCZSi9Xi8xaKXqur1wD7gs8VqS74kb4sA3gJSf622qNMkqy0azXCOxysk2hB1KC8N567hxhiTR0Xr8ahqFDhWkvON2xF3qK1pckHCtgjqHguHGheWNjhOxkNt4JbYMcaYoCj2HM8C4EkReQTYHzuoqv8sXpNyx13Hk3gslJxc4CjhUKxIaHYbwcWH2iyzzRgTIMUOPL2A7SRmsinQLgKPJm0EB7FabY33o+oOq7klc9wHMp3jKfUNtRljTFAUu3JBu5vX8UtVq02SFpA6Xo/HLaXj3leFkoxqtbmvbskFxpggKXblgr/QdNtqVPVzRWhOzqUoTu2u40mq1RYWifd4Ymt5Mpnj6WBDbcaYACr2UNvTvtvlwMU03cY6sFSbJhf4F5DGejehUGOR0NhwW6Y7kIINtRljgqXYQ22P+e+LyD+A2UVqTs45KYfaGre4jg25xXo8buDxejwWeIwx7VSxF5AmGwUMKXYjciX1Oh4SarKBV7nA248n6kWlbLLa6myozRgTIMWe49lL4hzPJtw9etoFd46nmaE2bezdhCWpxxPObCM4sHU8xphgKfZQW9divn++pc5qS1yvA24wCofd49EshtrilQusx2OMCZCiDrWJyMUi0t13v4eIXFTMNuVSyuQC8ScXuMdCCXM8WSQXlFg6tTEmeIo9x/NDVd0du6Oqu4AfFrE9OZWqcoF/B1J/kAmLWzInEm1Fj8cCjzEmQIodeFK9f7FTvHMm1Toe8W9/oP7kghCqjUEkm3RqW8djjAmSYgeeeSLyaxE5TERGiMitwPwitylnVLX55AIvXrjbIri3YxlqmVQusG0RjDFBVOzA8xWgHngIeBg4CFxT1BblkGqTDUgT5nii/qy2UGJqdCaVCyy5wBgTRMXOatsPfLeYbcinVNsiiG8HUse3jic2p1MXiQIZLiAtsXRqY0zwFDur7XkR6eG731NEZmXwvCkiskJEVopI2sAlIpeIiIpIda7anI3UyQVNF5DGioRCY48nszkey2ozxgRPsYfa+niZbACo6k6gb3NP8HYuvR04F6gCLheRqhTndcXdUvvNnLY4CymH2nxzPLHForF0aoC6hizmeCy5wBgTQMUOPI6IxEvkiMgwUlSrTnI8sFJVV6lqPfAgMC3FebcAvwBqc9PU7CmaeqgtqXJB2CuZA41DbZn0eESE0rBYOrUxJlCKHXhuAOaIyAMi8gDwMvC9Fp5TCazz3V/vHYsTkQnAYFX1V79uQkSmi8g8EZm3devW7FvfAsehSZfH3QgucaitxBd4Yr2X0gySC9zzQtbjMcYESlEDj6o+C1QDK3Az267DzWxrTqpP5HgvSURCwK3ea7X0/nerarWqVldUVGTc7mwITdOpYz2eqG+oLdyKOR5wU6qtx2OMCZJiFwm9GvgaMAhYCEwEXidxK+xk64HBvvuDSNzDpyswHnjJW0PTH5ghIlNVdV7uWt8yVSU5fog0rt/xD7WVJAWeTOZ4wOvxWFabMSZAij3U9jXgOGCNqp4BTABaGvOaC4wSkeEiUgZcBsyIPaiqu1W1j6oOU9VhwBtAwYMOgJNyWwTfOp6kbREguzkecBMMbKjNGBMkxQ48tapaCyAiHVT1XWB0c09Q1QhwLTALWA48rKpLReRmEZma9xZnIVVyQTiUojq1f6itIfMFpGBDbcaY4Cl2XbT13jqeJ4DnRWQnGWx9raozgZlJx25Mc+6kHLSzVVL1eEQai4QmbIsgrZvjsaw2Y0zQFLtywcXezZtE5EWgO/BsEZuUU+6IWnKPhyYlc8KpstqymOOxwGOMCZJi93jiVPXlYrch95omF4R9G8HFi4SGJD60Fp/jyWKozba+NsYESbHneNq19ENtSdsiiMTnghqz2jJfx2M9HmNMkFjgySN36+sU2yLEezz+dOrE6tTZZLVZkVBjTJBY4Mkjtzp14jH/AtJIyqy2zKtTgzvUZunUxpggscCTR47TdCM4EZpktYVCjT2c+ix2IAXLajPGBI8FnjxKtfW1v1abE98ILtRkHU9sW+uWuJULLPAYY4LDAk8eudsitFyrLRyiyUZw2dRqs6E2Y0yQWODJI02xEVxIBFX3MceX1dakSGjyE9Mos6w2Y0zAWODJo1TJBbG0aUeTKhf4Ak9IGnckbUmpZbUZYwLGAk8euVtfN61cAG7QiaTcFiGacWVqsKE2Y0zwWODJI02xgDTWk3FUE9bx+EvmZFogFCy5wBgTPBZ48ihVckHjUJvGkwxKkvbjyTSxAKDMS6dWteE2Y0wwWODJI6VpckEsaSDqNPZ4QiFfyZwGJ+PFo+D2eFQbF6MaY0xbZ4Enj1RTJBeEUiQXSGKR0HCWczyAZbYZYwLDAk8eOSlqtcUCkeMosWQ0/w6kjmZeLgcaF5o2RKzHY4wJBgs8eZSycoEXVKKqRJ3G8jj+dTvZzPGUej2eumj0ozXWGGMKxAJPHrlZbc0kF8T24xFJSKEuzSKrrUOsx2NreYwxAWGBJ09iWWbJISQeeJzGWm3hkCRs/JZdj8c9t8HW8hhjAsICT57EsptD6RaQqiZWLvCdl80C0tgcj63lMcYEhQWePIn1ZlLVagMvuSBeuSCxl5PdOh4v8FiPxxgTECXFbkB7FZtxSTvU5hUJDYk7D+TfBSGrygWWTm2MCRjr8eSJ+lKl/eJZbV6ttth9/2nZpFNbj8cYEzQWePLESVPCxr+A1HE03gMSaSybk22RULCsNmNMcFjgyZGH561LOdzVdI7H/e54yQX+3k0sKGWV1Ra2oTZjTLAEMvCIyBQRWSEiK0Xkuyke/6aILBORxSLygogMzXebvv3oYu5+ZVX8vn+TNz9/rbaoasJQXLzHk1V16sQN5Iwxpq0LXOARkTBwO3AuUAVcLiJVSactAKpV9UjgUeAXhWjbjv318duxkbYmyQVJ2yKkymbLpsfTwZILjDEBE7jAAxwPrFTVVapaDzwITPOfoKovquoB7+4bwKBCNMwfLzR+LE3lAsddy5OqVE6rarVZ4DHGBEQQA08lsM53f713LJ3PA8/ktUUe/7BZunU8yQtIUw61tWIBqQUeY0xQBHEdT6ruQMqULhG5AqgGTk/z+HRgOsCQIUM+csP8vZd0+7Il1mpL3eMJZzHHE8tqs3RqY0xQBLHHsx4Y7Ls/CNiQfJKInAXcAExV1bpUL6Sqd6tqtapWV1RU5LaVaUrmJFYuSKpYIK0faqu3dGpjTEAEMfDMBUaJyHARKQMuA2b4TxCRCcBduEFnS6Ea5v/oTz/U5tuBVJOSC8LZJxeU2VCbMSZgAhd4VDUCXAvMApYDD6vqUhG5WUSmeqf9EugCPCIiC0VkRpqXy187ve9pezzeDqQftcdjQ23GmKAJ4hwPqjoTmJl07Ebf7bMK3igSs9rSFwltfDzq1WqLiWe1hTP/eyAcEkJiPR5jTHAErsfTljm+sbZ063j8Q23RaGKPJ5bNlk2PB9x5HtsWwRgTFBZ4ciji+/BXYj2epKE23wJSt8fz0UrmgDvcZkNtxpigsMCTQxFflyfe40m3H49XucBfHqekFQtIwU0wsKE2Y0xQWODJoUg0ReBJGmxrrNWWvnJBOIsFpOAOtTVELJ3aGBMMFnhyKKHHQ+Puon6xmOKkqFzQmpI54A21WY/HGBMQFnhyKOo0fvg7LQ21xdbxpKrVlkXlAnArVFvgMcYEhQWeHEocakudXBDPalMlEk1Xqy37rLYGSy4wxgSEBZ4cSplckHSOfwFpuh5PtnM8NtRmjAkSCzw5FE2Z1ZZcucD97tZqS8xqa/Ucj2W1GWMCxAJPDjWkWMeTHEMSFpBqYkmdWO8n23U8ltVmjAkSCzw55O/xtJRcEG1mB9LSbJMLSkLUWY/HGBMQFnhyKHGOJ9bjSV25QGPp1L7HS8KtnOOx5AJjTIBY4MmhSIp06mQJC0gdxV8PNNSK6tQAZSViczzGmMCwwJNDDQmbsaWr1eZ+j3q12vzbXJe0slabFQk1xgSJBZ4cSpXV1qRygTQOtTlNKhd41amznOOxoTZjTJBY4Mkhf3Vqp8VaberVavM9Fop9zz65wLa+NsYEhQWeHPIPtTVui5B4TsifTp2ux9OK5IL6SLQ1TTbGmIIL5A6kbVUmQ23heFabu4jUX7mg1dsilISS5peMMcV2oD7Cc0s38/iCGlZv38+po/owuao/E0f0jm9Zf6iywJNDDQlZbbFAkLpyQVSVSJp1POFWFAm1rDZjii8SdZizchtPLKhh1tLNHGyIUtmjI6P7d+Wx+TX89Y21dO1Qwhlj+jJ5XD9OP7yCruWlxW52wVngyaFskguiserUOdgWoTQcIuI0TVZoD3bsr6esJESXDvZf1bRNqsri9bt5YmENTy3awLZ99XTvWMpFEyq5eEIl1UN7EgoJtQ1R5ry/jeeWbWL28i3MWLSBsnCIk0b2ZnJVf86q6kvfruXFvpyCsN/mHEq5EVya6tSxBaQpezytGGoDqI86lIfCWbe7rXp15Ta+9Nf5lJeG+dUnjuK0wyuK3SRj4tZuP8ATC2t4YkENq7btpywc4syxfbloQiWTRlfQoSTxd7G8NMxZVf04q6ofUUeZv2Ynzy3dxHPLNvO/j7/DDU/AhME9mDyuP5Or+jGiokuRriz/LPDkUKpabemqU8cWkIZSVKcuDWefXBB7//LS9hF4/v7mWm58cgnD+3QG4DP3vMVnTx7Gd6aMaTfXaIJnx/56/rV4A08s3MD8NTsBmDiiF9NPG8G5Rwyge8fMhs3CIeH44b04fngvbjh/LCs27+W5pZt5btkmfvbMu/zsmXcZ2bcLk6v6cXZVP44a1KNdjWZY4MmhlENtSTHEP8fjaGLv5qMsIIXkBazBFHWUn8xczp/nfMik0RX87vIJlIZD/OyZd/nLq6t5beV2fnv50Yzp363YTTWHiNqGKLOXb+aJBTW8tGIrEUc5vF8XvjNlDFOPHkhlj44f6fVFhDH9uzGmfze+euYoanYdZPYyNwjd9coq7njpA/p27cDZVf2YPK4/J7aD5AQLPDnUEG2aXJC8jkdECEnqobbWl8zxhtoCvoh0X12Er/5jAf9+dwtXnTSM758/lhIvqN40dRynj67g+kcWM/V3r/LtKaP53MnD29VfgabtiDrKG6u28/iCGp5dsol9dRH6dyvn86cMZ9rRlYwd0LXJMHquVPboyJUnDePKk4ax60A9L67YwnNLN/PPt2v425tucsKkMX2ZXNWPSaODmZxggSeHEno8sRsp/m+GRBrX8aRIp259jye4gWf9zgNcfd883t+yj1suGs+nJw5tcs4Zo/sy6+un8p3H3uHH/1rOy+9t5VefOIp+3Q6NCVmTX6rKso17eGJBDTMWbWDznjq6dijhvCP6c9HRlZwwonfWv5sfVY9OZVw8YRAXTxhEbUOUV1du47mlm5m9fDNPLdpAaVg46bA+TB7Xj7PH9qNvQH4XLPDkUEPKrLam/1FDIfHVavPN8YRjPZ7sutGxbRSCWq/t7bU7mX7/POoiDvd+9jhOHZU+iaB3lw788TPH8ve31nLL08s45zev8LOPH8GU8QMK2GLTntTsOsiTXpLAe5v3URISJo3uy40XVHLm2L5tZk6xvDTMmWP7ceZYNznh7bWNyQk3PL6EGx5fwoQhPZhc1Z/J4/pxWBtOTghk4BGRKcBvgTDwJ1X9WdLjHYD7gWOB7cAnVXV1vtvlL5mjmjq5ANyyOao0rVzQyo3gOgR4qO3JhTVc/+hiBnQv58HpxzGyb8u/LCLCp04YysQRvfn6gwv54l/f5tLqQfzwwnF0trRrk4HdBxqYuWQjjy+o4a0PdwBQPbQnP75oPOcfMYCencuK3MLmhUPCccN6cdywXvzveWN5b/O+eBD6+bPv8vNn3+Wwis7xDLm2lpwQuN9SEQkDtwNnA+uBuSIyQ1WX+U77PLBTVUeKyGXAz4FP5rttjrpZL706l8WH2lL2eKQx9TqcMqut/Q+1OY7ym9nvcdu/V3L88F7cdcWxWf+yH1bRhce+dBK/mf0ef3j5A978cAe/+eTRTBjSM0+tNkFWF4ny4rtbeGLBBv797hbqow4jKjpz3dmHM+3oSob07lTsJraKiDC6f1dG9+/KV84cxYZdB3l+2WaeX7aZP76yij94yQlnVfVjclU/Tjysd5NU70ILXOABjgdWquoqABF5EJgG+APPNOAm7/ajwO9FRFQ1b2lffbqUsW1fPcfc8jxfP2sUJ47ojdu+pueGQo2VBvyZ04fKHE9tQ5TrHlnEvxZv5BPHDuL/Lj6i1Vk6ZSUhvj1lDKcfXsE3H17EJXe+zlc/NoprzjgsnphgDl2Oo8xdvYMnFtbwr8Ub2VMboU+XDlwxcSgXT6hkfGW3vCUJFMtAX3LC7gMNbnLCsk08saCGv7+5li4dSpg0uoLJ4/ozaXQF3YqQnBDEwFMJrPPdXw+ckO4cVY2IyG6gN7AtX406YURvZr6zEVX4zez3ub/zGiDNUFtIeHHFFoCkIqGtm+OJfWj//NkV9G7jQwQAK7fsY+XWfXz33DH8z2kjcvKLf8KI3sz82qnc+OQSbp39HrfOfo+SkFAaDlEaFspKQpSGQ5SE3WNl4VD8sdJwiLKSUPz8Qk8gm/xQhXdqdlOz6yCdysJMGdefaRMqOfmw3ofMHyXdO7kVFC6aUEltQ5TXPmhMTnh68UZKw8KJh/XhurMP56jBPQrWriAGnlSfCsk9mUzOQUSmA9MBhgwZ0qrGVA/tybw1O7nk2EHccN5YZi/fzJsf7uC9TXsZ2rtTyjmLc8cPYP6aHYwd0I3qob3ix48b3ovzjxhA7y7ZBY+RfbtwzJAe7DpQz64D9a26jkLqUBriziuO5Zxx/XP6ut07lvLbyyZwwZEDWVKzm4ao431pwu36qENDxCHiuMfrIw776yLx85z8dYxNgR3erwvfnjKas6v60aksiB93uVNeGuZjY/rxsTFucsKCtTt5btlmZi3dlPWi9Y9K8jj6lBciciJwk6qe493/HoCq/tR3zizvnNdFpATYBFQ0N9RWXV2t8+bNy2/jjTGmjYknQrVy5EFE5qtqdTbPCWJ/cy4wSkSGi0gZcBkwI+mcGcCV3u1LgH/nc37HGGOCSkQKPs8VuL6nN2dzLTALN536HlVdKiI3A/NUdQbwZ+ABEVkJ7MANTsYYY9qAwAUeAFWdCcxMOnaj73Yt8IlCt8sYY0zLgjjUZowxJsAs8BhjjCkoCzzGGGMKygKPMcaYggrcOp58EZGtwJpWPr0PeayKEACH8vUfytcOdv2H8vXHrn2oqma1L70FnhwQkXnZLqBqTw7l6z+Urx3s+g/l6/8o125DbcYYYwrKAo8xxpiCssCTG3cXuwFFdihf/6F87WDXfyhff6uv3eZ4jDHGFJT1eIwxxhSUBZ4siMgUEVkhIitF5LspHu8gIg95j78pIsMK38r8yODaTxORt0UkIiKXFKON+ZTB9X9TRJaJyGIReUFEhhajnfmSwfV/UUTeEZGFIjJHRKqK0c58aOnafeddIiIqIu0qyy2Dn/1VIrLV+9kvFJGrW3xRVbWvDL5wK2F/AIwAyoBFQFXSOV8G7vRuXwY8VOx2F/DahwFHAvcDlxS7zUW4/jOATt7tL7WXn30W19/Nd3sq8Gyx212oa/fO6wq8ArwBVBe73QX+2V8F/D6b17VzAGs+AAAFMElEQVQeT+aOB1aq6ipVrQceBKYlnTMNuM+7/ShwprSPDd1bvHZVXa2qiwGnGA3Ms0yu/0VVPeDdfQMYVOA25lMm17/Hd7czKXb8DahMfu8BbgF+AdQWsnEFkOn1Z8UCT+YqgXW+++u9YynPUdUIsBvoXZDW5Vcm196eZXv9nweeyWuLCiuj6xeRa0TkA9wP4K8WqG351uK1i8gEYLCqPl3IhhVIpv/3/8sbZn5URAa39KIWeDKXqueS/FddJucEUXu9rkxlfP0icgVQDfwyry0qrIyuX1VvV9XDgO8A3897qwqj2WsXkRBwK3BdwVpUWJn87J8ChqnqkcBsGkd90rLAk7n1gD+SDwI2pDtHREqA7rg7oAZdJtfenmV0/SJyFnADMFVV6wrUtkLI9uf/IHBRXltUOC1de1dgPPCSiKwGJgIz2lGCQYs/e1Xd7vv//kfg2JZe1AJP5uYCo0RkuIiU4SYPzEg6ZwZwpXf7EuDf6s2+BVwm196etXj93nDLXbhBZ0sR2phPmVz/KN/d84H3C9i+fGr22lV1t6r2UdVhqjoMd35vqqrOK05zcy6Tn/0A392pwPKWXjSQW18Xg6pGRORaYBZupsc9qrpURG4G5qnqDODPwAMishK3p3NZ8VqcO5lcu4gcBzwO9AQuFJEfqeq4IjY7ZzL82f8S6AI84uWTrFXVqUVrdA5leP3Xej2+BmAnjX+ABVqG195uZXj9XxWRqUAE93PvqpZe1yoXGGOMKSgbajPGGFNQFniMMcYUlAUeY4wxBWWBxxhjTEFZ4DHGGFNQFniMyYCI7CvAe0xtrvpxnt5zkoicVMj3NMbW8RhTQCISVtVoqse8NRE5XxciIiVe7cBUJgH7gNdy/b7GpGM9HmOyJCLXi8hcryjij3zHnxCR+SKyVESm+47vE5GbReRN4EQRWS0iP/L2L3pHRMZ4510lIr/3bt8rIreJyGsisiq2x5GIhETkDu89nhaRman2PxKRl0TkJyLyMvA1EblQ3D2iFojIbBHpJ+5+UV8EvuHto3KqiFSIyGPe9c0VkZPz+W9pDk3W4zEmCyIyGRiFWy5ecOtynaaqrwCfU9UdItIRmCsij6nqdtxtApao6o3eawBsU9VjROTLwLeAVJtnDQBOAcbg9oQeBT6Ou/fREUBf3PIk96Rpbg9VPd17z57ARFVVb6Oub6vqdSJyJ7BPVX/lnfd34FZVnSMiQ3BXrI9t9T+YMSlY4DEmO5O9rwXe/S64gegV3NIhF3vHB3vHtwNR4LGk1/mn930+bjBJ5QlVdYBlItLPO3YK8Ih3fJOIvNhMWx/y3R4EPOTV1SoDPkzznLOAKt82Ut1EpKuq7m3mfYzJigUeY7IjwE9V9a6EgyKTcD+0T1TVAyLyElDuPVybYl4nVs03SvrfQ3+Fa0n6non9vtu/A37t1dWbBNyU5jkh3Gs4mMX7GJMVm+MxJjuzgM+JSBcAEakUkb64W2Ds9ILOGNzy+PkwB3fTrZDXC5qU4fO6AzXebX8Bz724pf1jngOujd0RkaNb31RjUrPAY0wWVPU54O/A6yLyDu68S1fgWaBERBbjboP8Rp6a8BjuHilLcLdheBN3p9uW3IRbOfs/wDbf8aeAi2PJBbg7h1Z7iRPLcJMPjMkpq05tTMCISBdV3ScivYG3gJNVdVOx22VMpmyOx5jgeVpEeuAmCdxiQccEjfV4jDHGFJTN8RhjjCkoCzzGGGMKygKPMcaYgrLAY4wxpqAs8BhjjCkoCzzGGGMK6v8DO2w2+qIfXH4AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x864 with 3 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "learn.sched.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 109,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn.opt_fn = optim.RMSprop"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 110,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e5effd0006694f8b9465770368f10d77",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>HBox</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=1), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 60%|█████████████████████████████████████████▌                           | 471/782 [00:54<00:36,  8.59it/s, loss=4.12]\n",
+      "                                                                                                                       \r"
+     ]
+    }
+   ],
+   "source": [
+    "learn.lr_find()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 111,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'alpha': 0.99,\n",
+       " 'centered': False,\n",
+       " 'eps': 1e-08,\n",
+       " 'lr': 0.041097058792876534,\n",
+       " 'momentum': 0,\n",
+       " 'params': [Parameter containing:\n",
+       "  (0 ,0 ,.,.) = \n",
+       "    0.1154  0.1074  0.2712\n",
+       "    0.4642  0.0251  0.0773\n",
+       "    0.1532 -0.3673 -0.1657\n",
+       "  \n",
+       "  (0 ,1 ,.,.) = \n",
+       "   -0.0011 -0.0573 -0.0320\n",
+       "    0.2008 -0.3239 -0.2769\n",
+       "    0.3984 -0.3123 -0.0246\n",
+       "  \n",
+       "  (0 ,2 ,.,.) = \n",
+       "    0.1285 -0.2558  0.0399\n",
+       "    0.3137 -0.2878 -0.2394\n",
+       "    0.3433 -0.1290  0.0085\n",
+       "  \n",
+       "  (1 ,0 ,.,.) = \n",
+       "    0.0248 -0.0418  0.3036\n",
+       "   -0.1312 -0.2179  0.1101\n",
+       "   -0.3336 -0.2348 -0.0767\n",
+       "  \n",
+       "  (1 ,1 ,.,.) = \n",
+       "    0.0456  0.0795  0.2704\n",
+       "   -0.2156  0.0853  0.1642\n",
+       "   -0.2975 -0.2942  0.1496\n",
+       "  \n",
+       "  (1 ,2 ,.,.) = \n",
+       "    0.1228  0.0656  0.2296\n",
+       "   -0.1653  0.1751  0.1145\n",
+       "   -0.2928 -0.2436 -0.1026\n",
+       "  \n",
+       "  (2 ,0 ,.,.) = \n",
+       "    0.0509 -0.0784  0.1688\n",
+       "    0.0356  0.0829  0.1083\n",
+       "    0.1043 -0.1619 -0.1195\n",
+       "  \n",
+       "  (2 ,1 ,.,.) = \n",
+       "   -0.0631 -0.1093 -0.0142\n",
+       "    0.1575 -0.1583 -0.0039\n",
+       "    0.0142  0.0071  0.1635\n",
+       "  \n",
+       "  (2 ,2 ,.,.) = \n",
+       "   -0.0507  0.0182  0.0554\n",
+       "   -0.0608  0.0539  0.0064\n",
+       "    0.1033  0.1917  0.1922\n",
+       "  \n",
+       "  (3 ,0 ,.,.) = \n",
+       "    0.2086  0.3090  0.1883\n",
+       "    0.3013  0.0711  0.0440\n",
+       "    0.1986  0.1047  0.1769\n",
+       "  \n",
+       "  (3 ,1 ,.,.) = \n",
+       "   -0.0698 -0.1122 -0.1371\n",
+       "   -0.3024 -0.4109 -0.0258\n",
+       "    0.0576 -0.2315 -0.0261\n",
+       "  \n",
+       "  (3 ,2 ,.,.) = \n",
+       "    0.0496  0.1536  0.1097\n",
+       "    0.0028 -0.2222 -0.1582\n",
+       "   -0.0730  0.0672 -0.0706\n",
+       "  \n",
+       "  (4 ,0 ,.,.) = \n",
+       "    0.4352  0.1979  0.1814\n",
+       "    0.0125 -0.3621  0.0257\n",
+       "   -0.1939 -0.1258  0.1820\n",
+       "  \n",
+       "  (4 ,1 ,.,.) = \n",
+       "   -0.1432 -0.3525 -0.0302\n",
+       "   -0.1732 -0.5920  0.1664\n",
+       "   -0.1539 -0.3100  0.2408\n",
+       "  \n",
+       "  (4 ,2 ,.,.) = \n",
+       "   -0.0249 -0.1404 -0.0865\n",
+       "    0.2370 -0.1524  0.0826\n",
+       "    0.0300 -0.1027  0.5192\n",
+       "  \n",
+       "  (5 ,0 ,.,.) = \n",
+       "   -0.1586 -0.1682  0.0931\n",
+       "    0.0312 -0.4744 -0.3492\n",
+       "    0.2682  0.1245  0.2067\n",
+       "  \n",
+       "  (5 ,1 ,.,.) = \n",
+       "    0.3556  0.2998  0.1535\n",
+       "    0.0354 -0.2784 -0.5595\n",
+       "    0.1108  0.2354 -0.2159\n",
+       "  \n",
+       "  (5 ,2 ,.,.) = \n",
+       "    0.0505  0.1575 -0.0254\n",
+       "    0.1372 -0.3818 -0.4462\n",
+       "    0.1371  0.1255 -0.0127\n",
+       "  \n",
+       "  (6 ,0 ,.,.) = \n",
+       "    0.0777  0.1305  0.0826\n",
+       "   -0.1980 -0.1805 -0.1943\n",
+       "   -0.2433 -0.1283 -0.2088\n",
+       "  \n",
+       "  (6 ,1 ,.,.) = \n",
+       "    0.1674 -0.2189  0.0199\n",
+       "    0.0209 -0.1233 -0.2526\n",
+       "   -0.2540 -0.0919 -0.2141\n",
+       "  \n",
+       "  (6 ,2 ,.,.) = \n",
+       "    0.4577  0.4764  0.1750\n",
+       "    0.4347  0.2867 -0.0647\n",
+       "    0.3361  0.2788 -0.0263\n",
+       "  \n",
+       "  (7 ,0 ,.,.) = \n",
+       "   -0.0784  0.4168  0.2817\n",
+       "   -0.0268  0.5341  0.2645\n",
+       "    0.1114  0.0549 -0.2043\n",
+       "  \n",
+       "  (7 ,1 ,.,.) = \n",
+       "    0.3280  0.5301  0.1857\n",
+       "    0.1831  0.6165  0.1975\n",
+       "    0.0522  0.0591  0.0596\n",
+       "  \n",
+       "  (7 ,2 ,.,.) = \n",
+       "    0.3769  0.5667  0.1352\n",
+       "    0.1156  0.5553  0.2041\n",
+       "    0.1246  0.1378  0.2080\n",
+       "  \n",
+       "  (8 ,0 ,.,.) = \n",
+       "    0.0112 -0.1768 -0.0490\n",
+       "   -0.1580 -0.1767  0.0858\n",
+       "   -0.0212 -0.1662  0.0941\n",
+       "  \n",
+       "  (8 ,1 ,.,.) = \n",
+       "   -0.1889 -0.2436  0.1075\n",
+       "   -0.1377  0.0369  0.0090\n",
+       "    0.0794 -0.2030 -0.1050\n",
+       "  \n",
+       "  (8 ,2 ,.,.) = \n",
+       "    0.1586 -0.2411  0.0877\n",
+       "   -0.0936  0.1274 -0.2144\n",
+       "    0.0249  0.1244  0.0640\n",
+       "  \n",
+       "  (9 ,0 ,.,.) = \n",
+       "   -0.1760 -0.1004 -0.2225\n",
+       "    0.1275 -0.1325 -0.1121\n",
+       "   -0.0867  0.0544  0.1375\n",
+       "  \n",
+       "  (9 ,1 ,.,.) = \n",
+       "   -0.0586 -0.3100 -0.1950\n",
+       "    0.1524  0.1024  0.1942\n",
+       "   -0.1451 -0.0015 -0.1857\n",
+       "  \n",
+       "  (9 ,2 ,.,.) = \n",
+       "   -0.1264 -0.1610  0.0209\n",
+       "    0.4158  0.2054  0.1472\n",
+       "    0.2587  0.0694  0.0612\n",
+       "  \n",
+       "  (10,0 ,.,.) = \n",
+       "    0.0497 -0.0668  0.0088\n",
+       "    0.1135  0.0949 -0.1528\n",
+       "   -0.1177 -0.2179 -0.2562\n",
+       "  \n",
+       "  (10,1 ,.,.) = \n",
+       "   -0.0944 -0.1828 -0.1875\n",
+       "    0.1394 -0.0444 -0.2927\n",
+       "    0.0188 -0.1533 -0.1453\n",
+       "  \n",
+       "  (10,2 ,.,.) = \n",
+       "    0.3324  0.0867 -0.0895\n",
+       "    0.3432  0.2566  0.1291\n",
+       "    0.1228  0.0833  0.1853\n",
+       "  \n",
+       "  (11,0 ,.,.) = \n",
+       "   -0.2602  0.1700 -0.3664\n",
+       "    0.0268  0.4641 -0.0678\n",
+       "   -0.1132  0.0809 -0.2418\n",
+       "  \n",
+       "  (11,1 ,.,.) = \n",
+       "    0.0745  0.1858 -0.1971\n",
+       "    0.1733  0.5401 -0.0912\n",
+       "   -0.1810  0.2881 -0.0839\n",
+       "  \n",
+       "  (11,2 ,.,.) = \n",
+       "    0.0396  0.0216 -0.2533\n",
+       "    0.0533  0.3088 -0.3272\n",
+       "   -0.3310  0.2306 -0.0213\n",
+       "  \n",
+       "  (12,0 ,.,.) = \n",
+       "    0.1021 -0.0608 -0.1499\n",
+       "   -0.2114 -0.2365 -0.0563\n",
+       "   -0.1063  0.0764 -0.0357\n",
+       "  \n",
+       "  (12,1 ,.,.) = \n",
+       "    0.0351  0.0740 -0.0672\n",
+       "   -0.1255 -0.0281 -0.0881\n",
+       "   -0.0921  0.0747 -0.2432\n",
+       "  \n",
+       "  (12,2 ,.,.) = \n",
+       "    0.0910 -0.0031  0.0222\n",
+       "   -0.1712  0.0052  0.0295\n",
+       "   -0.1500 -0.0060 -0.0032\n",
+       "  \n",
+       "  (13,0 ,.,.) = \n",
+       "   -0.0833  0.2299  0.1865\n",
+       "    0.0523 -0.1326 -0.0011\n",
+       "   -0.1028  0.0866  0.1831\n",
+       "  \n",
+       "  (13,1 ,.,.) = \n",
+       "    0.0338  0.1747  0.1365\n",
+       "   -0.0011 -0.1137 -0.2205\n",
+       "   -0.1047 -0.1990 -0.1358\n",
+       "  \n",
+       "  (13,2 ,.,.) = \n",
+       "   -0.0266  0.1153  0.1849\n",
+       "    0.2288  0.1576  0.0619\n",
+       "   -0.0713  0.0573 -0.0599\n",
+       "  \n",
+       "  (14,0 ,.,.) = \n",
+       "    0.1491  0.1146  0.1135\n",
+       "   -0.0444  0.1138  0.1508\n",
+       "   -0.0252  0.2128  0.2595\n",
+       "  \n",
+       "  (14,1 ,.,.) = \n",
+       "   -0.2394  0.0672 -0.1381\n",
+       "    0.0680 -0.1177 -0.0600\n",
+       "    0.0396 -0.1320  0.0907\n",
+       "  \n",
+       "  (14,2 ,.,.) = \n",
+       "   -0.0340 -0.1828 -0.1236\n",
+       "   -0.1123 -0.2498  0.0672\n",
+       "    0.0026 -0.2193 -0.2590\n",
+       "  \n",
+       "  (15,0 ,.,.) = \n",
+       "    0.0952  0.1118  0.0361\n",
+       "    0.1301 -0.1345 -0.1258\n",
+       "    0.1508  0.0688  0.0592\n",
+       "  \n",
+       "  (15,1 ,.,.) = \n",
+       "   -0.0211 -0.0484 -0.0959\n",
+       "    0.0264 -0.1633 -0.1461\n",
+       "    0.0238  0.1298  0.1569\n",
+       "  \n",
+       "  (15,2 ,.,.) = \n",
+       "   -0.0372  0.1232 -0.1345\n",
+       "   -0.1930  0.0786  0.0902\n",
+       "    0.0269  0.2204  0.0412\n",
+       "  [torch.cuda.FloatTensor of size 16x3x3x3 (GPU 0)]],\n",
+       " 'weight_decay': 0.0}"
+      ]
+     },
+     "execution_count": 111,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "learn.sched.layer_opt.opt.param_groups[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 107,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Adam'"
+      ]
+     },
+     "execution_count": 107,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "learn.opt_fn.__name__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 108,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.8"
+      ]
+     },
+     "execution_count": 108,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "learn.sched.layer_opt.opt.param_groups[0]['betas'][0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[1.6541821079595587,\n",
+       " 1.6603964240761468,\n",
+       " 1.6607887783166204,\n",
+       " 1.659656904959659,\n",
+       " 1.658147585958895]"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "losses[780:785]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3910"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(losses)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "782.0"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "3910/5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 145,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class PreActBlock(nn.Module):\n",
+    "    '''Pre-activation version of the BasicBlock.'''\n",
+    "    expansion = 1\n",
+    "\n",
+    "    def __init__(self, in_planes, planes, stride=1):\n",
+    "        super(PreActBlock, self).__init__()\n",
+    "        self.bn1 = nn.BatchNorm2d(planes)\n",
+    "        self.conv1 = nn.Conv2d(in_planes, planes, kernel_size=3, stride=stride, padding=1, bias=False)\n",
+    "        self.bn2 = nn.BatchNorm2d(planes)\n",
+    "        self.conv2 = nn.Conv2d(planes, planes, kernel_size=3, stride=1, padding=1, bias=False)\n",
+    "\n",
+    "        if stride != 1 or in_planes != self.expansion*planes:\n",
+    "            self.shortcut = nn.Sequential(\n",
+    "                nn.Conv2d(in_planes, self.expansion*planes, kernel_size=1, stride=stride, bias=False)\n",
+    "            )\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        out = F.relu(x)\n",
+    "        shortcut = self.shortcut(out) if hasattr(self, 'shortcut') else x\n",
+    "        out = self.conv1(out)\n",
+    "        out = self.bn2(self.conv2(F.relu(self.bn1(out))))\n",
+    "        out += shortcut\n",
+    "        return out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 146,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class PreActResNet(nn.Module):\n",
+    "    def __init__(self, block, num_blocks, num_classes=10):\n",
+    "        super(PreActResNet, self).__init__()\n",
+    "        self.in_planes = 16\n",
+    "\n",
+    "        self.conv1 = nn.Conv2d(3, 16, kernel_size=3, stride=1, padding=1, bias=False)\n",
+    "        self.layer1 = self._make_layer(block, 16, num_blocks[0], stride=1)\n",
+    "        self.layer2 = self._make_layer(block, 32, num_blocks[1], stride=2)\n",
+    "        self.layer3 = self._make_layer(block, 64, num_blocks[2], stride=2)\n",
+    "        self.linear = nn.Linear(64*block.expansion, num_classes)\n",
+    "\n",
+    "    def _make_layer(self, block, planes, num_blocks, stride):\n",
+    "        strides = [stride] + [1]*(num_blocks-1)\n",
+    "        layers = []\n",
+    "        for stride in strides:\n",
+    "            layers.append(block(self.in_planes, planes, stride))\n",
+    "            self.in_planes = planes * block.expansion\n",
+    "        return nn.Sequential(*layers)\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        out = self.conv1(x)\n",
+    "        out = self.layer1(out)\n",
+    "        out = self.layer2(out)\n",
+    "        out = self.layer3(out)\n",
+    "        out = F.adaptive_max_pool2d(out, 1)\n",
+    "        out = out.view(out.size(0), -1)\n",
+    "        return F.log_softmax(self.linear(out))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 148,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn = ConvLearner.from_model_data(PreActResNet(PreActBlock,[9,9,9]), data)\n",
+    "learn.crit = F.nll_loss"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 154,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d069badb10d2475282d21e52d72a1cbc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>HBox</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=1), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                                                                                                       \r"
+     ]
+    }
+   ],
+   "source": [
+    "learn.lr_find(end_lr=100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 158,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXwAAAEOCAYAAACKDawAAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzt3XeYXNV9//H3d7b33rSr1aoXJIQaRgiEKCK0YLBlsJ0QgwtucYiduMXOE9ydnx0nLnHBdmyMcQNsDAJTQpFEQEKrXpGQ0KqutKvV9j5zfn/MSKzESpqVdubOznxezzPPzty5M/e7R6PP3jn33HPNOYeIiMQ/n9cFiIhIdCjwRUQShAJfRCRBKPBFRBKEAl9EJEEo8EVEEoQCX0QkQSjwRUQShAJfRCRBKPBFRBJEstcFDFRcXOxqamq8LkNEZMRYs2ZNo3OuJJx1Yyrwa2pqqK2t9boMEZERw8zqwl1XXToiIglCgS8ikiAU+CIiCUKBLyKSIBT4IiIJQoEvIpIgRnzg+wOOl3Y2sr2+1etSRERi2ogPfIAP/aqW36zay7q9x/AHdI1eEZHBjPjAT/IZk8tz+NUrddz6w5d5ZO1+r0sSEYlJIz7wAcYUZZ64v2Jno4eViIjErrgI/PK8dABy0pNZufsozqlbR0TkVDE1l865uufqiUwpz6G5s48vPb6VI209lOWme12WiEhMiYs9/MzUZG6dVcW0ilwAth3SiB0RkVPFReAfN6X8eOC3eVyJiEjsiavAz8tMobowkw37mr0uRUQk5sRV4APMqynk1T1NOnArInKKuAv8t40tpKmjl7V7j3ldiohITIm7wL/hwgqKs1P5xpPbtZcvIjJA3AV+dloy/3TtZGrrjnH/y3u8LkdEJGbEXeAD3DZ3NAsnlfD1J7fT3ef3uhwRkZgQl4Gf5DPeObuSXn+APUc7vC5HRCQmxGXgA0wozQbg9SPtHlciIhIb4jbwx5dkY6bAFxE5Lm4DPz0licllOSzb0eB1KSIiMSFuAx9gyZwq1u1tZk+j+vFFROI68C8dXwzA5oMtHlciIuK9iAa+meWb2cNmtt3MtpnZ/Ehu71TjSrLwGew4rH58EZFIz4f/XeAp59wSM0sFMs/2guGUnpLEmKIsdh7W7JkiIhELfDPLBRYCdwI453qB3kht73SmVeSypu4YgYDD57Nob15EJGZEsktnHNAA/MLM1pnZz8wsK4LbG9Q100qpb+1mnaZMFpEEF8nATwZmAz9yzs0COoDPnbqSmd1tZrVmVtvQMPxDKK+eWkZmahK/Xlk37O8tIjKSRDLw9wP7nXOrQo8fJvgH4CTOufucc3Odc3NLSkqGvYjc9BTePa+axzYcpLW7b9jfX0RkpIhY4Dvn6oF9ZjY5tOhqYGuktncmV08txR9wrNurbh0RSVyRHof/CeBBM9sIXAR8PcLbG9RFo/NJ8hm1e5q82LyISEyI6LBM59x6YG4ktxGOrLRkLhiVy2oFvogksLg+03agOWMKWL+vmT5/wOtSREQ8kTCBP6+mkO6+AFsPtnpdioiIJxIm8GdU5gGwRYEvIgkqYQK/qiCDnLRkth1S4ItIYkqYwDczpo7KZdMBzZwpIokpYQIf4JKxhWzc30xje4/XpYiIRF1CBf510ysIOHhmy2GvSxERibqECvypFTnUFGXyl82HvC5FRCTqEirwzYzrplfwyq6jNHdGfaZmERFPJVTgA9wwo5z+gOPZrerWEZHEknCBP6Myj8r8DP6yud7rUkREoirhAj/YrVPOSzsbNV2yiCSUhAt8gOunl9PrD/DC9iNelyIiEjUJGfizqgsozk7jGfXji0gCScjAT/IZi6eV8uL2I/T0+70uR0QkKhIy8AGunVZOR6+fV3Yd9boUEZGoSNjAnz++iKzUJHXriEjCSNjAT09JYtHkUp7dephAwHldjohIxCVs4AMsmlxCQ1sPrze0e12KiEjEJXTgzxlTAMDaumMeVyIiEnkJHfhji7MoyExh7V4FvojEv4QOfDNjVnUB6/Y2e12KiEjEJXTgA8wanc/OI+20dGmaBRGJbwkf+Mf78dfUNXlciYhIZCV84M8eU0BGShIvbG/wuhQRkYhK+MBPT0nisonFPL/9CM5pPL6IxK+ED3yAq6eUcqC5i+31bV6XIiISMQp84KoppQA8r+mSRSSOKfCB0tx0LqzK47ltmldHROKXAj/kqimlrNvXzNH2Hq9LERGJCAV+yNVTynAOXnxNo3VEJD4p8EMuGJVLaU4az7+mfnwRiU8K/BCfz5g/vojaPU0anikicUmBP8CcMQUcbu1h/7Eur0sRERl2EQ18M9tjZpvMbL2Z1UZyW8Ph4rGFACzfqX58EYk/0djDv9I5d5Fzbm4UtnVeJpflMK4kiz+vP+h1KSIiw05dOgOYGTfOqKB2T5NmzxSRuBPpwHfAM2a2xszujvC2hsWCCcUEHLz6hmbPFJH4EunAX+Ccmw1cD3zczBaeuoKZ3W1mtWZW29Dgfd/5rOp8MlOTeH67zroVkfgS0cB3zh0M/TwC/Am4eJB17nPOzXXOzS0pKYlkOWFJS05i8bQyntxUT29/wOtyRESGTcQC38yyzCzn+H3gWmBzpLY3nG6cUUFLVx+1uiiKiMSRSO7hlwEvmdkG4FXgCefcUxHc3rC5dEIxKUnGsh3edzGJiAyX5Ei9sXNuNzAzUu8fSdlpycwZU8DyHY18/nqvqxERGR4alnkaCyeVsO1QK0faur0uRURkWCjwT2PhxOAB5BU7Gj2uRERkeCjwT2NaRS7F2amaZkFE4oYC/zR8PuPyiSWs2NlIIKDZM0Vk5FPgn8EVk0po6uhl88EWr0sRETlvCvwzuGxiMQDLNTxTROKAAv8MirPTmF6Zy3IduBWROKDAP4uFE0tYu/cYrd2aPVNERjYF/lksnFRCf8Dx8utHvS5FROS8KPDPYnZ1AdlpyRqeKSIjngL/LFKTfcwfX8TyHQ26uLmIjGgK/DAsnFTC/mNdvNHY4XUpIiLnTIEfhitC0yxoeKaIjGQK/DBUF2VSU5Sp6ZJFZERT4IfpikklrNzdRE+/3+tSRETOiQI/TJdPLKGrz8+aPce8LkVE5Jwo8MN0yfgikn3G8p0661ZERiYFfpiOXwVrhcbji8gIpcAfgoWTSthysJXG9h6vSxERGTIF/hBcHpo98yV164jICKTAH4ILRuVRkJmiaRZEZEQKK/DN7B4zy7Wgn5vZWjO7NtLFxZokn7FgQjErdjZqmgURGXHC3cN/v3OuFbgWKAHuAr4Zsapi2MJJJTS09fDa4TavSxERGZJwA99CP28AfuGc2zBgWUJZGJpm4YXt6tYRkZEl3MBfY2bPEAz8p80sBwhErqzYVZ6XzvTKXJ7dWu91KSIiQxJu4H8A+BwwzznXCaQQ7NZJSNdOK2fdvmaOtHV7XYqISNjCDfz5wGvOuWYz+1vgi0BL5MqKbYunleEcPLftiNeliIiELdzA/xHQaWYzgc8AdcCvIlZVjJtSnkNVQQbPbj3sdSkiImELN/D7XXAc4tuB7zrnvgvkRK6s2GZmXDutnJdeb6Sjp9/rckREwhJu4LeZ2eeBO4AnzCyJYD9+wrpuejm9/QHt5YvIiBFu4N8O9BAcj18PVALfilhVI8DcMQWMLszg4TX7vS5FRCQsYQV+KOQfBPLM7Cag2zmXsH34AD6f8Y5ZVfzfrkYONnd5XY6IyFmFO7XCbcCrwLuA24BVZrYkkoWNBO+cXYVz8Kd1B7wuRUTkrMLt0vkCwTH473PO/R1wMfCvkStrZKguyuRtYwt5eM1+za0jIjEv3MD3OecGDjo/Gu5rzSzJzNaZ2dIhVzcCvHNOFW80drB2b7PXpYiInFG4gf+UmT1tZnea2Z3AE8CTYb72HmDbuRQ3Etwwo4KMlCQdvBWRmBfuQdtPA/cBFwIzgfucc5892+vMrAq4EfjZ+RQZy7LTkrl+ejlLNx6ku8/vdTkiIqcV9gVQnHOPOOc+5Zz7pHPuT2G+7L8Inpkb1xOtLZlTRVt3P89oTL6IxLAzBr6ZtZlZ6yC3NjNrPctrbwKOOOfWnGW9u82s1sxqGxpG5pTDl4wrojI/g4dq93ldiojIaZ0x8J1zOc653EFuOc653LO89wLgZjPbA/wOuMrMfj3INu5zzs11zs0tKSk551/ESz6f8e55o1mxs5Ht9Wf8Oygi4pmIXdPWOfd551yVc64GeDfwvHPubyO1Pa/dMX8Mack+frNqr9eliIgMShcxHyb5maksnlbGYxsO0tsf14csRGSEikrgO+dedM7dFI1teemds6to7uzjhdc0T76IxB7t4Q+jyycWU5ydpm4dEYlJCvxhlJzk464FNSzb0cDmAwl7QTARiVEK/GF2x/wx5KQn84PnX/e6FBGRkyjwh1luegp3XlrDU1vq2Xm4zetyREROUOBHwF0LxpKRksSPl+32uhQRkRMU+BFQmJXKbXOreGzDAepbur0uR0QEUOBHzAcvH4c/4PjFy294XYqICKDAj5jRhZncMKOCB1fupaWrz+tyREQU+JH0sUUTaO/p54FX9nhdioiIAj+Spo3K5aoppfz8pTfo7O33uhwRSXAK/Aj72KLxHOvs49cr67wuRUQSnAI/wubWFHLl5BK+99zrNLb3eF2OiCQwBX4UfPGmaXT1+fnvF3T2rYh4R4EfBeNLslkyu4oHV+5l/7FOr8sRkQSlwI+Se66ZiM8HX126zetSRCRBKfCjZFR+Bp+4aiJPbanXfPki4gkFfhR96PJxjCvJ4t/+vIXuPr/X5YhIglHgR1Fqso+vvH06e5s6+dGLu7wuR0QSjAI/yhZMKOavZ47iR8t2saexw+tyRCSBKPA98MUbp5Ka5OPfHtuCc87rckQkQSjwPVCWm84nF09i2Y4Gnt5S73U5IpIgFPgeed/8MUwpz+HLj2+lo0fz7IhI5CnwPZKc5ONrt07nYEs333t+p9fliEgCUOB7aM6YQm6bW8XPV7yh69+KSMQp8D322eumkJWWzBce3Yw/oAO4IhI5CnyPFWWn8cUbp/LqG0384HlNriYikaPAjwFL5lTxjlmV/NdzO3hpZ6PX5YhInFLgxwAz46u3TmdCSTb3/G4d9S3dXpckInFIgR8jMlOT+dHfzqarz88nfruWfn/A65JEJM4o8GPIhNIcvvGOGazec4xvPfOa1+WISJxR4MeYt19Uyd+8rZqfLNvNs1sPe12OiMQRBX4M+tebpjG9MpdP/n492+tbvS5HROKEAj8Gpackcd8dc8lKS+L9v1jN4VYdxBWR86fAj1Gj8jP4nzvn0dLVx4cfWENvvw7iisj5iVjgm1m6mb1qZhvMbIuZfSlS24pXF4zK41vvmsn6fc187YmtXpcjIiNcJPfwe4CrnHMzgYuA68zskghuLy7dMKOCD142lvtfqePP6w94XY6IjGARC3wX1B56mBK6abKYc/DZ66cwr6aAzz2yidV7mrwuR0RGqIj24ZtZkpmtB44AzzrnVkVye/EqJcnHD/9mDhV56dz1i9VsPaiROyIydBENfOec3zl3EVAFXGxm009dx8zuNrNaM6ttaGiIZDkjWklOGg9+6G1kpyXzgfs1ckdEhi4qo3Scc83Ai8B1gzx3n3NurnNubklJSTTKGbEq8jL4+Z1zaenq4wP3r6als8/rkkTkPD24qo5PP7QhKtuK5CidEjPLD93PAK4Btkdqe4niglF5/Pd7Z7Ojvp3bfvKK9vRFRrj1e5tZEaVZciO5h18BvGBmG4HVBPvwl0Zwewnjyiml/PKueew/1smSH7/MnsYOr0sSkXPU2ecnMy0pKtuK5Cidjc65Wc65C51z051zX47UthLRpROK+e3dl9DR42fJj1/RFAwiI1RnTz9ZqclR2ZbOtB3BLqzK5w8fnk+yz3j3fSvZuL/Z65JEZIg6e/1kpI7wPXyJjgml2Tz0kfnkpCfz3p+uYuXuo16XJCJD0NnrJ0uBL+EaXZjJHz48n7LcNO74+Sr+uHa/1yWJSJg6e/vJVJeODEVFXgZ//OgC5o4p5FN/2MB3nnkN53Ris0is6+z1k6k9fBmqvMwU7n//xdw2t4rvPf86n/jtOpo7e70uS0TOoLPXT1aa9vDlHKQm+/j3d17IZ66bzJObDnHFt17kl//3BoGA9vZFYlFnb78O2sq5MzM+tmgCT95zOTMq87j38a3c8T+rqG/RSVoisaS3P0Cf3+mgrZy/KeW5PPCBi/nmO2awtq6Zxf+5jD+s3qe+fZEY0dXrByBDB21lOJgZ7764mifvuZypFbl85pGN3PXL1Rxq6fK6NJGE19nXD6A9fBleY4uz+N2HLuFLN1/AK7uOcuk3n+czD29g79FOr0sTSVgdPcf38KMT+NH5HiExwecz3ndpDQsnlXD/y3t4cFUdD6/Zzy2zKvmHqyZSU5zldYkiCaWz9/gevrp0JELGFmdx780X8NJnr+IDl41l6YZDLPr2i3zkgTW8Vt/mdXkiCaOlKzjFeX5mSlS2pz38BFaWm84XbpzGBy8fx4Or9nLf8l08taWeyycW89FF45k/rggz87pMkbjVHLqmRV6GAl+ipCw3nU8tnsRdl9bwm1f38suX9/Den66iqiCDm2eO4sNXjI/aB1IkkTSH9vDzorSHry4dOaEgK5WPXzmBFZ+5km+/ayYTS7P58bJdXPOdZTyyZj89/X6vSxSJKy2hM+GjtUOlwJe3SE9JYsmcKn5x18X8+eOXUZ6bzj89tIGLvvQsH39wLS/vatRYfpFh0NLVR0ZKEmnJGqUjMWBGVR5//vgCVrzeyP9uPcxjGw7yxKZDTCjN5r0XV/OO2ZXkZ6Z6XabIiNTc2Re1A7agwJcw+HzGFZNKuGJSCV+4cSpLNx7igZV1fHnpVr751Haun17O380fw5wxhV6XKjKiNHf1RfX4mAJfhuR4d8+SOVVsPdjK71bv5U/rDvDn9Qe5ZFwhdy0Yy+KpZfh8Gt0jcjYtCnwZKaaNyuXLb5/O566fwu9e3cdPlu/iww+soSQnjVF56SyaXMpfXVDO1IocDe8UGURDWw/TKnKjtj0Fvpy3zNRk3n/ZWP5u/hiWbjzE8h0N1DV18r3nd/Ld53ZSmZ/B4mllLJlTxZTyHJKTNFZApM8fYF9TJzfMKI/aNhX4MmySk3zcMquSW2ZVAtDY3sNz2w7z7NbD/DY0vh+CZ/ounFjMFZNLuGRcUdQu7yYSS/Y1ddIfcIwrzo7aNvU/TSKmODuN2+dVc/u8alo6+3hqyyEOtXSzYV8zv6/dx/2v1JGa5GPe2AKunFzK5RNLGFOUSXpKdIaoiXhpd0MHAGNLojeHlQJfoiIvM4Xb51WfeNzd56d2zzGW72xg2WsNfPWJbcA2UpN8zB6Tz2UTilk8rZzJ5TneFS0SQZsPtmAG40uit4dvsXQCzdy5c11tba3XZYgH3mjsYNOBFjYfaOGlnY1sPdQKwOzqfG6eOYqrppRRXZTpcZUiw+eW//4/AB79+ILzeh8zW+OcmxvOutrDl5gwtjiLscVZ3DxzFBDs///dq3t5clM99z6+lXsf38rs6nymjcplXk0hF43OByA/I5Wc9GQNA5URZcvBFjbsb+ZT10yK6na1hy8xb1dDO89sOcxTW+rZfaSdtp7+k55PSTKmVuQysyqfmaPzqSrIoKYoi/K8dI8qFjk95xy337eSnYfbePGfrzzvidO0hy9xZXxJNh9dlM1HF43HH3Bs3N/MloOtpKck0dLVx5HWbjYdaOFP6w7wwMo6AJJ8xryaAq6dVs5fzxxFSU6ax7+FSNDSjYd49Y0mvn7rjKjNknmc9vAlbgQCjt2N7dS39PD89iO8vKuR7aELuozKS2dqRS5zagoYV5zN1IocqgszdUKYRFVnbz9X/8cyCrNSeezvLyNpGLoitYcvCcnnMyaU5jChNIfLJhYDsONwG89vP8K2Q62s3XuM57YfObF+WW4aF4zKY/G0MmZU5jGxLDtqsxZKYvrhC7s41NLN998za1jCfqgU+BLXJpXlMKksOLQzEHDsO9ZJQ1sP2+rbWLOnibV7m3k+9EcgyWfUFGWSkuTjotH5TCjNZlJZDhePLdS5AXLe6o52cN/y3dxy0Sjm1ngz0aACXxKGz2eMKcpiTFEWc2sKueOSMaFuoA6217ey/VAb2+vbaO/p4y+b609cbzQlyZg2Ko+p5TlU5GVQlJ1KUVYq88cX0ed3Oj4gYfnPZ3eQnGR8/oapntWgwJeEFuwGymZCaTY3Xfjmcn/A0dDWw6YDLdTWNbF+bzPPbD1MU0fvW96jIDOFCaXZfGrxZN42tlBDROUtmjt7eXJzPe+ZN5qyXO9GjynwRQaR5DPK89Ipz0tn8bSyE8t7+wMc6+zl9SPtbNjfjN/vqG/t5rltR3jPT1eSnZZMWW4as6oLyEhJoqogg8qCDJwLzox4wahcplfmkZWm/3qJoLvPz3PbjvDQmn30+wO8921jPK0nYp86MxsN/AooBwLAfc6570ZqeyLRkJrsoyw3nbLcdBZMKD6x/As39vPU5nrW7W1mz9EO/nfbYQIBR2t3/6Dvk5OWTEFWKtMrc8lISebCqjyqizKZM6aA3PTgUL3jI+i6+wLsOdrBK7uO0tXnp7G9hx2H26g72ok/4Ojq8zMqL4O7F44jPSWJnn4/88cVUZqbTt3RDgIOqgszPTlImEh2Hm7jxdcaeGzDQfr8AWqKsli9p4mjHb0k+YxP/9UUz6cKidiwTDOrACqcc2vNLAdYA9zinNt6utdoWKbEm7buPg40d+EPOIqy0th6qIXNB1pp6uiloa2H9fua6en309j+ZldRaU4axdlpHG7tptcfoKcvQK8/cOL5zNQkqgszGVeSRWZqMpmpSbz0euOJybiOK85Oo7G958T9xdPKKMlJo6ffz7SKXOaMKSAzNZnc9OB+n89M3VFD4Jxj26E2Xtl9lMc2HGTDvmYAZlXnU5iZyu7GDsYVZ3HnghourMqP2IVOYmJYpnPuEHAodL/NzLYBlcBpA18k3uSkpzCl/M3/6OV56Vw1peykdY6fP3CguZutB1vZ3dBOU0cvUypyyExNItnnY0ZlHlMrchlXkkVasu8t5w/0+QNs3N98Yljpsh0N7DrSzvTKPLLTk3l6cz2PbzhIe08/ST7DH3jrjl5qso+KvHTGFmdx66xKppTnavbSQfgDjkfXHeC7z+1kb1MnAJPKsvn89VO4emopE0pjd8K/qJx4ZWY1wHJgunOu9XTraQ9fJLL6/AGSzFi/v5nX6tvo6OmnrTv4R6C9p58Dx7qorWvicGvwm4HPoLIgg7yMFMYWZzOpNJtJ5cGhrqMLMhLmYjZH23t4esthlm48SO2eY/T6A8ysyuM9F1ezYEIxVQUZnp3EN5Q9/IgHvpllA8uArznn/jjI83cDdwNUV1fPqauri2g9InJmff4Ar9W3sauhnV0NHexuaKe1u5/dDe3sP9Z1Yr2UJOPisYWML8kmOy2Z4uw00lOS6PMHeHlXIwBXTyk78QdjQmn2oN9OYkF7Tz+r9zTR3NlLZX4mST5YW9dMrz/A01vq2bi/BYAxRZlcNqGYuTUF3DyzMiaOi8RM4JtZCrAUeNo5952zra89fJHY1tHTz84j7ew43MbO0FnMje29tPf0n9RNVJqThhknvikcl5OWzOjCTEblZwRnOTUjJz14HCE3I4Wc9GRy0lPITU+hPC+NqoLBu5T2NXVSd7STtBQfbzR2UJiZykXV+fT0B6jMz3jL+i2dfdS3duNw5Gek8vKuRv6yuZ7UZB876tvYeaT9tL9zRV46N11YwQ0zKriwKj8mQn6gmAh8C/4Zvx9ocs79YzivUeCLjEzOOY529J4I/aKsVHxm7G7soLG9h8b2Ht5o6KChvYd9TZ0caummo7efQABau/to7+lnsCgyg7yMFAIBx9SKXHIzUmjp7KO2rolBDkMAUFWQQWFWKukpSdS3dNPT7+dIW89b3r88N52M1CTGFGUyp7qAsSVZTC7L4WBLN129/cytKSQ7LTlmv5UcFyuBfxmwAthEcFgmwL8455483WsU+CKJKRBwtPcGjye0dfed2CPf09jJ0Y4euvv87G7ooL2nn6y0ZOaMCV4Ws6ffT3VhJvuOdbHtUCsGbDzQQkdPP529fkqy04In15UET64DaOrs5VBzFx9dNJ6c9OjOVhkJsTJK5yUgdv8sikjM8PmM3FBXDry1S+ZsxpVkc8WkkuEvLM4kxiF2ERFR4IuIJAoFvohIglDgi4gkCAW+iEiCUOCLiCQIBb6ISIJQ4IuIJIiozJYZLjNrAOqAPKBlwFMDHxcDjcO42VO3db7rn+n5wZ4LZ9nAx5Fsi9PVcz7rn297DOVxrH82zrROuMvD/WxA7LfHSP6/EkufjTHOufDOOnPOxdyN4NWxBn0M1EZyW+e7/pmeH+y5cJad8vtHrC1isT2G8jjWPxtnWifc5eF+NkZCe4zk/yux+NkI5xarXTqPn+VxJLd1vuuf6fnBngtn2eNneG64xVp7DPXxcBrutjjTOuEu12fjzMui1R6x+Nk4q5jq0gmHmdW6MCcKindqi5OpPU6m9niT2iIoVvfwz+Q+rwuIIWqLk6k9Tqb2eJPaghG4hy8iIudmJO7hi4jIOVDgi4gkCAW+iEiCiJvAN7NFZrbCzH5sZou8ricWmFmWma0xs5u8rsVrZjY19Nl42Mw+6nU9XjKzW8zsp2b2ZzO71ut6vGZm48zs52b2sNe1RFpMBL6Z/Y+ZHTGzzacsv87MXjOz183sc2d5Gwe0A+nA/kjVGg3D1B4AnwX+EJkqo2c42sM5t8059xHgNmDEDs8bprZ41Dn3IeBO4PYIlhtxw9Qeu51zH4hspbEhJkbpmNlCgmH9K+fc9NCyJGAHsJhggK8G3gMkAd845S3eDzQ65wJmVgZ8xzn3N9Gqf7gNU3tcSPB08nSCbbM0OtUPv+FoD+fcETO7Gfgc8APn3G+iVf9wGq62CL3uP4AHnXNro1T+sBvm9njYObckWrV7IWIXMR8K59xyM6s5ZfHFwOvOud0AZvY74O3OuW8AZ+qiOAakRaLOaBmO9jCzK4EsYBrQZWZPOucCES27QsRBAAAGXElEQVQ8Qobr8+Gcewx4zMyeAEZk4A/TZ8OAbwJ/GclhD8OeHXEvJgL/NCqBfQMe7wfedrqVzewdwF8B+cAPIluaJ4bUHs65LwCY2Z2Evv1EtLroG+rnYxHwDoI7A09GtLLoG1JbAJ8ArgHyzGyCc+7HkSzOA0P9bBQBXwNmmdnnQ38Y4lIsB74Nsuy0/U/OuT8Cf4xcOZ4bUnucWMG5Xw5/KTFhqJ+PF4EXI1WMx4baFt8Dvhe5cjw31PY4CnwkcuXEjpg4aHsa+4HRAx5XAQc9qiUWqD1OpvZ4k9riZGqP04jlwF8NTDSzsWaWCrwbeMzjmryk9jiZ2uNNaouTqT1OIyYC38x+C7wCTDaz/Wb2AedcP/D3wNPANuAPzrktXtYZLWqPk6k93qS2OJnaY2hiYlimiIhEXkzs4YuISOQp8EVEEoQCX0QkQSjwRUQShAJfRCRBKPBFRBKEAl/OmZm1R2EbN4c5FfRwbnORmV16Dq+bZWY/C92/08xiYk4nM6s5dfrgQdYpMbOnolWTeEOBL54LTWc7KOfcY865b0Zgm2eaR2oRMOTAB/4F+P45FeQx51wDcMjMFnhdi0SOAl+GhZl92sxWm9lGM/vSgOWPWvCqW1vM7O4By9vN7MtmtgqYb2Z7zOxLZrbWzDaZ2ZTQeif2lM3sl2b2PTN72cx2m9mS0HKfmf0wtI2lZvbk8edOqfFFM/u6mS0D7jGzvzazVWa2zsz+18zKQlPtfgT4pJmtN7PLQ3u/j4R+v9WDhaKZ5QAXOuc2DPLcGDN7LtQ2z5lZdWj5eDNbGXrPLw/2jcmCVy17wsw2mNlmM7s9tHxeqB02mNmrZpYT2pNfEWrDtYN9SzGzJDP71oB/qw8PePpRYMReR0LC4JzTTbdzugHtoZ/XAvcRnKXQBywFFoaeKwz9zAA2A0Whxw64bcB77QE+Ebr/MeBnoft3ErxgCcAvgYdC25hGcM5zgCUEpzz2AeUEr4mwZJB6XwR+OOBxAW+ebf5B4D9C9+8F/nnAer8BLgvdrwa2DfLeVwKPDHg8sO7HgfeF7r8feDR0fynwntD9jxxvz1Pe953ATwc8zgNSgd3AvNCyXIIz32YC6aFlE4Ha0P0aYHPo/t3AF0P304BaYGzocSWwyevPlW6Ru8Xy9Mgyclwbuq0LPc4mGDjLgX8ws1tDy0eHlh8F/MAjp7zP8emt1xCcu34wj7rg3P5bLXh1M4DLgIdCy+vN7IUz1Pr7AfergN+bWQXBEH3jNK+5BphmdmLW3Vwzy3HOtQ1YpwJoOM3r5w/4fR4A/t+A5beE7v8G+PYgr90EfNvM/h1Y6pxbYWYzgEPOudUAzrlWCH4bAH5gZhcRbN9Jg7zftcCFA74B5RH8N3kDOAKMOs3vIHFAgS/DwYBvOOd+ctLC4EVHrgHmO+c6zexFgpdcBOh2zvlPeZ+e0E8/p/9s9gy4b6f8DEfHgPvfJ3g5zMdCtd57mtf4CP4OXWd43y7e/N3OJuwJrJxzO8xsDnAD8A0ze4Zg18tg7/FJ4DAwM1Rz9yDrGMFvUk8P8lw6wd9D4pT68GU4PA2838yyAcys0sxKCe49HguF/RTgkght/yXgnaG+/DKCB13DkQccCN1/34DlbUDOgMfPEJx9EYDQHvSptgETTrOdlwlO0QvBPvKXQvdXEuyyYcDzJzGzUUCnc+7XBL8BzAa2A6PMbF5onZzQQeg8gnv+AeAOgtdwPdXTwEfNLCX02kmhbwYQ/EZwxtE8MrIp8OW8OeeeIdgl8YqZbQIeJhiYTwHJZrYR+ArBgIuERwhe9GIz8BNgFdASxuvuBR4ysxVA44DljwO3Hj9oC/wDMDd0kHMrg1wdyTm3neAlA3NOfS70+rtC7XAHcE9o+T8CnzKzVwl2CQ1W8wzgVTNbD3wB+Kpzrhe4Hfi+mW0AniW4d/5D4H1mtpJgeHcM8n4/A7YCa0NDNX/Cm9+mrgSeGOQ1Eic0PbLEBTPLds61W/D6pK8CC5xz9VGu4ZNAm3PuZ2Gunwl0Oeecmb2b4AHct0e0yDPXs5zgxb6PeVWDRJb68CVeLDWzfIIHX78S7bAP+RHwriGsP4fgQVYDmgmO4PGEmZUQPJ6hsI9j2sMXEUkQ6sMXEUkQCnwRkQShwBcRSRAKfBGRBKHAFxFJEAp8EZEE8f8Bvm9m4iplxxIAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "learn.sched.plot(10,1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = to_gpu(resnet56())\n",
+    "resnet56b = to_gpu(resnet56b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Variable containing:\n",
+       "-3.0992 -4.7618 -3.4659 -3.3797 -3.8031 -2.4542 -0.7675 -4.1077 -1.6678 -2.2678\n",
+       "-2.7267 -4.5967 -3.1376 -2.5954 -3.6200 -2.2927 -1.1537 -3.2596 -1.4585 -2.3835\n",
+       "-2.9617 -4.1102 -2.8288 -2.6760 -3.2394 -2.3686 -1.2965 -3.2510 -1.4062 -2.1729\n",
+       "-4.1886 -5.7310 -3.6135 -4.0863 -4.4581 -3.1461 -0.4379 -4.7266 -1.7410 -2.9262\n",
+       "[torch.cuda.FloatTensor of size 4x10 (GPU 0)]"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x = V(x)\n",
+    "resnet56b(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Variable containing:\n",
+       "-2.6959 -1.5515 -2.4953 -3.2317 -1.3048 -2.0912 -2.4099 -2.9861 -3.2280 -3.7343\n",
+       "-2.4868 -1.7645 -2.4401 -3.0965 -1.4829 -2.0385 -2.0907 -2.8444 -3.1212 -3.5023\n",
+       "-2.1189 -1.6261 -3.0410 -2.8696 -1.5311 -1.9511 -2.1808 -2.8981 -3.5368 -3.7712\n",
+       "-3.4588 -2.2125 -2.0299 -4.5370 -0.6121 -3.8806 -4.6287 -4.5980 -2.3542 -3.2337\n",
+       "[torch.cuda.FloatTensor of size 4x10 (GPU 0)]"
+      ]
+     },
+     "execution_count": 63,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PreActResNet(\n",
+       "  (conv1): Conv2d(3, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "  (layer1): Sequential(\n",
+       "    (0): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "    (1): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "    (2): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "    (3): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "    (4): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "    (5): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "    (6): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "    (7): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "    (8): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "  )\n",
+       "  (layer2): Sequential(\n",
+       "    (0): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(16, 32, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (shortcut): Sequential(\n",
+       "        (0): Conv2d(16, 32, kernel_size=(1, 1), stride=(2, 2), bias=False)\n",
+       "      )\n",
+       "    )\n",
+       "    (1): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "    (2): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "    (3): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "    (4): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "    (5): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "    (6): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "    (7): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "    (8): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "  )\n",
+       "  (layer3): Sequential(\n",
+       "    (0): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(32, 64, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (shortcut): Sequential(\n",
+       "        (0): Conv2d(32, 64, kernel_size=(1, 1), stride=(2, 2), bias=False)\n",
+       "      )\n",
+       "    )\n",
+       "    (1): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "    (2): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "    (3): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "    (4): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "    (5): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "    (6): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "    (7): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "    (8): PreActBlock(\n",
+       "      (bn1): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv1): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (bn2): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "      (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "    )\n",
+       "  )\n",
+       "  (linear): Linear(in_features=64, out_features=10, bias=True)\n",
+       ")"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "resnet56b"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "resnet56(\n",
+       "  (conv1): Conv2d(3, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "  (chunk1): ResnetChunk(\n",
+       "    (rnblocks): ModuleList(\n",
+       "      (0): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "      (1): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "      (2): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "      (3): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "      (4): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "      (5): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "      (6): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "      (7): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "      (8): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(16, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "    )\n",
+       "  )\n",
+       "  (chunk2): ResnetChunk(\n",
+       "    (rnblocks): ModuleList(\n",
+       "      (0): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(16, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(16, 32, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (shortcut): Conv2d(16, 32, kernel_size=(1, 1), stride=(2, 2), bias=False)\n",
+       "      )\n",
+       "      (1): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "      (2): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "      (3): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "      (4): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "      (5): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "      (6): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "      (7): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "      (8): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(32, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "    )\n",
+       "  )\n",
+       "  (chunk3): ResnetChunk(\n",
+       "    (rnblocks): ModuleList(\n",
+       "      (0): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(32, 64, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (shortcut): Conv2d(32, 64, kernel_size=(1, 1), stride=(2, 2), bias=False)\n",
+       "      )\n",
+       "      (1): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "      (2): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "      (3): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "      (4): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "      (5): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "      (6): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "      (7): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "      (8): ResnetBlock(\n",
+       "        (bn1): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv1): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "        (bn2): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True)\n",
+       "        (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      )\n",
+       "    )\n",
+       "  )\n",
+       "  (out): Linear(in_features=64, out_features=10, bias=True)\n",
+       ")"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/fastai/layer_optimizer.py
+++ b/fastai/layer_optimizer.py
@@ -26,7 +26,11 @@ class LayerOptimizer():
     def lr(self): return self.lrs[-1]
 
     @property
-    def mom(self): return self.opt.param_groups[0]['momentum']
+    def mom(self):
+        if 'betas' in self.opt.param_groups[0]:
+            return self.opt.param_groups[0]['betas'][0]
+        else:
+            return self.opt.param_groups[0]['momentum']
 
     def set_lrs(self, lrs):
         set_lrs(self.opt, lrs)
@@ -37,7 +41,10 @@ class LayerOptimizer():
         self.wds=wds
     
     def set_mom(self,momentum):
-        self.opt.param_groups[0]['momentum'] = momentum
+        if 'betas' in self.opt.param_groups[0]:
+            for pg in self.opt.param_groups: pg['betas'] = (momentum, pg['betas'][1])
+        else:
+            for pg in self.opt.param_groups: pg['momentum'] = momentum
 
 def zip_strict_(l, r):
     assert(len(l) == len(r))


### PR DESCRIPTION
Plots:
- introduces a lr_find2 that computes the validation loss + metrics after each batch in the training loop for the enxt batch of the validation set.
- validation losses and metrics are saved each time they are computed (whether in normal training or LR find) so we can plot them after if we want.

Fixes:
- use_clr_beta changed the momentum only in the last group of layers
- use_clr_beta changes beta1 instead of momentum if Adam is used
- can pass all the arguments that goes to fit in lr_find or lr_find2