### PR TITLE
Fix typo in lesson 1 notebook

### DIFF
--- a/courses/dl1/lesson1.ipynb
+++ b/courses/dl1/lesson1.ipynb
@@ -1075,7 +1075,7 @@
     "hidden": true
    },
    "source": [
-    "The loss is still clearly improving at lr=1e-2 (0.01), so that's what we use. Note that the optimal learning rate can change as we training the model, so you may want to re-run this function from time to time."
+    "The loss is still clearly improving at lr=1e-2 (0.01), so that's what we use. Note that the optimal learning rate can change as we train the model, so you may want to re-run this function from time to time."
    ]
   },
   {


### PR DESCRIPTION
Could also be convinced that it should be "we are training" instead.