### PR TITLE
Asserts for ImageClassifierData.from_csv

### DIFF
--- a/fastai/dataset.py
+++ b/fastai/dataset.py
@@ -451,6 +451,8 @@ class ImageClassifierData(ImageData):
         Returns:
             ImageClassifierData
         """
+        assert not (tfms[0] is None or tfms[1] is None), "please provide transformations for your train and validation sets"
+        assert not (os.path.isabs(folder)), "folder needs to be a relative path"
         fnames,y,classes = csv_source(folder, csv_fname, skip_header, suffix, continuous=continuous)
         return cls.from_names_and_array(path, fnames, y, classes, val_idxs, test_name,
                 num_workers=num_workers, suffix=suffix, tfms=tfms, bs=bs, continuous=continuous)


### PR DESCRIPTION
Added two asserts to make sure that ImageClassifierData.from_csv is correctly invoked. 

The argument "folder" needs to be a relative path (relative to the argument called path). If it is given as an absolute path there is no error and the code still mostly works, but it breaks some functionality like data = ImageClassifierData.from_csv(..); data.resize(..);

The argument tfms of course should not be none (), since we might need to resize images, etc.