### PR TITLE
added LogSoftmax layer; modified import syntax

### DIFF
--- a/fastai/models/darknet.py
+++ b/fastai/models/darknet.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from .layers import *
+from fastai.layers import *
 
 class ConvBN(nn.Module):
     "convolutional layer then batchnorm"
@@ -39,6 +39,7 @@ class Darknet(nn.Module):
             layers += self.make_group_layer(nf, nb, stride=(1 if i==1 else 2))
             nf *= 2
         layers += [nn.AdaptiveAvgPool2d(1), Flatten(), nn.Linear(nf, num_classes)]
+        layers += [nn.LogSoftmax()]
         self.layers = nn.Sequential(*layers)
 
     def forward(self, x): return self.layers(x)


### PR DESCRIPTION
See [Gist](https://gist.github.com/WNoxchi/17ed83c3a0450cb4939b264d94c74054) for testing. 

`from .layers import *` --> `from fastai.layers import *`  can now import darknet normally via: `from fastai.models import darknet`.
The LogSoftmax layer works with the NLL loss criterion set by fastai's `conv_learner.ConvLearner` to produce Cross Entropy loss -- this is done automatically through fastai's `ConvnetBuilder` when loading pretrained models, but darknet isn't pretrained yet.

See [fastai thread](http://forums.fast.ai/t/project-implement-yolo-v3-backbone-and-preact-resnet/14613/50?u=borz) for how this started.