### PR TITLE
Bugfix: Typo in learner.py when accessing path 

### DIFF
--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -34,7 +34,7 @@ class Learner():
         self.clip = None
         self.opt_fn = opt_fn or SGD_Momentum(0.9)
         self.tmp_path = tmp_name if os.path.isabs(tmp_name) else os.path.join(self.data.path, tmp_name)
-        self.models_path = models_name if os.path.isabs(models_name) else os.path.join(self.data_path, models_name)
+        self.models_path = models_name if os.path.isabs(models_name) else os.path.join(self.data.path, models_name)
         os.makedirs(self.tmp_path, exist_ok=True)
         os.makedirs(self.models_path, exist_ok=True)
         self.crit = crit if crit else self._get_crit(data)


### PR DESCRIPTION
## Fixes the error below

![issue](https://user-images.githubusercontent.com/7297269/39413055-c2447114-4bd9-11e8-9e7e-89709f95c84c.png)


```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-33-bfd96ca26d21> in <module>()
----> 1 learn = ConvLearner.pretrained(arch, data, precompute=True)

~/fastai/courses/dl1/fastai/conv_learner.py in pretrained(cls, f, data, ps, xtra_fc, xtra_cut, custom_head, precompute, pretrained, **kwargs)
    112         models = ConvnetBuilder(f, data.c, data.is_multi, data.is_reg,
    113             ps=ps, xtra_fc=xtra_fc, xtra_cut=xtra_cut, custom_head=custom_head, pretrained=pretrained)
--> 114         return cls(data, models, precompute, **kwargs)
    115 
    116     @classmethod

~/fastai/courses/dl1/fastai/conv_learner.py in __init__(self, data, models, precompute, **kwargs)
     95     def __init__(self, data, models, precompute=False, **kwargs):
     96         self.precompute = False
---> 97         super().__init__(data, models, **kwargs)
     98         if hasattr(data, 'is_multi') and not data.is_reg and self.metrics is None:
     99             self.metrics = [accuracy_thresh(0.5)] if self.data.is_multi else [accuracy]

~/fastai/courses/dl1/fastai/learner.py in __init__(self, data, models, opt_fn, tmp_name, models_name, metrics, clip, crit)
     35         self.opt_fn = opt_fn or SGD_Momentum(0.9)
     36         self.tmp_path = tmp_name if os.path.isabs(tmp_name) else os.path.join(self.data.path, tmp_name)
---> 37         self.models_path = models_name if os.path.isabs(models_name) else os.path.join(self.data_path, models_name)
     38         os.makedirs(self.tmp_path, exist_ok=True)
     39         os.makedirs(self.models_path, exist_ok=True)

AttributeError: 'ConvLearner' object has no attribute 'data_path'
```
