### PR TITLE
Added a custom loss func option and some refactoring

### DIFF
--- a/fastai/column_data.py
+++ b/fastai/column_data.py
@@ -137,12 +137,14 @@ class MixedInputModel(nn.Module):
 class StructuredLearner(Learner):
     def __init__(self, data, models, **kwargs):
         super().__init__(data, models, **kwargs)
+
+    def _determine_loss_func(self, data):
         if data.is_reg:
-            self.crit = F.mse_loss
+            return F.mse_loss
         elif data.is_multi:
-            self.crit = F.binary_cross_entropy
+            return F.binary_cross_entropy
         else:
-            self.crit = F.nll_loss
+            return F.nll_loss
 
     def summary(self):
         return model_summary(self.model, [(self.data.trn_ds.cats.shape[1], ), (self.data.trn_ds.conts.shape[1], )])
@@ -197,6 +199,7 @@ def get_emb(ni,nf):
     e.weight.data.uniform_(-0.05,0.05)
     return e
 
+
 class EmbeddingDotBias(nn.Module):
     def __init__(self, n_factors, n_users, n_items, min_score, max_score):
         super().__init__()
@@ -210,10 +213,14 @@ class EmbeddingDotBias(nn.Module):
         res = um.sum(1) + self.ub(users).squeeze() + self.ib(items).squeeze()
         return F.sigmoid(res) * (self.max_score-self.min_score) + self.min_score
 
+
 class CollabFilterLearner(Learner):
     def __init__(self, data, models, **kwargs):
         super().__init__(data, models, **kwargs)
-        self.crit = F.mse_loss
+
+    def _determine_loss_func(self, data):
+        return F.mse_loss
+
 
 class CollabFilterModel(BasicModel):
     def get_layer_groups(self): return self.model

--- a/fastai/column_data.py
+++ b/fastai/column_data.py
@@ -138,16 +138,9 @@ class StructuredLearner(Learner):
     def __init__(self, data, models, **kwargs):
         super().__init__(data, models, **kwargs)
 
-    def _determine_loss_func(self, data):
-        if data.is_reg:
-            return F.mse_loss
-        elif data.is_multi:
-            return F.binary_cross_entropy
-        else:
-            return F.nll_loss
+    def _get_crit(self, data): return F.mse_loss if data.is_reg else F.binary_cross_entropy if data.is_multi else F.nll_loss
 
-    def summary(self):
-        return model_summary(self.model, [(self.data.trn_ds.cats.shape[1], ), (self.data.trn_ds.conts.shape[1], )])
+    def summary(self): return model_summary(self.model, [(self.data.trn_ds.cats.shape[1], ), (self.data.trn_ds.conts.shape[1], )])
 
 
 class StructuredModel(BasicModel):
@@ -218,8 +211,7 @@ class CollabFilterLearner(Learner):
     def __init__(self, data, models, **kwargs):
         super().__init__(data, models, **kwargs)
 
-    def _determine_loss_func(self, data):
-        return F.mse_loss
+    def _get_crit(self, data): return F.mse_loss
 
 
 class CollabFilterModel(BasicModel):

--- a/fastai/conv_learner.py
+++ b/fastai/conv_learner.py
@@ -95,19 +95,16 @@ class ConvLearner(Learner):
     def __init__(self, data, models, precompute=False, **kwargs):
         self.precompute = False
         super().__init__(data, models, **kwargs)
-        if not data.is_reg and self.metrics is None:
+        if hasattr(data, 'is_multi') and not data.is_reg and self.metrics is None:
             self.metrics = [accuracy_thresh(0.5)] if self.data.is_multi else [accuracy]
         if precompute: self.save_fc1()
         self.freeze()
         self.precompute = precompute
 
