### PR TITLE
modify LR_Finder.plot to use n_skip_end=0

### DIFF
--- a/fastai/sgdr.py
+++ b/fastai/sgdr.py
@@ -158,7 +158,7 @@ class LR_Finder(LR_Updater):
     def plot(self, n_skip=10, n_skip_end=5):
         plt.ylabel("loss")
         plt.xlabel("learning rate (log scale)")
-        plt.plot(self.lrs[n_skip:-n_skip_end], self.losses[n_skip:-n_skip_end])
+        plt.plot(self.lrs[n_skip:-(n_skip_end+1)], self.losses[n_skip:-(n_skip_end+1)])
         plt.xscale('log')
 
 class LR_Finder2(LR_Finder):


### PR DESCRIPTION
I would like to suggest modifying the learning rate finder method LR_Finder.plot so that `n_skip_end=0` plots all values. Previously, one had to use `n_skip_end=1` to get all values, while n_skip_end=0 would return an empty plot. The new behavior makes `n_skip_end` consistent with the behavior of `n_skip`