### PR TITLE
proc_df should not add new na columns if na_dict is passed to it

### DIFF
--- a/fastai/structured.py
+++ b/fastai/structured.py
@@ -433,7 +433,11 @@ def proc_df(df, y_fld=None, skip_flds=None, ignore_flds=None, do_scale=False, na
     df.drop(skip_flds, axis=1, inplace=True)
 
     if na_dict is None: na_dict = {}
+    else: na_dict = na_dict.copy()
+    na_dict_initial = na_dict.copy()
     for n,c in df.items(): na_dict = fix_missing(df, c, n, na_dict)
+    if len(na_dict_initial.keys()) > 0:
+        df.drop([a + '_na' for a in list(set(na_dict.keys()) - set(na_dict_initial.keys()))], axis=1, inplace=True)
     if do_scale: mapper = scale_vars(df, mapper)
     for n,c in df.items(): numericalize(df, c, n, max_n_cat)
     df = pd.get_dummies(df, dummy_na=True)

--- a/tests/test_structured.py
+++ b/tests/test_structured.py
@@ -1,0 +1,28 @@
+import pytest
+from fastai.structured import proc_df
+import pandas as pd
+import numpy as np
+
+def test_proc_df_fix_missing():
+    y_col = 'target'
+
+    df_train = pd.DataFrame({'col1' : [1, np.NaN, 3], 'col2' : [5, 2, 2], 'target': [1, 0, 1]})
+    df_test = pd.DataFrame({'col1' : [1, 2, np.NaN], 'col2' : [5, np.NaN, 2]})
+
+    # Assume test is the same as train but without target column
+    assert len(set(df_train.columns) - set([y_col])) == len(set(df_test.columns))
+
+    X_train, y_train, nas_train = proc_df(df_train, y_fld=y_col)
+    # We are expecting nas_train to contain one column
+    assert len(nas_train) == 1
+
+    original_nas_length = len(nas_train)
+    X_test, _, nas_test = proc_df(df_test, y_fld=None, na_dict=nas_train)
+    # We expect nas_train to be unchanged
+    assert len(nas_train) == original_nas_length
+
+    # We are expecting nas_test to contain two columns
+    assert len(nas_test) == 2
+
+    # We are expecting the test set to have the same columns as train set because we have used the na_dict from train set
+    assert set(X_train.columns) == set(X_test.columns)


### PR DESCRIPTION
Fixes issue #74.

The reason for the PR is that I found two things surprising with proc_df

1. I did not expect it to add new _na columns if it is being passed an na_dict. This is a big problem when you use proc_df on a test set which might have different NA fields in different columns than the train set.
2. I did not expect proc_df to update the na_dict that is passed to it, I just expected it to return the new dictionary but not replace the one that is being passed to it. This might be because I am a beginner when it comes to python.