### PR TITLE
Bug fix

### DIFF
--- a/fastai/layer_optimizer.py
+++ b/fastai/layer_optimizer.py
@@ -57,7 +57,8 @@ class LayerOptimizer():
             for pg in self.opt.param_groups: pg['alpha'] = beta
 
     def set_opt_fn(self, opt_fn):
-        self.opt = opt_fn(self.opt_params())
+        if type(self.opt) != type(opt_fn(self.opt_params())):
+            self.opt = opt_fn(self.opt_params())
 
 def zip_strict_(l, r):
     assert(len(l) == len(r))

--- a/fastai/model.py
+++ b/fastai/model.py
@@ -101,8 +101,8 @@ def fit(model, data, n_epochs, opt, crit, metrics=None, callbacks=None, stepper=
     if not isinstance(data, Iterable): data = [data]
     if len(data) == 1: data = data * len(n_epochs)
     for cb in callbacks: cb.on_phase_begin()
-    if isinstance(opt, LayerOptimizer): stepper = stepper(model, opt.opt, crit, **kwargs) 
-    else:  stepper = stepper(model, opt, crit, **kwargs)
+    if hasattr(opt,'state_dict'): stepper = stepper(model, opt, crit, **kwargs) 
+    else:  stepper = stepper(model, opt.opt, crit, **kwargs)
     ep_vals = collections.OrderedDict()
     tot_epochs = int(np.ceil(np.array(n_epochs).sum()))
     cnt_phases = np.array([ep * len(dat.trn_dl) for (ep,dat) in zip(n_epochs,data)]).cumsum()

--- a/fastai/model.py
+++ b/fastai/model.py
@@ -100,13 +100,13 @@ def fit(model, data, n_epochs, opt, crit, metrics=None, callbacks=None, stepper=
     if not isinstance(n_epochs, Iterable): n_epochs=[n_epochs]
     if not isinstance(data, Iterable): data = [data]
     if len(data) == 1: data = data * len(n_epochs)
+    for cb in callbacks: cb.on_phase_begin()
     if isinstance(opt, LayerOptimizer): stepper = stepper(model, opt.opt, crit, **kwargs) 
     else:  stepper = stepper(model, opt, crit, **kwargs)
     ep_vals = collections.OrderedDict()
     tot_epochs = int(np.ceil(np.array(n_epochs).sum()))
     cnt_phases = np.array([ep * len(dat.trn_dl) for (ep,dat) in zip(n_epochs,data)]).cumsum()
     phase = 0
-    for cb in callbacks: cb.on_phase_begin()
     for epoch in tnrange(tot_epochs, desc='Epoch'):
         if sampler: sampler.set_epoch(epoch)
         stepper.reset(True)


### PR DESCRIPTION
On_phase_begin always needs to be called **before** passing the optimizer to the stepper (otherwise the stepper has an optimizer that isn't updated).

Also, changing the optimizer causes to zero all the buffers in it (which is kind of logical) so we lose all the previous moving averages. For now I only create a new one if there is a change of name (so if we keep SGD with momentum for instance we don't reinitialize the moving average of the gradients), but perhaps it could be interesting to 'match' the buffers in some way?