### PR TITLE
Fixed bug when initializing conv layer without bias

### DIFF
--- a/fastai/initializers.py
+++ b/fastai/initializers.py
@@ -4,7 +4,7 @@ from .torch_imports import *
 def cond_init(m, init_fn):
     if not isinstance(m, (nn.BatchNorm1d,nn.BatchNorm2d,nn.BatchNorm3d)):
         if hasattr(m, 'weight'): init_fn(m.weight)
-        if hasattr(m, 'bias'): m.bias.data.fill_(0.)
+        if hasattr(m, 'bias') and hasattr(m.bias, 'data'): m.bias.data.fill_(0.)
 
 def apply_init(m, init_fn):
     m.apply(lambda x: cond_init(x, init_fn))


### PR DESCRIPTION
When using apply_init on a model with a Conv2d layer with bias=False, the conv layer has a bias object with no data attribute.