### PR TITLE
planet.py - modify def f2, so as to convert preds and targs to bumpy array before using sklearn

### DIFF
--- a/courses/dl1/planet.py
+++ b/courses/dl1/planet.py
@@ -7,6 +7,12 @@ import warnings
 def f2(preds, targs, start=0.17, end=0.24, step=0.01):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
+        if isinstance(preds, torch.cuda.LongTensor) or isinstance(preds, torch.cuda.FloatTensor):
+            preds = preds.cpu().numpy()
+            
+        if isinstance(targs, torch.cuda.LongTensor) or isinstance(targs, torch.cuda.FloatTensor):
+            targs = targs.cpu().numpy()
+            
         return max([fbeta_score(targs, (preds>th), 2, average='samples')
                     for th in np.arange(start,end,step)])
 


### PR DESCRIPTION
When running on GPU, both preds and targs will be on GPU and are tensor. They need to be brought to CPU and converted to numpy before using any sklearn function. This pull request fixes the bug in planet/f2