### PR TITLE
parse_csv function comment update

### DIFF
--- a/fastai/dataset.py
+++ b/fastai/dataset.py
@@ -111,12 +111,9 @@ def parse_csv_labels(fn, skip_header=True, cat_separator = ' '):
         skip_header: A boolean flag indicating whether to skip the header.
 
     Returns:
-        a four-tuple of (
+        a two-tuple of (
             sorted image filenames,
-            a dictionary of filenames and corresponding labels,
-            a sorted set of unique labels,
-            a dictionary of labels to their corresponding index, which will
-            be one-hot encoded.
+            a dictionary of filenames and corresponding labels
         )
     .
     :param cat_separator: the separator for the categories column


### PR DESCRIPTION
Hi fast.ai team!

This PR is just a small update to the function comment documentation to indicate that a two tuple is returned instead of a four tuple in the parse_csv function. Just a small change I found when digging through the library when working on a kaggle data set.

Thanks for all this great deep learning content!
