### PR TITLE
Improve LR_Finder's plot ylabel

### DIFF
--- a/fastai/sgdr.py
+++ b/fastai/sgdr.py
@@ -190,7 +190,7 @@ class LR_Finder(LR_Updater):
         '''
         Plots the loss function with respect to learning rate, in log scale. 
         '''
-        plt.ylabel("loss")
+        plt.ylabel("validation loss")
         plt.xlabel("learning rate (log scale)")
         plt.plot(self.lrs[n_skip:-(n_skip_end+1)], self.losses[n_skip:-(n_skip_end+1)])
         plt.xscale('log')


### PR DESCRIPTION
Specify that the y-axis is the validation loss in LR_Finder's plot method.

I believe that it is in fact the validation (and not the training loss) based on my reading of ```model.fit```.