### PR TITLE
Memory fix for sortsampler and sortishsampler in text.py

### DIFF
--- a/fastai/text.py
+++ b/fastai/text.py
@@ -95,7 +95,7 @@ class SortSampler(Sampler):
     def __init__(self, data_source, key): self.data_source,self.key = data_source,key
     def __len__(self): return len(self.data_source)
     def __iter__(self):
-        return iter(sorted(range(len(self.data_source)), key=self.key))
+        return iter(sorted(range(len(self.data_source)), key=self.key, reverse=True))
 
 
 class SortishSampler(Sampler):
@@ -108,10 +108,11 @@ class SortishSampler(Sampler):
         idxs = np.random.permutation(len(self.data_source))
         sz = self.bs*50
         ck_idx = [idxs[i:i+sz] for i in range(0, len(idxs), sz)]
-        sort_idx = sum([sorted(s, key=self.key) for s in ck_idx], [])
+        sort_idx = sum([sorted(s, key=self.key, reverse=True) for s in ck_idx], [])
         sz = self.bs
         ck_idx = [sort_idx[i:i+sz] for i in range(0, len(sort_idx), sz)]
-        sort_idx = np.concatenate(np.random.permutation(ck_idx))
+        sort_idx = np.concatenate(np.random.permutation(ck_idx[1:]))
+        sort_idx = np.concatenate((ck_idx[0], sort_idx))
         return iter(sort_idx)
 
 


### PR DESCRIPTION
Modified sortsampler and sortishsampler to start with the largest batch sizes first.  This should hopefully help with a few memory issues that were occurring when random sequences of batch width led to the creation of multiple buffers.

This is related to the previous PR for language models.

I tested a half dozen runs of each and in this case the memory issue didn't seem as severe.  In only 1 run I ran out of memory.  In the others memory usage was similar, but with the fixed version memory usage is much more consistent and grows at the same rate and time.  The classifier has a consistent ~9gig memory footprint with the new model.  With the old that varied from 7.9 to 9.6/OOM but tended to be higher than 9 and would randomly run out of memory. 

Given that one of the models managed to be built with a 7.9 gig footprint there's likely some more optimization that could be done, but in this case I think the consistency is important enough to warrant the changes.