### PR TITLE
FIX cpu tensor for image data in test

### DIFF
--- a/tests/test_lsuv_initializer.py
+++ b/tests/test_lsuv_initializer.py
@@ -18,7 +18,7 @@ def image_data():
         img = cv2.imread(os.path.join('fastai/images', img_fname))
         images_to_process.append(np.transpose(cv2.resize(img, (224,224)), (2,0,1)))
     data = np.array(images_to_process).astype(np.float32)
-    return VV(torch.from_numpy(data))
+    return VV(torch.from_numpy(data)).cpu()
 
 
 def add_hooks(m, fn):


### PR DESCRIPTION
This PR fixes the only test currently failing for a fresh install with cuda, by forcing the image data in `test_lsuv_initializer.py` to be a CPU tensor.