### PR TITLE
Deaults DataLoader num_workers to num_cpus()

### DIFF
--- a/fastai/dataloader.py
+++ b/fastai/dataloader.py
@@ -42,6 +42,9 @@ class DataLoader(object):
                 sampler = RandomSampler(dataset) if shuffle else SequentialSampler(dataset)
             batch_sampler = BatchSampler(sampler, batch_size, drop_last)
 
+        if num_workers is None:
+            self.num_workers = num_cpus()
+
         self.sampler = sampler
         self.batch_sampler = batch_sampler
 


### PR DESCRIPTION
DataLoader currently defaults num_workers to None, but assumes numeric values only in __iter__. This leads to a runtime exception if num_workers is not specified in DataLoader's constructor. Defaulting to num_cpus() as suggested in #348.