### PR TITLE
Added bias to RNN_Encoder init() to fix TypeError.

### DIFF
--- a/fastai/lm_rnn.py
+++ b/fastai/lm_rnn.py
@@ -38,7 +38,7 @@ class RNN_Encoder(nn.Module):
     initrange=0.1
 
     def __init__(self, ntoken, emb_sz, nhid, nlayers, pad_token, bidir=False,
-                 dropouth=0.3, dropouti=0.65, dropoute=0.1, wdrop=0.5, qrnn=False):
+                 dropouth=0.3, dropouti=0.65, dropoute=0.1, wdrop=0.5, qrnn=False, bias=False):
         """ Default constructor for the RNN_Encoder class
 
             Args:
@@ -52,6 +52,7 @@ class RNN_Encoder(nn.Module):
                 dropouti (float): dropout to apply to the input layer.
                 dropoute (float): dropout to apply to the embedding layer.
                 wdrop (float): dropout used for a LSTM's internal (or hidden) recurrent weights.
+                bias (bool): ** To be added ** 
 
             Returns:
                 None


### PR DESCRIPTION
This commit fixes the following error when running the imdb notebook, at : 
learner = md.get_model(opt_fn, em_sz, nh, nl, 
                      dropouti=drops[0], dropout=drops[1], wdrop=drops[2], dropoute=drops[3], dropouth=drops[4])

TypeError: init() got an unexpected keyword argument 'bias'`