### PR TITLE
Defaults num_workers to 0

### DIFF
--- a/fastai/dataloader.py
+++ b/fastai/dataloader.py
@@ -23,7 +23,7 @@ def get_tensor(batch, pin, half=False):
 
 class DataLoader(object):
     def __init__(self, dataset, batch_size=1, shuffle=False, sampler=None, batch_sampler=None, pad_idx=0,
-                 num_workers=None, pin_memory=False, drop_last=False, pre_pad=True, half=False,
+                 num_workers=0, pin_memory=False, drop_last=False, pre_pad=True, half=False,
                  transpose=False, transpose_y=False):
         self.dataset,self.batch_size,self.num_workers = dataset,batch_size,num_workers
         self.pin_memory,self.drop_last,self.pre_pad = pin_memory,drop_last,pre_pad


### PR DESCRIPTION
DataLoader currently defaults num_workers to None, but assumes numeric values only in \_\_iter\_\_. Defaulting to 0 satisfies the assumptions and probable intent in \_\_iter\_\_.