### PR TITLE
Changed nt to n_tok, to better conform with style guidelines

### DIFF
--- a/docs/abbr.md
+++ b/docs/abbr.md
@@ -152,3 +152,4 @@ Note that there are always exceptions, especially when we try to comply with the
 |                  | activation                          | actn           |                                                  |
 |                  |                                     |                |                                                  |
 | **Text**         | string                              | s              |                                                  |
+|                  | token                               | tok            |                                                  |

--- a/fastai/lm_rnn.py
+++ b/fastai/lm_rnn.py
@@ -201,7 +201,7 @@ def get_language_model(n_tok, emb_sz, nhid, nlayers, pad_token,
     LinearDecoder layers sequentially in the model.
 
     Args:
-        ntoken (int): number of vocabulary (or tokens) in the source dataset
+        n_tok (int): number of unique vocabulary words (or tokens) in the source dataset
         emb_sz (int): the embedding size to use to encode each token
         nhid (int): number of hidden activation per LSTM layer
         nlayers (int): number of LSTM layers to use in the architecture

--- a/fastai/text.py
+++ b/fastai/text.py
@@ -157,12 +157,12 @@ class LanguageModel(BasicModel):
 
 
 class LanguageModelData():
-    def __init__(self, path, pad_idx, nt, trn_dl, val_dl, test_dl=None, bptt=70, backwards=False, **kwargs):
-        self.path,self.pad_idx,self.nt = path,pad_idx,nt
+    def __init__(self, path, pad_idx, n_tok, trn_dl, val_dl, test_dl=None, bptt=70, backwards=False, **kwargs):
+        self.path,self.pad_idx,self.n_tok = path,pad_idx,n_tok
         self.trn_dl,self.val_dl,self.test_dl = trn_dl,val_dl,test_dl
 
     def get_model(self, opt_fn, emb_sz, n_hid, n_layers, **kwargs):
-        m = get_language_model(self.nt, emb_sz, n_hid, n_layers, self.pad_idx, **kwargs)
+        m = get_language_model(self.n_tok, emb_sz, n_hid, n_layers, self.pad_idx, **kwargs)
         model = LanguageModel(to_gpu(m))
         return RNN_Learner(self, model, opt_fn=opt_fn)
 


### PR DESCRIPTION
The style guidelines say that the count of something should be `n_` and not `n`; the abbreviations say that `t` is tensor, so I called it `tok` instead (which is used elsewhere).  Also fixed a comment.

Also updated `abbr.md` to add `tok`.