### PR TITLE
Prevent out of GPU memory error when calling predict_with_targs() wit…

### DIFF
--- a/fastai/model.py
+++ b/fastai/model.py
@@ -227,7 +227,7 @@ def get_prediction(x):
 
 def predict(m, dl):
     preda,_ = predict_with_targs_(m, dl)
-    return to_np(torch.cat(preda))
+    return np.concatenate(preda)
 
 def predict_batch(m, x):
     m.eval()
@@ -238,12 +238,12 @@ def predict_with_targs_(m, dl):
     m.eval()
     if hasattr(m, 'reset'): m.reset()
     res = []
-    for *x,y in iter(dl): res.append([get_prediction(m(*VV(x))),y])
+    for *x,y in iter(dl): res.append([get_prediction(to_np(m(*VV(x)))),to_np(y)])
     return zip(*res)
 
 def predict_with_targs(m, dl):
     preda,targa = predict_with_targs_(m, dl)
-    return to_np(torch.cat(preda)), to_np(torch.cat(targa))
+    return np.concatenate(preda), np.concatenate(targa)
 
 # From https://github.com/ncullen93/torchsample
 def model_summary(m, input_size):


### PR DESCRIPTION
…h large data sets by calling to_np() for every batch instead of once for the final result.

Notes: I couldn't use 

learn.model.eval()
probs = learn.predict(is_test = True)

for a large test data set without running out of memory and these changes fixed it for me