### PR TITLE
DL1 lesson 3: add missing import: display

### DIFF
--- a/courses/dl1/lesson3-rossman.ipynb
+++ b/courses/dl1/lesson3-rossman.ipynb
@@ -167,7 +167,7 @@
    },
    "outputs": [],
    "source": [
-    "from IPython.display import HTML"
+    "from IPython.display import HTML, display"
    ]
   },
   {


### PR DESCRIPTION
The line
for t in tables: display(t.head())
gave me an error before ...