### PR TITLE
Update pandas-summary dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -96,7 +96,7 @@ dependencies:
   - torchvision>=0.1.9
   - opencv-python
   - isoweek
-  - pandas_summary
+  - pandas_summary==0.0.5
   - torchtext
   - graphviz
   - sklearn_pandas


### PR DESCRIPTION
Previously the structured data analysis notebook (course 1, lesson 3) would fail on the `DataFrameSummary` command due to there being a change in how Pandas handled types and pandas-summary depending on it. There is a change in pandas-summary, but [the version that released it seems to have gone down][1], so conda doesn't know how to install it. So we have to hardcode it to the newly released version until the version changes.

[1]: https://github.com/mouradmourafiq/pandas-summary/issues/14