### PR TITLE
Merge pull request #334 from mcskinner/splits-fix

### DIFF
--- a/fastai/core.py
+++ b/fastai/core.py
@@ -6,6 +6,7 @@ def sum_geom(a,r,n): return a*n if r==1 else math.ceil(a*(1-r**n)/(1-r))
 def is_listy(x): return isinstance(x, (list,tuple))
 def is_iter(x): return isinstance(x, collections.Iterable)
 def map_over(x, f): return [f(o) for o in x] if is_listy(x) else f(x)
+def map_none(x, f): return None if x is None else f(x)
 
 conv_dict = {np.dtype('int8'): torch.LongTensor, np.dtype('int16'): torch.LongTensor,
     np.dtype('int32'): torch.LongTensor, np.dtype('int64'): torch.LongTensor,

--- a/fastai/model.py
+++ b/fastai/model.py
@@ -89,6 +89,7 @@ def fit(model, data, epochs, opt, crit, metrics=None, callbacks=None, stepper=St
     """
     all_val = kwargs.pop('all_val') if 'all_val' in kwargs else False
     sampler = kwargs.pop('sampler') if 'sampler' in kwargs else None
+    get_ep_vals = kwargs.pop('get_ep_vals') if 'get_ep_vals' in kwargs else False
     stepper = stepper(model, opt, crit, **kwargs)
     metrics = metrics or []
     callbacks = callbacks or []
@@ -103,6 +104,7 @@ def fit(model, data, epochs, opt, crit, metrics=None, callbacks=None, stepper=St
         num_batch = int(num_batch*epochs)
         epochs = 1
 
+    ep_vals = collections.OrderedDict()
     for epoch in tnrange(epochs, desc='Epoch'):
         if sampler: sampler.set_epoch(epoch)
         stepper.reset(True)
@@ -127,13 +129,20 @@ def fit(model, data, epochs, opt, crit, metrics=None, callbacks=None, stepper=St
             vals = validate(stepper, data.val_dl, metrics)
             if epoch == 0: print(layout.format(*names))
             print_stats(epoch, [debias_loss] + vals)
+            ep_vals = append_stats(ep_vals, epoch, [debias_loss] + vals)
             stop=False
             for cb in callbacks: stop = stop or cb.on_epoch_end(vals)
         if stop: break
 
     for cb in callbacks: cb.on_train_end()
-    return vals
+    if get_ep_vals:
+        return vals, ep_vals
+    else:
+        return vals
 
+def append_stats(ep_vals, epoch, values, decimals=6):
+    ep_vals[epoch]=list(np.round(values, decimals))
+    return ep_vals
 
 def print_stats(epoch, values, decimals=6):
     layout = "{!s:^10}" + " {!s:10}" * len(values)


### PR DESCRIPTION
proposed fix for #319 re language model train/val/test handling

proposed tracking of epoch number and loss per epoch during learner.fit()

use as per:

    vals, ep_vals = learn.fit(lr, n_cycle=1, cycle_len=10, use_clr=(20,10), get_ep_vals=True)

loss values can then be plotted as for example:


![ep_vals_plot](https://user-images.githubusercontent.com/37989457/38765537-35aea326-3ff6-11e8-9098-06cda56d21d7.png)
