### PR TITLE
Deal with training labels passed as one-dimensional arrays

### DIFF
--- a/fastai/dataset.py
+++ b/fastai/dataset.py
@@ -371,7 +371,10 @@ class ImageData(ModelData):
                 test_lbls = test[1]
                 test = test[0]
             else:
-                test_lbls = np.zeros((len(test),trn[1].shape[1]))
+                if len(trn[1].shape) == 1:
+                    test_lbls = np.zeros((len(test),1))
+                else:
+                    test_lbls = np.zeros((len(test),trn[1].shape[1]))
             res += [
                 fn(test, test_lbls, tfms[1], **kwargs), # test
                 fn(test, test_lbls, tfms[0], **kwargs)  # test_aug


### PR DESCRIPTION
I encountered a bug initialising an ImageClassifierData as follows:

`md = ImageClassifierData.from_csv(PATH, 'train', PATH/'train.csv', tfms=tfms, bs=bs, test_name='test')`

where the data has a single label per class in the CSV. This seems to be because in the absence of labels for the test set the dataset creator initializes a (len(y), number of classes in train) dummy array for labels. It works fine when there are multiple classes in the training set, but fails when there is only one class because there is no second dimension to trn[1]. 

This PR checks for this case and creates the dummy array as intended.