### PR TITLE
Fixed Seq2SeqAttnRNN self.out nn.Linear input size

### DIFF
--- a/courses/dl2/translate.ipynb
+++ b/courses/dl2/translate.ipynb
@@ -1260,7 +1260,7 @@
     "        self.gru_dec = nn.GRU(em_sz_dec, em_sz_dec, num_layers=nl, dropout=0.1)\n",
     "        self.emb_enc_drop = nn.Dropout(0.15)\n",
     "        self.out_drop = nn.Dropout(0.35)\n",
-    "        self.out = nn.Linear(em_sz_dec*2, len(itos_dec))\n",
+    "        self.out = nn.Linear(em_sz_dec, len(itos_dec))\n",
     "        self.out.weight.data = self.emb_dec.weight.data\n",
     "\n",
     "        self.W1 = rand_p(nh, em_sz_dec)\n",


### PR DESCRIPTION
`Seq2SeqAttnRNN` output linear layer should take `em_sz_dec` as an input size (like all the other Seq2SeqRNN models defined in this notebook), rather than `em_sz_dec*2`

**Additional information:**

I can't run this notebook on my machine (too heavy), but I am pretty sure the input can't be of size `em_sz_dec*2`

Later on, it takes this input: `outp = self.out(self.out_drop(outp[0]))`

`outp[0]` comes from: `outp, h = self.gru_dec(wgt_enc.unsqueeze(0), h)`

And `self.gru_dec` is defined as: `self.gru_dec = nn.GRU(em_sz_dec, em_sz_dec, num_layers=nl, dropout=0.1)`

So `outp[0]` should definitely be of size `[bs, em_sz_dec]` (not `[bs, em_sz_dec*2]`)

I've checked all the other implementations in this notebook, and I confirm they all define `self.out = nn.Linear(em_sz_dec, len(itos_dec))`, so I think it was defined here as `em_sz_dec*2` by mistake.

Let me know if I am wrong :)