### PR TITLE
Reduce progressbar CPU load during 'fit()'

### DIFF
--- a/fastai/model.py
+++ b/fastai/model.py
@@ -131,7 +131,7 @@ def fit(model, data, n_epochs, opt, crit, metrics=None, callbacks=None, stepper=
         if hasattr(cur_data, 'trn_sampler'): cur_data.trn_sampler.set_epoch(epoch)
         if hasattr(cur_data, 'val_sampler'): cur_data.val_sampler.set_epoch(epoch)
         num_batch = len(cur_data.trn_dl)
-        t = tqdm(iter(cur_data.trn_dl), leave=False, total=num_batch)
+        t = tqdm(iter(cur_data.trn_dl), leave=False, total=num_batch, miniters=0)
         if all_val: val_iter = IterBatch(cur_data.val_dl)
 
         for (*x,y) in t:
@@ -140,7 +140,7 @@ def fit(model, data, n_epochs, opt, crit, metrics=None, callbacks=None, stepper=
             loss = model_stepper.step(V(x),V(y), epoch)
             avg_loss = avg_loss * avg_mom + loss * (1-avg_mom)
             debias_loss = avg_loss / (1 - avg_mom**batch_num)
-            t.set_postfix(loss=debias_loss)
+            t.set_postfix(loss=debias_loss, refresh=False)
             stop=False
             los = debias_loss if not all_val else [debias_loss] + validate_next(model_stepper,metrics, val_iter)
             for cb in callbacks: stop = stop or cb.on_batch_end(los)


### PR DESCRIPTION
Hi fastai,

these changes reduce the CPU load of the browser (the host of the progressbar) while fitting a model.
By enabling tqdm dynamic_miniters (miniters=0) and removing the force refresh in set_postfix the browser doesn't have to re-render the progressbar as often.

> miniters  : int, optional
            Minimum progress display update interval, in iterations.
            If 0 and `dynamic_miniters`, will automatically adjust to equal
            `mininterval` (more CPU efficient, good for tight loops).
            If > 0, will skip display of specified number of iterations.
            Tweak this and `mininterval` to get very efficient loops.
            If your progress is erratic with both fast and slow iterations
            (network, skipping items, etc) you should set miniters=1.