### PR TITLE
 fix pytorch import error in CPU only environment 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ Use this if you do not have an NVidia GPU. Note you are encouraged to use Papers
 
 `conda env update -f environment-cpu.yml`
 
-* Anytime the instructions say to activate the Python environment, run `conda activate fastai-cpu` or `source activate fastai-cpu`.
-
+- Anytime the instructions say to activate the Python environment, run `conda activate fastai-cpu` or `source activate fastai-cpu`.
 
 ## To update
 1. Update code: `git pull`

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Use this if you do not have an NVidia GPU. Note you are encouraged to use Papers
 
 `conda env update -f environment-cpu.yml`
 
-- Anytime the instructions say to activate the Python environment, run `conda activate fastai-cpu` or `source activate fastai-cpu`.
+Anytime the instructions say to activate the Python environment, run `conda activate fastai-cpu` or `source activate fastai-cpu`.
 
 ## To update
 1. Update code: `git pull`

--- a/README.md
+++ b/README.md
@@ -35,9 +35,7 @@ Use this if you do not have an NVidia GPU. Note you are encouraged to use Papers
 `conda env update -f environment-cpu.yml`
 
 * Anytime the instructions say to activate the Python environment, run `conda activate fastai-cpu` or `source activate fastai-cpu`.
-* If the fastai library fails to import and reports this error: "ImportError: DLL load failed: The specified module could not be found", run this commond in conda:
 
-`conda install -c peterjc123 pytorch-cpu`
 
 ## To update
 1. Update code: `git pull`

--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -22,6 +22,7 @@ dependencies:
 - expat
 - html5lib
 - icu
+- defaults::intel-openmp
 - ipykernel
 - ipython
 - ipython_genutils


### PR DESCRIPTION
After installing the CPU only version of fastai library by running `conda env update -f environment-cpu.yml`. The pytorch library still fails to import and reports this error: 
`C:\Program Files\Anaconda3\envs\fastai\lib\site-packages\torch\__init__.py in <module>()
     74     pass
     75 
---> 76 from torch._C import *
     77 
     78 __all__ += [name for name in dir(_C)
ImportError: DLL load failed: The specified module could not be found.`

I found a simple solution by running the command `conda install -c peterjc123 pytorch-cpu`, which installs a cpu-version of pytorch. The original solution is found here: https://github.com/peterjc123/pytorch-scripts. 

I changed the readme file to report this big-fix and hope it will be helpful to others who wish to test cpu-only version of the fastai library. 