### PR TITLE
handle non-cuda tensors from pytorch dls, on gpu

### DIFF
--- a/fastai/model.py
+++ b/fastai/model.py
@@ -220,10 +220,11 @@ def validate(stepper, dl, metrics, seq_first=False):
     stepper.reset(False)
     with no_grad_context():
         for (*x,y) in iter(dl):
-            preds, l = stepper.evaluate(VV(x), VV(y))
+            y = VV(y)
+            preds, l = stepper.evaluate(VV(x), y)
             batch_cnts.append(batch_sz(x, seq_first=seq_first))
             loss.append(to_np(l))
-            res.append([f(preds.data, y) for f in metrics])
+            res.append([f(preds.data, y.data) for f in metrics])
     return [np.average(loss, 0, weights=batch_cnts)] + list(np.average(np.stack(res), 0, weights=batch_cnts))
 
 def get_prediction(x):


### PR DESCRIPTION
See [gist for demo](https://gist.github.com/WNoxchi/fdc06c5c5633211a8d8c2f5b0dada6c9).

I was unable to reimplement a [CIFAR10 baseline notebook](https://github.com/radekosmulski/machine_learning_notebooks/blob/master/cifar10_fastai_dawnbench.ipynb) with a GPU due to a `TypeError` because the pytorch dataloaders used did not return .cuda. tensors. `x.data`, a `torch.cuda.FloatTensor` is compared to `y`, a `torch.LongTensor`.

The notebook worked with an [older version of fast.ai](https://github.com/radekosmulski/fastai/releases/tag/v0.61-dawnbench) because the `y` tensor returned by the pytorch dataloader in `model.validate` is converted to a `Variable` and automatically placed onto the GPU if available via `y = VV(y)`. `y.data` is then passed into the function in question, instead of `y`.

I reintroduce those lines of code in this PR.