### PR TITLE
Using no_grad instead of volatile for pytorch 0.4

### DIFF
--- a/fastai/imports.py
+++ b/fastai/imports.py
@@ -3,6 +3,7 @@ import PIL, os, numpy as np, math, collections, threading, json, bcolz, random, 
 import random, pandas as pd, pickle, sys, itertools, string, sys, re, datetime, time, shutil
 import seaborn as sns, matplotlib
 import IPython, graphviz, sklearn_pandas, sklearn, warnings, pdb
+import contextlib
 from abc import abstractmethod
 from glob import glob, iglob
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
@@ -16,6 +17,7 @@ from PIL import Image, ImageEnhance, ImageOps
 from sklearn import metrics, ensemble, preprocessing
 from operator import itemgetter, attrgetter
 from pathlib import Path
+from distutils.version import LooseVersion
 
 from matplotlib import pyplot as plt, rcParams, animation
 from ipywidgets import interact, interactive, fixed, widgets


### PR DESCRIPTION
Volatile is removed in pytorch 0.4. This is fix is to play nice with the next version