### PR TITLE
Update train_clas.py in courses/dl2/imdb_scripts

### DIFF
--- a/courses/dl2/imdb_scripts/train_clas.py
+++ b/courses/dl2/imdb_scripts/train_clas.py
@@ -46,8 +46,8 @@ def train_clas(dir_path, cuda_id, lm_id='', clas_id=None, bs=64, cl=1, backwards
         trn_sent = np.load(dir_path / 'tmp' / f'trn_{IDS}{train_file_id}.npy')
         val_sent = np.load(dir_path / 'tmp' / f'val_{IDS}.npy')
 
-    trn_lbls = np.load(dir_path / 'tmp' / f'lbl_trn{train_file_id}.npy')
-    val_lbls = np.load(dir_path / 'tmp' / f'lbl_val.npy')
+    trn_lbls = np.squeeze(np.load(dir_path / 'tmp' / f'lbl_trn{train_file_id}.npy'))
+    val_lbls = np.squeeze(np.load(dir_path / 'tmp' / f'lbl_val.npy'))
     trn_lbls -= trn_lbls.min()
     val_lbls -= val_lbls.min()
     c=int(trn_lbls.max())+1


### PR DESCRIPTION
Hi!
        I was getting the following error when reproducing imdb experiments, running train_clas.py script:

```
 ~/sa/fastai_ulmfit$ python -u train_clas_bugy.py data/imdb_clas/ --cuda-id 0 --cl `50`
dir_path `data/imdb_clas/;` cuda_id 0; lm_id ; clas_id None; bs 64; cl 50; backwards False; dropmult 1.0 unfreeze True startat 0; bpe False; use_clr True;use_regular_schedule False; use_discriminative True; last False;chain_thaw False; from_scratch False; train_file_id 
Epoch:   0%|                                                                                                                                                                                 | 0/1 [00:00<?, ?it/s]
Traceback (most recent call last):                                                                                                                                                         | 0/782 [00:00<?, ?it/s]
  File "train_clas_bugy.py", line 145, in <module>
    if __name__ == '__main__': fire.Fire(train_clas)
  File "/mnt/datuak/virtualenvs/keras2-py3.6/lib/python3.6/site-packages/fire/core.py", line 127, in Fire
    component_trace = _Fire(component, args, context, name)
  File "/mnt/datuak/virtualenvs/keras2-py3.6/lib/python3.6/site-packages/fire/core.py", line 366, in _Fire
    component, remaining_args)
  File "/mnt/datuak/virtualenvs/keras2-py3.6/lib/python3.6/site-packages/fire/core.py", line 542, in _CallCallable
    result = fn(*varargs, **kwargs)
  File "train_clas_bugy.py", line 97, in train_clas
    use_clr=None if use_regular_schedule or not use_clr else (8,3))
  File "/mnt/datuak/virtualenvs/keras2-py3.6/lib/python3.6/site-packages/fastai/learner.py", line 287, in fit
    return self.fit_gen(self.model, self.data, layer_opt, n_cycle, **kwargs)
  File "/mnt/datuak/virtualenvs/keras2-py3.6/lib/python3.6/site-packages/fastai/learner.py", line 234, in fit_gen
    swa_eval_freq=swa_eval_freq, **kwargs)
  File "/mnt/datuak/virtualenvs/keras2-py3.6/lib/python3.6/site-packages/fastai/model.py", line 129, in fit
    loss = model_stepper.step(V(x),V(y), epoch)
  File "/mnt/datuak/virtualenvs/keras2-py3.6/lib/python3.6/site-packages/fastai/model.py", line 52, in step
    loss = raw_loss = self.crit(output, y)
  File "/mnt/datuak/virtualenvs/keras2-py3.6/lib/python3.6/site-packages/torch/nn/functional.py", line 1161, in cross_entropy
    return nll_loss(log_softmax(input, 1), target, weight, size_average, ignore_index, reduce)
  File "/mnt/datuak/virtualenvs/keras2-py3.6/lib/python3.6/site-packages/torch/nn/functional.py", line 1052, in nll_loss
    return torch._C._nn.nll_loss(input, target, weight, size_average, ignore_index, reduce)
RuntimeError: multi-target not supported at /pytorch/torch/lib/THCUNN/generic/ClassNLLCriterion.cu:16
```

It seems the labels have not the appropiate shape. I've taken the solution from the jupyter notebook of the lesson: 
https://github.com/fastai/fastai/blob/ffb2caaf22ea0ebd30f6dbb260021aeebfacc90c/courses/dl2/imdb.ipynb#L1174

Cheers!

  