### PR TITLE
Proposed fix for  #386 ImageClassifierData.from_csv does not select the rows corresponding to val_idxs even if explicitly passed.

### DIFF
--- a/fastai/dataset.py
+++ b/fastai/dataset.py
@@ -112,7 +112,7 @@ def parse_csv_labels(fn, skip_header=True, cat_separator = ' '):
 
     Returns:
         a four-tuple of (
-            sorted image filenames,
+            image filenames,
             a dictionary of filenames and corresponding labels,
             a sorted set of unique labels,
             a dictionary of labels to their corresponding index, which will
@@ -124,7 +124,7 @@ def parse_csv_labels(fn, skip_header=True, cat_separator = ' '):
     df = pd.read_csv(fn, index_col=0, header=0 if skip_header else None, dtype=str)
     fnames = df.index.values
     df.iloc[:,0] = df.iloc[:,0].str.split(cat_separator)
-    return sorted(fnames), list(df.to_dict().values())[0]
+    return fnames, list(df.to_dict().values())[0]
 
 def nhot_labels(label2idx, csv_labels, fnames, c):
     

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -4,6 +4,7 @@ import pytest
 from PIL import Image
 import pandas as pd
 import numpy as np
+import os
 
 from fastai.dataset import ImageClassifierData
 from fastai.model import resnet34
@@ -45,5 +46,5 @@ def test_image_classifier_data_from_csv_unsorted(root_folder, csv_file, data_fol
     data = ImageClassifierData.from_csv(path=Path(
         path), folder=folder, csv_fname=csv_fname, val_idxs=val_idxs, suffix='.png', tfms=tfms)
     val_fnames = ['8.png', '7.png']
-    assert [o.split("\\")[-1]
+    assert [os.path.split(o)[-1]
             for o in data.val_ds.fnames.tolist()] == val_fnames

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+import pytest
+
+from PIL import Image
+import pandas as pd
+import numpy as np
+
+from fastai.dataset import ImageClassifierData
+from fastai.model import resnet34
+from fastai.transforms import tfms_from_model
+
+
+@pytest.fixture(scope='module')
+def root_folder(tmpdir_factory):
+    return tmpdir_factory.mktemp('tmp_img_data')
+
+
+@pytest.fixture(scope='module')
+def csv_file(root_folder):
+    tmp_csv_file = root_folder.mkdir(
+        'tmp_csv_folder').join('tmp_csv_file.csv')
+    df_list = [{'id': 11-i, 'label': chr(ord('a') + 10 - i)}
+               for i in range(1, 11)]  # Create CSV with rows as (10, 'j'), (9, 'i') .. (1, 'a')
+    df = pd.DataFrame(df_list)
+    df.to_csv(str(tmp_csv_file), index=False)
+    return tmp_csv_file
+
+
+@pytest.fixture(scope='module')
+def data_folder(root_folder):
+    folder = root_folder.mkdir('tmp_data_folder')
+    for i in range(1, 11):  # Create folder with images "1.png", "2.png".."10.png"
+        img_array = np.random.rand(100, 100, 3) * 255
+        img = Image.fromarray(img_array.astype('uint8')).convert('RGBA')
+        img.save(str(folder.join(str(i) + '.png')))
+    return folder
+
+
+def test_image_classifier_data_from_csv_unsorted(root_folder, csv_file, data_folder):
+    val_idxs = [2, 3]
+    tfms = tfms_from_model(resnet34, 224)
+    path = str(root_folder)
+    folder = 'tmp_data_folder'
+    csv_fname = Path(str(csv_file))
+    data = ImageClassifierData.from_csv(path=Path(
+        path), folder=folder, csv_fname=csv_fname, val_idxs=val_idxs, suffix='.png', tfms=tfms)
+    val_fnames = ['8.png', '7.png']
+    assert [o.split("\\")[-1]
+            for o in data.val_ds.fnames.tolist()] == val_fnames


### PR DESCRIPTION
Fix for #386 

- First commit adds a regression test that can be helpful in demonstrating the issue. I have tried following the test guidelines, but it's still my first time writing tests in Python using pytest, so please let me know if anything needs to be changed.
 - Second commit attempts to fix the issue by introducing another parameter (sort_fnames) in methods used by ImageClassifierData.from_csv, that indicate whether the returned file names need to be sorted. The parameter is passed in as False, if the list of validation indexes has been provided. It is True by default.

Please let me know if any changes are required. Thanks.