### PR TITLE
changes to make imdb notebook run on Python 3.6

### DIFF
--- a/fastai/lm_rnn.py
+++ b/fastai/lm_rnn.py
@@ -10,10 +10,10 @@ IS_TORCH_04 = LooseVersion(torch.__version__) >= LooseVersion('0.4')
 def seq2seq_reg(output, xtra, loss, alpha=0, beta=0):
     hs,dropped_hs = xtra
     if alpha:  # Activation Regularization
-        loss = loss + sum(alpha * dropped_hs[-1].pow(2).mean())
+        loss = loss + (alpha * dropped_hs[-1].pow(2).mean()).sum()
     if beta:   # Temporal Activation Regularization (slowness)
         h = hs[-1]
-        if len(h)>1: loss = loss + sum(beta * (h[1:] - h[:-1]).pow(2).mean())
+        if len(h)>1: loss = loss + (beta * (h[1:] - h[:-1]).pow(2).mean()).sum()
     return loss
 
 

--- a/fastai/rnn_reg.py
+++ b/fastai/rnn_reg.py
@@ -106,6 +106,8 @@ class WeightDrop(torch.nn.Module):
         for name_w in self.weights:
             raw_w = getattr(self.module, name_w + '_raw')
             w = torch.nn.functional.dropout(raw_w, p=self.dropout, training=self.training)
+            if hasattr(self.module, name_w):
+                delattr(self.module, name_w)
             setattr(self.module, name_w, w)
 
     def forward(self, *args):

--- a/fastai/torch_imports.py
+++ b/fastai/torch_imports.py
@@ -28,7 +28,6 @@ def load_model(m, p):
     sd = torch.load(p, map_location=lambda storage, loc: storage)
     names = set(m.state_dict().keys())
     for n in list(sd.keys()): # list "detatches" the iterator
-        for n in list(sd.keys()): # list "detaches" the iterator
         if n not in names and n+'_raw' in names and n+'_raw' not in sd:
             sd[n+'_raw'] = sd[n]
             del sd[n]

--- a/fastai/torch_imports.py
+++ b/fastai/torch_imports.py
@@ -24,7 +24,16 @@ warnings.filterwarnings('ignore', message='Implicit dimension choice', category=
 
 def children(m): return m if isinstance(m, (list, tuple)) else list(m.children())
 def save_model(m, p): torch.save(m.state_dict(), p)
-def load_model(m, p): m.load_state_dict(torch.load(p, map_location=lambda storage, loc: storage))
+def load_model(m, p):
+    sd = torch.load(p, map_location=lambda storage, loc: storage)
+    names = set(m.state_dict().keys())
+    for n in list(sd.keys()): # list "detatches" the iterator
+        if n not in names:
+            if n+'_raw' in names:
+                if n+'_raw' not in sd:
+                    sd[n+'_raw'] = sd
+                del sd[n]
+    m.load_state_dict(sd)
 
 def load_pre(pre, f, fn):
     m = f()

--- a/fastai/torch_imports.py
+++ b/fastai/torch_imports.py
@@ -28,11 +28,10 @@ def load_model(m, p):
     sd = torch.load(p, map_location=lambda storage, loc: storage)
     names = set(m.state_dict().keys())
     for n in list(sd.keys()): # list "detatches" the iterator
-        if n not in names:
-            if n+'_raw' in names:
-                if n+'_raw' not in sd:
-                    sd[n+'_raw'] = sd
-                del sd[n]
+        for n in list(sd.keys()): # list "detaches" the iterator
+        if n not in names and n+'_raw' in names and n+'_raw' not in sd:
+            sd[n+'_raw'] = sd[n]
+            del sd[n]
     m.load_state_dict(sd)
 
 def load_pre(pre, f, fn):


### PR DESCRIPTION
Hi,

thank you for fastai and the course!

While working through the IMDB notebook, I had three things I needed to change before it would run through on my computer (PyTorch master with Python 3.6). This PR collects them.
As discussed on the [forum](http://forums.fast.ai/t/pytorch-internal-error-while-doing-the-imdb-notebook/16828), I'm not 100% sure why my setup has this while others (@sgugger in particular) didn't need it.

There are three separate fixes in this PR
- In `lm_rnn.py`, sum is used. This fails in when the thing summed over is a PyTorch scalar (aka 0-dim tensor), as PyTorch does not want to iterate over it. Probably a new PyTorch thing that will come to others as well. Given that the code uses arithmetics, I concluded that the object to be summed is necessarily a tensor (or numpy array perhaps, I haven't checked), so using `.sum()` seemed the right thing to do anyways. I think this should probably be good to merge.
- A thing that might generate some more discussion is the fix `rnn_reg.py` in the `WeightDrop` wrapper. For me, this errors because PyTorch [forbids](https://github.com/pytorch/pytorch/blob/5316cad5c2b10d5c3ef36b0314842593848857d2/torch/nn/modules/module.py#L549) (sometimes? perhaps the Python version matters) assigning a Tensor over a Parameter in Modules. The save thing to do seems to be to remove the Parameter if it exists, which is what the patch does.
- Finally, and this might be the most controversial / unclean change: I had trouble loading and saving modules when I tried to skip certain steps in the notebook, because the saved state_dict and the model had different ideas about `_raw` weights (I think this depends on whether the wrapping has been called). I try to ad-hoc adapt in load_module. This is definitely hacky. A more clean solution could be to do the `_raw` renaming when initializing the WeightDrop wrapper.

It should be noted that there is a [discussion in PyTorch on how calculated parameters should be handled](https://github.com/pytorch/pytorch/issues/7313). Depending on the outcome, it might be most clean to implement WeightDrop using that mechanism, but that would have to weight until it is OK to require PyTorch 0.5 for fastai.

I must admit I'm not familiar with the fastai codebase, so some things might not be up to fastai standard.

Best regards

Thomas