### PR TITLE
Added conda-forge channel only for jup extensions

### DIFF
--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -36,6 +36,7 @@ dependencies:
 - jupyter_client
 - jupyter_console
 - jupyter_core
+- conda-forge::jupyter_contrib_nbextensions  
   #- libffi
   #- libgcc
   #- libgfortran
@@ -107,9 +108,7 @@ dependencies:
   - graphviz
   - sklearn_pandas
   - feather-format
-  - jupyter_contrib_nbextensions
   - plotnine
   - kaggle-cli
   - ipywidgets
-  - jupyter_contrib_nbextensions
     # - git+https://github.com/SauceCat/PDPbox.git

--- a/environment-nopytorch.yml
+++ b/environment-nopytorch.yml
@@ -38,6 +38,7 @@ dependencies:
 - jupyter_client
 - jupyter_console
 - jupyter_core
+- conda-forge::jupyter_contrib_nbextensions  
   #- libffi
   #- libgcc
   #- libgfortran
@@ -108,11 +109,9 @@ dependencies:
   - graphviz
   - sklearn_pandas
   - feather-format
-  - jupyter_contrib_nbextensions
   - plotnine
   - awscli
   - kaggle-cli
   - ipywidgets
-  - jupyter_contrib_nbextensions
     #- git+https://github.com/SauceCat/PDPbox.git
 

--- a/environment-old.yml
+++ b/environment-old.yml
@@ -36,6 +36,7 @@ dependencies:
 - jupyter_client
 - jupyter_console
 - jupyter_core
+- conda-forge::jupyter_contrib_nbextensions  
 - libffi
 - libgcc
 - libgfortran
@@ -106,11 +107,9 @@ dependencies:
   - graphviz
   - sklearn_pandas
   - feather-format
-  - jupyter_contrib_nbextensions
   - plotnine
   - awscli
   - kaggle-cli
   - ipywidgets
-  - jupyter_contrib_nbextensions
   - git+https://github.com/SauceCat/PDPbox.git
 

--- a/environment.yml
+++ b/environment.yml
@@ -38,6 +38,7 @@ dependencies:
 - jupyter_client
 - jupyter_console
 - jupyter_core
+- conda-forge::jupyter_contrib_nbextensions  
   #- libffi
   #- libgcc
   #- libgfortran
@@ -109,9 +110,7 @@ dependencies:
   - graphviz
   - sklearn_pandas
   - feather-format
-  - jupyter_contrib_nbextensions
   - plotnine
   - kaggle-cli
   - ipywidgets
-  - jupyter_contrib_nbextensions
     #- git+https://github.com/SauceCat/PDPbox.git


### PR DESCRIPTION
According to the issue listed [here](https://github.com/conda/conda/issues/2800) in the conda repo there is an option to add a channel per dependency. Now that issue is not closed yet but there is no activity since Nov 2017. I changed the env files to use conda-forge only for the jupyter extensions and it worked. I was able to see all the extensions listed. I have changed all the env files to use conda-forge for jup extensions.