### PR TITLE
Fix errors caused by .DS_Store files on Mac OS X

### DIFF
--- a/fastai/dataset.py
+++ b/fastai/dataset.py
@@ -70,8 +70,9 @@ def read_dirs(path, folder):
         if lbl not in ('.ipynb_checkpoints','.DS_Store'):
             all_lbls.append(lbl)
             for fname in os.listdir(os.path.join(full_path, lbl)):
-                fnames.append(os.path.join(folder, lbl, fname))
-                lbls.append(lbl)
+                if fname not in ('.DS_Store'):
+                    fnames.append(os.path.join(folder, lbl, fname))
+                    lbls.append(lbl)
     return fnames, lbls, all_lbls
 
 def n_hot(ids, c):


### PR DESCRIPTION
Ignores the .DS_Store files while listing dirs