### PR TITLE
proposed fix for #319 re language model train/val/test handling

### DIFF
--- a/fastai/core.py
+++ b/fastai/core.py
@@ -6,6 +6,7 @@ def sum_geom(a,r,n): return a*n if r==1 else math.ceil(a*(1-r**n)/(1-r))
 def is_listy(x): return isinstance(x, (list,tuple))
 def is_iter(x): return isinstance(x, collections.Iterable)
 def map_over(x, f): return [f(o) for o in x] if is_listy(x) else f(x)
+def map_none(x, f): return None if x is None else f(x)
 
 conv_dict = {np.dtype('int8'): torch.LongTensor, np.dtype('int16'): torch.LongTensor,
     np.dtype('int32'): torch.LongTensor, np.dtype('int64'): torch.LongTensor,

--- a/fastai/nlp.py
+++ b/fastai/nlp.py
@@ -190,9 +190,9 @@ class ConcatTextDatasetFromDataFrames(torchtext.data.Dataset):
     @classmethod
     def splits(cls, train_df=None, val_df=None, test_df=None, keep_nones=False, **kwargs):
         res = (
-            map_none(train_df, partial(cls, **kwargs)),
-            map_none(  val_df, partial(cls, **kwargs)),
-            map_none( test_df, partial(cls, **kwargs)))
+            cls(train_df, **kwargs),
+            cls(val_df, **kwargs),
+            map_none(test_df, partial(cls, **kwargs)))  # not required
         return res if keep_nones else tuple(d for d in res if d is not None)
 
 
@@ -251,9 +251,9 @@ class LanguageModelData():
         self.nt = len(field.vocab)
 
         factory = lambda ds: LanguageModelLoader(ds, bs, bptt, backwards=backwards)
-        self.trn_dl = map_none(self.trn_ds, factory)
-        self.val_dl = map_none(self.val_ds, factory)
-        self.test_dl = map_none(self.test_ds, factory)
+        self.trn_dl = factory(self.trn_ds)
+        self.val_dl = factory(self.val_ds)
+        self.test_dl = map_none(self.test_ds, factory)  # not required
 
     def get_model(self, opt_fn, emb_sz, n_hid, n_layers, **kwargs):
         """ Method returns a RNN_Learner object, that wraps an instance of the RNN_Encoder module.

--- a/fastai/nlp.py
+++ b/fastai/nlp.py
@@ -188,12 +188,12 @@ class ConcatTextDatasetFromDataFrames(torchtext.data.Dataset):
         super().__init__(examples, fields, **kwargs)
 
     @classmethod
-    def splits(cls, train_df=None, val_df=None, test_df=None, **kwargs):
-        train_data = None if train_df is None else cls(train_df, **kwargs)
-        val_data = None if val_df is None else cls(val_df, **kwargs)
-        test_data = None if test_df is None else cls(test_df, **kwargs)
-
-        return tuple(d for d in (train_data, val_data, test_data) if d is not None)
+    def splits(cls, train_df=None, val_df=None, test_df=None, keep_nones=False, **kwargs):
+        res = (
+            map_none(train_df, partial(cls, **kwargs)),
+            map_none(  val_df, partial(cls, **kwargs)),
+            map_none( test_df, partial(cls, **kwargs)))
+        return res if keep_nones else tuple(d for d in res if d is not None)
 
 
 class LanguageModelData():
@@ -250,8 +250,10 @@ class LanguageModelData():
         self.pad_idx = field.vocab.stoi[field.pad_token]
         self.nt = len(field.vocab)
 
-        self.trn_dl, self.val_dl, self.test_dl = [LanguageModelLoader(ds, bs, bptt, backwards=backwards)
-                                                  for ds in (self.trn_ds, self.val_ds, self.test_ds) ]
+        factory = lambda ds: LanguageModelLoader(ds, bs, bptt, backwards=backwards)
+        self.trn_dl = map_none(self.trn_ds, factory)
+        self.val_dl = map_none(self.val_ds, factory)
+        self.test_dl = map_none(self.test_ds, factory)
 
     def get_model(self, opt_fn, emb_sz, n_hid, n_layers, **kwargs):
         """ Method returns a RNN_Learner object, that wraps an instance of the RNN_Encoder module.
@@ -273,9 +275,8 @@ class LanguageModelData():
 
     @classmethod
     def from_dataframes(cls, path, field, col, train_df, val_df, test_df=None, bs=64, bptt=70, **kwargs):
-        trn_ds, val_ds, test_ds = ConcatTextDatasetFromDataFrames.splits(text_field=field, col=col,
-                                    train_df=train_df, val_df=val_df, test_df=test_df)
-
+        trn_ds, val_ds, test_ds = ConcatTextDatasetFromDataFrames.splits(
+            text_field=field, col=col, train_df=train_df, val_df=val_df, test_df=test_df, keep_nones=True)
         return cls(path, field, trn_ds, val_ds, test_ds, bs, bptt, **kwargs)
 
     @classmethod
@@ -303,8 +304,7 @@ class LanguageModelData():
 
         """
         trn_ds, val_ds, test_ds = ConcatTextDataset.splits(
-                                    path, text_field=field, train=train, validation=validation, test=test)
-
+            path, text_field=field, train=train, validation=validation, test=test, keep_nones=True)
         return cls(path, field, trn_ds, val_ds, test_ds, bs, bptt, **kwargs)
 
 


### PR DESCRIPTION
Fix for #319 
- Add a `map_none` convenience similar to `map_over` (which, should we rename that `map_listy`?)
- Add a flag param to let `None` pass through `ConcatTextDatasetFromDataFrames.splits`.
- Make `LanguageModelData.__init__` `None`-safe.

On that last point, @jph00 does downstream code know how to handle `None` for the datasets and/or dataloaders? If not then this is only a partial fix.

@kevindewalt mind posting a bit more about the code you were trying to run so it can be converted into a regression test? I'll do my honest best in the meantime.