### PR TITLE
[documentation]: Adds NLP section to `abbr.md`

### DIFF
--- a/docs/abbr.md
+++ b/docs/abbr.md
@@ -52,6 +52,7 @@ Note that there are always exceptions, especially when we try to comply with the
 |                  | input                               | x              |                                                  |
 |                  | input / output                      | io             |                                                  |
 |                  | object                              | obj            |                                                  |
+|                  | string                              | s              |                                                  |
 |                  | class                               | cls            |                                                  |
 |                  | source                              | src            |                                                  |
 |                  | destination                         | dst            |                                                  |
@@ -131,7 +132,6 @@ Note that there are always exceptions, especially when we try to comply with the
 |                  | criteria                            | crit           |                                                  |
 |                  | weight decay                        | wd             |                                                  |
 |                  | momentum                            | mom            |                                                  |
-|                  | back propagation through time       | bptt           |                                                  |
 |                  | cross validation                    | cv             |                                                  |
 |                  | learning rate                       | lr             |                                                  |
 |                  | schedule                            | sched          |                                                  |
@@ -143,8 +143,7 @@ Note that there are always exceptions, especially when we try to comply with the
 |                  | figure                              | fig            |                                                  |
 |                  | image                               | im             |                                                  |
 |                  | transform image using opencv        | _cv            | zoom_cv(), rotate_cv(), stretch_cv()             |
-| **Text**         |                                     |                |                                                  |
-|                  | string                              | s              |                                                  |
-|                  | natural language processing         | nlp            |                                                  |
+| **NLP**          | natural language processing (nlp)   |                |                                                  |
 |                  | token                               | tok            |                                                  |
 |                  | sequence length                     | sl             |                                                  |
+|                  | back propagation through time       | bptt           |                                                  |


### PR DESCRIPTION
@jph00 [to your comments on #326] no problem at all
In this PR I added that `NLP` section and I thought it made sense to move `string` to `Generic`

I'll work on using sphinx to generate the asciidoc templates. If the person working on the docs python script can't anymore for some reason, feel free to let me know 

