### PR TITLE
bugfix for learner.py

### DIFF
--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -34,7 +34,7 @@ class Learner():
         self.clip = None
         self.opt_fn = opt_fn or SGD_Momentum(0.9)
         self.tmp_path = tmp_name if os.path.isabs(tmp_name) else os.path.join(self.data.path, tmp_name)
-        self.models_path = models_name if os.path.isabs(models_name) else os.path.join(self.data_path, models_name)
+        self.models_path = models_name if os.path.isabs(models_name) else os.path.join(self.data.path, models_name)
         os.makedirs(self.tmp_path, exist_ok=True)
         os.makedirs(self.models_path, exist_ok=True)
         self.crit = crit if crit else self._get_crit(data)


### PR DESCRIPTION
This is a one digit bugfix suggestion to correct an issue outlined in [this post](http://forums.fast.ai/t/trouble-training-the-model-dogs-vs-cats/15606) on the fast.ai wiki. The old version of the code threw the error below when using absolute instead of relative file paths. This change fixes that problem. Credit to [@thadar](http://forums.fast.ai/u/thadar) for the solution to my problem. I hope that this way it will help others, too. Please let me know about any issues with this PR, the format, or anything else.

------------
```python
os.chdir('/home/paperspace/')
PATH = 'data/somedataset/'

arch = resnet34
data = ImageClassifierData.from_paths(PATH, tfms=tfms_from_model(arch, sz))
learn = ConvLearner.pretrained(arch, data, precompute=True)

# Used to result in this error:
---------------------------------------------------------------
AttributeError                Traceback (most recent call last)
<ipython-input-42-bfd96ca26d21> in <module>()
----> 1 learn = ConvLearner.pretrained(arch, data, precompute=True)

~/fastai/fastai/conv_learner.py in pretrained(cls, f, data, ps, xtra_fc, xtra_cut, custom_head, precompute, pretrained, **kwargs)
    112         models = ConvnetBuilder(f, data.c, data.is_multi, data.is_reg,
    113             ps=ps, xtra_fc=xtra_fc, xtra_cut=xtra_cut, custom_head=custom_head, pretrained=pretrained)
--> 114         return cls(data, models, precompute, **kwargs)
    115 
    116     @classmethod

~/fastai/fastai/conv_learner.py in __init__(self, data, models, precompute, **kwargs)
     95     def __init__(self, data, models, precompute=False, **kwargs):
     96         self.precompute = False
---> 97         super().__init__(data, models, **kwargs)
     98         if hasattr(data, 'is_multi') and not data.is_reg and self.metrics is None:
     99             self.metrics = [accuracy_thresh(0.5)] if self.data.is_multi else [accuracy]

~/fastai/fastai/learner.py in __init__(self, data, models, opt_fn, tmp_name, models_name, metrics, clip, crit)
     35         self.opt_fn = opt_fn or SGD_Momentum(0.9)
     36         self.tmp_path = tmp_name if os.path.isabs(tmp_name) else os.path.join(self.data.path, tmp_name)
---> 37         self.models_path = models_name if os.path.isabs(models_name) else os.path.join(self.data_path, models_name)
     38         os.makedirs(self.tmp_path, exist_ok=True)
     39         os.makedirs(self.models_path, exist_ok=True)

AttributeError: 'ConvLearner' object has no attribute 'data_path'
```
------------

Changed attribute `models_path` in the `Learner` class to `models.path`. The old version was causing problems when working on absolute file paths, this fixes the problem.