### PR TITLE
Add support for data loaders w/ multiple inputs

### DIFF
--- a/fastai/core.py
+++ b/fastai/core.py
@@ -32,9 +32,9 @@ def create_variable(x, volatile, requires_grad=False):
     return x
 
 def V_(x, requires_grad=False, volatile=False): return create_variable(x, volatile, requires_grad)
-def V (x, requires_grad=False, volatile=False): return map_over(x, lambda o: V_(o, requires_grad, volatile))
+def V (x, requires_grad=False, volatile=False): return map_over(x, lambda y: map_over(y, lambda o: V_(o, requires_grad, volatile)))
 def VV_(x): return create_variable(x, True)
-def VV (x): return map_over(x, VV_)
+def VV (x): return map_over(x, lambda y: map_over(y, VV_))
 
 def to_np(v):
     if isinstance(v, (np.ndarray, np.generic)): return v


### PR DESCRIPTION
Hi, thanks for your brilliant course & this library!

I'm working on the [SNLI dataset](https://nlp.stanford.edu/projects/snli/), & created this `DataLoader` to consume my iterators:

```py
class DLBridge():
    def __init__(self, dataloader):
        self.dataloader = dataloader
        self.emb_onehot = nn.Embedding(config.d_out, config.d_out)
        self.emb_onehot.weight.data = torch.eye(config.d_out)
    def onehot(self, t):
        return self.emb_onehot(t.type(torch.LongTensor)).cuda()
    def __len__(self):
        return len(self.dataloader)
    def __iter__(self):
        for i, batch in enumerate(self.dataloader):
            yield (batch.premise, batch.hypothesis), self.onehot(batch.label)

baseline_data = ModelData(f'{PATH}/models/baseline', DLBridge(train_iter), DLBridge(dev_iter))
```

Here, `x` is a tuple, which gets destructured in the forward pass through my model (from one of [PyTorch's awesome examples](https://github.com/pytorch/examples/tree/master/snli)):

```py
class BaselineModel(nn.Module):
    def __init__(self):
        # ...
    def forward(self, batch):
        prem_embed = self.embed(batch[0])
        hypo_embed = self.embed(batch[1])
        if self.config.fix_emb:
            prem_embed = Variable(prem_embed.data)
            hypo_embed = Variable(hypo_embed.data)
        if self.config.projection:
            prem_embed = self.relu(self.projection(prem_embed))
            hypo_embed = self.relu(self.projection(hypo_embed))
        premise = self.encoder(prem_embed)
        hypothesis = self.encoder(hypo_embed)
        scores = self.out(torch.cat([premise, hypothesis], 1))
        return scores
```

I had to modify `core.py` to get this working properly.