### PR TITLE
import fixes for pix2pix part of cgan

### DIFF
--- a/courses/dl2/cgan/data/aligned_dataset.py
+++ b/courses/dl2/cgan/data/aligned_dataset.py
@@ -2,8 +2,8 @@ import os.path
 import random
 import torchvision.transforms as transforms
 import torch
-from data.base_dataset import BaseDataset
-from data.image_folder import make_dataset
+from .base_dataset import BaseDataset
+from .image_folder import make_dataset
 from PIL import Image
 
 

--- a/courses/dl2/cgan/data/single_dataset.py
+++ b/courses/dl2/cgan/data/single_dataset.py
@@ -1,6 +1,6 @@
 import os.path
-from data.base_dataset import BaseDataset, get_transform
-from data.image_folder import make_dataset
+from .base_dataset import BaseDataset, get_transform
+from .image_folder import make_dataset
 from PIL import Image
 
 

--- a/courses/dl2/cgan/models/pix2pix_model.py
+++ b/courses/dl2/cgan/models/pix2pix_model.py
@@ -136,8 +136,5 @@ class Pix2PixModel(BaseModel):
         self.save_network(self.netD, 'D', label, self.gpu_ids)
 
     def load(self, label):
-        self.load_network(self.netG_A, 'G_A', label)
-        self.load_network(self.netD_A, 'D_A', label)
-        self.load_network(self.netG_B, 'G_B', label)
-        self.load_network(self.netD_B, 'D_B', label)
-
+        self.load_network(self.netG, 'G', label)
+        self.load_network(self.netD, 'D', label)

--- a/courses/dl2/cgan/models/pix2pix_model.py
+++ b/courses/dl2/cgan/models/pix2pix_model.py
@@ -1,11 +1,10 @@
 import torch
 from collections import OrderedDict
 from torch.autograd import Variable
-import util.util as util
-from util.image_pool import ImagePool
+from ..util import * 
+from ..util.image_pool import ImagePool
 from .base_model import BaseModel
 from . import networks
-
 
 class Pix2PixModel(BaseModel):
     def name(self):
@@ -135,3 +134,10 @@ class Pix2PixModel(BaseModel):
     def save(self, label):
         self.save_network(self.netG, 'G', label, self.gpu_ids)
         self.save_network(self.netD, 'D', label, self.gpu_ids)
+
+    def load(self, label):
+        self.load_network(self.netG_A, 'G_A', label)
+        self.load_network(self.netD_A, 'D_A', label)
+        self.load_network(self.netG_B, 'G_B', label)
+        self.load_network(self.netD_B, 'D_B', label)
+

--- a/courses/dl2/cgan/models/test_model.py
+++ b/courses/dl2/cgan/models/test_model.py
@@ -1,6 +1,6 @@
 from torch.autograd import Variable
 from collections import OrderedDict
-import util.util as util
+from ..util import *
 from .base_model import BaseModel
 from . import networks
 


### PR DESCRIPTION
fixes to aligned_dataset.py, single_dataset.py, pix2pix_model.py, test_model.py
to allow to utilize cyclegan notebook in pix2pix mode
