### PR TITLE
Reduce memory usage of tokenization script

### DIFF
--- a/courses/dl2/imdb.ipynb
+++ b/courses/dl2/imdb.ipynb
@@ -296,7 +296,7 @@
     "    labels = df.iloc[:,range(n_lbls)].values.astype(np.int64)\n",
     "    texts = f'\\n{BOS} {FLD} 1 ' + df[n_lbls].astype(str)\n",
     "    for i in range(n_lbls+1, len(df.columns)): texts += f' {FLD} {i-n_lbls} ' + df[i].astype(str)\n",
-    "    texts = texts.apply(fixup).values.astype(str)\n",
+    "    texts = list(texts.apply(fixup).values)\n",
     "\n",
     "    tok = Tokenizer().proc_all_mp(partition_by_cores(texts))\n",
     "    return tok, list(labels)"

--- a/courses/dl2/imdb_scripts/create_toks.py
+++ b/courses/dl2/imdb_scripts/create_toks.py
@@ -20,12 +20,11 @@ def get_texts(df, n_lbls, lang='en'):
     if len(df.columns) == 1:
         labels = []
         texts = f'\n{BOS} {FLD} 1 ' + df[0].astype(str)
-        texts = texts.apply(fixup).values.astype(str)
     else:
         labels = df.iloc[:,range(n_lbls)].values.astype(np.int64)
         texts = f'\n{BOS} {FLD} 1 ' + df[n_lbls].astype(str)
         for i in range(n_lbls+1, len(df.columns)): texts += f' {FLD} {i-n_lbls} ' + df[i].astype(str)
-        texts = texts.apply(fixup).values.astype(str)
+    texts = list(texts.apply(fixup).values)
 
     tok = Tokenizer(lang=lang).proc_all_mp(partition_by_cores(texts), lang=lang)
     return tok, list(labels)


### PR DESCRIPTION
The current version of tokenization script (used by ULMFiT for preprocessing) converts each chunk of rows to a numpy unicode array. The size of such array equals the number of rows times the size of the longest row. While it's not a problem for smaller datasets, it makes it difficult to efficiently process the bigger ones. For example, the first chunk of 24000 articles from polish wikipedia has ~3543 characters per article on average, but the longest one is 280790 characters long. As a result, the chunk needs 24000 * 280790 * 4 (unicode) bytes = ~25 GB of RAM.

Running the script on a system with 32 GB of RAM ends with an error.
```shellsession
$ /usr/bin/time -v python ./create_toks.py data/wiki/pl --lang xx
dir_path data/wiki/pl chunksize 24000 n_lbls 1 lang xx
0
Traceback (most recent call last):
(...)
OSError: [Errno 12] Cannot allocate memory
Command exited with non-zero status 1
        (...)
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:20.43
        (...)
        Maximum resident set size (kbytes): 27308212
        (...)
        Exit status: 1
```

After the proposed change the total memory used to process all articles is less than 20 GB:
```shellsession
$ /usr/bin/time -v python ./create_toks.py data/wiki/pl --lang xx
dir_path data/wiki/pl chunksize 24000 n_lbls 1 lang xx
0
1
(...)
23
0
1
2
        (...)
        Elapsed (wall clock) time (h:mm:ss or m:ss): 16:34.45
        (...)
        Maximum resident set size (kbytes): 20484412
        (...)
        Exit status: 0
```
Interestingly, in this case the chunking is no longer needed and the script runs twice as fast:
```shellsession
$ /usr/bin/time -v python ./create_toks.py data/wiki/pl --lang xx --chunksize 2400000
dir_path data/wiki/pl chunksize 2400000 n_lbls 1 lang xx
0
0
        (...)
        Elapsed (wall clock) time (h:mm:ss or m:ss): 8:36.73
        (...)
        Maximum resident set size (kbytes): 23728512
        (...)
        Exit status: 0
```
