### PR TITLE
Remove redundant import statements in layers.py

### DIFF
--- a/fastai/layers.py
+++ b/fastai/layers.py
@@ -1,5 +1,5 @@
-from .imports import *
-from .torch_imports import *
+import torch
+from torch import nn
 
 class AdaptiveConcatPool2d(nn.Module):
     def __init__(self, sz=None):

--- a/fastai/torch_imports.py
+++ b/fastai/torch_imports.py
@@ -1,4 +1,5 @@
 import os
+from distutils.version import LooseVersion
 import torch, torchvision, torchtext
 from torch import nn, cuda, backends, FloatTensor, LongTensor, optim
 import torch.nn.functional as F


### PR DESCRIPTION
The file ``layers.py`` has unncessary import statements that make it difficult to export and import fastai based resnet models to other platforms for inference. I have refactored it to include only the necessary import statements:

```
import torch
from torch import nn
```

Also updated the file ``torch_imports.py`` adding an extra import statement as it seemed to give a "Name not found" error with the ``LooseVersion`` class.

```
from distutils.version import LooseVersion
```

Details were raised with this issue here #518 