### PR TITLE
Fix Dimension error in dl1 movielens EmbeddingDot model #599

### DIFF
--- a/courses/dl1/lesson5-movielens.ipynb
+++ b/courses/dl1/lesson5-movielens.ipynb
@@ -1538,7 +1538,7 @@
     "    def forward(self, cats, conts):\n",
     "        users,movies = cats[:,0],cats[:,1]\n",
     "        u,m = self.u(users),self.m(movies)\n",
-    "        return (u*m).sum(1)"
+    "        return (u*m).sum(1).view(-1, 1)"
    ]
   },
   {

--- a/courses/dl1/lesson5-movielens.ipynb
+++ b/courses/dl1/lesson5-movielens.ipynb
@@ -1737,7 +1737,7 @@
     "        um = (self.u(users)* self.m(movies)).sum(1)\n",
     "        res = um + self.ub(users).squeeze() + self.mb(movies).squeeze()\n",
     "        res = F.sigmoid(res) * (max_rating-min_rating) + min_rating\n",
-    "        return res"
+    "        return res.view(-1, 1)"
    ]
   },
   {


### PR DESCRIPTION
Add a dimension to the forward method of the EmbeddingDot model in dl1 movielens notebook to match output target dimension.

Resolves #599 