### PR TITLE
Correct property typo (self.data.path)

### DIFF
--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -34,7 +34,7 @@ class Learner():
         self.clip = None
         self.opt_fn = opt_fn or SGD_Momentum(0.9)
         self.tmp_path = tmp_name if os.path.isabs(tmp_name) else os.path.join(self.data.path, tmp_name)
-        self.models_path = models_name if os.path.isabs(models_name) else os.path.join(self.data_path, models_name)
+        self.models_path = models_name if os.path.isabs(models_name) else os.path.join(self.data.path, models_name)
         os.makedirs(self.tmp_path, exist_ok=True)
         os.makedirs(self.models_path, exist_ok=True)
         self.crit = crit if crit else self._get_crit(data)


### PR DESCRIPTION
I got an error when I ran the tutorial code of deep learning 1. It said that self.data_path was not defined, so I looked into learner.py and saw that on the line before this line, there was self.data.path used instead of self.data_path, so I believe that should be corrected.