### PR TITLE
Flatten target values array to feed into model

### DIFF
--- a/courses/dl2/imdb_scripts/train_clas.py
+++ b/courses/dl2/imdb_scripts/train_clas.py
@@ -48,6 +48,9 @@ def train_clas(dir_path, cuda_id, lm_id='', clas_id=None, bs=64, cl=1, backwards
 
     trn_lbls = np.load(dir_path / 'tmp' / f'lbl_trn{train_file_id}.npy')
     val_lbls = np.load(dir_path / 'tmp' / f'lbl_val.npy')
+    assert trn_lbls.shape[1] == 1 and val_lbls.shape[1] == 1, 'This classifier uses cross entropy loss and only support single label samples'
+    trn_lbls = trn_lbls.flatten()
+    val_lbls = val_lbls.flatten()
     trn_lbls -= trn_lbls.min()
     val_lbls -= val_lbls.min()
     c=int(trn_lbls.max())+1


### PR DESCRIPTION
RNN_Learner users cross-entropy loss that expects a single label for each sample, so this cannot work for multi-label classification out of the box, furthermore, we need to flatten the data to prevent mismatched shape errors.