### PR TITLE
Ensure pytorch version is less than 0.4 in environment-cpu.yaml file

### DIFF
--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -94,7 +94,7 @@ dependencies:
 - widgetsnbextension
 - xz
 - zeromq
-- pytorch>=0.2.0
+- pytorch<0.4
 - bcolz
 - prompt_toolkit
 - pytest


### PR DESCRIPTION
Now that PyTorch 0.4 is released, the environment file needs to be updated to prevent pytorch version 0.4  being installed as there are breaking changes in this version. Matches the pytorch entry in the file ```environment.yaml``` which keeps version 0.3.1.