### PR TITLE
fix typo in Learner.__init__ path management

### DIFF
--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -34,7 +34,7 @@ class Learner():
         self.clip = None
         self.opt_fn = opt_fn or SGD_Momentum(0.9)
         self.tmp_path = tmp_name if os.path.isabs(tmp_name) else os.path.join(self.data.path, tmp_name)
-        self.models_path = models_name if os.path.isabs(models_name) else os.path.join(self.data_path, models_name)
+        self.models_path = models_name if os.path.isabs(models_name) else os.path.join(self.data.path, models_name)
         os.makedirs(self.tmp_path, exist_ok=True)
         os.makedirs(self.models_path, exist_ok=True)
         self.crit = crit if crit else self._get_crit(data)


### PR DESCRIPTION
@JannesKlaas one of the new incantations was spelled `data_path` instead of `data.path`.