### PR TITLE
API changed: s/accuracy/accuracy_np/

### DIFF
--- a/courses/dl1/lesson1-rxt50.ipynb
+++ b/courses/dl1/lesson1-rxt50.ipynb
@@ -218,7 +218,7 @@
     "log_preds,y = learn.TTA()\n",
     "probs = np.mean(np.exp(log_preds),0)\n",
     "\n",
-    "accuracy(probs,y)"
+    "accuracy_np(probs,y)"
    ]
   },
   {


### PR DESCRIPTION
This change fixes the error below by bringing this notebook up-to-date with the API changes.

http://forums.fast.ai/t/lesson1-ipynb-error-typeerror-torch-max-received-an-invalid-combination-of-arguments-got-numpy-ndarray-dim-int/10707/24

---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-10-0ea0e0408d35> in <module>()
      2 probs = np.mean(np.exp(log_preds),0)
      3 
----> 4 accuracy(probs,y)

/mnt/disc1/fast.ai/fastai/courses/dl1/fastai/metrics.py in accuracy(preds, targs)
      7 
      8 def accuracy(preds, targs):
----> 9     preds = torch.max(preds, dim=1)[1]
     10     return (preds==targs).float().mean()
     11 

TypeError: torch.max received an invalid combination of arguments - got (numpy.ndarray, dim=int), but expected one of:
 * (torch.FloatTensor source)
 * (torch.FloatTensor source, torch.FloatTensor other)
      didn't match because some of the keywords were incorrect: dim
 * (torch.FloatTensor source, int dim)
 * (torch.FloatTensor source, int dim, bool keepdim)