### PR TITLE
Added write_dir kwarg to allow specification of a custom writing path

### DIFF
--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -16,7 +16,7 @@ import time
 
 
 class Learner():
-    def __init__(self, data, models, opt_fn=None, tmp_name='tmp', models_name='models', metrics=None, clip=None, crit=None):
+    def __init__(self, data, models, opt_fn=None, tmp_name='tmp', models_name='models', metrics=None, clip=None, crit=None, write_dir = None):
         """
         Combines a ModelData object with a nn.Module object, such that you can train that
         module.
@@ -27,6 +27,8 @@ class Learner():
         models_name(str): output name of the directory containing the trained model
         metrics(list): array of functions for evaluating a desired metric. Eg. accuracy.
         clip(float): gradient clip chosen to limit the change in the gradient to prevent exploding gradients Eg. .3
+        
+        write_dir(string or None): allows passing a custom directory for writing temp and model data in case data directory can't be written to.
         """
         self.data_,self.models,self.metrics = data,models,metrics
         self.sched=None
@@ -35,6 +37,11 @@ class Learner():
         self.opt_fn = opt_fn or SGD_Momentum(0.9)
         self.tmp_path = os.path.join(self.data.path, tmp_name)
         self.models_path = os.path.join(self.data.path, models_name)
+        
+        if write_dir != None:
+            self.tmp_path = os.path.join(write_dir, tmp_name)
+            self.models_path = os.path.join(write_dir, models_name)
+        
         os.makedirs(self.tmp_path, exist_ok=True)
         os.makedirs(self.models_path, exist_ok=True)
         self.crit = crit if crit else self._get_crit(data)


### PR DESCRIPTION
Writing to the data path is not always possible. In Kaggle Kernels for example, the data input path is protected.

This change adds the option to pass a write_dir to the Learner which will then be used to write the tmp and model files. 

Usage:
```Python
WDIR = 'write_dir'
kwargs = {'write_dir':WDIR}
learn = ConvLearner.pretrained(arch, data, precompute=True, **kwargs)
```