### PR TITLE
Fix "Input contains NaN, infinity or a value too large for dtype" error

### DIFF
--- a/courses/dl1/lesson3-rossman.ipynb
+++ b/courses/dl1/lesson3-rossman.ipynb
@@ -4181,8 +4181,8 @@
    "outputs": [],
    "source": [
     "for v in contin_vars:\n",
-    "    joined[v] = joined[v].astype('float32')\n",
-    "    joined_test[v] = joined_test[v].astype('float32')"
+    "    joined[v] = joined[v].fillna(0).astype('float32')\n",
+    "    joined_test[v] = joined_test[v].fillna(0).astype('float32')"
    ]
   },
   {


### PR DESCRIPTION
To treat nan values of continuous column we can use fillna()
Per: comment by NitinP in this thread: http://forums.fast.ai/t/afterstateholiday-input-contains-nan-infinity-or-a-value-too-large-for-dtype-float32/8586/12