### PR TITLE
Updates image scaler to be more efficient

### DIFF
--- a/fastai/transforms.py
+++ b/fastai/transforms.py
@@ -365,8 +365,7 @@ class Scale(CoordTransform):
 
     def do_transform(self, x, is_y):
         h,w,*_ = x.shape
-        intpr = cv2.INTER_AREA
-        if(self.sz_y < min(h, w)) : intpr = cv2.INTER_LINEAR 
+        intpr = cv2.INTER_LINEAR if(self.sz_y < min(h, w)) else cv2.INTER_AREA
         if is_y: return scale_min(x, self.sz_y, intpr if self.tfm_y == TfmType.PIXEL else cv2.INTER_NEAREST)
         else   : return scale_min(x, self.sz, intpr)
 

--- a/fastai/transforms.py
+++ b/fastai/transforms.py
@@ -364,7 +364,7 @@ class Scale(CoordTransform):
         self.sz,self.sz_y = sz,sz_y
 
     def do_transform(self, x, is_y):
-        h,w,_* = x.shape
+        h,w,*_ = x.shape
         intpr = cv2.INTER_AREA
         if(is_y < min(h, w)) : intpr = cv2.INTER_LINEAR 
         if is_y: return scale_min(x, self.sz_y, intpr if self.tfm_y == TfmType.PIXEL else cv2.INTER_NEAREST)

--- a/fastai/transforms.py
+++ b/fastai/transforms.py
@@ -366,7 +366,7 @@ class Scale(CoordTransform):
     def do_transform(self, x, is_y):
         h,w,*_ = x.shape
         intpr = cv2.INTER_AREA
-        if(is_y < min(h, w)) : intpr = cv2.INTER_LINEAR 
+        if(sz_y < min(h, w)) : intpr = cv2.INTER_LINEAR 
         if is_y: return scale_min(x, self.sz_y, intpr if self.tfm_y == TfmType.PIXEL else cv2.INTER_NEAREST)
         else   : return scale_min(x, self.sz, intpr)
 

--- a/fastai/transforms.py
+++ b/fastai/transforms.py
@@ -364,8 +364,11 @@ class Scale(CoordTransform):
         self.sz,self.sz_y = sz,sz_y
 
     def do_transform(self, x, is_y):
-        if is_y: return scale_min(x, self.sz_y, cv2.INTER_AREA if self.tfm_y == TfmType.PIXEL else cv2.INTER_NEAREST)
-        else   : return scale_min(x, self.sz,   cv2.INTER_AREA   )
+        h,w,_* = x.shape
+        intpr = cv2.INTER_AREA
+        if(is_y < min(h, w)) : intpr = cv2.INTER_LINEAR 
+        if is_y: return scale_min(x, self.sz_y, intpr if self.tfm_y == TfmType.PIXEL else cv2.INTER_NEAREST)
+        else   : return scale_min(x, self.sz, intpr)
 
 
 class RandomScale(CoordTransform):

--- a/fastai/transforms.py
+++ b/fastai/transforms.py
@@ -366,7 +366,7 @@ class Scale(CoordTransform):
     def do_transform(self, x, is_y):
         h,w,*_ = x.shape
         intpr = cv2.INTER_AREA
-        if(sz_y < min(h, w)) : intpr = cv2.INTER_LINEAR 
+        if(self.sz_y < min(h, w)) : intpr = cv2.INTER_LINEAR 
         if is_y: return scale_min(x, self.sz_y, intpr if self.tfm_y == TfmType.PIXEL else cv2.INTER_NEAREST)
         else   : return scale_min(x, self.sz, intpr)
 


### PR DESCRIPTION
Uses a better mechanism to change scale of image if it's expanding. CV_INTER_LINEAR  is a better choice than CV_INTER_AREA for expanding an image. CV_INTER_AREA is better for shrinking an image.

References #618 