-    def _determine_loss_func(self, data):
-        if data.is_reg:
-            return F.l1_loss
-        elif data.is_multi:
-            return F.binary_cross_entropy
-        else:
-            return F.nll_loss
+    def _get_crit(self, data):
+        if not hasattr(data, 'is_multi'): return super()._get_crit(data)
+
+        return F.l1_loss if data.is_reg else F.binary_cross_entropy if data.is_multi else F.nll_loss
 
     @classmethod
     def pretrained(cls, f, data, ps=None, xtra_fc=None, xtra_cut=0, custom_head=None, precompute=False,

--- a/fastai/conv_learner.py
+++ b/fastai/conv_learner.py
@@ -95,14 +95,19 @@ class ConvLearner(Learner):
     def __init__(self, data, models, precompute=False, **kwargs):
         self.precompute = False
         super().__init__(data, models, **kwargs)
-        if hasattr(data, 'is_multi'):
-            self.crit = F.binary_cross_entropy if data.is_multi else F.nll_loss
-            if data.is_reg: self.crit = F.l1_loss
-            elif self.metrics is None:
-                self.metrics = [accuracy_thresh(0.5)] if self.data.is_multi else [accuracy]
+        if not data.is_reg and self.metrics is None:
+            self.metrics = [accuracy_thresh(0.5)] if self.data.is_multi else [accuracy]
         if precompute: self.save_fc1()
         self.freeze()
         self.precompute = precompute
+
+    def _determine_loss_func(self, data):
+        if data.is_reg:
+            return F.l1_loss
+        elif data.is_multi:
+            return F.binary_cross_entropy
+        else:
+            return F.nll_loss
 
     @classmethod
     def pretrained(cls, f, data, ps=None, xtra_fc=None, xtra_cut=0, custom_head=None, precompute=False,

--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -35,7 +35,7 @@ class Learner():
         self.models_path = os.path.join(self.data.path, models_name)
         os.makedirs(self.tmp_path, exist_ok=True)
         os.makedirs(self.models_path, exist_ok=True)
-        self.crit = crit if crit else self._determine_loss_func(data)
+        self.crit = crit if crit else self._get_crit(data)
         self.reg_fn = None
         self.fp16 = False
 
@@ -385,6 +385,5 @@ class Learner():
         return fit(self.model, data_list, n_epochs,layer_opt, self.crit,
             metrics=metrics, callbacks=callbacks, reg_fn=self.reg_fn, clip=self.clip, fp16=self.fp16, **kwargs)
 
-    def _determine_loss_func(self, data):
-        raise NotImplementedError()
+    def _get_crit(self, data): return F.mse_loss
 

--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -14,7 +14,7 @@ import time
 
 
 class Learner():
-    def __init__(self, data, models, opt_fn=None, tmp_name='tmp', models_name='models', metrics=None, clip=None):
+    def __init__(self, data, models, opt_fn=None, tmp_name='tmp', models_name='models', metrics=None, clip=None, crit=None):
         """
         Combines a ModelData object with a nn.Module object, such that you can train that
         module.
@@ -35,7 +35,8 @@ class Learner():
         self.models_path = os.path.join(self.data.path, models_name)
         os.makedirs(self.tmp_path, exist_ok=True)
         os.makedirs(self.models_path, exist_ok=True)
-        self.crit,self.reg_fn = None,None
+        self.crit = crit if crit else self._determine_loss_func(data)
+        self.reg_fn = None
         self.fp16 = False
 
     @classmethod
@@ -353,4 +354,7 @@ class Learner():
         preds1 = [preds1]*math.ceil(n_aug/4)
         preds2 = [predict_with_targs(self.model, dl2)[0] for i in tqdm(range(n_aug), leave=False)]
         return np.stack(preds1+preds2), targs
+
+    def _determine_loss_func(self, data):
+        raise NotImplementedError()
 

--- a/fastai/nlp.py
+++ b/fastai/nlp.py
@@ -40,8 +40,7 @@ class BOW_Learner(Learner):
     def __init__(self, data, models, **kwargs):
         super().__init__(data, models, **kwargs)
 
-    def _determine_loss_func(self, data):
-        return F.l1_loss
+    def _get_crit(self, data): return F.l1_loss
 
 def calc_pr(y_i, x, y, b):
     idx = np.argwhere((y==y_i)==b)
@@ -159,8 +158,7 @@ class RNN_Learner(Learner):
     def __init__(self, data, models, **kwargs):
         super().__init__(data, models, **kwargs)
 
-    def _determine_loss_func(self, data):
-        return F.cross_entropy
+    def _get_crit(self, data): return F.cross_entropy
 
     def save_encoder(self, name): save_model(self.model[0], self.get_model_path(name))
 

--- a/fastai/nlp.py
+++ b/fastai/nlp.py
@@ -39,7 +39,9 @@ class SimpleNB(nn.Module):
 class BOW_Learner(Learner):
     def __init__(self, data, models, **kwargs):
         super().__init__(data, models, **kwargs)
-        self.crit = F.l1_loss
+
+    def _determine_loss_func(self, data):
+        return F.l1_loss
 
 def calc_pr(y_i, x, y, b):
     idx = np.argwhere((y==y_i)==b)
@@ -152,12 +154,16 @@ class LanguageModelLoader():
         seq_len = min(seq_len, len(source) - 1 - i)
         return source[i:i+seq_len], source[i+1:i+1+seq_len].view(-1)
 
+
 class RNN_Learner(Learner):
     def __init__(self, data, models, **kwargs):
         super().__init__(data, models, **kwargs)
-        self.crit = F.cross_entropy
+
+    def _determine_loss_func(self, data):
+        return F.cross_entropy
 
     def save_encoder(self, name): save_model(self.model[0], self.get_model_path(name))
+
     def load_encoder(self, name): load_model(self.model[0], self.get_model_path(name))
 
 

--- a/fastai/text.py
+++ b/fastai/text.py
@@ -204,7 +204,9 @@ class LanguageModelData():
 class RNN_Learner(Learner):
     def __init__(self, data, models, **kwargs):
         super().__init__(data, models, **kwargs)
-        self.crit = F.cross_entropy
+
+    def _determine_loss_func(self, data):
+        return F.cross_entropy
 
     def save_encoder(self, name): save_model(self.model[0], self.get_model_path(name))
     def load_encoder(self, name): load_model(self.model[0], self.get_model_path(name))

--- a/fastai/text.py
+++ b/fastai/text.py
@@ -205,8 +205,7 @@ class RNN_Learner(Learner):
     def __init__(self, data, models, **kwargs):
         super().__init__(data, models, **kwargs)
 
-    def _determine_loss_func(self, data):
-        return F.cross_entropy
+    def _get_crit(self, data): return F.cross_entropy
 
     def save_encoder(self, name): save_model(self.model[0], self.get_model_path(name))
     def load_encoder(self, name): load_model(self.model[0], self.get_model_path(name))


### PR DESCRIPTION
This makes setting a custom loss function possible by passing the crit argument to any learner initialization.
For example, now this is possible:

    loss = torch.nn.NLLLoss(weight=class_weights)
    m = md.get_learner(... crit=loss ...)

to get a learner with a weighted loss function.

I removed the `hasattr` check for `is_multi` in `conv_learner.py` as I think it's always true.
Correct me if i'm wrong, as I mainly use `column_data.py` currently.