### PR TITLE
Add jupyterlab and official kaggle API

### DIFF
--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -31,6 +31,7 @@ dependencies:
 - jinja2
 - jsonschema
 - jupyter
+- jupyterlab
 - jupyter_client
 - jupyter_console
 - jupyter_core
@@ -101,5 +102,6 @@ dependencies:
   - sklearn_pandas
   - feather-format
   - plotnine
+  - kaggle
   - kaggle-cli
   - ipywidgets

--- a/environment.yml
+++ b/environment.yml
@@ -32,6 +32,7 @@ dependencies:
 - jinja2
 - jsonschema
 - jupyter
+- jupyterlab
 - jupyter_client
 - jupyter_console
 - jupyter_core
@@ -102,5 +103,6 @@ dependencies:
   - sklearn_pandas
   - feather-format
   - plotnine
+  - kaggle
   - kaggle-cli
   - ipywidgets


### PR DESCRIPTION
JupyterLab is now [ready for daily use](https://blog.jupyter.org/jupyterlab-is-ready-for-users-5a6f039b8906) and will eventually replace Jupyter Notebooks in the future. It has full support for *.ipynb files and gives the alternative to work in a more REPL-Style workflow.
The official kaggle API is very convenient and stable in comparison to the unofficial kaggle-cli. Both packages together are adding less than 20 MB.