### PR TITLE
add model.save method to cycle_gan_model.py

### DIFF
--- a/courses/dl2/cgan/models/cycle_gan_model.py
+++ b/courses/dl2/cgan/models/cycle_gan_model.py
@@ -217,3 +217,9 @@ class CycleGANModel(BaseModel):
         self.save_network(self.netD_A, 'D_A', label, self.gpu_ids)
         self.save_network(self.netG_B, 'G_B', label, self.gpu_ids)
         self.save_network(self.netD_B, 'D_B', label, self.gpu_ids)
+
+    def load(self, label):
+        self.load_network(self.netG_A, 'G_A', label)
+        self.load_network(self.netD_A, 'D_A', label)
+        self.load_network(self.netG_B, 'G_B', label)
+        self.load_network(self.netD_B, 'D_B', label)


### PR DESCRIPTION
add save method to cgan/models/cycle_gan_model.py to provide same experience for loading and saving cyclegan generators and discriminators to continue trainig later.
This affects only cyclegan related notebook.