### PR TITLE
Fix misnamed data.path access in Learner library

### DIFF
--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -34,7 +34,7 @@ class Learner():
         self.clip = None
         self.opt_fn = opt_fn or SGD_Momentum(0.9)
         self.tmp_path = tmp_name if os.path.isabs(tmp_name) else os.path.join(self.data.path, tmp_name)
-        self.models_path = models_name if os.path.isabs(models_name) else os.path.join(self.data_path, models_name)
+        self.models_path = models_name if os.path.isabs(models_name) else os.path.join(self.data.path, models_name)
         os.makedirs(self.tmp_path, exist_ok=True)
         os.makedirs(self.models_path, exist_ok=True)
         self.crit = crit if crit else self._get_crit(data)


### PR DESCRIPTION
A recent change to learner.py resulted in a misnamed reference to self.data_path instead of self.data.path.