### PR TITLE
add missing lesson1-breeds.ipynb notebook.

### DIFF
--- a/courses/dl1/lesson1-breeds.ipynb
+++ b/courses/dl1/lesson1-breeds.ipynb
@@ -1,0 +1,5952 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Dogs breeds\n",
+    "\n",
+    "https://youtu.be/JNxcznsrRb8?t=1h31m8s"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%reload_ext autoreload\n",
+    "%autoreload 2\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastai.imports import *\n",
+    "from fastai.torch_imports import *\n",
+    "from fastai.transforms import *\n",
+    "from fastai.conv_learner import *\n",
+    "from fastai.model import *\n",
+    "from fastai.dataset import *\n",
+    "from fastai.sgdr import *\n",
+    "from fastai.plots import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "torch.cuda.set_device(0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Kaggle Dog Breed Identification. Get data from https://www.kaggle.com/c/dog-breed-identification"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PATH = \"data/dogbreed/\"\n",
+    "sz = 224\n",
+    "arch = resnext101_64\n",
+    "bs = 58"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "label_csv = f'{PATH}labels.csv'\n",
+    "n = len(list(open(label_csv))) - 1 # header is not counted (-1)\n",
+    "val_idxs = get_cv_idxs(n) # random 20% data for validation set"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10222"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2044"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(val_idxs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If you haven't downloaded weights.tgz yet, download the file.\n",
+    "#     http://forums.fast.ai/t/error-when-trying-to-use-resnext50/7555\n",
+    "#     http://forums.fast.ai/t/lesson-2-in-class-discussion/7452/222\n",
+    "#!wget -O fastai/weights.tgz http://files.fast.ai/models/weights.tgz\n",
+    "\n",
+    "#!tar xvfz fastai/weights.tgz -C fastai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initial exploration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "info.txt    sample_submission.csv  test      tmp    train.zip\r\n",
+      "labels.csv  subm\t\t   test.zip  train\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!ls {PATH}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "label_df = pd.read_csv(label_csv)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>breed</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>000bec180eb18c7604dcecc8fe0dba07</td>\n",
+       "      <td>boston_bull</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>001513dfcb2ffafc82cccf4d8bbaba97</td>\n",
+       "      <td>dingo</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>001cdf01b096e06d78e9e5112d419397</td>\n",
+       "      <td>pekinese</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>00214f311d5d2247d5dfe4fe24b2303d</td>\n",
+       "      <td>bluetick</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0021f9ceb3235effd7fcde7f7538ed62</td>\n",
+       "      <td>golden_retriever</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                 id             breed\n",
+       "0  000bec180eb18c7604dcecc8fe0dba07       boston_bull\n",
+       "1  001513dfcb2ffafc82cccf4d8bbaba97             dingo\n",
+       "2  001cdf01b096e06d78e9e5112d419397          pekinese\n",
+       "3  00214f311d5d2247d5dfe4fe24b2303d          bluetick\n",
+       "4  0021f9ceb3235effd7fcde7f7538ed62  golden_retriever"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "label_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>breed</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>scottish_deerhound</th>\n",
+       "      <td>126</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>maltese_dog</th>\n",
+       "      <td>117</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>afghan_hound</th>\n",
+       "      <td>116</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>entlebucher</th>\n",
+       "      <td>115</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>bernese_mountain_dog</th>\n",
+       "      <td>114</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>shih-tzu</th>\n",
+       "      <td>112</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>great_pyrenees</th>\n",
+       "      <td>111</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>pomeranian</th>\n",
+       "      <td>111</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>basenji</th>\n",
+       "      <td>110</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>samoyed</th>\n",
+       "      <td>109</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>airedale</th>\n",
+       "      <td>107</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>tibetan_terrier</th>\n",
+       "      <td>107</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>leonberg</th>\n",
+       "      <td>106</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cairn</th>\n",
+       "      <td>106</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>beagle</th>\n",
+       "      <td>105</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>japanese_spaniel</th>\n",
+       "      <td>105</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>australian_terrier</th>\n",
+       "      <td>102</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>blenheim_spaniel</th>\n",
+       "      <td>102</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>miniature_pinscher</th>\n",
+       "      <td>102</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>irish_wolfhound</th>\n",
+       "      <td>101</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lakeland_terrier</th>\n",
+       "      <td>99</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>saluki</th>\n",
+       "      <td>99</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>papillon</th>\n",
+       "      <td>96</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>whippet</th>\n",
+       "      <td>95</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>siberian_husky</th>\n",
+       "      <td>95</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>norwegian_elkhound</th>\n",
+       "      <td>95</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>pug</th>\n",
+       "      <td>94</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>chow</th>\n",
+       "      <td>93</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>italian_greyhound</th>\n",
+       "      <td>92</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>pembroke</th>\n",
+       "      <td>92</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>german_short-haired_pointer</th>\n",
+       "      <td>75</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>boxer</th>\n",
+       "      <td>75</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>bull_mastiff</th>\n",
+       "      <td>75</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>borzoi</th>\n",
+       "      <td>75</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>pekinese</th>\n",
+       "      <td>75</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cocker_spaniel</th>\n",
+       "      <td>74</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>american_staffordshire_terrier</th>\n",
+       "      <td>74</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>doberman</th>\n",
+       "      <td>74</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>brittany_spaniel</th>\n",
+       "      <td>73</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>malinois</th>\n",
+       "      <td>73</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>standard_schnauzer</th>\n",
+       "      <td>72</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>flat-coated_retriever</th>\n",
+       "      <td>72</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>redbone</th>\n",
+       "      <td>72</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>border_collie</th>\n",
+       "      <td>72</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>curly-coated_retriever</th>\n",
+       "      <td>72</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>kuvasz</th>\n",
+       "      <td>71</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>chihuahua</th>\n",
+       "      <td>71</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>soft-coated_wheaten_terrier</th>\n",
+       "      <td>71</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>french_bulldog</th>\n",
+       "      <td>70</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>vizsla</th>\n",
+       "      <td>70</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>tibetan_mastiff</th>\n",
+       "      <td>69</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>german_shepherd</th>\n",
+       "      <td>69</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>giant_schnauzer</th>\n",
+       "      <td>69</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>walker_hound</th>\n",
+       "      <td>69</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>otterhound</th>\n",
+       "      <td>69</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>golden_retriever</th>\n",
+       "      <td>67</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>brabancon_griffon</th>\n",
+       "      <td>67</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>komondor</th>\n",
+       "      <td>67</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>briard</th>\n",
+       "      <td>66</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>eskimo_dog</th>\n",
+       "      <td>66</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>120 rows × 1 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                 id\n",
+       "breed                              \n",
+       "scottish_deerhound              126\n",
+       "maltese_dog                     117\n",
+       "afghan_hound                    116\n",
+       "entlebucher                     115\n",
+       "bernese_mountain_dog            114\n",
+       "shih-tzu                        112\n",
+       "great_pyrenees                  111\n",
+       "pomeranian                      111\n",
+       "basenji                         110\n",
+       "samoyed                         109\n",
+       "airedale                        107\n",
+       "tibetan_terrier                 107\n",
+       "leonberg                        106\n",
+       "cairn                           106\n",
+       "beagle                          105\n",
+       "japanese_spaniel                105\n",
+       "australian_terrier              102\n",
+       "blenheim_spaniel                102\n",
+       "miniature_pinscher              102\n",
+       "irish_wolfhound                 101\n",
+       "lakeland_terrier                 99\n",
+       "saluki                           99\n",
+       "papillon                         96\n",
+       "whippet                          95\n",
+       "siberian_husky                   95\n",
+       "norwegian_elkhound               95\n",
+       "pug                              94\n",
+       "chow                             93\n",
+       "italian_greyhound                92\n",
+       "pembroke                         92\n",
+       "...                             ...\n",
+       "german_short-haired_pointer      75\n",
+       "boxer                            75\n",
+       "bull_mastiff                     75\n",
+       "borzoi                           75\n",
+       "pekinese                         75\n",
+       "cocker_spaniel                   74\n",
+       "american_staffordshire_terrier   74\n",
+       "doberman                         74\n",
+       "brittany_spaniel                 73\n",
+       "malinois                         73\n",
+       "standard_schnauzer               72\n",
+       "flat-coated_retriever            72\n",
+       "redbone                          72\n",
+       "border_collie                    72\n",
+       "curly-coated_retriever           72\n",
+       "kuvasz                           71\n",
+       "chihuahua                        71\n",
+       "soft-coated_wheaten_terrier      71\n",
+       "french_bulldog                   70\n",
+       "vizsla                           70\n",
+       "tibetan_mastiff                  69\n",
+       "german_shepherd                  69\n",
+       "giant_schnauzer                  69\n",
+       "walker_hound                     69\n",
+       "otterhound                       69\n",
+       "golden_retriever                 67\n",
+       "brabancon_griffon                67\n",
+       "komondor                         67\n",
+       "briard                           66\n",
+       "eskimo_dog                       66\n",
+       "\n",
+       "[120 rows x 1 columns]"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "label_df.pivot_table(index=\"breed\", aggfunc=len).sort_values('id', ascending=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "run_control": {
+     "marked": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "tfms = tfms_from_model(arch, sz, aug_tfms=transforms_side_on, max_zoom=1.1)\n",
+    "data = ImageClassifierData.from_csv(PATH, 'train', f'{PATH}labels.csv', test_name='test', # we need to specify where the test set is if you want to submit to Kaggle competitions\n",
+    "                                   val_idxs=val_idxs, suffix='.jpg', tfms=tfms, bs=bs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'data/dogbreed/train/001513dfcb2ffafc82cccf4d8bbaba97.jpg'"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fn = PATH + data.trn_ds.fnames[0]; fn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAfQAAAF3CAIAAADckC6rAAEAAElEQVR4nJz9d5xlWXIVCkfE3vuYazNvmvLedLU3093jNI5BIwtCDglJyCAhzIce6EOA9NB78AHi8eAhEAiQMLJIM8iORqPRGI3G9/S4HtemvK9Kf29ee87Ze0fE++NkZhejQaDv/OpXnXU777nm7LN2xIq1IvAVJw9ZaxLrrEECMQiJNc7CbDQ0pIkhR2hQVUUii8aIDhUAxQAYJDJARAhGAMqoVdSARsgFMVXkGLlhq/F46n1M0kbishi0DCIMxlkAQEPWEloUDVVVeO/bWZuIrKHM2TSxjcRmFlMSB75hpGEko5giJ8SpQWuQoQC1NsmTvOUj9oezWcEAKAx5ljSy1GgM5URjmRhKnC1QqypMpsWsjCLgXJKljcwlzUYiocysLs7l3Txp5XZ5qXtg33JnoT8eTdrziyHC1at3stYcudanP/t8t3fgwMHjX3j+pfe99+LKKrzlLfu/5Zv//GQy+cVP33jHO9+fZtRsd4bjgpIsREmz1mRWqKoqGlQiMkhEBKAHIE6nUyLYt7Rgrbl44c6pkz0iXZjvgobUmX37Fm/euNbpdDj4EEKzlVWzopXl0+G0Nze3tbWVNHIv7DEWsVxeXiymI4qxk7pyezjXbJdl1sxTZt9p58Pt9U47TxKzvG/xxZdeOn3fuWlVzap4+r6Hnv30Zy9fWS1LwIffMC3i4r6j7/jdDywtn/AVhGKWGC9xNU2GLhNKoBCYFBCwg6bbGMy8L5Gk0bQmwRBnIpEsMiuoEUhAUtAU1IE6BeJkBQFICRVIAZUQAJQUQQEFQcgIAhMIggKlsYT/8aGqez8jIgBEEFVFBWOMcw4RJTIzO+di5UXEOYcAIQQiSpKkivplzywiuHuoqqqKiKqKI0Q0gCAqIsqCqgBgrbXWGucUgZkDRwZFRGbPzKqaJEmepkQUQog+WGsJsP4IKIqIxhhr7VinrVarkeWqGiMTUWIskZXIRBYRUUEVmTnGKCIU+9Y4NBQCF0UxK70qAloEo2QQCMiAUr32VNWmcu/HrNchGYgxcoiqCiD1Ya3N09RAOp1Om3kmMRiS1NF4tO0SUmVWUQtgISJEATXgHNpNVQUgIAscoWIgY2yST4tSwAJaIQNALOAjxxg7VFprRSSE6BKX580gPB6PG81mCEFAEbHwXgQWF3uHDh2SjdtpmjbSjJlnk2lZTK21eZ4TofdegI2zEbWoKgW2zqXeGGOISBFEhFnq6x2juCy11sYgs7Lw3hORc25SzLIsq9+StTbLsvqS1f93NpvNZjNV9d6HIHmefO1R/yM/8sO//Zu/Pj/X6bZaiDg3N/frv/2ewRgeeeK+7/krf+O7/8oPbU0gn+swJoPxuIvRGGOMAUJEJLJJkjjnWDWE4H2MMQpo/TtEdNBOPne+eviM/aZv+qZf+7Vf+97v/d4LFy584AMfP3Xq0B9+9M59J+AnfuInmPl973sfIm5tbU2Qut3uc8899x3f8R222WwQoALHGDlUEgOBGpJOqwkxeB8riQSaWHLOpraBUQHAoBIAgSAiqigAKObOpKkLgkUQ4YpYgKOAR2EDSqCWjMkoSQiMnYxniqAcvQgEAVBAcM4BADMLxxAqX1FIjE9MbqBh0VixgA4NIzBiBARF43JRZMTJZDocV4PtcRXUmmRpYSFxNiElxCRPVdASWkIBdcamadryEgL7qAASYlVVChwcoo8yC0EhJEPr3KDkwXA4nhSa5W1yjqMKxuXFpUarOxxsHzly5Fu/bd/VKzeu37g1HE+uXr2+tbktAoiogohokcSgRLaERHYP1g2hMcYiVf21M2dOra2t3by5+vf+3t9621t/Zbi9eezY0Vu3bqnw0cP77t5dPXbsxGi0Xc7CSy9tzi3AZAQpQSOBhYXlZntOCRWiD2Bs4gMPhmPHms11RGlWVp1WzxLEEAnEOZMkFkm8L1//utdeuXHTmmSu033xhS8u9uaffupVP/VTb7/5wQ+ZFL/yBx/7Rx/+zQeffO39Z+7rV9t5mqB1o4mGAOgQm63mXHt7FtWqy/K0mSNy5Go8GUWOaYqZaxSxACBSABCACEAAAEAMpAACQAigBAAKAFhDc43PooqqoAAA/Mcg+5c96lPU56qhfw+aAaAGUATYQWoRRPqy5yGi+mz1CffOXJZlnudZloFoVVUsao2x1sYY65OzSowRANI0TdM0xqp+JyKiIiEEREzTlIgsGWstAABL/X4AIFS+pEJZmBlYEbFAVMWqKOv1U8dS9XtS1V47NcYAYFQBImMMCxChj5F9YFZRILLOOetSZx2ZGrpZVQlQVFQ1Rt2J0hCNMSISoyciIKqqSpHJgSqIiiC5NGk0sqKYiYoCKAALxygqAOBswqAKSECkqCCRAVElcVlUCJHZRwByzjU7zTRNZTZU1RgjGSaiqBJj1BoERMgaa62qVjHEGKbTSU4YY5xBaQBr8K0Ro9XqKEKM3iQucdYmSYxRUaSMxhjjLCKKCEAMMYqIcwkAcFRFyLIsTdMaapUwSZIa0EVkNpvFGMuyzLIsSZKqqkIIzjljjKoaY754Ef7xP/tXL74EP/nPv/OhBx5sthrve+97n371KynLP/bJ5/7VT//7y7dg/6EkMhbiW+35JhaqyszMLALGgDEGjcnz3NqEqPIx1NFAfZ1mEhe6kLe7v/H2d9xagXFRrfe306Zrduf/5g+94pOf/OQP/52/f+TIgX6/32q1vv7rv/7C7ZXBYHD95uwXf/mtNvgSFVRVOTAHBCUkUBIBVRBREFBCRktoEI1FQURDYBBQBZRVVTWGKiRpnjqXEiIra6UsBmSu08oT56uoYAGiiAFVUEgsiEgQZg6qggacczYhFGLmEKOKRNAQMHrnrURnowMRI6LBQCYYLCZgKTAgokAIXFaBADuNpNls5w4ciSNwBtEagsyQEJFDYNbKR4KICgAcA4tiVVUqTIjTMjCHgjgKVyydalqWfjQbtDpKlBRFJYV02+3+cLi6sW1sfub+R166eO32ql6/u3p7ffP2yoYqEFkRUEUicmh8YFQwiM4YIgKOxGhBjDHNVnp35XavO9duZsPtfrOZz3WPzSbjQ4cOcSyLorh+fbS5vpGk9vDBA69+de/q3TsAs3KiQaAKOi3CLFRps6EmcSaJgpEJmAFd1uhY1dQRS1Bl67DbaS302hJ9nrjh9ubiXNvYbFxUmbWdVnPfQm9xAV5//4Prmxs/+8//3VNnG+/5pR/7S3/1//qhv/bnfuJfvv2+oz0tOnlz/8r2eHtYaDuOwmDh0FJ/WjQaWZYngmrTFkolKsNxaa0jBQBAEAAGLAEIlXQHKkm0xnTY+TVCBVCoHxVQRQWGLx9W/zEHEdWRO/z3cX0diVtrjTEIUMOxiCCZP36f2PuhPnONNd57S8Y5Z8lIjCEE3T1qLIjCKWGSJHUCQURVVRXTaYyxBv2iKMiiqhJRjWX1+wGR6L3EKCIqUENSqGKMEepgD5FwF+URQar6Q4kCkKZ5YlxqbVJVPkTZCQZZAlesMURCxBo7DGKSJDu7C8BkPEWQOv+okwYAZlbjwFh0DRfFV2XgKnofKEnVpMqqCCwowpEZBIFctKSqiKhEHGOkSgQkgvelMcZZ46wBACJNMDhAydKyLAXBJA4QQwiRuQ6cFQFJrSMkpyWHUA2HgyzBIDHG6Mgk1qV5Fn0IIdRfYBWiJcisMcZE4RjEEta5FCIyS2SuMwsGZe85KhDWYbIqxhjrb3gn2N/Z/utdYWclJEmS57mI1Cjf6xYHTt//Z7/tiWEw73vm0zeuXQfC17/hjR/6yMcv3hgNL47yFmTt+TsbQw+03Gmg90RIZI0RZhaAKCLeG+P2XqVG//qfl9b56adPqOrnntv65V/6Z88+++yBE2df8do3/tIv/dKtje2iCIUC5p1HX/nACy+88M/+9S929s+HENKOm7G1oZjVix8ADJKxJjFkyUxmU2dsYp21qUFS1Yq5jKGBRKSEBgkQkOogS8WhOOBEGQzaBDNwlWMWabVy79ws8b4KPrBnBjDAkhr0oMIMAGDJWiJLCAoIRGiNYQAFETUVswgyV95j6XVqKLfaSG2WuNSBITKIBlGZ0jRrplkjy5t5Nh1uOyu5SQypaERU51ySuDxLRuNpNau48kYps05dIqzT6RRQC08wm80MOJSSoRQTrKZppyzDpJrMtTshsPdlo9VFhV63d+3Wyp27ax/5+G1F+K3fe+9kFvsxdxYQXAjMUUTAEvnonTEWyQEgM4fAHBBJLaXN5Mb17X1Lvfvvf/Bd73qndXT0yOlLFwbXr948dfpo5pI3veF4UcyU5cb1OwuL8wvLh2gZi+1RLOOkjFvDaRXCgc5c5EAELJg12jYGYbQuaySJdWTBIaSddq5i23lSViEx4pKUFbZH/a3+6NyDj1KSXzr/fDOFwzQ8c7r3hscP/8q//Bc/9b6f//5vnj+2uPnXvvXgb//23SLCcvsctA+3MZTZZLi6Pt5eWW4eVMRZ5VUlTRqZaxXFdDbabtsEUVABUBEC1KE7AqNBBcKdNUcKggAgiAbqQBtEVRVUoN4I8E8E7rtMys5Noqqgioh1tlTH4zVS1ygm+OXPv/PcP/LPZrM5m81G01nqkna7ba0rYpxOp91ut4aD+mDmsixFhEhrDK0BSHaPqqqURUSISCPHGGvMTZ0jIGUlBSRDRJ69iGRZxloTCyzCqIKCRLQ5rKytrAVryZB1aeIcWmdc2gIABRSBEIL3PgSOMWpEBWERJdw9mzBzmiT11+KcU1VEQ0TOmUK3LVqwok4wABjHPlRREZOoKopABhUQhNBaSgrxooKgDoyQiQiMQURrVgSViYAACVGrynuMrjktS2bOsowQo7CAJlnKEkjqbVWIwBgUDuVs4qmJiAY1qlhQCwYossq0KLz3kaMgAJVAFDnGGFOTqOoO+vNO9obWiEhkjRw1qpIxxuzkfKh14lXvnfUXcu8PIpIkSR16I+KVTXB3t/edrH7rN37DEvgSXvvax65vTH73D5+ZMrCBuaXFmRi2qXXZ1CsWRZIkaZqmLgXYuTTex8Djnd0aoN6/kRQA8h5x0nzLW95y+Mz5d33gow888MDP/dzPvfDS5gPnFt73ydvnTrYha7//mQuPPuo7vX3NxWkJ6aioFhcP3Llzxyau3qAQWBBEglRRPWL0QRygSQCMArFwCBpjRENkMDEKhgwpKIAiqnabLQBAjUY1Tw0kqecYo0yKGakmyGTQITZTK2AFcDiekEaj4qyxqSVrYozBeyBTXwBjzO59JUEleC1BXCWOODXQTNNmA7PEtPKcVFA4AUxMklggCX5SGAk5Yu4sIlQxAoB1Sd5Ic6sVsYOYGTFJalwjqvGRZ7OZAARVLgQwOkPBiJhYbvKhg70qzqajoWqapS4GLQu/vrKGSTNvtte2+ovL0F06+IcfvdtsQZlylrdFNHIUgVixzRwIW2cdglEhYQJBAgI2olVRHj2SOYeD/nqSWmfMysrKwsLCwQP7Qlldv3G7KsosdUmSOJfMdReubw3yNGNwWZ4L2EZrDstS0flYogKRNvIO+XI2K11u1BIYyRKbubzZzKuZl1iJL4DcocP7r9+8tdzrSogYy+3t4dqtu089euap0/Mf+ugnD506iyXcePc7f/gnfuxX/+U//r5vf0vY/r3Pfrpcu3NxAvNzcwcPLfcSWPK23zId7/1sNqsKLlmUraGs015QZgBREARRYlQREgAQaBECA+AuUwMgpCDAgCCgoIqgBFznk4DJnxTcAQDvgWPajcUMIADEGBGAiOrMWvV/uHncy+rsPVjHU/VN7r1Hlzjn2u12fefXqXqj0bAxBOEQgkgIIVhrd4JuImYuiqJe3jtsjAgi1mdADEQkqqpqrUNrCFEEsiyLojFGRRQBBVBCRXAZIIIAVFFAPYVYlN4Yl+e5MS5JEpe4LGsiturX0mB2sX4n2g3ehxCyLKs/WoxRd17dGmOqUEVT+ZAyB5OYLGuIKGIigiqqYBEcAhpQS0li0lG5LcyImCigmggGQJUkS5rBz0IVEcBaSAkRCVQqzr2oCkQVUuD6glk06ogDgDKHuhIAoKKxCj5PM+MSYKliEBKJOwkTWZNaIwjCgKg1XseS66qCQUKSqCJAqKoI9QcM8t9TdkQiEqJIXavZjaDTNAU0kZVZsAoxxqoKlnVuceHK+uRzP/cbiQNDgAJvf9/nfu+Dn8taaXOxO9zoF6MygE8bc66RD0eTFhlFAjJoCBFJBSKKogaxlpyzRES4c7Mg4r7Dh2/c3frf/8FPvvKVj964ceO33/m+paWl+x86evPWrXYLXGPee9+a5xcu3igKOXfuhHOt7UmIkK4M2GKMoIr1kgWEHQJQrLUCOisClnGPeUS0ZRBiZascxRpwpEYRgRAMR88cLVFNWllmiNEZAjIOTcA647ZVkKLyGAqjaB2ZhFxid8IdYdYKwSCRkqnvlljf70wIUgkQgEUoYpipTT0XERxigpAR2owMEUngUKYGLEanEeogx5CzYIzOBpvsQyPFNMmUEgaMZRU9W2dEgUErjhzBiIrnQJEnpUmjBJmOoiXf6zplilVcX99c2Vw98/B912/effDxJ8dek9bd7v7WsB/TNJtMC1VMTBJjRFUCgMgxhjqWsgDOoCE0AFnuVDXNkhs3rp88eXxzY2M6HhZEeZZMR+N9S0sAOj+/cPPmzTzJZuMZAFRVAB9dK5coC3O9jUH/zp2VuaV5MlgU48yQMU5NSKwLVRyGmTQza1Q0CFeEaZ5gp5lNRpvzndw6M224Y4f2n790gyS88snHr118z7knHrhyddTI8dqlUXf+wkOnT+3vyd/5G1/38Q+tvfsdV1+8PBxvj7bHRbczjRZWw1XnXJ5kzU5aFr4qSmuSPG8WsRCMAAQYARkQABVAFLEuaRFqnYVifeOCqjIACNSIK/Qn52RqLN6rgu7B/U4UhlRHzTW4E5FIzRv/cWfbA/f6FhiPx2madjodiVxVFYfYbbcXFxdXV1cBQLEOeamu1NUQWYM4EVljiCjGyBz3ykt1QbV+P9Za4EiABlFBEZAALZIlE2NkhVgDdH0/EgGicelegqKqUZCDUvBl6esPbq2tQ8XEpdba3KWpNZy4GGMIIYSQuURECl/tbV31NlAnIsaAJRCJVVUqo0XrywqA86ylO5dURJWiIhJFgwAioBoJyNZfuzGGcDqdJs60us1GmhqL0VfT6dSXil2XZA3RKIgqjESAWuOPGgCOIsISAZUMEEBZVWmWkTWsykFVo0EENPzyU1hESG2dAlZFlaZp2shM4lTV+1gFH2MUBjCAWBcskIiMtdYlAiLCUVhVBTQK17hfBY+GonDkCBFjjKziDPULBqFosrSRdec6W+vrBw8vTyaTVqvDiEkjVlF9lDCbJYCKJm90VLXyUvlZnUcqkHG2LEtUMlKXQGJ9IYjo0vWby8vLr33ja9713me++k+/6ubNm89fuH3gwFx3cZmIbq6sVVV14sQJZl5dXQ1At+9ujEZF3oY8Ty1whQC4s3Ht1PpjQOecCARhiaK4k8YSWc+CihyBSY2AQ3QEpDiclgRCoEIM4A0CIhqEdp4RURSIUUQxihazyWw0AdFGlmWNjGwiIoEZLWYmmZQKwKIKrIy7tC1iBEI0ZJ2qCIgwVKW6wNNZaKRJKyE2mpA0nU2JrLGJUYhVVQS0ZJwla1W5rGazYT/L8rlWKwJNZnE2HVcli5IxBolQMShElsDAhUxjiWJurU8tRIy4NSq9F4eSJMnC0oE7m7d8kI2tUWxM+hOPOaxtz1RSMo555pxzNi2KAgQJsJG4GCoNkVCyxKTOOgRVnZ/v3Lx5S+ICEWysr6oqoq6u9A/tn8uybP/+/dv9weZGP1axMbfAzPOddqy8ElnQu2t3m0dPtLJsZXVCCx1nks3hqNweLHW7++a6++bm1u+sSC4lB8tcVYUIJxZdms7PNVDBufTK9VsQAUKRGXnogTPjweaV4fCVZ546O//Uf3nHL37Ldz859+jTrMNPP/OeVzz80Ftes3Qoyfvr3RcurH76+U9gDlsT4GY1nVbgJ83OXJ65UeAQKw3OIAo4RRFCRVViqHd3AUXYoU0QZDd+F431f2tQBdQvX+j8XwD3GtH3HqmD9BCCsa5Gedwl0GOMgPbLnmePcK+xFHYJH9o9gHYeF5EaKIlIEVUYAFilVnpYa+49Yc37A72cDojIXkFVVRNQQwiIoqIiEu8B3PotGDL1ayMqgvcEOxyCGkNkdxQ4oSzq2kPA4I0vTOGsJaKWzZ1zzjlAMAToTJ4lxpgQODLD7jfDzEQ2TVNXjo1xraxRjcoQowNqNRpZkgtD1LpO4Dl49SyeOCStPKuYI3sL1gKCAUAwxgaivNmYm+ukLqmqYlZFDxQMO4QkS5kpeB+FjTGWkCUaYGMQjIPga4ULIRBBVYlnSUSisII6kwCIMgJoVBEvUSJakyKKYlUFVjEqnqOLKID1RSGbRPHKqhDrrA6NYdVYlQAaQgCAZJenqpOq2WxWp1879eg6O0kS216YTiedud7Fi9dOkRsV4XDW2l7bKuJIBFrtrgnBRhiMxjybNBoNv0vB1XuGsXXYYWIUREGMABBCkFgnHNTpzA0Gw6tXr7/m6YeuX7+5vb195szR2Wy2srKW53meNw8cOCSiAHTq1JnRaJRmeVL5wfaQRW2zkaoqKAIhkQnMkYUlpJQhIpARqwAkdXilipQDiqpGEYcQSQOzQ6y8z5xppqmzgKBIkLnEOjOVYAgJwDgksj7KFBWYU4R2ZtqtXMnMygKipM66NIkyFYHIwsJKBOgAEckCK1hjyACASvQqgaEUqFjAEBkjMWCMxD46TbjK2mnpo1Q+TZPMNQ0BM5e+sgZbzUaz1S68TCfb0ZeANksTP6ustREQRSRqFK4CA0unMT8Yx9RAK8knBU+G285CM88Y0GVuc1S4ZvvK9TsLh08cOHrypYtXySAAMXOeNbMs81UFAKgw350L5TTMZha5kbrcWQPKEkB5aXG+KKd5lty6tXLy2OG7W8M8h/n5eWdsv98H0bu37549e1pV19Y2OthWFqsUZuXd69MDC9v7DxyM4cBgNDLYHGyE2RjSo4MzBw/22t275dXlYwcMQpiNRJFVokYjwsE38zRN8fWvfXpre/qP/+m7+0P45V/9oc9+7vOveOOrP/ThFz/43j80OP+JT6898a37r1y6c+7sie2tl5Zas6Ypjpx+4vT+0w8c06Nn5te2r3x4kH3yU589fx7KYrvZwQ4mJVlDwkGESJAiCWOiFBWNoBJ/SaQsAkAoslMFraF5F0//5LH7TjXvnrC9RuQYY2L21CY7vEqMEe2XL6jeW0/bOw8idjqdqqomk4lBStPUkqmqqg7njTGKGDhWVRWFydkkSUTCXibBIjV164wty5IA67ehUKsSVEQIwQACEaiyqCrXakuXOEWqBQkiIFDvkqCYAIAiGSQEBQURBhYCZ51NnbXWWgKpaYbAk9lWlmWaZUAYPKuqcw7TNPpKVdEYBKcqHD2DVwgZpJnLunk3NGK04eDicqPR6s3Nn3/hxUpCYB+kisHHAAogEXrthSIUXgIpIVhFAEOGaOnoQeMSVt0YjgeDQRVCq9XqLXb7g1GapgAQYy1UtcYgc52fEBEqAyKoAiIgQiUQmavIymoNkbMoCuBtmtUiFAC01rk0Ue+Z2SZOQGdlpUUJAGhMkmSptcYmNdeNRGav4l1V1toY2RgjgAAQWEQkigIZNBYBBXwM0ftARFF0deWuqjaz7L77Tq7evtVpt55/4aU8y0KYTCYeicazYmFxKU97s7Jkif3puF5dqXPWWCRU1cAsCFqLbAGIGB0aY5yx29NxkiRHjhy6du1Ks9nsdtuIOp2OFxbmY4xra32RWMt4jMHJZDSrbP317V9cxL/w1LHt7W0FmExmZQj3P/BAq9X5zGc/n+aZKDKgCggoAGmtI44ZASKpASVUC0DIFqSZWgvsSBNDqaMscakzlkzUcn19fTCoyEGnnad5poo+xkajNSsLUczzpiJOp7OqqohsICuiVeCKIYhGwQhGARUo6o7mYTdyAlWlGBOi3GrbcjeF+QTmUmjamGLoNJLKT+fnu9NisrC8NJ5OELEZZ/O9Reuyzf5osD1mTMBkEahk8gJl5JIhcKyYfQwxxsQuoEpiJDOSW3AalavIPmu0SqZxxKGH7UoHs7hdxJmPzaQVY0Q0tVIixqgcCaCVuUaazrXy1EA5HVWTSZ4lvfm5KRWDwSBL0iRJtre3QcSSmQzD2bNHZpNpnmVVVTWzfH19vdNqNxqNMm4naFB0eX7p6qWrRPbp17z6uS9+/vLN7YNH22vr41YKh5bnvvZNbw7T6XOf/FR6ZH42mRw/vDhYubnUTZ965L5xf3WunXJVdDrd3sJSf1g0uwtv/913n7n/oZMnT32mf/HGJf7Nt31x//JTK7dv/OiPfePrXm8Gm+/bvnvxzIn74kZvuNru9yVruX3HGl+48MziI28pPX/u8+c/8/mLz31h1F1s3FqbNXvLw5KDSbam0/ZSbxZ9Z6F7Z32lqoojrd7Gxoa1tlaM5HneaGbD4TAxVpX3CqEIu2QIfHnOfSel3SVM6lUBAEKAiDVu7vyCaE2FW6QaZFVEd6usnl/mXu5lYO6N3PfIdwCIBojIItUvUSNvDZH1XVpn9IpQK/gRdzSXAGCJ6mKSQQIAgp0Nhn0AgDqgTiXU0SKDRhbWOj83AqBIisCqNcrXbyz6xBLVb5NQDShHH0LVm5+TEOe67dl41O40N9c3ksRVVbXca87NzSFit9u9u7IaY9ze3j5w6Ihzrr89zLKsKApAs7i4WJblbDaby9N+v1+Vod1sZlnmjO315g4d3L96987iQhc1HD1ycGPz7nOf/pTEECOgy8FQljUefvzx8xcujQufNlsmyfrD6XNfvHzm3Mnnz19Fi5253qyslpaWpBhXVVVHspbqmkQIvpyf74YQoq9EpCbQjUEAqIoIAJ1Wu5nl4oM1mFgXyqrZyhHRe1+WMyW0zjHztJil6GySJMleWVXRkDFGtL5uIHsKXAFVRbNjWaj1MHVlAgDqsB3uycDqHwIkIqwSlSNIBBVSAeU8zVgCgkmyNEmSyLU0PqCSqgJKrYo2BhGRAJwzBEhml6zAHXZxWvlacFUXaUIIZVl675m53hTrik6e5zHG6XSKrlvnFqpqQ1WiSqPZcNaub2z119dBdK7TiiIC6JTUEoOCooACgKhFUERUREVlFQESiVJGBHUoCcXUYurZWXKG5touTbM8r1RBQayhbrfbbDYH29vOZKpqHBHZzDRizFS1P56yApASgAH0AAQaAQARWCPV/BghqiKgABgrCBFgFhmZIYqq5ZTmG60CAKxOKlFKizKyAHNcaLeBqAyxCj6qEKGiSM0JIxljUgIgjAAQQxRAVgLVOpyPbEEQjGpSVjALPAswU6smTfI8Q8/oEXCvesbMAJJlWTNPNXjvy+3tqpnaxFCr3cicI6LZrJzrdBFxMBj4Mna7zTzNSEcEGGMcjUYoemB5iaMXkcoXhw/MhyrORuNuK33FYw9/6lOfv3n1ylyn3ci2t/vjm+uwkMAbXn220WpfuHItzZvbhfqK766PHCZe6e76ejvBZrNpm/lgsLW0vKwQimL8dV//1S9cuDQebx9pHnzk9We/5tXf/Vf/yt/vQ/V7b/9Pb3rT980m43Z37sKLt9OYJLhUmUosJwfy1qy1cf7Zhx9/8tw3vOEb3/yGFy7f+cl//7azBxvPXF4/uL+zMZmgAMSwenelCP7kqTO37tyebm8302R+fh4R130ZqqJCZV9BTlgTzffE3Kp/gtB9j23fA+LdfWJH867/f5H4sPv0XbhXVRUVRNJ7qrFf8m5fpl3gv/9plyA3xuzIgnZzf9yVwwMAWgP68pN3HiXcBRU09aYBYNHGKsQYCYQI0Zk8bSy02xw8V9VwowQJbOjAQu/AvqVWq5Wl4fr163Nzc9VsMNd0WdY+uNxLkqSKHBqm22mFTj6dzkBKZ3hpcS4Oq157YaLjUX8U8rB/ebGaTr742c8Y8AvtY0UxzLBz5kj3NY9/89XLF4bDQVW4Vqv16ec+99wH3jspodFN7q7eWe2DyaDbhLWVOw8+eN94Vt1d3dx/+PCtK1cW24lB7LTbxuB0OhWRNLEISTUrAO5xokn0PsQIVN//xqI1wKxQ1/sIlLTm9Mhai845a60ixDLW/BvXKntmFDICxpjAO+wKWUdEiiKqIYTMUOJsYq0JQYvCz2YhBKsvqyHhHtbOOkRRFUZlVUFhAEGQ6XjqHGRZZkG4KoL3XJff0k4IQRgsYpZmaeZQgTlkaSoSJXKQWNdgjAFEzCwSgUHBem1Ej+yNRmfJAAOAsWgtkgSjnFn0GgkUQBTU5qlTdnmW5Gk2mYxm0zERCAcUMHUJA8AgCCurqKolBiCAeskxq5IKqKoxVJsaVISRUZyCZag2BkQ0v7DknIHdHThJqNdtAkDwXFVVjJUh9BB88J3cqGIQrVjLqGWAisUIBvWoSKIADII1qcoi1iaKEJRj5CpWhYcg6MWUHFOK7YYj7xd6rSCm2eh678VSwVSWZVFFASRD1loGiKwWAQgRSA0xqI/kDKKygkThILFQMQjGIpmMK5z4MPUsxmBqyDkXwRh2SLIDBCrCBqnRaMx32gQyGmyVkzGJSduNLM2UeTqdCrNtJjFGA6aRZ6igkXu9ng+lNeiZVSRLkzRNiqJwZO7cvnni6NFJv7pz6+b99z+4f38PDLQ63d7CdrPX7S5Nbt/cHpfxC+cvf+5zLy5059zy/jLqJHI3ySqOa1vbZqGJRLdv33r4kYduXL9+7MFHVm7eYaL77z979drN8cr41GtOJI3waz/34//p5//1t3znazZXvthuNrnIjx45/rf+xh8+/crx9/+tv/XW3/rp6VK/fajzUN4Y3jw/vHMjmub9R45/y9c8+cATr/3ocxfe+o73tqwYsPOdtNk6fv7qjdVr6Mti3lBVVdPtPhKhxCRJnaHaQqKqiLU9R2vvBd5zF/0xx72oWmMu3CNrgT8C7jXA/q+c+UuQ/V6Yrk07BC+br/67YB9UZGcZ3HuqvZ+JqHYS1RBW47uqRhUDaO75SDsfhFBFEdER6U6dQkU1s67iaME4m6ByDEWMZZQkd7bTbaYOFxfmLVGn1UgT2243B/0bw431+08d2R6Pup35JEuHw/F4WizOt4txX8IYBUg8RFVhiyZLG0mSZEmWuSTP8263PZ2M+pvroHL21KFeJ//ksx86sH+u+/iDJ470Fh8/3YDmZFYe398Wss9+5gvPfXEzAXjwZHrpRrW4r3X1zuTS8MK+g/sOLS3019fuP3d/tXVrPB4zAROOB+MkgbzTFn25vrAjKwIQYFZhVAsKhAoYVETBilWE8WyKiKosIiCGmGsBO6ZkTG1UjnVt3RiH1iiQSAwcEY2jus6vLCIMHDUGARVhEAYVrP/sXUUA0L2Lzl5VkUWUURhUQRUIRMAYYw1y9N57CWItJakdA1Ys0QcnYBOxAqgQWFIgZvXBc4iAmhiL6IhAeOec9fIwRFmaapJArftCrF0UtQYsTZId3xGBKlgAJUJgIYK5bhuUBLSaTvJGAwGREEEFVEiIVVQamYnCMUpgrkX3RIRorUEQBsAa+2tTB7NMp2Wj0chaeZomLFXwVVFMLUnNKAlwKKfRe0MOmbkoF5YXWSCKllELzxOKNmgVlQQNcsBa/mwQUERQldmjMQjKWlMrKghecVjElPhg2oIQF2zbS9VyDY08nFVEMUbxQIIOyRhrM2u5KFSUEAyIIxWHqqmzFKqadOMQJXBUQgupIReilgIVOhGDQYNEjtGCOmfqPA4AaNfbrSjOWrJGQANHAQCyHGNZFK6ZTiazUFbNZruRp2tra+V0dubU6c2t9TxLm3k2mYy8L4tiSiCdbnu4jWma+hjJ2I3Nft5qj6oggSFvbIyKN735q5595uMf+cwXTh462t1/bHV1rVPo+uZsoZvMxlPfkHajtT0uyqh5u7W6vnbg8AFAmRaT08dP3Ly92pprPtE7du35T3WXri88dPY7v/XRxX3x+o3rWZZBbG9u04nT6Qc+dv0v/W33p/7s173vE2/9ru/5/vF/+X0/HR156gGABKbFG1/1gDfVI2cWH/jRv7oyrH7r997/nmev3nd2/337elvD0UPHj1Ub69vVLJYxzdNOmlYSOWIjzyofasIRkFAUdwII2C2x/s+PXRpnF173aPddl/+94H7P7/zPIX4P2Wuw3knn6/sNXubj90wo974lopdx/2Xn0d5+cw+412G77lh2EQHQUG10VgURISQkIEAFtIqoKIrOiJeo7MlYAhbxqaNmkvS66fxcu50nZ0+fmE3HlnA42DJRH7zvmMPq0L7Odn+FJFmam/fF6MTR46w42d4YTWdlWTqXzndas7LyxYgwq6LPGllvsWctVeVMAeYWesV0e2V97cTR5c9+tnj0L56ZjIYxzq5cPq+T8ju+47taOa1tDf76D3zXjbvr7//wM5vD4qH7D9zd3F5sN7cLf+nGWq/XaCrMNu50UjPjCL5EaxxAasgC+CrMzXfr+y5GUUIA41xmjEzKElEYNAr7EC2AtRYYZsUssa5WNwIiswrXmh+701GhTuysQ2MMWTSEHCESq5KqURUBZrWJi8KjyXiP3EBEm7iXd9vd9VIvJ+Ed5SjWOiao9QJkUyaiEMVXlfeQGLCWkiThChWNkETW0gcRMYjKPJKxxCAxgrCxpGTq9UD13qYqu6LMXV6aIjMgWucQ0YfAIkmS1OutXnt2ONhutVqpc6WvHFGaZiEEazQxhGaHWQTAyMoggtpJY4xcSqiEI6hQTWYS1zuMiGgQVBaIEQmx3ewKyHA8m85mCNGgGJOq6vagnyUOWNgXJJq5hFySElitLNQ+aEUHqGRJEmvKGCOTZ5GddFUUVUQmXCEkYJxaG1VFUMX4SO00DRinmhH7iQfwwcBsNp2QhTRNiRw5iOojK7GSUyIk5dr2TmRSgzZzrGYcoweNoAFiqcrRqCKK+qhKTpFEIJQ7DhRL5AyAQBQxhoyp3YzlaMTbHP1sGmIkxCpEay0AMiEx+tJPpzMim6dZkiRgyCXG7uj9EUEqPyWIjUYjyx2axVsrq4OxvO41Dwz6E8qbzEWjt7xy+cZTr3vD5ZWtD37y5lve/GRZxvd97HNPnTvx+fM31+6uPXxmqRoO8ED6+ENnZLauxh49fmL17q0yBuuLA4cPQGIb3WYcT3F5rtO/vrDI1597Z94zd29OOo0mRxt9Rmz+6g98/9vf/YFf//VfePwNZ1/32q9Y+8L5fYePzoqL/ZdeeOnSFab09EOPHjz7aN6wt9ZHR+4/Ntf4ys8++5+KO6sHD8wHX+XjgbOomRPFrN30IpONWRn9XK9NgIoIQCqIgICAOx6m8D8C3Hup8Hvx9F62ZO8XagnklzD1/1NYv/fYea7wHlLvkPu75Vm954CX47x7lDa7okyEl9/87tawy+oQAu18dBbdZYQRRQGBFFCUsPYBkRKiTpXHsQoOqdHM9vc6Swtzi/MdjVU7TxIH3VwdxyxNmiafm+9Mi8mR/b3ZaNNP+j5D5N4Xn/t8cXbwyGOPHj7QK3x7uD0Gwl6vuz0abW+Xg/FWkiTNpF0JTadSVjO01FlY7i3OO+Qg1gswuq3tMnOYJp3DZw5cvnIhSTNfTj/64T84duLM93/nn//YJ577ww89893f8T3veu8HuvPLr39Mnvn4p4ZlFavZEMEqdBupTRKjURQhckI1AyAgqIAqqAiiRhSNMwC1NEBUVWpXGqEKAmFNcItE7z3HCAA+lHvLgGFnO1bA1FmyCbGiqiKxQhSOwg4tc00nRNjlhYwxVVV92VVhzc7GL6CABAAGjICIgBeAyIHBWrCpYzSTwkd1ZFxKFkCEwQMn1jhnq7JSiQRiDFnjwBAzx6iNTrumlXysvN9xThljms0mIxMRo1VVLyhKBIZ3JQAAaFV1bm4uz/P19fXpeFJMZ0SUWmtJEQR3S1sO1KAIigsjFNYdqEdmVLFA1lpTJ6MASiCoCCCAVHgWEWugkdkkcUQShWezKRGARARpJAYEE1JjIMuySTlWBFBDaBwQWLQ2iUA8KkFBlWMtrKiVDCKEiBpFUNCqzaIQI/oIQbFp0Y1Cjrg5LJpWzayKlYB1CCYhB5Ywgo9RgnegloyqxshGAVUNWYMEYILzoBKQERGM8WzKIL6MDESWnDEiUUJEFUvoEqPKANEgJtYAUQixLEuvJcdgCYyzojKZzkKoEERCtIGTJHU29PtDZVla6GVZwsx5nk1G25JYkRiCTzPb7jTKchYMBaS5pa6YdH2w0pnfF0gv3FyZP3jiXR94ZunQ4f1njnzqxRsWKW+3vnh9DbsNjxBMlrY7nV6vPbeoqRjnJmXZW1rcHg3bc/PNhc5LLz1/7sGHmWDz8rOdQ51x3Dz+qgdvvfT8kbOPbN243U47DOTydDS6+r1/6S3veudvfO4Dl771h77v3W9/26uXjnfm96Gh+x98sPfAA7e++Pza9ef/+f/z7ovX4ZWvhh//1z/70Xcc/8l/9TMf/+StTgGLYULLB9fW5ead4WBQdRbSTjOhygNLHUeAGkBAqC3stQr4y4P7lxx7EF+vfgTcw3HdbdOh9Ccj8feOvW1gD4KJjCGDiKiAuy9xb7oAXxrvf+m7jTHq7n249/S6lCUINc1eG1oB6gz65V9FJASoPeIExXzHuF46323tX5yfn2s3U2tBCNAZaGWunXMrSVTifDPr9RrbE8gPL00nxfJid3nfgSNHjty8filruGF/LXVw8MCh6XKxtbUV4gyl7LayAk2n01GkjUHf+9hqdpqNDqokFhuW1vobjQ58+jPnlxY6xw4dePjB+8+d7nzkIx+Zn++Ro0uXLq6urj766KN/6nWvvPDFz197/tOvfOB4uz3/+S+88PTp/TbNbt269ckrs1YTIPrpdOpL8AJZgxfne1vDoaIh64x1SsiiPlYhhKyVcoxRgDgKqCMiY1VCFHZicMcmpqWvanFqlPpamJ0dlgiQVNVzBIC6F5Aq7JmVojCrkDXOvJxmReG60eG9vNzODy/XV2pWF+uGc1EqY1KbUAMwSWyWurIsR6PRNBa1XAqAokYTkVGdQWOMGqi7eCXWIYGEGEIYTqv65ULQyAhgnXXkXBFU0SlSGYFZKkZVYi8Fh71wAf/8w/Nzc3MiMhgMJpMJsySJa7fbNdV1b3CkqqSQ8xjIKFAE8oJVhIo1CLo02wFcFQRBVINkUMdTJNQsSzqttJGSSgnsjYb5bpOYDYJF0sgc2CIlSTKtRqoYlRgwgmW0TJYhWe8PQlTPwsyiL6tNqyxhAc/EkCrlSqkKgmoC0nKaxPFirl1THVlqNYgTw9DODaAhMgDCjFEQpJYwROYgyiqMtThHWAQ0mZXlqORpwEKScaThjMdlVOOILIEaVaPRojgUQxBBAYCMcy4NwmXha2rMIOZpYkGDLyX41BhrUEQy67Isc86UxRRAD+5f7nRa08k2qm5trC0sdn1ZKgcAOXDgwFZ/o3f0mCNHYC9fuLa+sZ025idBnr857Cw0VgazueVeb3755vWbc3lncW4eWSr1jRS7OT1wrHdsOV1Iq8MLtp3wXMtMhptnH31oc2XN5BlDsjUc3/fwo3HtOXLJ+tZ2q93bHlZ50qQIUJTzncaNiy8szrWa95+dXb3RWFjeGhYLiwcno2FrcXG8tb7V31hYXtjc2jrxuq+YXL5+8crNX/ylL9x3Lv3rP/qPYCJXLt168cUr7373+yZLJ5ud9s3bd166vO5yaM53CpaKRdEqWAVSBVBbNyVABcXZHwPoL0fKe2BqkIgsmR3xjIhErqHT7T4Iu2VMY0zYUbt86anuBfR78X3sC2NMap0zlohAVJn3kD0w1yYsIFRCRGTeMRMhot0FCwJUVdotGte2rvrXFHz9QrU7UlUNkjEOdkQGAAA7HeiMQcQ8H2cuSRPbbmb7lhb3LXY1lMPB5kK3gVItLc7PtfIsoe1BP0+TuU6r0dk3Hk/L4FdXV41NTp4+M57OfOCrN24OR+OjR49njdbd1ZW7K2uz2WxpaWmDWkXlZ7OyLCKCTVzDgFER8RWGqr+20nRw7syJbu5Si6EqsnT17Nmzly9d8lX8zu/8i/2NrdFocmj/4ZdeuiBB7rvv3Mc+8sxkPMuy7MKFS8ePHnvX+U3n3N211emMl/Yt+Mhbw1Gj1R6MpkIGjSXj1BhV9BxjkLQFs9nMGpOSRY55mjXTLAY/3h5mSdpqN2pd4Hg62ukToDuYu4PUiKrAoBzVGEN2p6UMM7NKDfd7Hq49FzEz180q7l14O6swxt31SLUfCMEgog9llmUGSZXz1DWyvPLlcDicVMbUZAcgggKIQSXQ1FmVSKBZkqTOIgH7EEIYRKwv9J64vm5zNp1Oaz1eCGHPVCwiXvjl9SYid+/eHY0qY6DTaRhjGmm2vLzsvdcdcv7lFU+IeRnIJZSkYFwQM63iuAyl5ypEgbp8JACCioQCgJ25eV8WMVajUSisplaamcnzfDabqfeZtc1Gw5IBZGdNM2+g8cLgRb0AcN2PBICk08i9qI91N4gdZBcxaGxRMTMHiIiiSIokzM122xkutoalkWpWdjOqpGym1Gy3y+hVQmZNSpYSg8I7DnUiACGwBBpENIbIsdtpAYCHoM4hpMHTKBSxlNTlzBw4qKqpmVCWEKJYstY6a4mAA9eGCGtt9F5cAtYAGmOMTZNGmhGqhlhVVbe7uH953/awX5YlgVa+tEREsLSwOB6Pbly7W1UwNz/1ZTWaFVvrtxpZ+8UL2/sPNq/fHjR77aNHFgdRjp0+0J9MR0WYVLLQaxcRN9f7SY6d9vLq2s2nHj7hUnjxwhcXX3GmGvU7jaUjR4/evHSp0enO93rjwh/qHJqOt/MFQ0eON166sTXwkxl02sudfUvTGxdHm6vH7jsA01W4++nJ2nqj1y1urxZVjr3mcGuw1R+4NOsPBidOHr/80Q+mSf74w2f3/3+Xzr90Ldy+9sXnrxYz+TNf+eY3PvXkN/3v/+K7v+97v/Zrv/Z33/OeT3zmueH2iAkoyWFPbv6ye4n0T0Kc1JHvvcr0vcfrB19eyfc85X+dc783Et/DVlWBXSvTl9BEe0T83tPl5ZPUlpG9HYhVd+3ye3lArPtK7TRYJKLaxQtQ+3x3mJm5TlM4DEebW+vRl8NWdrLTTPIUCcNsNpxNtBrzwnx7vL3ePrg/S0klBj87efwkcLx64+a1K5cfe+IVd1ZWTx47+vxL50OolrvLqsuz2Sxx5siRQ7NpuHPh7mg8O3jwaCPvrK32h4NR6lII3MnzQ0dOzoZbWT63sn73ta98ejIevvrVT/zBH/yBcckbX/u6EMKLL77w4P0Pnjx++OrFC2ioYeDx+0+vrW0MtvpvftUT169ff+jB++uvKMkbr3r1awfbw3e///23V4e9pbnAUkaOkQGInMldE5tU+EEIMfgoFBDEGRtN9N7XDXzu3ZXrnpHDcVHLCkVkB9mZo4owJEmSGKoXQI3s9WWV3WPvotSaZvgjulhVdWgAascBAaICqSFEDB4pMLOvypkztttlS4Rkmp02igKKQUKs2ytUwXsCrcHdIDpDdqeXmaauUVupY1VVIcYYSi/OBQCwiQWlKvgQZKd3po9gkZAEkJDw65ag0YBOJ2/mDeeMQSQAJJUQ69aPxpKt1YcgALDR1yxL8iwB4OjLECpBQWOLEINgKVRGUzJ6sZ5RABOeiABHESRC61yauSS10Eido5CSb7iYu5hgIPEqftseC1WBCqmz0VfTyURVs7SRplkZpPRcRYqKZdRZGcoqIGLgWLB4Qm+AjQkAEdUaaiZZbgx5z5NphrDcnpvrtpNk3VnKLGUGUtCcICNKja1mReoaZBIfaFJGHxFN6tJsVt12ab49GheBm53e5nB6+caoYJhf7lDWEpNdvbVy8OjxO2ubRemXl5eLomg2mwgyHQ1BuZXnoDybDnudjkSvsTKgaeJSt9NcYTAbZdb114uHzyzed/JoORxgjMNBHwyNi2LxwOHb/e1RxSMfDp84PZxOX7oyrAtCZIwSikSWKCKdZiOUlfjKguY2SY0FZgnx+PE0se765buG4bVPneu1G+Bnp44fbmZ0aP98mmpvob25dac9l8dYttqNjbzb6y3ORrOFI8e/8P4PdrJ0udv4Nz/5y9/15x/bt9C6efVyJ8uWjp/qX73Zm1t+z+997C0PncLT58C1fvVDH1989Km3/NDfAIiDlSuhf/fuC585lNlydXXRtXLK126u7jt17q1v/W9f9Zave/fvv+87/re/e+vzF3/mZ35lewIXt4AACkg5axc2L4yznbmS4e7G+r6FDSAThGY+MisRZdYkoE1HK3fHB/c3Sg8bw1neXS7Upo12NryABDZJKcmjYhFEAI1NYowIYkHqNMsCkzKSTnnuywJ63TCgLnXu7RAi4rAgsjsl0LotF9eFL6cKLDtyaYYdQF+yfR/ZR2AAsKgmEcCgak1Sm3MtGVfbowFJ4fY4W17sDQYDQhVfRl8tzHe2h33vy263DShzC/M+hsXF3rQsVPVgY4iieZpVRTEcDA4sLZ88egSEq3JyYN/yXLeZGArRj8dDljA3N3fuyKnu/Lxxdjid3VlfvXHndpJnx8+cGs/Ga2trANLMU1BJDI2HowsXX9Jw6O7aWhl08eCRVndhOCm3RxNVjFUJoUg05BSP7ev5Sf+h+05lFvOjeb/fTxN798aN7/nu79pcW59Np69785v/4Y/9+I/+2P/xtt/4LUryN7zxze989/teeOni/gMHttbM5UsXVleHTz1xrttpPfHEE1/84guHDh75qX/3tiwHpTRrz49nXHhYWDzQ3x72F8bDrT4JWAZTwbHlxqHe0ngwno2mhCZvdNK8U0QdTgsGk+bNSXXJWmvsjs49xli3elCgnbagxtZ3IhElSbJHCXxpEWX3qFdFrYUnovF4WFdxY4whVKiQpmmWp8V0psp1LxbnnCpziMzsKK3PsxeP12r6RqNRv9C9q05EGqmtqqosSwGsq+6V995rnidAO3X4uqNcvd6ifdlxbY8e66VJUjMDICoSURVVi7JiFkKkoEhQG0AAQNXGGKtKAZiDjzEwMFAgm6KCAQRlFeDIwhQFxE+1juPBqkGLHDGCKqEIMTn2qAQqJA6RyAFAmuTGokO0hCoSYwSUEIJEUQUicrDT6t5aIwqWnYQIwAogiFA3zmap1KO1xkdhAYBhUTJiq8FZgpCSReMIGUQQIyAaxwgiUkkUEHQuzUyaO882xKooiqXlfUJ2Y20014aHTpyMlPTH5dZoIlUh1bST2k4jbaQkbEMxYWYEAZGymCbOdFttreVJRASqqlGkTtKbzaZDWlyMYGg0HHPpIVbGJUVVRtZZWU1n5ajwo0rWt7YmRWmMxbrXoirsaukQcXNzs5U3mo0GBC6LmZDpdebmDnT7my+cu+++Rx4+Men3+5vrNy72U4R2RvedPhaDn+80ORRLC/MKvtPqgqNDB/eLjy7PdGPj4fvPfe7Tnzp+5smv+eqHyWZubnF+acyln/VH40J6pw888IqHME/uXLq4dN9jJ06deuwrvkLvrl66eeXs4w9A7pqjrdXzLxzoLTsGwLyxtO+jH/7oN3z7N127dmO7mhYb1zGNf/Pv/uD5i7e8ptfubF29u3FltT/h8MLNW3EMjbneI2f2r26sEBpnTCO1VVARDVGEowXXakJkTdOs03Fe1SJMx6OWBdjtEWCATD3ygyhJEgQxKEaJlAnQgkWV/1HH+L04/d5IDXEnxwcAQNpRbdZmlhB2WVeDiARUa+eKoJEhCkQAiICoWvfsdYmqAgszK7NRREQDuNhuZxi5GMzNzTFR0m4ZDBnGM2eOzc3PF+VUUKYznm83MouzqhwNJ4m1BOicW1hYzPO8qCqj0mp1+v3Byt3bnU4rddTrzdVSna2ttUkxWt6/TzT2ep1m99xgPDQIp46fuHvrdlVVy72FdqN55fJFa+3rXvOm69dnWbOx3t+OVTkcDgWNc857DyidTqcc9yeTyQbxvvlmmqbKcTjYRmEuY/Dl3Vu3263m1Ut33/ZzP/fkKx7/F//8n37nd33vR5/5xH/+2f/QmV9IDT75+CNbG7YqJ8rVnds3Pr9eSKzyPK/K0f/zf//tf/GT/9ZlrY1+PwRMbWNl5Uqz3fGzarG3tHlngxlOHVuWorx07eapI8fqHslKKMRoASmqhChQI3sdBdfhPFprjCmrUCNpDe4iO9zscDjcg9d7/5bdAQB7cF9vADXEA4BzzloCUQCoqipN06qqvI8hFKoFADQartPpVLOwFyvUWaBzrvZY1Qtvj2Cp/y6KICJACAK7dqrEGLXW1uAuoCgvg3v5Mk0EFoxlgaL0RSkcI3NQFgJJnVMAZAFlRI24w1s1Gp3awASq5KyzaCQqgqhaIgFNFGTXOOIEolcgFIBa288SNHAMygFTBwAoyj7GxEDqKLWuCj6xDlh8CLJbsGZmJCADCZIjQzYFMhVrjHHqtYxRg4codQ9VFokMqhhUMUajiOhUYOhlJlVRcZ7aTpMks5qgWlDRxKgKWFIiERIxzAABShLs9XouSyMrM5Oxhw+10ea+mHgGrrhh4MhSu5lqimRc4v20ad24qCTGNLGs4qvCYd7qtovpmIiQLAqraoxCFowxWdYQXy0uLqrGre1Bw1iOsdNuF6ykpmQNShVLxTAcF1PvjXF7/ZoApdbbkkKWplmWZWkStYo1D2Aocal44KpIjZ1rtxrOhOmgHOnq7RvdHG9fHS0vtV0iDz14VrRMTD7eGg4Gg8RknU7v1tVb+5b2P/7mP339mY+eOHmGyF948eKVyxcfefChZnP+5vatzuZk38kHxW+FiMmhAyfbCy8899zHPvvZc+fuq25fv/78c6948AR6vXL5xo//+Bd+/B8+9uQrX98pwoXVK2cfPfvvfvHZfH9+eCmfbM9Gs4uvef2b//Q3vWqwObqxttWflu//6LPnr16/eqs/vNGPCoozsQZck8gqkEpkBK9osuZwOkPwTCkjJI1MCSwmrIjGIhkCJKqd63vqFBQhVQEg0Z0hSl/2uDdgh3vaD1CtMf/vGHndofKRiCwAaF0QFlFFsQ2yQCooGlWEEa0hJGdTBUajtf3a4c5QpP7GrTKxppw0lBRiw6Rp5vZ3lhYXW0SsRWmTBIixHGtZNYlss1kPdcqzRrvVUB/7/W1nMMboLPnAm5v9lZW7Tzzx6L79y6w8GK42pb0g3cgVILXajdFUtvubWZYl1vky3Lp2Z3lpafXOVjPLM2qmFnudpvd+fTCWcpK2uo3MSvQ+BjIpgCwuL6mfzorq0tWrwLz/VDNx5hOfuPDt3/aW6Wg03ty4/8zp5cXFyWRSTiazYf91r3r60kvnn/v47X/yE//7s89+8uKV8fbW6okjB0KsYlUU00Gn5e7cvjyZ9v/wD37nH/6Tf/rOd33k4HJ3bnHp0uVrm9srBUE2744ePLS1tnrtxvpiq7Vv/5H+eGqTLFaViAc1atCmIjEoRhEEZt2bj4Fo77E01/nZ3l4Ou70ha4an7prJzERUd83E3W749QnvTfKIyNpUa1l78OpERJLMNbIshDCdljFGRTCJExGOcSdvqGcMkBHVenAKAu5M+6mtk+zrkKJOHQHROeucq2LYcb4B1UVc2FVtvQzuZBLWndINKiIlREKgahCVVFkRDKAS1HtUUnehEw8IrnaKKitIUVaAhErGUpJQFIqCIlBQJYqqIGoCK4vUn6oCYbGKNkRF1NRoDs4bV/mIiJ6lmI6VudXI0iQxHBARIiEqkhi7M5EtqMbUoBEgC8QYECIpKqCJosQkSoiELgHQKYtG9YXLU/IBq1yKFDsJtjLMLEjAhDSxoA4VlWPlg5/yxHiwicuyxmg8sQoH9i+PJwWU0ftqodmgNGWhwXBUjEcmzaaDEc4tW/XWQGJVkYyYxACIR4iEdV8TYokoGoWAFJnLslyY61aTka+qvNcVcWrTkkdi3DRAAIroMIEyKoOxxqgq12NSALD+Q9TtzEvkoiiMQKvVSROLhrZHQ2tgONgyit1mo7fca5Cs37ldzKZVMYFY+SlZNMOtdZtoYmJuMWqca6XD/ua5B8/9//7Ov8lz+Ls//kMrN68s71u47+FXRHJr09CvBtRevrVdvvTMF87dv/Toq177Iz/6b5YPN//uP/in2+ubzSrS2taxZlu2xg2THn/4se/6wbs4t3DHh/Z9Zwe3Pj8j+VN/ZvnW5vXV27cc0td/y1d88pkPZrc/meatw/sO7l9w577z1aPpY1du3H72U5985nJrMJxuTX3FJaQtJKNgBM20KpxKnrcmkwlCbHdaZSxbaRPZkewR91RHIbuhN0YVEiAAlhqD/7hJHV/Coe8gOCAg7WROQHuRe5aliFgrMUQgxijKylBAYq0laywCxChQN4TC6XRqUC1oFKXaDAiIiEe7kmX02PHDaZoS6mw2O7h/aXl5+er1a7Np1UQ5cfjwpGz7yOiLdrtJdlFEZuMJADQb7alMqjKaLBkMxt1uG8iVs+r2HTh9erK0tOR9nBWbc4vNyXQrKJTem6rRaTdWVjdWbt1MjXXtzmwyW55frg55FE0wWx2uRNHUYbeZVWo4VpVnXxWNZl4U06Iozp06Nu2vDzZXtwcbSwvz7XzJl8XxI923fMM3fvJ9713t929cunR4efnTzzzzrd/2F37u537hscefePDU8ScefvC//cJ/fvTRx5cW2tPhvEvs+upWr2sno43lpVargVkS/+W/+D/+8vd+5w//rb/8f/6jf/L+P7yoCA+dTu7Eo1evX51ubc81uxWX1jXAZpNq0mgmU47KgaNmWYJpIFMBaH2Jmdl7X4agCtYa61JrLTMLIOz2ZWNFRambQNTMe90bWe+xsO1VVvY2+zJ4InK6U3oViSKCgKzCLEmS2CSpjegxagjcSFtVVXkOHOvIHaroRSRN071CLgIAgupOl9E6lFdVJLI2sdaiNbEo0SgpqWKUPVUV1t1Gd8A9CohgnQTUAzPIOgMoHEBZEQksIJK1aC0a8D6IsAIbEjBgDJKpLQbWIjowUSlRYsEowAIUrSLUFI1hrYIGVUT0rBRVg1QsqGIdVESZsRoDOWsNUuIsuLSRp9YJm+iDECMrKCgXACQxiGdKG4YkMaKiRtEqOk1KkEqUFVhQjUVjmDBijMykmQRk0Cpi5TXmxEgBwNmkbugAKMEiEyoAInQ6SysrK+fufzAfDm/eubu1fXdjq3js8ft0YzNvJKPJNE3SnLxtuWY7T2V6rb/hnHOJMSLGmkaaE6AvJgRABAZQCEBAavZKkJirKsQoVWAOkY1jhsGk3BzNKMunfjKJsWRS62ZB0SYOUZVra4+qUm2UAqyqikvPIebONtp5kqTKUvrKCYBSlqV1ylkOhwBQr6TFhblmTnPd7PatW42mq4rm4aOH0+CrwUBnMa6tf8e3vP6//PyHLz//4umHHli9e31ajCdez93/KAtdv7rS6u17yzc8enPzC7C8NI1w9PAhCOWhZp6BLDby9vKpz3z8Q6/4s1/3kfe8+xfeunn4off/7Lv+8t0r15948Pjb/uPPnDh7/9vf9a4f+pG/+Qe//ta1lea5c/tj5WeTYS721u2VI8dOZZYP3b/cqY729p996cqNL16+sT6OJTNowqoqhOhCKM+eOra2ens2m/Xa+e27q8KecrvT4VtEkUAUWAR4dzwAITIoITIAgNZ0yZ/oQEFQUFTa7Q5QF1QjkUUQVMSXTY0yKiBNbYqGLIIBEkRUAswTShAdImmQEIGljijn0EPljy90x8PNbrd74fbqSAbV1o2l+YXVyejWleHG7TtVgMPHlnrdhQNLvQmPi1k15VH0AQTTJG9359rNhkG8e+dmWc7m5zqLyxAilBWnWTYdTH0sL11+qTPXs2nWyrL7z50up7NOe34LbQyy3F3a11veuru1tdk3ai0EUcmcsb3WeBY2tqfTacFCWdKs2FfBz8qijIGStNlpLR88ONoe93q9b/2WN334Hb93+eL5B86du37tyjt/551/7hu+4XOf/sz9Z053m81H7j/7++95H/qYG1iY61TLC9evXx32R2fOHBxt9/NET506cefOnSTPzj//7GAy+un/8E/f/Y7f+aVf/q+XL/vt0a2HT5zcHozWtjd77Z6iW93aXl4+OJ0NC9UQg4YCU2aoREtAcG6+BncwhupuwER1zC67tXQBiiJ1w8fZbFbje72X1x2bawvoXhoH9/jRhIGQwFBU0cCqai3lSWKMmcbxZFJ671UlBsgyJCIgZBVWAcLEJQBQVVUVmGzcDSbqeUUIiCrqXBJCiCEgYuJSclYBgo+sdct34p1ikOzY65OX4xU7q2KMkYNXVWuw7iFHoNYZUkQgQa3tzqiqQj54RLAEuusgrBMcZ0mBBJRUhCGoqghKDbsohgFQFcEhkWNR9spEJddiemOBvDEpEJUzUW3kaZLllhCQPEeNMW/kHHxds0YEVQaJZJixRFJCtQYjmhQpRcnIzoRLhUqUFaMAK0SkQNpMWgFBIXDkqIFBgoG2YjN3VWRSAWRERJsmibWJu3VrcPvuGJIbt2+v3LwDjQZsDmHmL7z61Q+02+3pxYuNNHfUDCGEUFYTJgVSj2wJNUtdlqUiUpaRiBBBUIURyKhIHdrliTPGTIsqClSBiyDGJmsbG/1ZaLh8UBQBk4Do0lYoisQkEuNeLGnqWBGQiMrZzJGpx9nMZrNyOiMig9TKrJIRtF5wMqtiVJumlObjoprNJtVscPLkQZVZms9vbAxC4CxL3vveL3zVV73a0/TM/Q/8s59+5ec++pHByhoonbrvXH73zu07d8qCDx4+iZS+eP6lh1/34NXz57/xm544e+z0B3/7155+6GEYjz/wjt9sN7PXf893nf/DD7zujW888ODD/+CnfvM3f/m/fvMP/tXb7/vIt//I//XS77/jt34Tvu+7Rq9+1es37lybDfqH9y9VgzKJ1Xxik3LWX+kvLiydWVjoh+a45VYdFcjKXGlAm7o0befdyWjLIhOHYuyhu73cTmazCVEH0bAIsQBEEiFRhQC7jdtl59urGfMdmcAfPe4VvcA9gTwDoiAg6u4TVQFFvS93bE1kEZFAnSElzEyDCFiVK2aphCvkYDTGSjILeQJNBw1LzWbayrM8y772icXZbPbg/Q/MZrMjR45cv359MBxtbA2MdQvdg7EY314VrGBftzvX62D0S72FsR1L8CLAzIlJsNmx1vZ6c9evX0dyzVZn/364cet2nucPPfTApJ9sbfXv3LmzVIWFpeX9+w92Gy0LGstyvt0Y9Mej/taL/W1hiGV5fW2tvZCiiCUiUoNikFuNLMkaGxtbc+1Wp9PZ7G+Dr5p5njeb64Nht92+fPkmR5rvdp548jX/9l//0le95fHHnnj83/zbf/+Kx58oy/J33v4H584d/8JzWz/zs3//937v925vGubgq2K+k5w+fuzGTUHh1OL99534yMc+VE7X/+bf+5FbLzxz6kj7F//j//1f3/qr/+ynX+LhlhNuGzMebzOa1tw8G8MuDdb6CKVGG0CkFAZUMBhhdxTvjkaQrDEmSq3rA9mdGbMTmKOJAhLYGMBaqKTKCta6movZ4cQB6ykY1lrnnCETYwziDSCRTbK0mM6Mdc5B3VEuWm8Qi6JAsPVQxr35i/fuGfpHjpdFX2TAEBGFyCEGIgKyu1MlCXEncud7lrMl6wiQFQzU06YIDYACC4sKGTKAihAFWRlRDFhjTOIMkYDWjSPRWvJeEYWACEFI0ChpFABKDCsyK9aD7iMgQgTLBCwQFZhB0BIb72nGOq84LXwQaaRpQlhI4RATV6uXjQExO1VjNoCOQLQSEjaoaFUwIFZgKsIMzTTChLkQLZkjIROoIa9kUKNQkOhVYhkLhWmpdiKZ0zSzzhljiCJgxYoynEnSW7gzrKTRPnnOHjl6KLHuxRdfmF/cf/TY4bX1TZE4mUz6/fFkAlsDOPXQ0nA49N7nSdrMnCADQJ6nMUpUEd5xISJaZhaWVMGm2aysEKGIOpyVC8tLoyKUAJlJCy7AOUVj0jzMqtSm7EewkxVCLWetMSVzibXWICmz96ws1lrniNLWsOBJMWnnWbfZMA2rXI18SNhtb66zh6w7PnnsANisCnBrdXs23Pimb3zTF5+/mOfj/NbgwJGjqc2JbG7h1pWrN2/fPHToUCPNiMtQFCcOLfzCf/4vb/lTb37NE0/cuHBpcPdacWC+AfB1X/0GaOSDz3/y2LFDs+Ho1ImTv/Lx3/nr3/hNrXb3q970F2Glf/GLd77lzx38wLuffejc0RMnH1m5+HwxCrnpSGn3LRwvt6cZN6+/eGdjfauiaMYbc1hOHUgIIGQobTQygthNzWD11kLDRAMNKJ9+7KFnn/2MIAlEUCERJFVhUBYmFa4nuCoiglGEOmQx/wNwl5f7j75shlJVMnRPZ+Kd+26nvUy9HygDoIXaaYStNOfgfaiUqwSiMZJYsAiHjy/mzrRS282zXqd5YGnxwP59i/O9/W4lhLC0tJRlWbvdfuSxszcuXR6Ni0vXbuSt3qmTx13a6Q9nNm1fv3F7fatvmwaib+d58FJMp9GmqrC11Z9MJqy4ML8wGk3a7Xa/v8ksg8Ewca3+1mhx4aAIjgYTPAq3b90SDmtbtw/sO8i+iOVkdXX9qadeOdfO79y5sz5YT9IcUCfTyXRSEmKeptaZ6XScJ46cHU2mzdROi5DlMNweXTx/4wd+4Js5VLdWV1za6e3rqum8+w8+9m3f+QO//Vu/MR6OvvXb//zP//yvHT7m3va233DOJUkzMa123i1pduvWyvrqBqrevH69223dd+r4aDz44Lt/Z2m59+DXfvXFP3jP9/2dHzx9X/GjP/b3V/vl0UOLpdLN1c0Qi61R3yUJA0bAIPWNiyiKBqoQ9wCUmVl2bHGKxMyKxqDsVEcVRKHVasVdQrzO9mrmvaY79vb4ve0/yVLYFcIiGEFh5qoKk0k1P9/qdDqG0HsfY/Tel1XFOlVVIBSEMngAUFCTuDqZqE/KUPfyFxFBr6oAxhKRqPoQayknABlERQA0wLwTq+w0K9yL3Iuq/jBI6oxVZ0kARNPEEhESACCjkgIoqjIKI9YNAjSKADMiRaIobOq0g8gQGdJ60HpGWWD1MaKPAMIqwkggiXNVjBI0KAEQq4lMyObwfKcoiqL0ImIAEKSdZ61Gc1ZVypXGaBGsI1QA8SAxMyKgYEhRFSEoWFIrJs8Sx4CVSohxx3mMzlgfSlAwEEmjZ19xnAWZGKiKstO0c/PtdjMjAT/1s9m09NXC4tEkSTbX1h955BXFbPLStWunTp6YMn32xQuu2bq1tl4VZb8fQOHIkdbjTx2g1tLly5f7/X6jkaWpmxSliDRbnfGsgKACokBERgBZNAgzK5lkVkzTNK1YJ1H3NzrRJKWECl0RhQwyaqJYT6BNdnXTtIvsBhAU0FoOsYrREqV5lrodhcCgLFApcQY4qSYBJCTKzoAfVgKNw8d63mo/uMvnb7baeWrtwvyh93/o04cOH5sU2h8Ptqfh4cce3hqszc03jxw9ujTfThN7+/btLLENss1m+j1/7lsn24PVyxfmUjp7ZGGyfXfh6KH+6t2mtEou/XS479DBG5cuXfrgR3/k+/9yESJcXv2Jf/IP77/v5JGF408/cj9X2zdfuDHZrhr7Frvt5trK5r6FZDQsl5/4U60LV0N1Zf327Q5PDjQJEWXMPJlA1Ka6mzduHFhsxmL65KOP9BdWCfm1D5167oOfkY4oMAEbAFQ0EFFEkYxJBATIMFggUjSKpGhk9uUdsHpPY4B7oyrZaUYKWA/zrvEcJM8Sre1IuFOnRUQClNkw+lJj5YzOtbKFbnuulTacYixTChlVbfBt0HnTOtDQfR0ThpNWlk0Ga3a+89LNS4889bSEyfLyvOCR8xdvXL52d27p0NrmeHMw3R5Olvcfvn7pfIyx0Wwr2MmkyBotIruxsXHx/KDdaTbS7MrVW29645OPPfZYb65z/vz54/tb07E+9YpXrKzcGQwGpHZrdX2xO39gcbkoCpXy6LEDd+/cvHP7ak1QhBA63XlGU2xtD4cjtZkQF/3Q6XSGk2msSo4+TRfGk+mBQ53D8wu97trnX7pujLly+cql6xtvevOf+df/6r9+1ZsffMd7nxlWbuzNv/tPv/aVb3n9008+9c53vjNOpi9cvrtv3z7jGout7mg0VHWJa66sDq5fv/7wI+eOHDr86Wc//uRTj37qV3/pqVc+sfbxDz/+wNe//Tf+w6/++tt/+j/9zlYJi8sNSrNZLENUHyMLCltQQ0BoYuoswo7SkQUUotQ1P0BEDLzbdQYwhB3WJa0LnsxE5HYCPYLd6YN/lHM3xsUYYz3YFlGVyuCrqiILWZYZYyaTyayYOmNrJf54UtTFyxCj977W2yRJYmyCIjvVWkARZVYRlVDuFHiJmHeaLiAYBgEVBKsqAvWEmHo65T0e6a860QohiMRGmrVarUaeGgTmQICGgOq2pLVV15nE2ESwHmTe7uRZlkosfShVpZGnZVkqxyTJULSqKiJq5DlTEmP0gX2UirnwPCn9tJSAxJB4QM8YFBWskkEy836FiBJLzpnEmdSQNWRJEiKLQhBRhCASaGKttaQ6Y5bgIXjgYESdQhYxnTJ5tBPWbe+3fZgK110bRIhDVI7OoAUBjo40MwZBUHZMMxZrKWtCRMHYEEKMARVQGUHyxDUbKQlPJyMJYaE3d/zYkV63U1az8XBEaWs0Gk2mM0Q0SVorapVMUVa1sTYq1C5GqXUWsaoXTRCOMYYYPUcWSLKc0UTAqCSAUU0dYTaxUt5ZBKQ7qluDVO/6qlq7pGDXWeccE5EzNnUmTWzubGYpIZZYzHfyhW4jMQKxTBKdn2v3up3Yv7PQW57OorOZcflnP/vZZsv9lb/+lzZXrxZFf2Euc6hba6utRrs1vxRHowo7IRYQ/dxc4+7ty8tLvbKcbfa3kkZz6cChd73ngyfOPriwfKQIPN/bPx5Ncj3z0vkvNhvukYfPPPfpj4VyEP0kcfQVr3nVyp3VdmuOMLty+fbBA8cuXrjmbGrjWgXGzR969sLtfN/JfqCPP/eF3uLyaLD2Z7/2Lf/xp3/me/7C1/zF7/jWj3zog5/4xMdv3rz5yVXqtJubm5uI0Myzra2SCHyE3kJjNCsbnflp6WdRkVzSaLMKRX+vaQXvOfSe+2TvZyYFgLrptiEwWH//KpGzxEYfZtNJmqbznW4I1dbWFiXZ3FxXQnH88P7FXpPibP9iKxZDLiet1Mw3kiwxoZghx4X5+UP7D4AZLywsjMfj++67r9/vz/UW766uLR84vD32n/38+XEFV6+vUtY5c9+jX3zhfGRM3KDRaE0Lv7k1HM2qLG8FxsFg0G51ktQNNjfKYnz61PGzp49Xfra+uvYVTz5559bN0Xi702lWvnjDG77i4qUXDx06sL6xet99962urn7uc5/LG639+/d7H0MI/aGAoaKMa1uDrVFRRQxKIeqkKBGMcy5LbOIMCgdfRR9u396a7ySjkZ+bT9rNVpbYwwcPFLNp9LMscSt3bpVTeeVTDzz00AOD/ua1a9c2NqGZ5QCwuNgrZmOWanlx/vKlF+bn8yOHF62JaRLPnj2+sXn70MHlw4cPdZafvnDl+qNf+TXv/LV3/O0f/9n1EZx+6MD12xuL+w9fu37LmgQB9i30Rlv9ZpqU1SxrNesqJQAURTEtyroxC5AtiiKEUAtndbeD297AW92VnNetZtrtdj1vS1X35I+q6hK7t0JEYi3YU+DMJarKHCSyqhq7I3jfHozrLjWNhsnzfE9+45zbW4dwT3cwDZXuDHbHOsOIrCLSbLdEQOTlBo714e/5B37VqTYBGmOSxOZJWgfFBBp9ZSwaJOUQQrWb5rusngtM2mzmaZqIxhg9gBCoKhOiJUMKiJilaaPRmJaBdSchigpl5FkVyqBTL2WEWQDPxGgFEyDDCj3ZAgBCJaLEmsSaxKEz2EisRTEopAFFDLJBMMaQFiSgiCqWo6kC+WgqoQBJoWYU4jjEYfCFcEQCQjYozKrsjDUKwEKAqbEcRFVJCbROP3bcbpWtNaRiCIFFuHKEWZpwVVqjqTOWyBq0SNaSIcqyZDotyqpCRLQOgBQQDRVVUCCRemJ0ncejApjdWCDWPf+Fo4ooJFlDkRhJFARIFWsawfGUdg0yBtAgIaJB5J0iogjuJI9cD47AHaWXQTBYz24FC5I5zRPbSChx4kjyhFp5njfSx44vG2MH/Smoqarw4Q9/fn0VXvkU/LW/8u1zLSzH61yOFpYWoPSf/PBHPvaR8MM/8o39/kbeMPnhhbB5twgTSKzJMzXJrJLewv5nP/7c8cMneu352XDa63Q//bm1ffuWxsP+gYMLWcM0m8lHP/KhRx57+M6dO5NJWXmYm18ebJf/5099/Nv+9MEnnngSbn1q/sDhM9/+fR9+2+/OHzt3e1D8/vs/9KlPv/SP/9GP3L72Eoby0QdPnzl94of/tx/9gR/4C88///zvfn4jy5P11bWTx44+95lLr3nN/caYu6ur129u3h1CnoLNk+HMHz9z7uLla935nvflXlS+c0vc0wpmj3DfezDsNPWq+yQAgqACgaSGlDlxzhHOpuPRKGQO5uc7vblmp5VV5fTIgcWFTlZONo7sm9+/2G6ntpUa0qph7WwyTp11ljrN1pYvszwZj8ePP/6492WWNy9cutzszE8KXdkYfvGlq4KNtc0J2dbcwv7CByqura5vnD13f+nh6vVbFVOz1QU0/eGokSYbm2scq/37Fh59+H5rwBezajscOHCgP9jYtzQvEl73+lcOR/3haIs53F1b2dzcrIJPsrzX66V5oyiK1XWZFGV/MBrPvJCNajcHo7WNQdxtmeCMtQTMHH1kD3m7mWXJ5uYAEUQgeGi1YDKEN77hocuXLtx/5lSoik9+4sZXv+WBVz399K/8yi8vdY6LSJIkrVajmE1RpdlKttZvdztJs2GyJKpOz505fPTI8pOveHg8HvaOnBOluxvbCwdPFJz+7R//id9+140HHll6/vxG1kjTpBmDTrcnnVY3T9OqqiApa9c+AJQ+VFVAhCTLa7V+ZKmhvB6TjYgovEfjGGPqYXu1z1zv0cXuFVTJ7RQwaYec4XqAFqCY3Uq7cm3QQSJKsmZRFFUViHa6gdaBeZ0npWla8z/1UI4QQiPdtd3u3NRaT4PJ8ybvGOtAdiVbiFiFe3Tu1trUJWmaWkukoMq4ZwIhxL0RuLu7CoEYVN2RQNb2aAsoSOBMCizBl8qSJykgeu9FBVStIWsxJUzFZLkNEeykpFnw3kcmtKgkLBCjoHUiMbCqcogSHLCaaFBRE4MO0YIlCQxIqFY5ATAO07RpKAtiteJQiFQyKoqSceZjKYoKDhFBOGqkumETECAQMosqVoJIDpFELYJhwLjTMw2CBABjbYqWgCNXyioSVJRycohm5qvpdCIB0gSyLGkk1nsvokAI4AMroLHWliEq0E5Ly7rnFCKCIfZYu5YRBEGAGJARd0cPKAAaxLqzAyJyiPVQEWfIgK1XVR1N1CtPQUVBRL1IjIxJtkMyiKoyRkAQQkkZcVoAe0ecJZQ548wEUW9du3Hi+OnDh49bk27cvC2pOXRWD52+f+LN9spmJ6PMNger/fl9y0//2W9++sm70JrLhsOEAAbbRFSEkDZSJnv51p0jR0+9cOXGI4+9Io5n18+/dGi+R0ZPHDJlefehR46v3LoxGExPnztz4PDC+csvfeHFSz/wAz/4wY8+8/sf+sDC0sHv/JbDb3zTV370ox/v3l3pT2bP/YO//23/nx/5rXf+wT//mQ/8zu/82//23/5buXX7SK89HVVv/fn/+OpXPX3rKnz64x99/Rve1D5pZ9PxB97/vsO9fP5Vx//0m161srLyNV/x9BdePC8mmQV874c/lpjs8ovnT548tj2a7dzSu4Oc9oL0PUT4UnxXBcS6AwDVA2jqTqSJq7yvgmeDGkMrg6Wl3tGjR02xnqcwDWVDJl1HrVwP97InHzntIKRG1+/e1lAWYbhv6ZCIOMvF2LPC3ZU1pM/neX7qzOm0kVbRs8hw3N/cWn/w4Ve+9wNf+HPf/Gc+8pFPdHtLX/vaM+cvwObdm2mzc/TQ8lOvet3HP/W5Zz7+7LETJ9vtNoC3RlGDQ3UEWbsxHBepdY7sQw89VBaTO7dve1+MJsO84VZWVhVgrrdU+DAuuYjVnZXVouowawA3rYrhZDKrYlFxZMibbVXdnVkChExgAKMmLXGpadRqLkEXorUxnbznI8+fOX3w81fvJoRf+y1vyhL3C7/+jtvrrDAbjUa9ufn+pAohNHM3KoK1nd6+g9Vsy2VK6kaj4CtI0na10cfMy7g48pqH1z734i+/9e2/8Kv/of2Df/N9H7h07mij8ObazX632Th78pSKuXDt8okDJ7ermztpWT39ioAVQwjGmJohJSIlA1I3KVe7KzCvF0Bd+bTWFkVBu62B9hYJIsa4x3HX8ikQlZ0xLBYSY40xET0HDkFVuTWXAZFxvpZaxhgV0SZJmueqWoVQer+zf1ibOSdxZ8Z13bCinmUjQD5GAJAddhBkN1i8t2OHbWS53SF1ALDuqaQAkOc5Rx+jF2ZnLDmyzhAR+tI5U5d6rbWCoByiABkSohjKooqWMLeOAYui3PEKmtoXhkDYVAwAzpClQjgYBDWqCCVH5aCOgByAgKoABjHKJqqKarCYWkiISI1FNMAqaMlESAnTSKkHnCGN1U+BNouijFpGYSS0zlpHqoIS2KPu9FWtvwlWVK0L0QmAQXKgBIoqgoJkAVCtscZaQQQW4CiESZb7GIuiEhWTNk2mwjLxUvdcIFfXtWOoR0CiYyJVrVeYINQ+RkSEaGBnrBUIwv9L139HSZpd94Hgvc99JnxE+szyVV1V7T080CBAAiAIGonQkCOSIjmUKM0ZGa5WGq2OdGbnjGak2Z2RdqURlxIpiQ70FiAsATZMG6B9dXWXt1npM8PHZ5+5+8eLzCpA4HdwClnZWZERn7nvvt/9GYfMAhFAYd1B1BZDJ5AhEhIQA28Y65wD0By47ziR3XWZBSCHQAiETPCpmx0hIMgDGNmgNRatdWgosChKQrJIbjeHC7cvN+rXK5WGLp0xYSzZyxdW375+7YPveWS+qVoxX2gtvPby2zYrnvqBT8DOyAVhUiYbqzc7c42w1qi353bH2VPv/9jNG6uHjt2/vbldBcjzdNC3jU79C3/0hYUFdujpU9e/cb7V7qxv3FaVaLnV3E2SF15/pZ+ltYXWE+952jr22a997s7q9g+dWPjsF7be8cwSkO206kfmYHfj1rHFGZePfvdPPvfJH/nwicPLk9Hwp37q4bhSe/bZr7nawhuvvvL9H/2++44f/bVf/c8333xpttN57gt/2Jlb+vDHPvH7n/nC/+Pv/vznnn3hi197lZsiH/cwqrG7vcxdEzF31zr17sMMAMYBIgjGEAkBERC4Zc7pokBw2pQmh067urK8WKlUbKkrrGxWw1ZQ6TTV8cWm5NV2TcRcD7vboqp0PtRlnox7RdnIsswYN0h5p9PKC33u/FtRFESVsDB6kus4bg76e7MzzZ3djXYLXn35RSXFztbqxo3x0cXZUaMSxK3f/5Pn3v/+97/76cdeeeUlICMFznQarUZlsLcjBQAZ5uD0meMIbjxGa4rRqLd255aFMgzDXs9wEQJTg1ExmGRCOcBiazeXUVtbN86oNy72uuO8JK6kDCulASCv1WIMCEAAcBSqP05l7jMwGBMqUDXGIWBBmefX1vcCDjOd5qsXrk+Gfc7x/sce7K3vjnUZgrNp5pxDFeoinZ9pbfcT0qVQQbPaNKDfvnSt3qhKyRfSUZ5lcudOyMqkvwb53r/79//7P/u//fNPf/5twWE2Bsbt2q3rYVCv8Hg0GvGqcoBWawDgnAMTnhBJ+65tDhnt754ZY5aIMUaARP5hROfIWMdV4Dd3dwETIu2ctfqe3d5+dh84wThnAgXj4NsCDUwTQZqmjLEgCPxvzPPcq6uCIPC0+gM3Ko/Ra1eSf7wBfOkAJph3GAZGRG5as6dojLtHcS288srpUiOK/UA/sgalLMsyTydENgpCqYQfkGpdCiEYF+TBFgba2FLrNHOOTJkXzrpGNeZSOoCi1AxBCIaoBHPIvAMScmCyqgRzEmGcu9LKwhC3ljEiJwCA4VSGYgFIo0YquQssOMdJkkThwCrkxFgOgiy3KRnKJ6Ub5uUo01kJmYXCkSHGkAlgkrw7KwoCT3D1CAyQl9tCXmpgxJhg3t3XB9QDBUTkyDhNjltrndYA4DhzjopS+5zcMFA+s9GUZYnot1rIOYF1riSGVoREmgCm6mWc1mAgQuYxO7QIDsgQHYR6IgL3kw9v7oqIiP56kXPOelKf4yg4Mi+Gdm4/vZM4EjBuvUWBA/ARuMDElNhhkFiAEoGUAQB0giMyNr8ghoNkaFm/X+RZGQRBjHy9P2hUYf0zL7336fs++O7Hdwrg7VP1INy+MbyxdnV2pnVkcWmpEtTnW5BnupSTcf7873wOVDXLLj96/5m1vc0TZ8/QuAtY/OR/95FP/eYX965cmF9ebs0szCwe6vXH596+PLNwYrffXzpy36/93hdmD63OLy4cv/9ka7Fz/qULP/5z78lBPv/ii1dvrv3u7/3Hf/I//o9GF//oF/7+X3zuc41qWKvV1jd317f23vP+Z3YG6awcLncq9y3PNqR714MnT586ubp6iyXD+1Ye2rpxoc5MQ+HP/Nhf/dJXXg2Y49q6CL7rsc+Lv1vc/dNIyAjIOOQIDhyzzvtMEKJgEERBPY5nZ9r1SpylSbfbbbRyhVG9FccKQkWdWjwabL/+8p0oFLg4F8VScKrUa5ZBps14PFbxgpRBp90WHPNicv3GNf+UFkXxxGMP/Ptf+uw/+Id/68KFS994Ze+vfeLBUnd2Nt62ZXL81P2N2YVJHz736T/+ub/z95545MFbq3eGzDVqkeAQKGZNEYeCrI1jh4yaTfnWWy+NRoNWq4EYAGNJXjjLb9xa3+0lUbWFkghErXFoVLi9vf72bjfLC67iSqBKY7PcMsb8I0o+iI2sRyEiFTlAVDwvtDXEBHl44ezZs2+ce6MeqczA5bdXGcDpE3P9SQqhDBoVjFSaJ0QkjMsK0yC2ubq+NFcbppqg7MzMTgb51k5/YX7mc5/9woMPPri5vd3vjf+n/9+/vf3c11uzy//in//CTO0//Kdfe7kRQHumtrY17o+7Rw6f3tjaVfu7LiIi5IIzALDOG8wwvW/qaa1FJriQRhd4YLvvs7GMKcuyVqv5PFX/dANAWZZlWQrFAaaBMABI4BCAPC+LiBwadAhwoHodZ7kv3ABQGmsccMm5VKNJwhhjXARCekw1yXJrbS1SB02GQ0DigAQMEbnzbTiB3yn4odHdxCgA/BtPH/USW2QkGJfca2zIWZ2nkzzPOGKlGldCj/3roCxUGAglCdEiAsPS6FyXQgittS1LwXmtElfCSJf5ZDIR4JSUQcADyQUHRGIcGAouVWlZVtIkc5PMTjKbl6SNG+aAiLSfE2t9ohlZJdi+RQFJRhJdIJBzFDIujUu0Hud6WJSjUk+MLS2KMHYOnAXmSKAfawI4IqatteSvEHLtHc24yHUJOPWDBnb3BNVgquhljHl5LWNMKVWWpd+T+CvhYLp9K8sSvaSYc2uoLEsAEIHyo5iD48CiJJwCNWiBLAPjnANyYH2YvWAgEQSCBMYRGKCoV6211hjQFh1yZBwFY6wsjSXnCIihY5wQjLXa2ZDAAjog68ABs54+BawoMiGEFFwgcHKcgZIiEDIdrQuhgqCRFa7XS1CIdrMmhd3b2Wk3oL8DrQh+6GOnHzvzQC2Kjx4+IpsTSZaXSd7bU84MB4NqY2bu0Imbmz2KqjfvrH7oQ+/dvn1l48b5uTrX+cgZubS0stsdn79wtd1ZOPfW1bcvTf7tL//LP/v0Z1967bWVQ4fmlxfe8753v3H+jUuXLux29x5uLu52eyKuy6j52Dve+ZP/wy994BH1Ax/76De+8ucP3X/65W+9sbA0+/BjT65u7Q2SgqtYTtYVZ07n8zOtU8eOBBx+8Re/+NM/+8x2t7907PTa7jBoL527cvvSra3nX74QVcM1ExxMUO9t0g8mZt/RuZciICJwloEDsoKAIXEyCzMzyagXCbG4MBtJkUxGQojZdufJ40pyqFXCIu3PNqv3nz7i9GQ82LWmqFViAruxuZ3neRDFSgZ5XkaNI3mejsZ9RJuko9FoUG9UH37kkUlaXrp26+r1tU/+2M8Uhv/8z//yz/+d7+kPJk8fdcZC4TDXLKx1/v1/+tz7P/j43MLhty5eHI5HzXo9CtCZolmPluZm02zUblSstdZpgV58LwajiTZkIVhd3zv39qrjcvnw6e3epNudrBw+dmPzRlEUxjgmJJfCWq/UwTCIpmfMZ3xbgwSIGFfCojQyCCdp5ghlHA7HCQAMh/0jRw/1dnfKIn3wzOk0GV2/vhkF0G5gHFc5k8PhRHAVBTEQzXeazBb3n1wpkp10tPX046cVK5o1Ba7sDje/93s/1O/3b1y79ld+/MepNFcuXz/9zEcgcb/3O5/+zd/53KuX4Mzpue1umhnGRJRB5gu0MYaQe2FqUepqtVrse0H7iaAPbS/y9MDt3FcDrXVRFPV63fdP3oLGOVeWZVEU1VoNAADdQba7c9bnnfq8b2TkZ5AeYc/NAZ5jfABIo9FotVp7e3ueyeNZmNPqjBiFd43AAGA/YZG56W0JDvYhczs1Qjj4YZHnOWOMC2+aQdZajsA4TMYpA4jDUEgeCI+TAEOM4kAp5RBK4ywAMo5ccgIeKGQCwzAKQ8VYXpRlbgiYp2MjomcdMTBA6Ji2ulBhNazGgSCwmSksEwAqGJeWiMiBj94mj2AwZhwhEkw3Qk5wshYlZ2VBuTWTwo60TgwlJAqunOQF44wx5ExYMsYxspxQeBYnWGuRMeEQEBlD5JwrFgCAQwdgHQLAFIqVBRlyjDHOuAPHODHmmVbTau6cc0Bgrb+0BQlnHXMkBBCBJgQApUlrOmgB76kkYC0RQ7Lkif8O0IEDmC4wiIBkGSBDy4g4oDYlHaQbeljgHgQQ95VljsgCATCBhjs0SIhggQDFVGB51x2FA2MAZB0V2rTn5ifjopdknFfnDp/gIhink93x3okHHuxu3aos5kVufufzl89d2Tt55NjoCy8v3W+PL80t16r3ryy3lbJGnXvlwuSFK4+++4Of/qM//wf/27/4f/9P//iRR47VQm6q4dHH7rvxzfVRrrojuL2W3Pfgg++onXn0aQ7x0cFQbG0Un/7q5Zn48v/1i1/7m3/r/X/jp/5WbWH+t//Pf2uC4j3PfO9Od/Cff+1T8xVotFsE7p/8k3984+qVL37xjQcfmT9/4eoHP/qD33z13NuXr52uTN640P+5n/nQ8ZXlt869POr1lmcg5u6Pfuvcx34k+57v/yt/9pUXIi7m2/WZptob5CyO9p/Jb0tA/o6/3r1g/iQzZMAE5yEXSqJiKBUPgiBUQknpZeONWmVxab7M13qjYbCyUBbZzVvb1Rha9UA7e/TokSxLjDG90ViFYb83mJ9fLJDLUpd5YUpNUCiGlVA0G9VaNUqSZDLYk4ycnjSrc//sn35sd3fIoTi8tNScmd/c6b38xsV3ve8D1fBzf/B7r/3Df3x8aWlxfGUgOaVJ0qwFRZ5yQVkyyeMUHY1Go1OnTisZXrp0Jc3t5mafWGV1ra8NhGGrP6RBn/pDNr680817SqlKXONKFoXO8lIIEceVvCg4596Y3mpnrQcPXDYZ53ke1xtFniJXEaswxoSSpm+dhfmlxd7OzvWbN6TATicIldjuJcfbYpyk47IMBBXWVcOoOxzVYr6+tydskqfpzVursbJuodXv7bz7ve+s12YvvX31oQcePvfCNxfmZk4/8cjo7Vdzzf7aP/679508/fN//9/cvrHDY0hSqNTdQZPuYB9+QYb7HBVfvh0hODPlle9Dc/cOY3wSk5QyDEPYZ777bfT+jcEJLeyPJn1xt96JiBixaSYwETEh7m7MfWFkjBAbrVaWZZPJpNDGWhACwjBUSjmdHTQWQIzQIqI78Bw+uC2JETpgiPxucWdZljkySkgpJYNpIglHZq1WSjWbzU6zFcexX6+UUooLxhhZ540opw0pw9FolOQZAFNKIePaWIcQxBW5f0y1rwiIxIDybALOBJKHgZSCCXSKsUhyKSX37kuERIjIkUuuAgK0hMZRqT0eYvJS56Xd3Bts7413B5P+pBiVNgfuZABBnBrIgVnODeeOcULJeSBVyEEyEowQLAPiSAxxOrNGgQDOkLG2cKQtFIZyo3PSBVrNgDgCkiNryGolmDVl6pPRhQjDkIiSJEHGCdA6PyFHZByQOW+Fg15mJlBIJhVXgQhCS+jIu2ZyxhgTHLn0ABnzwC4iQ2JIHBDB5Xle6mL/1iSY5lGYg2mPX9v97WOdc7q0JgejwVkgi+A4IGcYx3EQBIJLf2URudY2TfNbq9ul0WFUJS56o8mt9a3uKI0bs9dubW6PigLCoN1yEbxxtfuFb7z26qVbv/1n137nz174N//hS7/0X371+RdfqcatWtxJhuU//Ue/dOr4A2DY4WMnP/W7X33XT/+N5uLczs7mwspJ5A3joq9+fXTyiWcefeKZSm3pp37kp77w+Re+50M/8sY3fvej3/eo0WA0twa/8Ad/snj46PLRU29evNxZXL52e/xffvNfZnk5GA6v3rj+//m3v/3xH3jH408+dfXmrT/97OdXN7bvf+SJM6eOz7ZhcbbzlS9+zpX5mZPH3vHE8je//vWleahFwdVLb8/ONJvVCkcKOFuarR1wme8dnDLG7jV9hX2j1wNzQcYYl0EURfV6vd1uz87O7uzsMMZqtZqUMo7juc6Mc+7Kpcu+H3zooQfe//73nzp1IooibW1RFFGlIsNgdn5xZm5u5fBRxmWa683d3e3t7TBSczNtxUW1Gq+sLFej8OaNa4P+3n0nj4cKX3/55d7uVrteedfTT4Atszx96803JqOhYPji888988yj7Ta8+trLVhf9fj/P0yQZB0GAzkrOdFlYPTl0eG486V25ev7mrSuTyWhpaaHbH59/a2vtTuEs394ZvfTm27t7ab2xkGXYmV0EpvrjySTJuZBxXEXkaZIb7awhQM6Y4CpQSimlAhW1W416rVKtRIoLIGutLvO0yNL5+flS56urq/3h2Cszk6QYp0m9CYeOLtUa1TAWIDHJs9zo3V53Z7f75ltXJmk2t7ConR2OR7VmY+XwofX1rW+99Oo7nn7X819//tDyIgPafOPVnfU7cwudyTe/8eijZ77ypV/9wAeOWwe1Oq/GAex7gR0gLf5Set76wWXFfYKZL4tu3wIL9pP2/Aw2iiJf0IlICFGpVDxibr7tmKY44D5Ce69xdJqmeZ6bfe9GrfV4PO71ep7wXq1WO512q1WL4xgRy7K0+6iRJ7+5fTtiz60/uD99XvPBPGA6Q/rho3G1Ws2yLAzDMAwZkBCi1+sJhu12uxIFWZbleS6ECAKJBFpP/Yudc6YsPUzBOR8MBu12u1KplGWRZRkSeIwpriIRIgjOAsk5ERmdOJ0iFJVYVCMlmSwzkyemSLXVcCcvDGCm3aiAwqKVcQFB4ZhFDszDoI4hcOc4EoAbld9mu3xPQ/rdQxiyYCgQmGsKNwOmBkYanVk7imsa+IggteScFc5F4CKgIGJdIrTTbB1OAN7MoVKpOGesK6zR5DTYfdWikECCQBJJBwqAETqHpbEZoAZ0iIQgGXEECcBKxv1b5X5f53zvbv1CyBgTfvYLQGQBgEUSCAEYkADgCBKRAQmt9RQkBOuctVYTWCIqgwoROWvRETgUhAyRA8VR4Ix2zjDu0NOCnHHOBZM0rkd7/Sys1zIDUWNmqztkMgYurCUhmC7zssjrcRQpmaYTFhWcQTacQAqhgyaHj7zvob/9N37s07/1X/7+L/xc787Feqx3tq7t7Nw8c+ZoeObkldcsY6zVauzubR45fOj69auc4wvPf2M8SF94AX7pF3+CMwXAfvdTv//e977/7bcvrEanNzfWrl58MxBwZLn1d//7n7l0/lWw6fbW+jueeuxf/+vPPvigfOaZZ65cu7G2tkEIl1crP/Dxj924fPnJRx7a2bhz+a03W7X42b+48e53dt75nneub2zUW21iOErT19968/r1yRf74dQIkHFrtSm1cw6RK6WK0hCBkAFXEQHTzlrjWm67P6Kjx2YcR0dYbdT7/b7ijDl3bGWZlcVyu2EmIyxynSSPPvjAzML42LGjzUZlca41Ge3tbq+1m7XRsLs4P7u3twfEAESWlrvd4c52Vwhhi2x2dtY5x7mYW5gnh71eD4V0FrKi2NnZuXhh6yMfefd7P/J9V9580xhj8quAwSRz9fbKN755/tjpJ37zt/6UWHT2wccvXLg415lJk5EAu7zQkQKOHz2S5S91h2PHw9bCMasaF25sf/PN69dWbdQIDSlNnBwH8g4KDBEDyH3xOqiSvkQerHOe9QEA1Wq10WjUonhnZ6fb7VprkfOp6mfKAvRWHDlwFsexcy5Jkqcfe3w4HnW7vf5oWJSGMRYoEXB0ebo4W2f55MTKTIxluxI8/ehDN29cOSmtioKoKs4+fHqQ7pG0cTNuLnaaJ0+N9royaoKqRovHvvxnf/4P/sF/Zhx2u43jx4+fu3hOgZqbm9nb2wvjKMuSaRyS5ETe+lH7NTuqNtyBmIjI0BQqKQ0hAnLwrSoiOueMs0DT9WAap0VARAxAFyQEKCGEEBymOUrknGzUEdGblfiC7l/KauO55r5GSyE8L34nHXvDdyLy6xDsu5gZYww5pVStVqtUKp5DmfcGByuT8ORKAPAseu0VsUTVas0Y0x/lOi98ypRzDpG8g2WWpUTWX2y/4sVxDABFUVhr/KOy/6YzwUMh0NNqjCmd1QgUhgHn4AgRMQgCdJIMz62ZnW+UhkZ56SYaDGYOdWmS3KAM/BwBwTEERg7BMZraq97duexX9u/4zsGhJ0AcApYZ0y+SATrRqFXbC+3e4I5xxjpHnHERcAyMZdYYLgIiH2iOyDgBQ3KWXFIUfniBxBAkCAvkzeQRCAn8nz5VlgAQGEdGgMYvT4ScgB0QlxDR4RSbOzAo8FJ5RLafFQ0AoIuSMc5QeH4NkXGOEVnftPvRKZBlSEQEjNBpBOAIjCHnjAFKZBxBZ5lUiGCLLHVUSikAnDGlsqAYzrVr2/0xMTnpbTfDmoxUdzhqVOvGmFocJK4okkGzMotKjKmoRfVYRqwwMVA5HHz56+cvvf32iUOdrz730vJs3JyfXaiEBdJfvPD64fWdevMxDtjbWv2NX/38//K//O25Vm0wGHQajVCq3/uLX/jGH33m2tWbR46c+Mmf+5u97mDhcPbyS6udZvWmgWwMP/Z3fvSPf+uPHnnw1Lde+uZDD57ZuL176riYbR/6iy9/q1JrhKq9292rBuzl578Oxr4JJZalKYuHHnrq6pUbR48e3bizttfrPvToI2++db47HLz76SeZe+m5XDnnyHv9TC1YlRCi0GUQhFIqSy5LJ7k2fpQSRuGJ2apUARM8N7Ysy0qlsre9tTAzw4BqlWgwGJw9cjjpd1WrEUVBlu0cWlnZ2Fi9df3S0kIbAPr9fhQqznmtVuNMAghyI4ChEEwpxRVGcWAN+aKZ5/lwOCyt63Q6ZZ7XajVHWy+99M0T952YmZkZj8c5BVJVx+kwjmNrrSk1Y2xrN32AMQC4c+dOo14JAsFlICU6wDSXR48/2phZuL01+MqzL7/4ek4Sjh2f3+knjAR3aBEBCYkACfeDqnzFubcD9Z3vvRudoijG43E2noxGI9/n4r6tLiB6Xjl5tQ5ClmUev76zdjsvdJblzjnvbK4kV8iI0Wg4ka6oNZqhK3d7m2vb20JG43LQqdVeeu28qoaLh2YSPW61OlcuXj2s7fyxEyCDOxubvau3PvzDn3juiac+/ZnP/8I//PT6nbeOLTY3N3uT8fbK8tzm9m69FhtjmOCMMQv8bsVg5FWjB2O2g08dVcS0a4apr7r/Mak4AHBA4FNNMgAwAI4l2497RJp6wDgAnRecc7jHTMY554wtjbO2NMZwxhCxZKwsSyEEWUPagLFA5Aj8S8H+yI45Im2KJCVtENE6FyLbZ607EVXiIAodEAP07gf+Hwsl8zQry5IL9NXfr95GwP6+wBrjnJRKiUBM+XZlWTpnA+nDR8g5x8FJTpIjEGlL08BSJi2VWWGsNla6UEbIhVTM2FITaiJDzCKziG4q8GbGOALvfEb31ndikv6SeLPvWtwXW9VskghGswthKKJBt7ezc+16DxYW6pGILEa5sZOi1DRhUvIoyDLjRWdeaOoYOgfGWsaYnyUwZAwIwRFYRuCpMI6mJd4h+C84l8QIEDzqt1/ZhRfD4F3EnMBNbYAIGdB0P4CAfiVAV6JDLoAhIaAj3xGA76SILIHlnvDKAYC0LRgTDFBwxpE4AILlzlmbKScJtDUZAYXSccEMgFTQ20vrTdWuyNbswsVLd6xIeRk3kElNo9FIVKs14ZKiFDol0jozhTQ6LYpk0qk16p0FkwzvjLOdC7vPvfZHD51l73/Xwx/6nnfM3vfOl69tmPhQM3Dr6+tnH354oQEvPPvF937848/9xZcff/Kp6zdu7Vy4FARhWph3ve8D/99/+4uf/NEfG4yz5M6dqy8NlxbC1+7kR2cWmh/43hdf+Gon7lx76+b8/PwDJ59otDvD3sVGPL+z13O6ZNno+z7ygU/9+u9fen3tX/+ff//mtevf+uY3n3jigdFkUqlU3vOe97z2ykuMwcNn7/vCl744N9OpBpDneVlqzy1zDoRAxqUChohlWWhTgHP1SNVqlVqlUg62Fmbnu4O+c+CMnYxGtVpt0C9X5nlZlhr4+uqtpx48nfVtFAfWlY898vDMkUNKOHSF4DgYpaNBV6KrRAESMIZCSCllHKhgcbFeryejbhxHWltjDAOQUlSqkTSOyOZFev8DD4VhePny5ds3r8/OL+7s7FSCgos4z3OPmjrnDh9eubN1GxHr9fq5m925+dmoGgZRlGeTGzdvHz5xttk+fO3m+qf+8BtXt6DVgag1s7baDestNq0bjsgiWb9ddM7Twz2hmeN/xRb1iCsReTIJaWOM8VAGMOZbYP9M+s1lGIaGXJIkiFitVieTibNA5DjnyAQRFbkuyQwG48WGNAYuX7slqahwuzdMsvFoUkw2B+P7HnpkVNhyfce6dHXt9okzJ0xavvaNF6rtzrH77o+U3nzzlcXTD3zyRz76A9//sz/yVz85HPbe+fTyjZvryWS9UVEEWgaKkANjzDngiGjc3X0/0pQmDQIZSU5EtVqtNNoz0+0+NEdEYA1OWbGIBMiQTy2gQwCY1vr9fETO+aQshRBIAI6QAAm8VCIKJL+HR4/77TkYyxx5gQyzxIEYkUMQgjPkFgEJUVtjCw/dYBjcLe5xVEXgRVEgojPWWmeJEHE8TvI8FYxXKnUViCzLTKERcTTJwzAMopBpnacZEYVhWKnVdFH4ldk38n7gAAASAUypLQAJ52Flxhjn3pfDIhlC7bgQUVDnQczW+wMHwjEsnU6zIiOhiYMQZMkh8yeQAxI4h4wDuv0R4jQ/AXH6v3umxvceLFOsKGbnKu967OTJE4ujwd61K9e3t4dvnu8hBwwjWak0m9USzERPkrInoKKJHIEjIiACNA4coWQC0duMoCPnyHgOo+RTzYHb5zr68QHnDFF48IY4I8cBBBFH8CfKwT6byg/sHABz4BDJs5/2G3nhnXsAkfz0ApAjMSRyfhMJ6Ec13lqcAoaMOQ7IkJAsOiLryNl6JEyZgiubEQ8CqSQKyTlHBXG/3y/LsirlSjOO75vd6fZGozSu4Lg/qRGEetRsdYqYbazvagPNQ/OhCtFAMs67o8QxWam2ZKVuTdbbHr2x7r71a2/8+mffuO9kPD/b+t6/9rF692oljvs7O3/37/30H//R7z/32c9/5CMf6Q2GH/rkX/vD//Rrx46fCsPwV37lV37h7/+D//Aff+Wxxx4/2a7/w5/9ie7uzifT4blvfN2aPN3rPfjgg5vbW7PthYtXrg7H155653sKQ9s2O354UdLmrYtv1EN45H3LX/3yF+87fXZ2bu7mrVUAeMc7n0qSBBwdOXp4b3PjkdMnz5+/UuOzAI7AAReEjCx4c1O/4yZrFMd6NWrUq2EgAGymAl2UttSatCVX5sXIuiiCTqcVIZVFIjlIiSrEQLFOp9FpN2+9fX6m3Xzo4QdXb1xWXBw/dsQUeTKeMMaMnkRRJU8zY0yz2W40m3EAAJBlGYAj0EGg2u2WtfbIseOvvvo6Z3D4yHK/3+v1urVadWVpYXd7J8syAEiSpFarjUaDI0eOvPDy7b29vfmFJXnxJnLRH4yiKIhDZU3Jo5O/+QfPfv2l6zlApxVxVe0PLfAKgUJEAdahI3KIhsiCI+vUQQ97MGq21u43E+TR54NeHgB8cDNjzM8oGWMOyFd2/68Q0f+MlNJZQ8xx5IhIDo3PxzClkhDXGzodbncThbA8FxkISMWZtbfWds4+MTccbWuHzXotTdOz7/rg1Re+XpPq0MxMsrs9c+LkjctXu9dcEEbtQ52vnf/sy5/90m/8+u/1dsA4iOLKzZv9So05QOcQiCEC4wzJAkAQKG8z4JxDzqbLHQNj/MbeAXiVw3Sq6YzzRdyX96nlP02bLXB3O05PoOTaMMADsznhM1oZq9VqcA/jlk0XRLSlIYZOeJUMMmTMi9KBO0QQ06h0ADBkLDGyDonQESMQXIqiKEbDCedcKo6ccS6Q8yTLyBqmmHHWpjbNUmutUoojWOeYY5zLMGZeRGstlfsDCqKp8sqDNhwpKzJdZoCBDKpSKYeonY7iCoPIOVNYKDUpRoEKw2olMIhMuLykzCY6HWelFYqJyCED5FMqyBTB8HDXd5LVYJ/G9F2L+6SrEVnIeCBShXsz9UnjoY589NgjZ8YXr26/eXFteyNjVZANWZJOS6gLYICEhIBccGSSIyNCrxBjxH1VRpLEGDif28YIGcA+ERgBgDkk2O/iAQSBABAEjKH22lMAcF43SwSIfiVxbqpOQgQGHBCVFERIzjrnEB0C8wGcWpfovIc4cUTOph2WAMv9quBdCpGIWQa2GoXdSUYGGnNRq1kjspJjtRpz2VlZWr525VKaJFlv+6kHzvZ2dzY2144dO/bWhUt5AVd3rBnvLC3XFcGZU7MXu2maZkEYLy0tFaVOy2I0So3R1uRzC51Kq4KTbjdNPvdCGofpxY1/8+MPtff29o4cOfTuzsrskfvXVu+89/j9X/yVX6nUZ0/fd1ZKRTo/ubIctKqDze3y+O6PfOSdu3fe+sY3vvbUk4+P+t0HHrj/5pXRy9/82se+/+OFtht3NnZ78GM/fuTlV89xpCLNamF+6MiR3sYdRjrPs8FgdGdzZ+Hw8Z2dnfWtvV/+T28iwW/++g/9+Rc/myejRgwVDiVYC4YL6bhyhS2ss9ZmWdaox81qPZQUMCcxt0mui2xu7uRwNFZClnkhpajG8XA4vO/EcXKmtHqwu9luxP3ujlKMC7eyMlMU2d7OVhxwgeV4OCKiarVan53d2Fwj65LJBJFrU2bpREqpdTE3UytLIyR3ZI3WiEQAWZZdv3rFutK58tChI3NzM91ufzgcuqGpVCqlpmq12u3uBUFw4cqtxUOn8xw2t7ceXVpRIfaGo8l4UG1UmzMdjvSrv/3sjdu3U4CZ1iKG4dZevwDqzM1qZwEtADEEQEtkETQCFXY6E/KNKu2rN73pygGlBA6UAfvDNv9j+wsDlGUZhAFjrCgKhxAEASKmacpt6QCBvOOgVIILIciqKBDDSaoT3a5JxuzqVgb81pFDKysnjmTi+qe//FwthBMrM0jt+dby+guvlcOs2WmEjK/dupGl4+On7kvTVDEG44vjO5OnHl966l3/4jO/9/lf/uXf397tL85WxhOvGCfjgVUEQE5g96WEXi5CzJPKibJkbA+mepz5iHPnXBSEdxvH/S+QwFqL+w37geYfEWMl0XN1jENExZkHOThMz+00WwbAOQKAQMqDon8vDuac4/tfs/0LZIms9L+UEZHQWqdpOkmzKApkoBg65IwJEftfieR1U8ZYpUQQBKEK8zxP0lwpVanEUoiyLLvdLuecwTRT2NjpjEVKyaRAQwasl6whysKaQttBXgA4a3VR6DJzjII4qIVBdcAdFyozJi1cVrrCEToEZNrnOQEAEif0JZXRdBB5F3SnafLOd4hQDo5ada4odsfjyfra7VhEkSyc1cwFD599bHF2ZmVl6fLq5mp3e1DkkkO7Dm44MZa0BQcAWiBTFhkRMC4929SHenCGDDkKtC4F8GRy8iIlBPRX27G7FCYH4IH4aVMONNVBEPmdL961kGWAfplniEiOe+duZx2AdyVljN2dm/v+CJGco2lkO2PIGHDgyBhnTCAHzsibogBHFAhElhGiM93+qMyz0Sg5cXiek+lt3M7Gg4eOH4pC9vCxpdJBmWyIEBqxbMYw22oUGK2urSeTca3VYkxyzlCGZEWnvVRk2TffXhUAJ4/Mhp1RFEffPL+3fn5vmMAz73FfPr8ZBeyjH/7g5uro0Xd/eJSbty9c/fAz7zv/6vCxnzjz4h9+KnRwcqm1cfvCrVs3Z2blyuF6rWlfevXPv+8j75okmbH9cZo++ujhrKTxZGNt7e1DR07o0h5fWpgkw1azysNqtTWbWZJx87W3rz766KPPfevFUw+2Brv9//lf/Cvm4Jn3P8rA1jZxYgvKyVJOilljrEMmeLUWz860W7XIZcNiMuSSZpthJeqAamVJSozlUEohjTGmdLMznXF/j9DqPG8vz/T6WycPLzVCOTPbyNLVkyeP16qV7vZGvVHVGazdXp2b6ZB1UilErMaVUEWj4TiOgrIsk3SstVZKVaIw5wXn0mhrbN5o1mq1lb3e3u3VW7Mzc61Ou92uI/LxYKcoHedxNkkRg8FgUG8ncQyMsSTPsoIybZaPHGvMzK3t7F29dPmV27jYPBypYHt3L6Fuo9FpReFwPAkiAR77I0JyQI6cRecOKsuBZNffZgeMbPx2lpHfuE/HffsRo4RTzonf0xNDALDWJknSqoRg/XYBACyCYEwQ2t5wWAlDptQwLZUAW8LlW6O94bVMA3Nq9tB9+WjvjbfuzLZmrnc3Nm6tPvnEA3eu3LC6WFicffWN1xdPHMkG22GnPd7drcRNMHubN2584id+9JEHnvzkJ/8h8oKjcg6Mc4AeGJ2W6zzP3b73AAACAyRAQM45I/L61YMdDHgq6IGpHNFBQXduynzHfVsY//3Am9UA2H1A36+F/mQe0HUO4K9Ayns3TEieTQFTaMQvovsXyDln7+W5jyZpUWiHwKTgnFsLBMA555wJIcBRXqTEMIoipRTjnNBNLeCB8rzModRlXpa5EhKRQqV8xB8RISPBQDtGLOAKLASZ40VixlmeFem4SJwDY8BqMBqYSxmljHV1CFwqSzDJdOmAqwiEcrQffQPgo3AYMQCyCIJPpxK0z5qZFvnvDrlDiaJwbJjq/igrTTTTrFA5yZP0q1/67MrhY48/+MCTT5680+1dW7+1PeoWtsj3orLUWV6mpS21LY3NjbEWAiXcPlsOAZBzgZwhs94c2REAAQKCA3CA1idbOZ9tDdOFh/bX+WlzRNMgEgQQyIADOGJT26/pyq+tl85yYgTAHDJDwMg5ZA4dIALnwDiBM86W1nJA5wjRGWMF45JxzpAYJEVZrccMXaF1dzAMBXIGaZqu9tRkNK6FEFcbFe5Wr14DDUfmsstXr506fay0/APvOlWfXdgdpnlhr1699r3PfM/rLt/a6+b5eFJoFwRBrW4RNjbWwziaW5pD6ywL94Z7QtaCqLbp8tMPnvzU8xdnaxBy6NEbn/zEwumjD/wf/+v/8/3veOwXf+U3/+//6K9u3bn9wNkzsWC//It//smffixbTX/mb//k5csX37hyrrDwtVe+8a53PSUk2mR07L758SQ5d+7ZUKVzs1irdvLeTn843O0Plo8tjkvMi3J7or/5Zvrou9uPvedDv/ObX37wDG/OzrVrARPx1eu7K/NninySJamxlpxWgisVVes1IVi9GnLQzqa1CBZbtcWZei1W68PgyKHlze3dQHDBsJdmUkA6GVcrUS1kNbEw22nqSb8zU5+tx0anaTLe23WhXAgjVQmbthLaIkMAsI4DktGSoxCqVq0sLsxqY9N0rywtgGPcAVnOhZQqTNRoNOh0OtVYFQVP0pE3I9zb22MwkipGMnEcp4OyUqkkSXL4cHucl8PRpN5pxPVGY2Z+Y6938eLbt7bg6LGnNrY2x4OuUpVaWCusLbO0UqsWRYZgOboDjxTcT3S/d08M+ww/uGfeCPuygIPtsidsHHhsGmvCMPRwhxBCBMprHoMgmCqGHBGBtZYsebND66DZ6YC12xt3BFf1mSgZDbdG5dqLFxoV/Jkf/2RTnvnqZ/4giDrdje1Dpw+NB8XK/JFaGKf9cS0KwRT1UGzdubn0+FEYJNCs8Zv94cULIdbO3rd840bPyQAtJ0tIYNFZtETGkeFOoiMOyJB5eoNvpyUX1lpvizL92JxLgDLN7v3gsO8IiPf4ETkEvn+KOOOIyGGfuYheyUrTOdv+6cUDixty3njdktPWHGyVnLUHr+/rnq+Ofnnw3xdJlgIAFyIMYiZFaQ0RAuJoPKlWYs45ARNcyVACYlrk0lAcx3FVZlnS6/XLvFSKV+LQ02w4olJSKnWgy+olJaFwEGgnJ6npJcVgPJ7kmodgLVgLjIEQnJEyBejMlWXBmSEEiwgykDLQjuWlVkHoRxxTxGqKU08h6v0P6Q7uw79kngo72VhJKURlc69gFzcHc3KhEzQi+eRTK5PxZO3GcyQqqt554EjrpG2lZRk8MJ9lxXA0GYyS4SQbJ/kk10XpkklqOOnSWu/r7xjjnDHGpAMSiAYQGFkgBmgBjXG5cwYRACWgJ80LBw7BAPpCfmAOQ0jEuZgOZwGmEX0MGMPcCcD9Nn7/0lpwDtAb13DOgUsiZ8EaJwD9sueXEseYFczbQ7K52Y5i2N/dHk2KZl1xBum4HGs5u7wy16hcvbV2dL7ZnKk3QrnT3Tt6ZGlxcflPPvMcKTgb1YDxx556+u2LV7Yvv67S4dF2bINgszfImSNhdJJWFE+G3WazXeSZ5Yw5cqWthtV1mnnhaq9z/ORwsFubb/3a5y9+7aWLVQ7cwKQ8d2rl5K1ufursE3/+7J+/991Pl+LNXXLv/6FPfPGll44eOyLn6o+cOT07N7O1vlGVYmIzbsdRVXZm4yeefPDNN9+6XZbC1R9/6p1v3u5i3Frf7mPY3BqXT37g4V/+nT9TEuIZOHb2qetX30Q5+58+9cL3f/SByCzleZala5lDFwYVGUX1ZqvT3t3dcWVmIKtHcmmmsdCsQDHeunMnnl08tHx02B+YMEQhTJ5Vo3DcH4hGREIFoRwOu6O9jWF/PsLGue3VD7zv0ee+/lVGxdLCwp1btwRCJYrRTaMyizyfjIcErMgSKXkUBbXKTLfbtdbleTocDqMoCqOKMWW7PZMXmdalEmxnb3symRw6dKherw57w3ojKjXOzMzs9tfr9Wp3NGq325deuja3Yk+fOTtKsyu3br7yxpoDOHms8sbq5VqjMdtaKHSpdckDwTnPyoScZugY+GaUM3LkgKbBOPdYhN/jsOYZgR5KPvBNVPudJmPM+T+d01pXq9VkODDGNBqNqFrxOv4oiia9XSJygIAcxVSN6QCCqLKz2zW6QBSo4t3hZJLQ8lzDKTkeDX/99z/93//Ej5cYv/japdhmLzx/7pn3P9FqVQb95Nb69Q/88MfW3r5Ubddn2x3IUCeoL9yZO3QfuObv/Ppn1m9vxWEHtQSDBBrIABKhdaQJdKAimkYy+fbZldZYay2itsYYRwRCsYMoPt+Z4b7BO9uP27b3FF8AsPu4CnM+8dEJ9I2cZ0g6JjiBJbC+eeWce5JdQVMfUku2dKVHe6bL6rQGICJymI67fX7k9LsfPV7z7JxaraaUMqbkjEVRNOr3giBgjJVF7oNI/AwkCoUXzhZZYq0NpGjWa5VKtLG+XqvE9WrMOQNHzpR5nmdZViimDY1TGiYut9zyUCPLrCac7lvIMUYCrEAnGTGmBgDggBEyAm6ROWAE7GB+jdM6NS2FzpUHax3sU4voHsHhdxzDsjLbrnOTZP2t5RY8/dDKYpvy0frDDywZPZlMJtrxWmOp0TqUFnx3dwSyYq1NsrLQBkUowmqpaZzkyMRgMFrf2CxzHYZhlqSDwYAIkoA5B2SRU8CAOed0mWlDlRrkBUQ1ZDwYjvMwbApR3drtzc0G1lrPCeU+M8sREuRpurS01O/2AqkYY9kkabVaWmsjq46Mu5ve68IwjOMwz3N/BqzT/pHzj2XIsNBlUZTOOU96AABwNo4CUxaMTCxlNZIMXZ5M0sQMWCsQ2IhkO2KtECuSYmYlumolLrX52vMb8yustXi4JHH24cd39nr1jdeDSnWr22eVeC/Jb2wNgnrczwricqebLy50yrwEQ53mzM7WVjrJzdGHRqNBp1Ef97scTKsSDnY32hUpSOcDVwvBZLAwC66E40eCVqv1E3/rR1/85gs//IOfKMrsn/6T/9d73nn0J//6f/Mrv/RLywuz9508HjBx+8aNRq0mGL957Xqz2SR5qDea7PSToD731Rdf/8gnPvnZr3z9W69cPnRoFskdXmwPtu48dPqIxKKc9Odn2rJ9arvbW9/p7fRHGbHGzAJJub27wxGOHZ7fWb/ZqYrjKzOK8lY16O9uF8HDXKqvPff8/PLKhctXugN3/0OHyOjFxU5FYS0EPekutKInHz4z26oohrOdYDwa7Gxt1asxZ1Ak43azUYkCcqZIM601MXTOaWOEUFEUaZMGQeBBf+QiDOMkSXZ2u2fPPnDx4uX7zpze2tze2tpqz87t7u4uLCxsrF6TQYwsJFGd5OzKjW1Vm//qc69tD2Dl2MqDjz7++3/86eEY6g3QDiqVYMPEPnNZGw8CMKWUElLnBUPiQAKBAXGfwE5kVeQfrgP2tH/c/Jv00zX/TT9EVeyudp8OHkyGnHNtjQfruZIA4OX73JbOOQfoCIkxH5Ll71TuZe3GOjIcQAkpJBtqXZGiglBnLtAZG5VLTXj89IrJ9n7wBz+cpL0n3vWIkzaxk8KW5y68ubBw/Mjhk43FE/3NyZ9+5muf+exzu92y1lpJNWrHCrIl6YIy4woDmtDFrqmd9cwfPw32jMlC6+nc0tmDhc1aWybFvUqlKaMESAjhMy28vNEPvcMwhH06olcIyTAQQnjPXuectnZqErU/SnRhYK0ty9Jo7YeaknHOeRRMxbF2nwUvhFBCGlMe1DoRRZU4rnqVljbGaGs8K0hIQw5KYx1xKYSSTHBn3XiSMsaQiSCqEFnJOXJBhCsrK5IzcCbPM12UftgppeSNpjaYc+10niWuIKaRFwQohXehRcbQMWQKkaPlCrjXWDpCQg/FEQH51uDbDu/nwBCIkO4CgnRgk/jdjqCt9pIhM64adrpp/spbu08+OP/0I09fWX3p5NHayeWF8Sjd29naGU4q8dKhWjsXxlnMJCY5OjBcFiWiJLuxubkyO7/YPDqZpJVKRSnV2+vu7u6OQmUt2ZIYCcEkB0LwJmPpJJ0YcuM0ZwZCbqOIZbFIx2OtjRC8VokCJZ2xFhwD12nXinRkTeaYVjxoNAKibDjsy5YyVgOAClWlHltrsyzpDrqVSsWbCigVShkwxrTWZaGp1M4RMME4B84ImLXWoi5SA444Y44zWxJzlOeQl1CGjAixtADOOaZDKCULONva3Ou0Z1dOVS1Tl2+v7w50AmG10TzeiKyzjRBKlzWEPdKWohIstKuDUVojwSkDwUbppKVaZ5968Mrla6+sXmw1mzAuKmCdc3mad2aWjDGlKcUcs0qkyWSN8RzSC5eLcbb1mdf/L6XgW5eSI4eXTj/9/sry/BdeWN0rOziKL3zp3Kmjhz/2oR/+sz/541CIZz78yR/867/47meGP/bjP/EXv/ZbL7/+9gOPn7m9l3z9pctLh5cLxtPRIL29FSHW5o8emm+F0lUCdfHq2uUrV3Z6o878QjWuDif9cZabMp9dmm/XoiwUD95/uq7o5tW3Hj791Nbaaq2jzp9/OxlPdrfWGrWo3Q4CzjpzC81GtV1Vr37rq4cXmkBqc/POe57++NbGKmdUrVZortOoxDrPdkbD8XA47lvJ/RASBQprtC4LowsgLRQzptTalmVpbT6ZTNI0n4zHN29eT9NJb6/rnKtWq4wcByyzvN1uE/HCoN6HZYuimGSwtNTc63V7o/Gho0fE7t44TzNNrjSWT3yrJxQyH+ZDTpvCPy5I3CvDrXfWu9cxbf/wX3tfFEQ8yJ+bdqzmv4ILGEN2YGznjDE6Sz34bq2thwEhI+cAEB0Rs0QMwUouAcA5ILREDLlggRRKWTMepFmiNdYq1UqLwbCf5W/f3nrn4w/86Z9/c3tnD+rNwyeXLcpau/XM9/ygio69+dq5b3zq18+dv7Z6ZzwagwgqzjIgZBwkePUKzy2gs84R4L6rOTiYRhUREZMcOUcLNJ1DOEMA1lrm99BTR927Q1HrNCNwzhVFcXDetNYSHaDHnbQFhgZ9GRSBIvD/2BqwB7ulQVpOe/NAcsa8hzBHZoicNdZasA4YIjIHkBut8O42S6gg8B16lmXefh0BqSy9+6B22pFTTHm2U2m0c04pHijJMSBnkKy/nxiSRgBniixzZAIhlRKBEhMZAgAxsigMcxYDkEowlpuCPF2QkCMDYIw4Ii+no0hf3503wSd0jr4zph4d0L67ggfc4R6ci/0lVEgL2TifVEU1asy7yfja5h3n1oOInzh2MnP9te1dTtRpNWO5YLJgPOpHLUEMhbBM6tIZcJYzIRSUFd6KUWuDZVlRsl4PO9XO0eX6rWRitDUloWGSi0BIJZEzV5isNIUMgnGmL1y6dWdjbPO0U22IsDMajfweSDEyYJXCSlSZjEbpJJ/t1J0px+NRsx4qpeZnolyA1lDqosxSUwDnXDLHAxBY5nmZ5yUCi6JKEAScy1DwajUsSpOVhbFkCR1Q4aw2TgqBnHPkBjAxFowrrTBkUEhDNteOrLEWSidqoQgFT40c7g5Ly3JdDAqnES7fuF2p9U8vZ9qaVrsJQrQJ2oXZ2tsz1vDJpIHgtJnpzN0aTjav31luxa2I3nO0HkTBhUvrgEAMC8IgXt7tjTTyqNrqOw5BY5ikPJhxCmVH9nurrUrzi8+tGn31xPFDobpTpqO5Vv3q59+cacBv/Mm2DE984GM/+8rzz2/21f/wN7/nN5/9xnNv37p4Z+9OBtH2YE+/DYE0jg/HSbPRihVv14N+ZjbevMxcmU5G3W7XAZtbmC10uXHzGjFcXFpptecZc6+9+I2Pfd8HimS400877dnXz71JKAbdrSuX1lptTmCOHToso8rWzk6jXh0P+7ev3FFCBoILwZr16pUrl5JxH2crQSADwZUSaKRSKuDMmdLqMgiCSiWSUpamDE0QBEFUqSTp2BjDAIUQHoaVjUaz2b59+7ZU4e7urlIqDKcbtSzLAuUBbgIBQRDEcYxhJCXkZTFJs7zQcb2Jo4ktjRNlDtxRiQCcM4ZcCuEcOW2sAckVI+bAEjEC5CAcQ0Qk0veW9QOcoSxLvn/4Oj4lz1h3b1CRVypNpTMMEbEoCi+5hCnBw3OMGQEBkHPImIf9vaWX8SAyISATyIRSCjlzyCal3jSWZXlT8fnq3N/+5//ql//d/zF052XjUNBY2u1un3vx0iRLvvni729t7XZ7KSKXUasdhqVlmggZMIZSoECuSaAR3EiLGg0CMkJG3hiGaOoCJoT38iNkbt+Xwlk7dfdGdiAchX3wgHPOGPozEMexL6HpoAv7DlMMETkjhkRgrPWouiZrnfWgEABoZwXnSooD6xfPndd5oW2ptWaAigvOp6Pse5taYck5IKt1mqZaWxUIyYUxBjhjPojDlc650lgi0tYFQcClZF6I78Aay8BphGQ8iAMVBZIxJkUQCMk5ApEQoij91dSWOAqOyI2zbqrKceAFu84BWSC09B0sF/I/I+5xarz3MPdAMfDt44jv+vOuTCohKsYLo4WIVDyzPtj79F/cfPdTleNHwuMrK7FCyF1WFIrJVrOS6gFnTCFZ7sg5Q0YyJZQ8fnRunGTjdCAFMkyHg7FSanFufkAjMmAVknUSXMB1ICUXrt5o9wbdarPZnltaWZj70lde2NiwTA5JNpwpyVoy3BHjnOY67eWlhZvXr3HIz953yBqztrZajaPBYDAeul6+Xq2BUqrQZZGBUtBuVxuN9mQyUQwjoRCZ4CgE8zdEOhln4/FgMjGAKq6oKJZKEReMcw4ISKV1riTSlgwCU1IwIAJrS4CJAVu6gqzkBCQ31ve4AEtQqdUX5+qb27vFaHgZJ1rDybAasSAMw5mQD3oDxsRAgwig2WqeOnm0GYkXvrlx6+rlM/efmquI8SQLlpl2MjG4PcjtpB8iqCAqHUsszC8sZ3JimMjSlNfbQYZZgSyoODd5++pYMKs43VjbrgX1CYQgdv63f/e7xw+/UEyG48Gn4yjcjdWv/sHnRmNz5Njc3jC9vXnp0JFj3W7PzwZ7vV6Ryr2dnfGgu7TQMWUpFSMiWxbW2larMjc31243yyI7vLy00o7b1bibjyAItjbW4yjoDbPZGb2yxI+fPLOx063XorTUHEky3m62Nm5fne/EAJAlqTFmNOg1G7W9vc1apWJKnU/GuizydBI1mmEYdZOJ5GgKXhR5URTOGediIVgURXlWWpNLLgAsAMRRtVJv9LqD2dnZrZ1dBBYFYTJOvSf4aDQmQkNKovOPvnVGa1jfyA6dbBlnb69v7PYHUa3uVMAEF7r05nicM86Ic2YsOLDTXpWm8hpg4IvPvU3Svfj7AZ3Dc2MOOvFYTV02D6BRxhhyT/Sayvp9uffPqSnLaT9G00qKgMDJWe3Lp8+hcM557SiS4ZwRZ4XWptRYAAneh+Af/vP/dXd77QPv/1AZzHz22TfOv/XGt166ubcHhBAG0GxWa/U2AUuyUoNljHtqOoFDcBxAMIkCnOOOhMPp0JI758F3AOBTaBvdvvKWiACdEtJ/Ov+RjV8PAKRSUkpDzm9xhJiSzgttFKI3ZOWci0ABorU2LwsL05Qlv6x6g6mGijlj/oxxH+RgnXcYQQKOU794hkgAyPm9VVI4R1mW53mWJIlgPIoi5AgGfBAUIhIw4yxzVjAuhOBCEVJprDNa6wLIBpxxzqKoEkUyVpIBADrJOJA11lZDqfOSjCajmSNrbVZMxkUW1iIAQnBIyJyn+BEjW3AE8CQTAADcZ71w/O7FWoMg8B5aU+YRoZf4fPejztEBK4t0lBWhimvNOoDU+d4XX0geHeYoZk8ut+OAAHNtnIOsEgjkzIEQ1vLCZNo5sExK5C5U0GhGcRyHYTga9NM0HU12q9KAIJQMDHCyAozgBUOaq9fSQTLeHcw2K+967L56GD7/4mt31vu7/b6SfHZufmamHQaSc1yYmz28snjfiZXV2zfOnDoZxUE6OYUMXnv5lVf3tmaqMNOJqrU4z/PBIMkySLqTpDtZWqxWK4zXAgCeTIrRcCczoJQ6evRIlzsgXToSoWSSJdrqPIMwsMDAOmc1aMsJOBNKhAxLBCIOzrnSgS1cUloEZ4zp5zA3VzdFkWgrrCOEZqu+lk1GAxjd3FSMzzYahxaWWs2FuU5nsPtSGEX1uJpPJovz80cObayuwzvfXau78XDSvf/oIpfVYe42uslad3L88JHUqW6mr69tDdZvpHnRnl8CUfK8X6aFca5ai+u1Vl5mzWYD0N2+dS2qtS5urD548vSw233u4uqRxfkC7SCHLR81TrwCvNbq9EZ3smRcCSQQkS6TybgatZDzRqcT11rD4VBWxM7OVrUSHT96JA4FGR0zO9OucZssdOr5uH/7+vVDR440WnPj8Xh+6djKwtzcfDspzMb2Vp5NJpOi3WqSs+trtxbm5ge7dx488WDI9aULF9/37ifW19dn6kTk8jzLxuN0kpg84w4YUrA/kbPaWF0UptCmSJLx7PzyAQ9PF2WS5sNBEvQGjUZjdnY+TQsVBFFUkXIshMiywhiDyL3yOc/z0WiUk97bAxQwt7C4sbN7/fauiFg1jNPBsBLGkVEWrDVElkAQ95VDOuf2rQbQOa9+RgcA6p4+6aAfp/1UUncPV9IX63vbdn8YY5zHoMvCZ1OgmPb7xhgHIOAuqgEAACQQyTn0v5GhQwAgowtd5hoKY4wpqBqH7fZskeU7/UHv8s03btwuMzew/D/+9h+tbhadKrSbcOikQrGcZVlelsUk4VIAAwfOuDSQARFZNyW8MWCcBSjCEqRzjjsuufBGXQcIuGBsihMw8sosAJAo75IjgdBOEZVAKWTMlvbAGcYBZVnm0yqQM+QMGSMAY01htPXR65wjQ8k5E3y649m3d3faWuustT7tCYyVjEVSAABZB8Z5LJ7sXfhaOICyKIq8ICLkzJIjjdoaKv0S5c8yAQByxjnzUwIC64wl6wRjyLlSEgQXglty1hgki1IKjpzzIhnrIgWTCzSBEJw7S1gw4NYAGuZ7dYfMcu44EssUeMeYg/rOYHoDHSxKvopPqz/7ThDGr6J/2UA10qbUhiELo7B04+54pKK42VpWteLSrb0765cePbPwzDvuP3V4qUx2drfXDtc6DoiQo5QWisIW2lpnyjQdV+oNprAoMiGx2oiBu6xIBCsECi4E58gscnKcEWcmxuLU4Zm9wTAbbNarlZOHZ9LRiVjecht6fn72yJEjnVZDmzydjK1Jt7fWG7WoHssk6ZJVgmG9XnvyyfsXFuqnT51VSnlViLWaiMbjZDAYvP3WJWsRyFqDvMwjsJV6pdOZTYe7kGcBlYxxBGMtubI0uhSS+9wYDsikDLgIpFKCZ8UeEHNAQGgcZc46r7yV0kkkocA6Y02WJc6V5MpBUE/CUTEmRSYpktL0GnEYK330yKkoCvIyu3n9xvyh5cWVxY3u5k5/9/SpE6+/fbXYGYsgnFs8eurICtF6vRbcWtt8YPnQ8Zkjt9bWb/a2av1hK1CUAarq3NxckqUbu9uM88EoB8TO0kxalhjFb6/eajXrjZWV2/2e0cVsuzMepvXZGVT53mBci3S7Uedg0VkGLuTRkaX5ubmZXq8LIIeTZJxmI2PjWqPZbmhTJKNkca51/NBiNQw219e666vG2Vs3RkG0e/zUmedfuvTe9z6ZjPu1RuvG7RtWZ4HsVCtRtRJPhoPd7Z3Zdq3TalUqlblGsOfS27fvcDIz9UagBMahKTVZYxA450WeBjJigFJwFURxRVmgsszLshwNBkopqQLGuLVUlmaSZONxUqs2RqMRInIutdaeQuXtR6QMiEUOuc2tcy4Ig2YTOisdB3Dz5i1AqDSbBnAwSVgY1VwNnQbnI3cZCC44FxLTNAWGyICQIYJD6x84dY930wEmQ/tqjIOiz/a7S6+4OLBn8VNH46xS6mCH7V/Fz2MZY44B5wwt+KwxzoCzqcYDERkKH3yhtbHWAemAMxkCMEyNSa3NVRCpoNqZuXX9+qWNYZHS7GJzvtMsssmd7T1SPUTiHONQyVAyDtZq0MZi6bwFsCUgzpjgJBky4pYYOuTOOeG4PZgVAEkpEFHzfS6QcwgkaGopSvuxupLIIGqtffwDAHDOfaAJY0wwxxg6JLLGOEBi2tpCl2El9sMJJjjw6RQaAGymnbVeH2utZQQM0Ye3SeCKe2svQ0SSUCLP8Z7i7vNECDGOK0Jwa632a6bg5MgY7ZwLcDoaNsZkhRWCBcKvV4IjMCaAYZEV5DgDS1ojWWNKKQQAjNKBMzwSWFUCLNMMkaOQYVbm5CwDwwnQoSSGjjFiAIFDYOTNupxH1nHfpXxavoEBHOi43HdsHukvp8oAAJ8YxYBHDiIzLs24cGnqLMaxahcYlenozSt5mrx59kR07Eg0N1crx9o44JKhZCJQTFtypQNLDC2ZrMjG43GSTZQSjLFKLc6Gfca44IFiUiBKhFAyIWQk9PJse7ZT3+5Nhnsbm9uT4d5gvl3dGJWVKNBFtrE2miTDLB3leWbKtFoJqnGwdkeHgQgD2WzWDh8+fPr0kdH2ahh6f1Ux12l1Oh1ETCbFj/3Ix3vd4dZm987q9uVL165fW8vHyUDnWWG1BWdAW1cmmhSIMOo0qoU2DhkyLhlXXCguODKGKEhbIkbMARIxAkYcLaEKIm7MOMsFhygKGSMpeDoZJnFL1kOd5jKQiXU317szcbS72Xv47H2NRlXbUhOUZFDKU2eahXWFalDYuXy1i5gXdmt2niqCjTZu6b1e1OSP33/6ycPBxqa8fPlOnqYEcHM4KONEctapacNsf9zNLM1UZp0wrYV6octRkW3s7s7OzhyeP/LGGxdbnU5vnNXjSBENh8OjS4vCOZsnlSjURRFIlU9GO1sbS0tLXEadI7PdctisRehMb9A7uth5/JEHKxLPvfbK8aOHlxdmf/t3v/Dww8uNzuzN22vtudaVm2tnlwKlRDoZV+JAKSGUHE8miHjmzJls0q9FfG1tbbZ+/OzZs5trN8+eOjXqX3feEkvISCpwVIvi8aCfpRNTFuPJSAgWV6M4DjFQ1pqytGHABTKHEIZhoKJKNZ9M0sk43d7eEUIUWZ7mBRFNTQS5UjI0ILLSam2EEHOLi2fPJhMr7mxsJLk5dHRxmOsky1UYFtrWdchJMbCOHDgHFhgTnEuy6dSVSqBDAkLrjHPOOumL28HI9OCvB7X+AGPx3/P6JgBgQvi6YX1oG2NKKWstsalMTwhhHfiQHGTMOQvoELmXwZOnNjNCzpAYY+gcCIBaHFlkSaF743GhKYrrnaXlnb09imoTUJMMC6e3dm43a9V6ZX5s8zCMOKeJyfu9HkNbrVYqcVhmOZDnrHMGAkkgSbAcWOYpZU6wKVvGWuscY4xLwRjjxlig6eeyFveTjxiiFzEhTpmRpdbOOW/LTgj+NrAmI4bOWm0NMOQohRDIWRAEyBhyBpw5IGttWWprLUvKaUFzJAEZIGeMM4aOOBBawwgEIgFwIihLFHeBGVEUhfcViCoVjpCmqXMuUCIIgqIotC6stU5KItJaJ0niQDCmGGNSMAYEzjrntJ6SKznj5JwztizLPMu0BlWDMFAoVelMMbGlyR1KgYBkEQwHQgccCJ3jxNl3B8q9Tc90fA8+SHBf6+sxsXtJ335Ac3DnfccRM0AJmYXxqLQSmu3AsUaW873NUSNuNuNaVu68dXVzZw/6Y7j/dPO4WCYix3gUhgFXkQVi3CIKwkKXDqjZblmr9/b2OGfHjh0rRoYzVMwp5gKmIimiUIQBiwKWJSPjYKZZsd38+rULN27ByuFaELa11lsb64Nh39miVqtU49AFWInEwuLMaNibnWnOzHRMmZsy3dvtFd3e4uJivRFxzorxYCsZFUUxHicX3nhNyqjZmH3w9PH7T97X3RtkqZYyYEpO0vTO5taF6zcv39zoJsBtFtT86unVbgKntkKlMzYSjiEZQiJgjHHGGUoOOJ4kQkouZRQITlrrIgqkEGytdM04TnUWKglGl+OiFlTKLH/t9fOLCzPzi7PHTpx68/JbN++sHj99ItPlN169ELUX28uJNaY7nvQH4/mZTjLonT06c/71tc0ra2fvCx47c7ytRadVW1lZ/s/Pb1681M0tVFtQahACalXsD3dLAq6FcRa5WD61sre3t35u78SZlf6uJqdHyaQehAtzs9VKtHHj2v333Rcrvrm+UQ2DzuyMCsThI8cuX72+sbFRWWrWWu1jKwt1AVhOdre37oy7u5trtUB86+W3dnbg4UdrgYoefeS+7NVzK4cOn+oYoYL25s4kM+lkDCLqdbsnT52+eOGto4cW3nrrypMPLc7MzAx7W9W4cvPmzWqYF0WBjjgyAXiQjTk/P5+mk+FokCSFA6uU91HFIAiklMaY8SQBgEpcq0RVTwcrjAmD2BgzmUzq9Xq1UhdcjSbbgsuycFlWDodpnudKqXa7feXcpY1dW6mqlZWV26+8zoKoMzs/moxJ+zZbOrCGDDpC4ozQOWCO0Bv6eudTshacc99mM4D7vgKeJHPQTh0YlMcqcPuBZXzfTIas8TsDXyWMtdM2VghbmilgzaZl0f+/2zcuRzRCKOQ+OpJZA1meGIuOy0q9IR1mhdvY2zPGYVTNDCSGWq1GWhJhOM4sRax0mqEDsFyhkNKhTrISHHKQjDPOBDoJJNFxAEb7wcUcADw1GRERPbF9KrVxzh5QFb89/Gha6AlqjTqMx1prFYaImOaZ9+8KA0ZE2hpjLBMslDKMI+DMWDsdriJYY7OiyPO8NLqqGQfkiAw8LZMLZAyQcXDGOmsFMiEEY2iMcdqAuJvchB+/zwdkKwAwxlrnEDkyMRpNiIhLFYaxc25qtRwEdZbSvvWPUkowPrUJA9Bam6L0/sBRFMVxHKrApoO81MOs6I/LYeFy4lbEoILBOLNeZ0+OnEHSXndkRHDQBbD9+BLnnNgfyvvN4H7sLOT+FANZ5sWgd+EbJOAE3AE44t4tEyAJAucckOWAAWeckQBizjpdMGcFQCh4qGQcKikYY+yvPNxZXu60ZyRBt9Bdokxrnaau0IGKOnFthkQwSIb9cZekrtTjaHvZ2QTcJIrKRs1FsUFWlqQdD+pzxzLXfu3C7nOvr69uW4NtEdRRmW63V40rjVo9GY8FwNxsK5LcFKOFuboUOhltN5vqxIllwczG5p1Et86cPO7y8cb1C9u378QBnDm7ImN1Z7d7Z2fYnF25enN3pnNsfvb4XOdwp73QCD9VlrbVWGKsdfP67rWru5ev7Jw7P84JFpcWgrix1e2PyyysVrgUkzRl0dgaA44qgYikQmusNhxwnNrZueYkLaNGo3TQG47Caq3bHyzJqifQEgITAhg6a8AUnXq1JnGl3WwGrCnZcqe5t772lefXf+e3/9Wff+XZLz/7NZKxtuzanT2hRKXeSNI0jFSnUalW5Wy7snbr2qmTR+u16tkTD/RG4y997bmvnduLqxDPLa91RwVwzSUXsjAlR4pC4cpcl2kUyLpJAUBJUY0boQgECyKpAqlCJbLJiGy2uNBhWJx/84p18N73nFqcb2tno7C6sbnriA3HWaVWB4Ber/fqq7ceuL/55OMPXr9+8dTJI7V61KrXlGv81m//7vs/+MHXzr1tAUsHhdHGmCeefPT29Sto8ve947GTR5YuvPna0cOLvZ1tLtzxI0dNkTfjYNzdW+g0R3u7VcXHo0G72ZJSdPv9uFJRUTgcTWbm5ya7FwyJlFTipGYxD6tSRgxIgTHZCHQ2GvSazXq92V7b2Eyy7Ogsv3l7AOowiw+dv3anMtPYGKw6br7+/K4j+G9+7JOjLP7l3/zdeLa13ttszgVFNzx4vvyD45+vvCw458DYVFxKxKUQQkBB+O06En/4FFC6R1YyhW683Jrtv75zPgeuLEu3zwCBe8KtcJ8g73kmvsgEQqZp6gU7iOjZ9FEQ1uv1/mCvUqmMx+Oi0I1W3Tk3mky8U7xnoHMlvduSj0nBIhOMC8k5MgYOyQkGAtHqIpAiFBzBkbFAzhskdLXhnDMUDsgY59zUvmk4nlQqFSVDb9iJggcqFEJsrq5GUeTzNa1xXtJlHEVxnBZllucWSMiACV4Yn389tUoOgsBTqAHAz5k98f/ActEvb9XatFgj+g0OIiIDzPOc7WuVONyFywjVQXEXYVwBAGenTCYA3/izMAydI9ifjSA4DwLlpU/nYGVpytLAVFUEQgiGIowVY8yTh0ajycCNeDkmzhkGcVUaRbZwhbZFmqowtOT5ngaMZ2CCN1E7wPIs3LVuoG+H3f2MBdFHxh24h91zHDDkCQ6IqPsWLQTOuzIQAlhy5GwcRZycQFCcS44WyOSltfZbb/bmd7aXlqvtNjRbqlGPpbEW8qqqDYZ6e2OTqUBEshGHhbNmMmq1VqxTaUKlTrRTzbhBoIeDYWfh0O074zcvXzt3ZbC+B5pXVWSRdJklISeBhlFZrwjJWCggDoCp8PrVC0vzzWeeeSdj5Uvf/EaWDs7ef2ZrdXL54uVssGcnXV2AAUCLrVr9yImTL77+5tr27skji8eOnbp5ffPa7s7ye54Z9jRDmTJTqcDRQ4cPr5x97/uC8dh++avf+ubLb13f2Fqc7ywsL+/2R/3xQKqwLK1AJEOWDGMSjAPtwjiK25wTCqBinBTGMGOFc4udlu0mPkne7RMDkIFELMoSNfX4CELBItlpNKJ68/jy+m996lcdYKtZKR1zGDz8wGGu4v5gDC6vVoK19Y2lxeZwsFvm5QsvXXn04UObq19OcvMDH/94a/H8n37ptXR7a5jYmcXlSWEAQQA6q11pgWwgeahUKPJ6vV6NGogcDJKFsizTSaIECyUyxF5/TzDbbouFxdmHH3742pXzxLjRZIzZ6w5qjdbTTz/94osvvvXWLaWg0+l4nvKhQ4fmFzrJaDjfWInj+Pz58wDMWlvokpAfPXr43GuvHzm8VA3aa2trxaS/tLh4aGlZZ+nN29eGw+GxQyuVQCwsL/W3NxhCYY11LisyGdQrtQoTYpJOkmIyx2cbjRYJVeNhTkHuVGlZro0ry9yWwhFjQslwOM6yssdEWK1FW3s3WzMLGC68dWVnpzdcvXwJI7j/0WNBuPsDP/g9hbZ/8Ed/+M/+2T//jT/63atrm2FeAAX3NpteXe+LtXPOOgf7Ch3/JPK7eMu3MdAOkM9pudl/QWes/+5BW+bJjpxz/G7F/WBV8MiOr3Slo0ql4oHme/k5BwC4X5umwAiCR6g8URt8BPb+YFNa698GMkByknOOHBhzwJwD6wCInLOMpi6qCHzKyyTC6eZVcM4lF+RQa+0FpagpKcbW2iiKvIea/4xSSgfk9DRtNQgC7ax1ThdGO+ucq9Vq/lPc65PsjRn8+zyYXuD0bCQHHx8OLoRvbe8perSvP9DmHsydgPsVQ2uN4L3WiTly6KM8gcgyxnwamZTcGeCcM8atc/6dScaFEAJQW2uKwl8PnNpXIQFJLmUQAgpbQgFF5soDJ8ypbdY+uYVwSo1kdBdm2R/mABIc2AvQX+77OE00Ih818O2eDwACrAMiJOZtFvY3B9o4xhlXMgxUICUSlWUOpb4xKHbdeCvPl9LguGzLRk0qokAhjznLJNeVSNWbVRB6kthJlt1ef+no0aMrM/VutxxnGRuaqNaUlfZzL928ud6/fof6GTDJAxkRGWMmwmaVKOComR5XK7FiFk0frQJbvP/djzXq0a1rV5KkN9+Z4bPtvc2dE0cf211f393oVriuSqhHbL4ze+rosaurN//6X/3h8xcvv3bucn/rwqmVZZ3bO9eeW1laVCosU6vTSVwFJbES4dxs++jxTxw9MfOlrzy3utGdTLooVSQUQ7e342aaqASvKNWptrJkPErG0jKdl5lJ6vUmcZFzEWCZDPr1et0wrhgjhMJa0qUlEkKEUlhTJGXRc9rkwhZRFI47tfjQqVOXLl46enR+thWmpc3LgngY1yQH1azPVmo1gLwoMkAXVMKdXr49TK6/3HvwkdYr33rp9NmHn9qbfOmVKw+eOXFjfUuoyDkQYI2ztrBKYjUMw0BJIyQX1ukiSZ2hSlSJogjDYL7T7nV31lZvcw5n7jt84vjDnNHNmzettfVKba83IMK5udneYHzhwltf+cq5MITFJXXs+JGZVt25nIiuXrr84ovP/+gP/GQUB1ev7504vSiYYqUotDZl0Wo12o36s195+Yc+9viZM/d967mv7m3eWVyYO37q5GQ07I2Gw0GvGYWdeqXRqhXJSFWiUZo4TkEguRImL7NsPBh1WTkBoViAzOdeOgvonMDRaNIfDci6peWFIIxLBzwIJ0mm800Mqv1JsTMYv3V5c3sEf+Pn33fj9qUPf/Sxt96+mKSVn/7Z/+71N948f/78oUONQTKMpby3E3f7xZ0QtNbOGNpnvPgW3tNacN/M7m7jtS+v/45DWwdT8c9+cDM52s/omD7U3z6b9Qfbl09ba63VQRC4exKRcJ8N6e1o/J/TiETB4zg2zjHvoOV7XmPs/r4B0XmbPM6QhGUQIKIjsA4KY9FZco4BAkPuvIWYL5TIGAJMbcrDMORcgudESgUAHjmp+YwUY4wxgktCQEBALMsShZRSgmOuNM5OVzjFhQW0YJGAjLVgDzx0GeceMXfOkXU0hbDMwRbnoLj7dortf/9eW617q6LISlcUNs+NtY5zlIxzC2iM91/2l1kJZFIyFJzxlJCMc+jRbUQmiDGHbJIXZOw03olxpZSQgZQyQCQuDHFjbK6tcZYYcs6SMvMM0qnNJkNPfJleSJiaOwIA4P4dgNP+fb9fmN4nBzWdIRy4FIAjQAQ3LfD7PT4iECdyYP04WDBAYsiQMQZcMC5BSODSG7sR4dC1xkWxu5vumTLhImNhpyKZkQZJqiiUkRQIRcZsWZfYCOp5DRF7g2wU1qoLh49w2bq5uvfWpdvPfbNXOuCRaLabBoNhWlibKhEJXbTC0FjNwXTiSAm0xtQrMlRRuybJpMPeji6z+Va7VqsIDNJRlozTYlKGCiiAVLvNW5uki/Z8a7i1fv+x5SceuO9Xf/XX++n2A2ceuHHtxvbtw61WZKwhSNG6lO05dEbPVBrtD3/wvtNn5p574fy3Xr20vVc6UzrgMwHMxnWOGEjRDOLAQFjD2c7MrVu3IKfOfAxClkZnnBX9iQxLIYJpjUAkzgmAc8EYM8AswLgwZJ3RzsBOojuNSuXw4UoQUKmzRjWw/WxnZzfk+tji3NZeH+zkzKlDr73xdrVZccBmlmh1pzfXge5u/8bt/u3tvfnDp544m1+5vVqL65OiBIaBZFIw0mXEVS0KBcNYxs5ZnRcMUQZSKVmtRHEQXr12SQpoNRtxyOI4DKMgjiSAy5kmojffvF6U8Fd+9COV+jjP8k984qmyLEfDflmWKpCHDx+uVqtRIO+778wrr7x0/PhxYKuNViPLS2K4sLSYJOM4CqzRi/MsmYzeeOP1IAiSJFlbWzt65gSm+dbm+uljRwbD3vLy4t6ga4tsdqY5TCblZFSFeLYRzy/NgiRilqmQgBE5AVYKIil5NZaM74GLlpfzPC8dDdISmBRMXL+zU1Ny9damAfeNV27c2YX3fPjkKLMXbuyGzdlKc+bKzTt5Yf/zb/9upSalVEQgvLfoQa/tHOxbOeK+C9hBJziV53x7e/hff33v4Tt6B99ZbvbFN55dfffgnLsDc+D9/YGz1gMUppyGkXLOGaBzzhd9AJDBVFkpUHLOkyzTWlty7J6Pw5wzBJ54wgistY4ASDvnOEJhrbDgKTMCETmBBXJ2ao/NfHMJxhgqLQIw77RzT04pR0ZTT0ZyzpWkXU5McESe65IDMimY4AoYciads0A+A8MvZuR3RQQMkAFKLvyIoixLs5/fTfuNKUwtOz1rFBhn+F91t379uKe4W2cAHROMSyGl4D4+EYyzwofHHviT2TwzxlhLZPzVUkJyzi2RMy7LciVkGFeVUnL/gmVFiYqcs7m1aemSXGeFKw3oaf4QAU1ZRIA4nTtPLQe+7fDxS0REQFNn3H23e8LpzbS/Ekxr+zSNCL0hNtJ+gh1zRM5xAM6Z5CgE4yiJqF6t+uCstLSTXDttyrLUWvegCsQlsp52CY4nViy3Kw3JF9tV5WxZFpPhCF0WBlSt8Cjk4SyMhuOykCyo7CXl6p1bL7928+LVxCAgjxVUnZZJmk7yJK5G9UoNrYu5BUZSYafGhCQE2W7H3d3tO6vDMAiWF+aUDIxx/d1RUZhXL71eEUxKFQeKUVkk5bULm2+d23z0qZkPfvSZGxfPnzl76u/9rR//3Kf/9IUvf+uD7z/01iXuAiGEYsIqZi1lpZlYXQ77OwDh8tzKJ3/4vfMzjT/+0xeGQzh+YgFdqIRMkrEtNaU6AtlozCzMLJSTdDQaVbgqdUFGI1BdQIPBRDttTWm0AxSMgZREoLV2lgCFdiaxaICy7mhcurmZ2Qdng9IWxpa1emy1TEZQD+1SO8pGe2s724uVo2dPH8usGyZpc25hfWNjvkKFNt1hOer2ZbSbDUe20EFkuCutwyiMhWQl6FYUNOOwKPJ2s14UWnHVaLQEk3mSl2WGZCRnHGyzVV2Y69SqyjmXpqm1enPjljWkAhgOgQEeWVlZ29x8+OGHX3/9dWdLyTBUQbMWB4Gothplmb/58tv3H3sgrlazohxMJtlu99jRlfXVO3mevvH6Gx//yDOM9PNfff79737QleXsTHtzd7C1tZOO0q3eyJX2wo07jSg4fuRob2drWGjB3LjoFq5cXFwI4qDUejxOPdNR8ACRG00MuFKhVOFWb2CAV9tzKIPdQSK0WTh6f4DbOUt5dHRvdOHhJ0/+tZ/8m//z//5P3/nuJ/Ki6I6zYZr/l9/4VKfeUDU1ThIpoUynXkw+DWDaXwM555AzX1ysMW4/E9w/TweaTLhba6bV5Dv20AeC0umTO8Vavq0A3fuAT3+jR1H2axPbd50UQniajS/u/g0kSUJEYRxNFxLv3DLlK3rvEuCAQICOLDDOODJG4MCRcTbTujC6EoSMSJMFsozAcSJDAshYx7lFRE/f0FqXpTHGCCFATrMriMh3vaEQaWE8CwgQi6LMilyRCiLFSTgAJGLIhBLMca01aV3sZ2cf9OMe4fDon1KK7Ydv+DOgdXaw02IHjSz8pceBaTAAiEw7IgQmmQ/vQQaIjlwcV7mvp9aasvTwUJHnlXrNn1MhpZTKM4WM01G15sGg0thCGyKfXUTOFciEY4IYot93OEOWwjBwgJYcESMLztG0tsO+inf/8PsRz4i0/1Xn/h2Danbw73x0oV/n3PTtAABD6zt4jkwwnIYcIloibUxRFLa09x591ZZShlwyKNaHhabRYFjMRjJUrZCsdBTyMAqEZHoyGu5ujisAjPOo1tEuuHJj65U31lY3yARxaVVpGSUO05xxiqKoEiuJrl6NFCcpRaWmOORFOmGcitxI5VrNZqAqunTWMefE1vbu9es3M8Rapy3D2JJxDoXEMBCl1mu39v749/64PVuda1UkZT/wfe976OSV55690IhOMufAaOeydDgiNnaYJr3+/PLK9s62KcYLi2cfOrWw8cjS5csbouyFarnM05qUPIiN1lZrbc3G7TsSRD2ukC7BaG41kIsA0u5YNJqOrACSDJmSIKQlV1rSthRCWqLCIXKRlMWoP85FGJa92XZNqcgARnGwstho1KJksNOM+KYub1y48sz3fejG+o41BMgOrxwOe1thXGnn3RNnHriz3c/Gg3c9+dBr5y81oqg0uhFIqViJplWNG1HYS8eCRRpKXRbj0YAR00XJAQWG950+vru9wRgJAYiU52mWjvr9nkBtyX3s+565cu3GYLgXVyucsytXLpdlceLksSMri5yR0UXWHaUT9vb5CysrK3t7O6t37hw6fPTU/AlE0Fl68cL5hx9+8PTJo+t3bv/oj/zgw2dP/Nmf/CFp3WrWr95Yb9Ybx06ufPHzLz10dmZ9fe+Z971rUDAjK1FztlaNxqO9/iQNk1QIBkI2Zud0UQpkkQqYpSItrCUpor/zP770Ix9n3/P9P3R7q3dtdV1UmscXFp780Ie/9Af/bntYfO2LXxhruHhr81N/9FlR6ahaZ3e0/tyL14RQeVbW2zODfFSyUkXiOx4WXwmQwDknGEM27eSmNfueLf+9IPu9lRrukTJ9R6GZgggMPahysO2me374Lvrv1fNT0h3zNZ0xdpCL5Dt3qUJrrVAyDEMPXnPGjDO+LBrnfEUin40JjgQnL2wEhCmNkxhQzg0jnwmBDNE6cIa08xGVDsD6VcbaaaAFZ9PcUKuth02myUqAKDhjjAthrdNFrq2VQFxKRvdkH+9nrioh4Z5kKwQkIo5MCckZRwKyDqbBb2SM9aDCdKNwUBvd3ZUWvx15vnenJYxDRIYcAFA7R+SkYAw5YwzIkbVFkTNAJTlKDiSFCnB/wM28cbNz1pFUQmud5oXHc6SUcRBKpZwzwLkFdAiE02QWjswnFgE4uOtsi0T7mRUH9wFOY/NoOgs+CNU7QFnuuZno7mRVMEY+oxr2bY8AiCjk5KclnAimIYZARKNJor19k/P7U4lcckQV1QWzjAUakklBMDLMOTDu6tpeXbBmwGoBUigUo2QC/QHMnG71R1nSSzCstWaPPPjEMdbs3l4fbm30mQglY0piFIWNqgwFOWfr1WpRZPVqZXa2OUm7k9FYSMdT99BDDw0Hkzy3jAfdvcmNa+vdvSFjFQizwukyHRWWAqIKhzqPo0qSlWb1gl1YGoI7/553PVJf6LRrjacfX3n9cjIejxiWXOZpMoliG1ZYMclvXX67Um2r0OTDncXWzA98+B0V/q1nn91YXByNhqNOp9Oo13q9FMCBw63drXanGQRBMh4SWc5RcJppqd3tknSugCslgQsSjJAsMM4DY0wQBIml0hgeydKRLkqW6msTMCGrKihcGZBTyMnQeNQHwE41fONifvjCRVlr5uMR1zaMq81W59Lla08/9fTa3sBZ/T0f/MDbV24uzXW4VOMkqVcCxVliykYU1CM1cqZIJqFSmS7Wbt0qCug0KzPtNme0s7WuJB5eWYpiubuzCaRnZ9tz8x1bJEVRRlFQb1TDMAgCfvrUMQs4M9uc68wQmI319TDg1Tian51vNpthGKyu3dlaX3vooQcAbafdLIs0mVgw+oPPvO/S2+fW79w+dmh5cX5BcvaNb7ySykqjMd9sr2j30rFTj7791ptvXtlYu33jo9/7TDcZijiotJbJFZVGQ3AicJNxUhrNjAbrpCNTlAKVUPxf/rNH//W/f+PZl/74Ax89/dDT7/3ma2/+/qe/9OQHv7/SWuxeufT6BV2bi7cH2UvnLv63P/0jr7z63LN/ceG+E+1kxNf2dq0MW3Ot6+v9dqR8rhvuY+6MyPitue/CjXUwVZ8yRLLWHSAs+0067oMn8O1Y/PQFOfev9h0l/u4Tvf8k+v/qRZH7KU7TiSIg5nkeBIHv1qcYC+OI6JWclUqlWq0Oh0N/m0kuwAuA9ntB450MiAiYI/SyfrKOAXDkyEAbAHAMkCNyYAzQWUBH1cBHBjpriTFGDhG4QMkAyfoVCoQQigvnnNaaBxL2GSUyUJkutTVJlnEpOJeMc0dkfbqs7/enqff7A8X96KUoCJxz5JVfRAzA+HFxOG3wGWMHexc/KDwIfb0LvhPhvWEdQRhy/3drrbXAgAsVCJ5ORkjOGWPKMlAiCOJQKmv1oHRKSaEUERV5kee51hodjcaJ4FxKGVWqHjzy+JQIQmNJFzrJiiTXqXaa0DFeavIIy5Q6ih4NAuu+S+fuUfiDe+KAKoN4YFRA4INo9+8qBr6w+2QU2qfdEMOpiQWA84GBBEAIxjnjwAACcmIMOCfOABGZsdbYMme21EABD4lXeVy7vdltKNxBDcUkZKbViNr1alCvvHlum8vQicBKcpHNnHCBKjmxmFWqkZKSdIFoOSjJJThtiKWlnguj9tw89e24TKKYV2vxVrcfqIrjcGe9u77WG45KDRVnwNE4NSlXWIkbMXGTpYnhRYmxjOdXoN0OX3qlJ/mlycnD9Up4+oF3ZGK4t5MZa63Gbi/JxlZnMBhCtQYBmrQc9DeGM/P54eWj3/OeB2KWrm1XJ8Mdrcd5JkajfrVam5lbIMHq9aoSbGNrrcihGkO7Uzl+6Fi9unXh1lApFCxkgFprQ0BcSCEqgZJRlOWlcc4CdzwowKYWdgxQz4VoOhWocgipFDyWqoLgHrjvyKuvvHHu5Y1P/JVjW+tbM532aJL3Rv1HHn+0Pxru7OxUW51hr2vKVDLebFTR6YoUkqPlUJEs4oyD1WW+tDgPxNLRsEi1kkxwSseDBx84U5RZXFGCQ70eV+IwCMXOzo7OxlEUnXvz9SisPPze927v7K2v36nX61EYTpJhMp6URbY4t0zkRqPRnTvr4dFgYW7WOTM/P/fss1+t1msrKysf/fDTMzOdL33+Mz/3sz/z5S9+7nd+809+5qc+0Wk176zeeuD+9964cePZ1ZfCKJpZONl9/o0r1y60m/FXnnvzyuWNlUV88Ozxw4fmazaksijKojO7PGJ7etjLcmN0SdqIMFQqPnzsyH/7M+r8tfX/+BuX5792+ZGnHggaM+OkgLCytjM4dKpy7mpy+MSpJ9775NtXV7/41QvtFrx9sddqVFcWVoKoduPmlWYnlJIbXyj38VxfXyyQErI02pdRKQRy5pFVdHcTsQ+aRLxnsnpQqg4aLCKCg4afiO4RQNG3T2XBGyVK6fk5fgLrn1P/TgQXnhujlAqkQsRRMvBka88+TJLEd8FOW7uf9HmQPT3lVvisIusIrPCpC0JoradKSODA0JtPkqMqE/b/T9p/BluWXeeB4FrbHXP9u8/nS5+VWWnKoQAULAECIEiCpGhE0ahFqaURNdL0TPR0xMx0q2eip52mRx3UhEaKGTmqJbVItkSKJESCAA28KxRQvirLpc98+ex979rjtlvzY99781UBILt7TmRkPHPNOfu8++1lvvV9dqpWJhmEviMizsXOFFcqUVLKqqqqqkoiaa0lj1wIYIwQSm3QeeFkFIHkDImC6o4QIpIqryYPutkzphAAFEURvg2TEGFNnHMTn2Hw7JyVIabzm1N+IUKwd5iFxPqIeq7IJpOFhQWlZDHJELziqiyy7YO+EthuNur1GrnEO0PWaSqJqNtd8t5XVTUejweDgalckqhms1mv13HWwAUA46w3npxP6ryszOFwNC5snCZLS92sLHd7h8AVl4LxqbWusQYRGUfwDAE4Mj+Lqaf54Ew4zAGRJ5hyHSGa9j0IPYWiTbijhtx8EQVjgSwlpby/uffDH3/q6tWrRak3NtZ39nvOU6VdqU14F0JGANoTeOcRPPWRAMGT855gnOn7Ztg/GDx0YrUE0+sPuLNL7fpwP7++WawsNWNoMylFvQlJbTjJ7u5v3u0dHk6K+kJTCC04RLGMOYu5SuIoka18Mjx38ZF6I7p5bxuEPXPhsorY4eCwdDjJ7Hiotw6z+71JNra1dKHd6UZLXucFcSjAcSaYqmUeZLQwrAqq9KjMa2314qu9Wzd7T73r0bXVzrkLhkkCJ71tFuXe2vL67Zv3UgFMw+HWAHmuomTf3ilGh0srq3/p53/oD764P8l27twdWVd0uq1ef9i73l9YWLq3fb/RqJ19+HykGDmtq2z/cAcZHVvtBJNYZMwjak95pcuyEFK5qqzXEhlFuTbWg0prjvPDqjHpQ12wifbLsVxM6gdjqguMOb9x/e6lC+z+ru82Gov1xv6dOypJao329v5BvdGqjO5G0U7vYGV58d7mzt7WJufcMEjq8fpyV3DmdXXm+PG1U8feeuut3t7+ytLi5Ye7oSIQR4v3Nm8pwZxOiMza6vLrb7xqrV5cXFxbXsyr8vHHn9rc2kqS6P7WnbX1DWs1MlWW5f7+bqOeLi4ubm1u6rLqtrvOm/Fk+OEPf/Bb33p6f3frzKmnqmx8+uTGaNifjIbrq8try0vXam8OBoOXXnj+7JmHltfOfOHzX798+cru3uTXfuP3Tpw496Wv9z72keX3/8CP/PZn/vGNWwRs99iJC1/82ktLC81Tp44fjI3g9cIOwbmIJ3k2UUrsHkye/coruzmo7vq7P+TubO3++m9f/R9+9W9/7ZtPc26fefbgr//v/vrjW9X9QXF/5+DLT/+xiMACdFdi5hOt/fjwoFarAWhnNWNTfvq8QoKIAhARBeNBQ5sxhvMUHx/Ml8zrMyG+nhdw5qFlKOOEzD48DGDqHxo4i0fjtvBFHMdH94xQwDHeCSGKoigJAl2dcx4g0jl34sQJ59ydO3cYY51OZz5U5eYK7IwFdOacj8ty6qrBmeIqieMw/1qWlQNiRI6BBAGSKSk55ypSgNq60lnrWQjSpZRRURSSi2AKbWxV6QIR01osuOCcV9aUZemIojRxCJNciyQqqkpbG5A6uNqFAYLp+O4DsqMLcX2apuEy55KZiBjk4GkqujnTbyCIoigA3TwfCmvIj8wDibXlZW3KbJhVVWWrcuKcEnxxoSU5i5VEgqD+zjkGRufeYKC1zvO8LEvnKI5ls9lsNpuDg8MA7nOeppSSSTTWcBXV6g1LmXPO6FJKubiwUBiLTIRB5NA2CSdnNRGRIw+zVg8R+ZmE0IOsEIBPqTUhLkDOWbja6QYTim7kGWNCcEQqTZlXeaeBi4uLi4vL167fvHX3HnloL3SsLxqN2DrSzmljXIg+kCOighFHDiCIEXOIjhvLS3C3NvdPrndFY7EaDweGM6qXOst2q47pxI0EMpzYXt+VBXNJKpZq9UmRM2EjhRIIHXfe2IprLwqHe4PJQZ4Nhgeeqt4kY8yPx2NLMBkXg0GlK5Si3lpZjaMGsah0lbaGO4oYWM4lE84jMVY4X1mQhU+d4J5Dye/u+ta1YX3ltXZXbd3dI8cvPHT69o2tp979gdeuvmmtN8Y5bSqdVfm4mBy46rCcdH7mp36x1eJ/8oUv3982ednjSiTNpqopKlkFfqJLbQnIorMIgAIX2nUisuQBwDoSxoIF4OBparPmkCRnjpxzzhakeUeTd9b7wpJj1jHrsBS0ttBiEY9rbHUlq4oCvI0EX2i1JkQoJHFByEptrHdRFC0uLmRZ1u12OcdB/yAbDzrNhqqnzpq3Xn+dc35845gQwpnSWsuAnGWT0eHly5d6+9uREm+8efXChYd6vV6znsaxYoy9/MqLnYXF1994dXFxYdDfT+uN7Z375HyjWWNAu7u7xtjJaLiysrK60jk4OCBvq3JyfGOVoTt/4by3bjzc/8GPfOjv/crf/cgHP3DxwlkkevPN+x/6wOLVV66CRYHJu5/8wDPffu7Tv/+tn/25T3Y6nX/wj39DxrBxKv74j/7862+8NBrB8y+9eunieKj7j5w/Y/q9n/rUJ++9/PJoMozr8b29cbRw4rEnLh6U9PqeThfxvBrsHx4Ohv1icq+o4P/193/1Z3/pl597/pnNwy2ZRPUGM7pAD9yTc+QdeOZDwVnOguZZi2ua6ob6+zvqnH/mcRSXp59faxmb1x4QEQMt42ij77uPKTbNKDo41cSd4kl4TEBtj1HowYYMIAC6c66WpI5b8BSq7S6YiDCn4iSAe/DD8UTeWLLOWMsZg8B4QXAetHFo/dhPJWwD6y8kIOEcQo1hboZ39Np5cE5CZECWvPReG8OYCFdiyaOncAJSyilAz14h7IvzEd8jUB52UYCpwes8RCcEcI7m4E70ANyZ5PP1FKYcZZOJEnKl266Kcntnr9Sunqgw/qQUV7JGROTscDisqureQZkkrNlsdrvdSCrnXFEUh/u9OI5hzmz1fm4BVXqdJIlSMWNVluXWjVVai5Sy1jpnrXHOgw/q9c477xORBnVnCx6nTFMghKKq2Ex7IVxiWHdLDjGoKU+tC0MfhXMebjMT05jCaVNV+uGHzw+G4/3eoTEgrI+SmJAPRuPF5SUAT845CBxTQAbIUIFBMAgKQBAKIDCWkGA/G68fW20160Wph0UVi6jCtBxXYGRk0Y6qsctNZOJOrFLgXldaK8Ei4SRw8N4bp531tsotbR8MHem8GFlX7PVHDlwoRBal0RUoWavVGmmtiaCs9eDJeO89GALHkIPwyLz3hRdZVRFQ5VjE0srQ9btFqbef+siAo1rdWLz51r04aqytHhsOR0sLK9a6siyLYlLprHJaF3Y8KMBPrr7wlQ++98Lacu2f/Ivfe+FNOHXSRim/ff/W4tIaItPeee8kIyG54pwxlEKEPy7vwDknGTFiEllWWfQePCdgIDgiFsZqq32akrO5M96Ss945ZwxNBN26f+2xh89jwu/f7Q2/+o1jxzeSWnrz5vXrh36xmz58aWFl/Vi93RkUxXg8PDg4aDabeT4xuswmY4FgtNSaCWRWl41OJ4qiyWhYFIVSolFLhGCPP3Zla2uzKCe12sLlyxd3d7cZ+EajftjbjZPElEV3oQ2Ii8vdzS1dS6OFdmtzc3Opu7C+uppPst3Nreeff/6xRx+9f//e2tpakkTnzp0Zj0bOVvc379y7fafZqK0tr3zyYz/42c9+9s/9+I89cvmytaZ/cBhB+8996ke/+o3vFNoeP3m2tHJrd/A//fYfI8LxY529w9Ebt/YPh/TWm/cfu3Lp7v3ttfPrGtLbW4P/9r/5Fz/34x9gycLu0BbQuNcvnt26+oVvPX/5yXfd2Nzzxn3tG1/7u3/nv/6n//T/GQn40R/7+Fe//LW9vT2ZRO2F1miywzxYIAiK3rOQm+wDhGX0PfB92jP1U0dORPw+jMfvge9Hv33HD//0p9OsKzsXEeF8qusSYCSg4dRGmDMP0xAYZ0I3HFkIfhkBeY9EPDAzCJxzHBkw8sHuyVvvvTdTd2nOOXIempDWeyLKvHfOWeuQwIMjN7W9loI7IA7EiI5enikr4MwhEVFoDXoEh2CMUYoJzgjBOYd+5nMfLGedo7koVgjhQ+3Ie0fkibxzYU2Av3N5ccrwBviusJ2O9L0BQOSDPjmXpkm31TBJVOVDU1aR4JGSnCMDRA7euLwsx+NJlsGx9U7g7piqtLqSnCvBRC3mGNI0AB/eYNp8IEDriTwyxgTj5LzXxlsfcVaSA+eJPELozZJ3DtGHoD1IR4eYnRDCfFsAcQp/EPN6eijRBIGBWaM5CJLiLJEM274QnHH5ytU3tnYG3W49TpPhODM00tYOx2MPaKZNdkIW1Hg8ESACkEbGERgjAeSNM0JEHpmK46RWH2unLXCeRJESLC6tceCbrU7SURS5YdV3edFOEyAG1hCBIAXIrNXG2RJhUhXOWcY4sbjQ1ntCTMtS19KF5eW2FIn3qHXpfYWIzDB0kpz3mqxknKF1rnS2AioInAPPIQImPeDAWD9autU7cex4PUkbzeX+YHL2+EMvPPvKseWNNI3jiCUxasNKg8YWUjAEc+O1b+psZ3Ht5M//zAcWvvrsMy/o/f7+6rGmEMw5stYRA4agUISBbmMLnI5UAGPEOAnFrWBgTeEseQssNGA4A2LeEQMkBAJPrCI/MuCIcuuWFo+9urkPrjh2/ux4ONjqj7QpG0tL461dnuX39/YnRZl70M7V4jgk49dv3C0yOHE8XVtbZUjeOxlHHdVE8tl4ZHUZK1avJ3GiwLtbt69FkTp5YmNrazNJpC6LZrN57969i+dOxnF87qEzpbYqjt5883XjfFFkTz31VFkVh/2DNI7zSRbH8fGNjZMnT+ZlL06i0Xh49szJz3/+841a7fb1aw89dFYgO3vmxOtXX/vEx37ws5/5zGd+799//OMf58i+9uXXDg92L54/tXuQ/fGXvrl+5mSt0V5dX2dSZEWWl/C5z3/z3Kk1VM2VY+d7/Ty3amJkf+yNhQrS127eHEzswCWtk1dQ8Zy99Tt/8jwD+LmfePy9T13ZvHfzBz/8wVs3D77+5S/vTmIpkoqCx4Vj+KD2Ehpa+KAhNT3ehu9h8JBmQlg+jBHi94u359WYd/xwWj1HmMd5gWf5p0M8zc4VZ51DAAiWQ34mMhMkxx25sgwK+NMhTyQQUuR5Ds4DgAhlAyHCzE3mrfPgPJDziIgCBDJgTAjBZox1QgwsO0R0CMFJlsADYxYQnQPvhRCeyFLwPsXprBMROQ9Ans2anDhtTVsPEWMYilfOc8AwUEkIjnwQE0ZEDhxn02TG2am68exWEQIdJSm9Q6ltFrmHex1+VRkz31/FUrtGREJAPuxZa1u1WHXa9bQWCutFkRljwHkiStNavc5QKSmltzbLstAMCSafpSkZTFk0kZDzpGNkrDXeOReJSHViRKy0LaqyljQZMwyQkCETKLgn8N6biWHeG/LOeUceAByiRwgN8TDP6j2R92FyOsjThwxOIOOAEoMJgOGCeSAPoLUOc2Yqim7cuZfneaOVNNudw8HgcJDXm3G9XsvyEhgCYyGPDNSsMBLlKbQzkKEEFCE1UFE0Ho8XGrK70OTO5IOcEdbjyEJJ4FutdHGty2LWG+77wieYJLJWlmVVGQeOcxCMGSDnSpLKWOu9j0TEmLSmcs4JwRhyxWuxiBnjlamcqQCAC2HGQAaZY4Z7K6yMBHAiT5aM5+QBtSfnvXSgJIssPvMMHP/plTt3Jxvrp2M12j88OHlqfTIeKpZyqRNBMchYJ0VJzhmy7uRyMurd8GZybP3cJz/yHqleuXZnxNHl2Zg8B0CJKARaAm2RI1lWcmSScUBinhgg594zxpvxuDSTylXkLToGAOiAeetGSIBATBAQVQTOusz4sR1Nhoe6gkyo/b2DegqTDMRunrQA47hwhEJ6xqIkYSqShFk2ZgJqDeguLSyuLNpK59nYeIfkKq0Zh3a7mSYxkbNWAzol2ZXLFxqN2mOPXb76yssXL17kHBcWFrg34c/4zr177YVOf3Cw2F2Ok+j27ZtrK+t3ykrrylpbr9fPnT0/6I9OnV0NeUOSRsfWVhbandHh/uWLF0yl7965ffvOrR9+6Icee+zRzc3Nbrf7nWe+/Uu/+LO/+Tuf3syG44KOn+jIWI0m487S8tbu7v7B4PLFhziY3cPx8Y2zz73yeplX2UGejarbW8V//X/6W5/9nd/xjp1/7EOqe/qPv/P6P/30Z5JanRRsrDX/3e+/+NjDq8aMb11768T6yg9+9NS/+fQ31o+d3Ozv9nb3Wos1U+SBeBaKBsQ4MIbkpogw56HP8B1mYM0B3AO28Z8RgB99AH2fIH++x/wvOqb7AYYJm7dtMWEAJby7tZac55zbSnPOQyNSCIF+SmGsxwoRnXOGDAOQnHHOuWAMpsIq1lpGEAZkMXAiyRMDBtxPC0yciCwQJwIHwJEh46EdDU7JCDhDJCBPnCESWs4ER+uC+apzjrznjLO3r9W8b4FzEZ6ZFS3OuDSMsVDwDCnUnKwEBEBz45SQ+swHax/cO9GqR4wJa21ZluRcLCLJ0VT5YDB0zgExzjkTAoCFNu72wUGz2YyiKEliOTPZskZLIRCRESCQJ8emw//oLAULFRmpWpIiIlFWVVjmmXHeE3hgXAInzrlgktV46pzTWldaB0ddB8QAtLVBnCAMhM25VhqAhc44Q+JCShVLJRjXIf3xXltTWWOt45wz5HnlhYqFlHu9w7wsmu1UyXgwHk37SFOSTxi18N57poBcEB1DiZxQMHAMwDm3v7fVrdHK8XXRqu2Pc1uUYH3uBp1OZ2FlIUrocHg47B1yxjvtrnHeG250QYAQMWCAzHlmGSoemvXWWuPLskIiVGp9bcOYKh9lRIYLlIy8d7ZydkQMBXrvGVnQHjgqJjgRGODWE5TOMgMOVGVNYTQV8PLLh49fuTge66WljT17WzKTFzkKJ7hjDBnjUisCW5bgvW+qamG5lhndu/dW3Fj7+IfeV6tf//xXb9ZbElgsUTDBwCNYT4wRAy6JM+KMGBE4h+SDHH+jWYulVaIaa6+BKm8dEiEYe4iIQMH3nGuPwWJy5OnkhYtlPro5OBhm8J6Lp3kxuf7m/vHlmoxjplSSJnGUgiiKoijyzDp77typeppwBlmWCSGA4XA0WmhESnIpuZJC69KYKollq92idv3GjWtJGp84thFFcm9vJ0kSxlg9YgCwvb3fbNWVEu9+4nHjqV6vj4YTYypGvtVqRTK6c/NWq9Gu1+sHBwdRJE+dPP7pT396sdO+dPlCVUxeeO65r3z52s/85JMPnTl7//79Z5559pOf+Nibr78Zx8m3vv5Ha0u1ezuHvd74yrve8+VvvXyi0Tx34dy93e2l1ZX+eMJIX7pw8tqtWx/7yIe++IU/2r67XQzgvZebL71+q/DqIz/4yV/7d58bw1tff+0uiWb3+LmyPLy3c/tTP3TuL/3Fn0Mz/Pof3fVa/eJf+A9+9Te/tBbJdqtxuHWwLOoWEYIECWOMwDM+c70IePBOfA9VBZxpwszB5XvJNs1e5EgFZl4En9bcZ6K+iBhmo76HB/L3eSnvPcJURsbNSiDBz48xJpkMb8el4JxXVWUqHTp8U2RHxpChQOcceIokBwAL3hnvvbeWhWptiPq99+CmymgBVR0jT0COEL0K3qTkgQtHs1YmokR0CEDWe0+MvHMWvPHOeuZ4KNAAVxwF90DGGHQgg2+4daAkcoZ+2rNGPvXnA4bOOSBggjPOQt0jpFvz5Z1jNxAErcbpbTpac2cMZ1R14aqSGOOMpYqTF5U1o+GkyCutQSio1+u1tEFEeaW1s97A8uISIuZ5PhgMGGPdhYVGo8EYK7M89HmtNjQTa2aMISrOJedecgGePHlGECmRFxUFRxGvqwq5MEIpKWUrbjnmQpbELHPCAwAxxLIMNlSI5AEEYnC38syA8xTWnhEAcGRCiDmtSggBnDHyIQSI4qa1djTOslLXa3Gr2Rllk7K09WYCs/EKmrFuGCAJ8AhkgBFHYDx4unoAcuMhDAcHZqkhyNQichbLbIKpbyxB0jTj0d5oMFIopapDKXWhwasEBDFCHwbJSEphgSRH9Gi0Mdpyz5SKkzhpxPXMOe8KT5ZzxsBoU1ldCNdSiBwsVbpyBUOSxC3zBNr5ShvyFpgDIjsB8N4ty+a3n948feIJckUt9qvHVrc2X08axKMCneVMCh5Jzp2LgLj3UGfD4aDUjtWaa1Lx3fEkYnTuRH1rb8KlYgq5R/RAnlCAZMIgIQKCw/CZ8IYREygiJC+RSDEBpSPmCcAK4NxPPIEhMF5Y4pq4R2ERmZAv37rnTNFq112jfPr1W0kMG5dXj9eXqqrKynJclIwNoyiKk7jdbvcO9joLC0qKfDzKyyqJCDjjnMdxLKXkDKqqtK6MIpmmqRCMc95qN7vtzmuvvXry5Mlut7u8vPytb33rg+95PK3ViqLodBf6o2GSJIO9Xcagu9jZvLe1s7Wzs7W73F1iwLvd7oXz59+6+Z12u314eHj15etXLp8cHvZraXzjrTf/6l/+WKvVuvrqq6PR6P1PveeP//iLP/VTP1Fr1Pu3bjhk3YV48dix125eZ9wVxfgP/vD3VtZPMca2t+/3euOHL5wurD390Ln8c5/53/7Nv3XttVcTX/36v/nDD773Sq7Zt1/aKqN+3Dl2eunYW7dvxtLkJbz73e+KW/Vn/vjzH/nQ+z//5Zf+3F/4P7QEbG3em5Bp1GRVVUjTWRhGgEg4Gwl/gKdH8H2KEbPEn3nwf0bI/gCU58H7dxdq6Ah78vsd88cwxmC2rzjvg5BZEKpiM+NMay2LpiGqEEJJpbUmAkagIqWkRERnHREJxjkyzvmkKEMDlgXWoHfGG2s9hKAQpkxCmrHpVZpaa721YYKHkMJKcuRAnqbqA54DC71bbbVH0OSMd05wUIIQGGOST0k7WmvmMBIynD8J5sg7IA/EEGGms8KksIE/ypAYuhlUHt38HiRAf2oihLNDcEZlkXvvlVKETBdVlWvrYG2tC4BMcIZMax2kbeI4Ho5HURQJydqdphIySeKiyMaDYZIkxpiqKINkZRzHkYyUUojp7OR8SJQYYC1OlIw9gLE207rU1s+wuMhy6521VrtpzyTIHLdaLUvekXfkKbSnpWCMVS73xlptwDo+7cxzwbkmmorGcRZHsUQodVVVVZ4XxhjOeS2NhBAHBwfjvFxYaJa6gpCQoodZMQ6RWQkI4BzzHtEDIDhH3DspZeXLcqJH/V7kMeWMEuaKgreh2ebAytH4AEksLy1ZLTfv7wEJoeIoEsBd5SvnNKLnkqF2nAenIOIgVBIvtDr1eq23t88YSCEYB/CVtZV3OZKLWawkR2e01ro0nJEjdMID986RNmANcAIgOzHjqijGQ7O63vzM733xp3/yBybjIk3h9Onj9+68SlARagRFiIwpKaWPuPfMZf3FdrI/0pv37jeW1alzT2LUHWav3b43kV5zYBqs9d4j8lhIRGstMMcYB/LhMhgiBzK6AmCCs5QxJAaWAJmwPvIT7aHQ4L014AAUMQ5MDPJMxRGPm5mzjnEC1+12N84+NL65yTlP0nqYSAztJEd+aXGlzCfjUaU4C/CNpOLl2OajRq2uIiEEl6reaNSKcrK1tdVuNwXDqire//733717F9Bn+fjJdz+RZRNkzDm3tbXV6x8WZamSuNls3r17V4ro7NmzX/7iVxpp/ZHLj+7s7Pyrf/mvP/SDl/f29op88vM//+Odduvu7Zs3r99YWlpqNGvPP/edqjJPPfXUs995/uzZk1/5ylc+9alP7b31cpw2nv7m/sc+tbxxfPWx933kX/ybT3/wgx995bVrvcP+449dfumFZ5974fm/9As/++8/8/uO/Dee/s5at/27v/m1X/rpD/Tub/8X/9U/QwWg0or4/bvbS6sbRbZ98mT3v/vvfvO9FxYFp2tvvvHii893I4CkcaB9q1nzSh6ODpNozl90iME7jd45z/2nYu7/3Ie+/Qg676GLCGEanvyfWXOfbxIhmkZPtVpNa21Ah5tORMYaP5vwpJlXiZTSmel4auivOmsZY0LxqVRkPlEog/5GEDtxzhFV4DzMJj9DDT3gT73ZtNqUZWG1ds5Y78kZ8CQkQ5qmFaG2Ho6gjBLQNrT1FDALGNgvzjljjCAersta683U5WN+seGLKIpYcHea5U/hV5y/856FPqMQAuajBkfEdK2zMNsMhOFtViNX6X6e53kOAElSX0hT4iKMVqG3UspOs6G1zkZD3l7X5GxRlfnQ5CMBvpVEnST2pkiQRFNKmTLJENF641yZq8oZS5WXhBHKthDgEBxVxjEeVcgkQibQIGpw43wCSUycgeQRTx0yYymvjNZaAUdGEphiTKLnYIW1ANBSrdKUhSuMrRgSkctcnpcoVFQ44zlHGTvAqrIeEl5rmskOkwyD+oTTzPo6A3s4SgUHgFiKOE48GW1KRIxjhcM2k4wUlV5nersIfQCG/YlQKvLY0VUnlrYst30xaTcA2BKOWihUXUDGdH8wAK6StpoYx2Iomcuq0oEXcV1KaYDYYMS5sFXpK9dsNZdWV7Qu79y/0azXrDXeuFqk8kkliK821+5sbd5b69XihDnKqVCMLzZaSoiq0BJi4S2zpa5MRQBColRcqKWV7pt3rl5U9cbrr37wydVuXB8O84dOv+tbX3x6deFMPW1xTzyySD2CAyZMWraLcdmqN1hqtoa3tray5aWTP/qhVVFu3bxRVKUR9YV+WY0kH6c1i07tFcsrnXqjQ9aVRUHWsaDeqXWapoP+Yb2eNgTnVKx3mqNRdq/oKE9lVbabrb3+ZGN1Y5SV40m5IBpU+VTJKtdF5s6eWDvdXs/f3F1sMO9do652dnYA2PLSSr8/qQDiViNG1qino3FfCB7Honewf+rUCYW1GzdeP336dKeZvPHm62drZz3p4ydW41iB971ez5N+6r3vefpb3xBra2+8fuvyY4/fuHfvxPFjJiugNGtJQ5fVhqzF7cXRZPz5L/zRj/7wJxvdznOvPfv4e548mVa5iwaTMRB/7qXXWqk8f+ZUp1FfX+7eeONVp7Onnnz3yy9+++LDD+31Dr/45Ttc/tGjG1e++rVvLDbg+aevnr1w6ZVvfv3xkxsbMRxKvbpUe3Jj8Rh/hJy++8JzP/y+p74wGNwa49W7d+yxtX/+9TeqInd1aKXJWldeeXjla1/+6qJNd/bzWgT/8S//SJOt/dtPf9Vf/OFnJofX6FrsAaUXRkuQETW5k957yxCEs2SdA0YtyWTJRgE+GE3r2oGk4L1L4zTM5mhrBQAnYJ4qC3PG+nRoHtB7j9Mu3ts2AQSojJ4r1uIsSApUSEYQEoYwXh5G0R0DP1OQD/UEpRTnXMaR8a4qbFEWRCCliKJIREqQstYKQLC+cjlnrt6QTDjGwXgTwg4gMsYKoXhSl7r0jiobQJMAyHtCFD5oWDmHM7YFF5wh1qXe7m1PJjatx0msgnlRHMfkEQEZESchiAtH3hKz3kryznNEoSLGhTfktZbGpmmMTEzAOgArgCngHHOALjHGgMO0EEREQeQ910YplcQJADhjwXkefJe4mAP3bLeeLmBwGPXeB7GFcIPiWp2IPJEjElprcj6E26EKGfZea3UkpBDMGFOWJcxK/t5oIuIMmo2abNYSzlIlI84OD/YERym5lBIFOvLeeu0sp4gh8xyFB4YMkUvBGXA9yTyEoQOIhZScM2u8c1WRqziSnHugSlfGEEeM47gsSwbeEjEkwbycVqtQggWAOI6TJGJIRGSMNs5qU3ljHSFnBhhnSAyZ4MgiCcQ4IiPGBGeKCUAk4IwB+DSKk1QRubLKnXOMgVL1yla5zitXEVAkkFAismbSKEeT8Xg8bqhOt95qdrTwXueNet17P8nzafERuUMEjhEBkbdumoeip7IsK6Mjq7VDYFBvpTIReTG2zsVpTIyYQG98YBRZ9IQoUyaBCcYlB16rcUvkjPWE3nEkdNrbCsgJFJasLp1xY12UXPBxVrxy9Yai3eXmu04srlR5fv7CRZOZ0aQfxaJdT2MWl1YgA6WURseEUACSga0yU2YS5eOXL9jq1s07Q1vlkVQT7yeTCSgRCzDajscTcN67wN8RwNxEm6XVlvFuOB5Za9N6TcaRGbjldvNwMIwFcvAK/ehwD0TcbsTG2MlkIhDr7QbUo2YaCfSx4kLgeDyWopRSEmFRFFqXaZru9/aUEt1Oo1lPW/WakFjEkeR47869CxcuvPHa64888shTTz21tbVF3htjlFKPPfLIc889d/rkqW9+85vve9/7v/WtbyVxzWjHOb/2xrWHHzp3+fJlq6uIy8Ph4VvX3njk0UcvX7pw0Nt9+JGHW932KJtcfvgh3RvF2Lpz6+a7HnlYgH/mG1//6Ifef+/unXNnzrZarV/91d9WESRxo9Dmr/yVD3vvqwE1usvN9ThtLf7Jl5/72b/0C7/2b3/76Rc319brtzYnr1//3Lkz7VajNh4cfvQTH//Epz71d37ri3meO2s4EGOMOAeGjnCc5Y+/69GVhYX7S7f7h/vdlfXf+fd/8NyLr159bn93dzdN03a7ned50J8KgW1ATJoRDUPAyPmDKgri27pwIUb2ft7BC5UKMQ+rj37xp8Tg3/3D784D5m89p7EfPVUi2tzcpJmpxbRHikhEYTwqlE6999bZQIrO83w6BGSslHKhsxDHqdY6d6W1NtQe5mHyvNQDR4oY8xMQQnAeZHEZ5xLAEaEjAPIWkKPjNsxUEiCG2gBnjBCttdpPZQbKLCcuSl0ZA2CdFiUxrMrSKRFwNODDNMQWUz3I+fjSNAEi0lofXfOjdbCjJz/fTf1M4o2IRPBd9d6HPZPNBGPAeaYiKSURVboIVKQ4koYREQmGkquYcYlAzhamjOOYMSYk40IQejJGW1+VZnv3QCmIlUSpOEODAMwjurSeOEKwjoNHqTzDvCiZd9pUpEttNHEluBIRt8QdkUhjIiLnEICjEww554KhdR6ACQ6hi+O9IxKAPknTKnLGOgdkvLfOeLBEPhGKiBhwRCZQSC4kk4FxRd4CA0ueMWRCePSeiEuJZNCyUAgCzhygd0GXA7TWw+H4kNumsoJzlcRprTYeT7Is98SZkIEChMgZY5YoOEMCojGm0FWe5+iJiOI0qTcSYpgVIwcUp7EucsaYB1sSGOYkMIhYrdPaywZkbCy4IHTOF0YrlIJxRo55y8kq9F5wRtYZ7QpvQKhUDSZjXQAzk1Mrt099/H0swvWHVg7u3D3o71kPzQUhhOAsMgRpveZLholk3KX5ZFKVVIxrjeZjl88UY3vQG+2PSxEpJMqLQrGEMV5qY4wDT5JzplAwASgQOHmM4rqqtPOl9WA0cRZxp7kp1zotlTZa9drt+7sABGQacUIl1RSsdJuKYyRRMScVOu/LqgLMhFSIqE2FDNJakk+GgjHOWaQihuSs4Qyc0cP+6OKPPHzYOzg4OGAcT2wcb7fb29vbVZ6NhpPVlfW7dze73ZWbN2/X682iKCbDyb07Wz/2Iz8cKfEnn/vsu554XCmRJvF73/dkUeRPvefxQTYe9nZkpGLSjz1+5U9+7debzWa3LlLmnn/uO2eOr21v3u3v7yw0G3dv33z88VMbx08SiN39gz/5k6998od+8PWtzXv9wXMvV7/y93/67rj6z//ev/kv/vO//oUvf+2Zb7/5sR99//U337qxfRD1Bu967KIR0e997nN7vUNvA/FDMEBCbj1W2l598/rHfuDDxXh4+uFLx6vytWs33njzxu37sIu7ABBFkbW2KAprrZQyiiKYjT4CAOdciOkcf5DaC8xhBhCYF4HM6h1oZ53zwa5nWuMWDxgdAURoNtTzvcH9CJq/A5XesaMcxfc5ttJMPiyguZgd4WSstY4F94+ZYjxBUBUsta81BGei0o5LUW824jidTCZxHAezimnBZzYVhW8/YMbPscYopaJoKprHuZRSggNg6B0AkPWOMSRAzhEZ95YYQ+DMOaetNc4hZ0LKoiqRg+BcCRNGpYDAEjqYOh95IussC8PzQnDOAwsIA+uPB+HiqTzZd2+f/ojjyrxpEe7OA3CfZ0MwrQFZDDrriMiIMxAcI6kAQEohhMjI8el8D3lXldo6q701C+0OgEdE570lr40zzjuCGodanDSbzTSKiYJEg3POpJESnNVIWO8ImEcAiaA4T2v94XA88SjLWrOj4qTUblxUSVr33jvGiTxDiRylkIyDLR05X1mL3jGkMOckuEyUVJIb6yvruDHIwRMwdOrBjWVimqg5D15IoTUUVVlUxKdRgiOiyhkAFiWxEpHn5IC0ttZRkeVpFNVE6sju7vfyyK0v1bsLKx6hssY4y4UgRGusJQaCWWsdMgLPAY012hpjNDmDEjljXJFnxhE5MITgSJeuirisnPZIxJEArBBpu82zsc6McSYSEHFAAuLEVeR1wclGzDMAA1YgggAWQ1Jr6HI8zqC9DHs9+OJX7144ffbiqVXg2F5ojsb18WSQlROhEIB7K2USxwwwZlJAt5HaasRs1o58GvmLp5fv39sav3VYuZIziYjIpTWMLHAgJPDeMeBAXggWJ/XewQAZNVsLcc2ORqPhaJKkdVtWEdileuQY1Nu1bBiBiEZ5wSrbUFSLULEqlVIKBMrQ+9yYQAHmnCMKRKrVkliyeiOOI8GZlxy8rRBst9Vo19Olpe5h/+DylUs3b9589eVXPv7xjydJgp6s9dv3d3Z2dlZWVlaXVl999dWVlZVG2lpZwuN1TwABAABJREFUXn3lhZdffvGVSTb6uV/8hZdffG53794PfPCDeTEaHxxunFhcXm7ked7v925fvy71ZLHGGiluj/b3y/5/+At//v/zD/9Zu52858knn3vhpccefzeX8fUbd/YOB+1O9+SpU1lhzrzr3Z/5xrWf/+VPvHjjzrHzl97Ty3bH5bWt/dbGgmwvqO7iWqtVZZMDbf7NZz/3/Iu3rUqIkBF5AkcABJXzmbES2W//3h987Ac/snd78/j6sXv37zz96v7J9TindjCLGA6Hzrk4jsO8d6fTmUwmRVHMA1KYEmAehKg481kLeO0gFOYpVFL8zDp1ztibR5rfMxg/CjRH48p3/PYd+O5nrzzDn2nvrdPpBILG0Qo1EQWddwAviLNgtsmQcxnH0/MRQiDwPM+NcWVZBtGC+dsFBIRZmjLfV+YXNR6PlVL1en0yyStjOZcI3JLljAHnzjuEqS0d40HsngjCpuiMcz6wFL2fznZMJRmQC+G9ByHnYBvuWvhWCDGZTGAWs4fCVEi2+Iz1d3RxaCaSPEfz+Qqz6fwPEIEIzw+1fGMqRiCEUJFggByZ944BRTLMoQAA+XIihVRCoidnLQIlkRK11HvvQp40nSpCLpRCvhHHURTJSBFRXulJnhW6Ms5WXidxTUpJNFX8UUA84mk9UsxHYlJoBzqvnLHEmKdyMrYE1rlA2RJCVMJxzpgHOCoQRp4BMoRsOGCCIyInrxCkYgwFcIbWIwQzQu4JnbOVIe99vV5nDIQQRJ5zRA7OkTXGeScUF4oD85qM81ZyITmzZOtpvSY4FWPjHSDnURylaW+SWeeEEFwI66myxjoUTJRlCUIywS04rXVlNIBP40hJJ6Ukhlkx8Qgikp6oqDLkxKQwSESOce60GRuthDyxtjE87I9HQ3CAgZdPEJogjkCEDMQ5Akglq0Ui50ScQIBQrclg+Npr8PIrmyudhWQy7qzUT6fH79+xeZ7rintSnClChoIDkBKsWYuz0Ui6PKHCjbdOr608cfnEzmH/9qH2zHMeeUBtvEIhpOKA3rmitM5iHMdpHPV6PY++4UBFkZCJdjpCUZfWSOaLrD/ZT+rtTk3WWu39Q7+7v9/tdpNI2GJYOSHTiBw5U2UWVBx5B5XRDAznPImkNgWQBe/BYZwmAF4JubjUTtN05f3vc87V6/X3PPnuVqMJjvZ39qRUiwuLV69eXVxcNKVN4jpnCkHU0sYLz714+sTZf/tvn/1P/7OfuXP37sUrFxmjl19/YWW5++73PjI8ONje3Hn0kUdXW8n29Te2b7z2nkevPP30MxfPnBGM/6N/8M9+8ic+trfbu3f3vpLpV7/+tCduQaweO7mzP0SmLCbPvPT6j/3Cj1OUbg/HX/jqF+9uD6mz/Pq9QxXD9d/9g7KE5W7iTLF5eNjr2cUOBsFGALQ+1BuYQGG8II6Oq69889nj62uZ2frGN19bXFC7o3LgBnP/ijRNpZSBttDtdueZ/rwmg4gi5gEOENED8JkkJA/xIMLUW45zmpEjvxuyvyesz379APqP7gTviNznkBoi0KMRdHhYnucPxH4ZC4ULzrk3nmiO9UgU4jNM4lRXBtELoYio1+shohBKGz0v6IfXD9/CkWTiaIlmNMg6CzKOIhO56UgjC2OVDjyxMGppvQfmUXJOTKkgV0BEIUJ3QMYYbx2iY4gSmAcA59F7AeiJMCjAzIXbAJz3xto4jmu1WhRFiOicA+eQMT2rs9E0VZmK+biZR9U7NlrOjph1hNJPqMYIZAQkJFNCMoY8EIesCboGzjtrrSKvkHEAIvBOMwImk0iq0WTsvTfBz0UKJoQQUqBXObq8Gk+y0prSGUMeGHLJsipninMEhgTgJGOSS84ix229215caB72x9t7g2FWMQUqrRe6mNlch+cwT4jEnCmFEEpKyRSSBa/BO/BEppI8FlwYR9ZbjwzQe+tTFTHGCBkROg/GgXXWeZdlYxkpGcmwGARhJ3ZRHCEHgpBzlQggVBTxxIBB8EWhmdaNJGkuNJiSB5NJXlhCkJHywJwLf0bonHHekCOOwnvnrXZWR1FUryUxs8CZMcbYChiTKBDJeBfHMY+VGxERSSEKW/WG4ziOTy0d5ySZZ0U29s57wsrbsrSMAAXAzF2HAAQHLnhWTRr1Gk+SvLIegAm4uzW5t93vNIvOySYsLa3SePPezmRsgKI4rldWAwPnjHC8FUdFynVZQtljUF9cXL780Pq1e9tbw11bWS+lq4xxiA6VFExI73VpCustgWGMV8ZXWvcO9pvtZGVt1WuZV56yIVjrqkKBB1e1khqAYbZq16LVpTZjMBxUkQQl0FtDjACZiqKyKDyid955DaCM1uQq8gKIpXHTWUe2QufG/YPj5851u92rV68udhbOnT4DgFYb8CSE2t/Zf+LRJ1599TVyILka9kdVob/6hTd+6Ice/at/5aNf/epX/4//yX/0h3/0ew+dPyVjsXZsUXAvhV1oRL27N7yuHn/oBDlf5ZML504988wzq6trP//zn/qt3/zsI49eUmnj9MrJkyD3Btm3n3up7aMTDz2movTGrdu3dgffeOnNG7eK5gIcjkEl4gvf/E6923DEkzjqMD4c9YnEufOXLb8e1+tlP2MYhiC8J+BcEJeWcRUlu5t7Z04tbh2Ob95568K5E29dv9tuqLwo59F64GYQUZqm4/G4KAo3V0jnPOBjEPb2ECiSSLNyswcKiiNzwb4Q2H63c847QsV3Yvt3CUYepcocRfYpnsI7Q/sQjWqtw2Omsl8zA9VURgBzbRkfxBUQPSIvS43I01QAwWSShXWw9Lb8w00t8ahWi+fI6Gc9VUSsctBlJYTiTEgZTTVOPHjvkBEjD0TMeeuZIS+9SCPliUzwiWUMEbzzNvRvCRiiYtwSeRfkhbkBomn0BcAZAhBDB7R6bF0ppZRyzmVZNskmVVU558hY+F5FJHr78WAFj4J78CHkHBVXngvnDRJYXSmlAIG8JW+JCJjnAEQ+jTiiB0/Ok0QPyMC7ueoNIiKfDwEREcVMGm8JGEoVJTEpAQKIs/F4LCRjjIB8LJliIuKCEeTOKCVjrqCelnnhXGUIwFYckHHmUQAXyDgXCrhgjHmrOQMOBOTBWSAnABj6tB7XaokSsjK6LEvvwThnnIkwBpp2l8kDA1KCI2FVaSYY50w7DeAZY8SQScEYI7DOWyAnGfMIjLx3hoU9tNIMfJzWGq0mSjueDAmFVBKBG+MteaEkeqatk1Jq63VVeSIgJxAiwZNIwswkVylFiFprQpjHYsY6IXjEI0OlLZ0Ft73bU1xEcdMY8rpAhoDcWY0CEBkwwRlJAeicJbKVBs6Y5AzEqF+2o05N6c2t8fbeuNNOqSwwFbxTb06aw9GhNdRoNsH3hRDeGCJfryUL9dqgHPmi3+nE4EfL7eb50yuv3tndug+OG2uVR66NR2YRBKAAlMZ6IMcljbIKACoLzqMnllWGMYaF8QCCcHV1dVJoL3A8GXuyC912msbaVEkSpbUYnM1NJRibU8RarSZ4OxmNI4kySYz0UrBY8Xot0oWrvJaMJtnk5rXru1vbeZZdPzjMxpOHHjqvte7t9trt9qVLV25ev/XI5Sv/6l997pOfeEIIbrX7G3/9p379Nz79i//Bjz71nvc+++y3gcHLLz9/5cq5vf3tl577xuOXLm2cWH/jO8/arFjpLg4P+6zZQWQXLjzcH0xefuWNT3zqk6+8di2udV549rW1jVNf/uazH/3YD2vHf+X/+3snTna+82q/B5BEcPzs0u5BP25IEKroj1VNcS4H40JyjNNWWWSvvn6j388akyoOn4qQ/AMSscqCJXc47C2srG7u9VutFiqxPy7a3YWyLBc6aa1Wy/M8fMIDuCuldnZ2wqcygOM8/rXOAbBQiAFgiMwBADFrPJ+rrBDgtJLBjsLHURD5vvH7rHp+FIze8cSjkXvoHH43Wiml5u+LR+y2w8rQdMiWAfMECIyX2gDjgGisB/BMcO99ZbTHB2wfgHlSYpMkmXITj3QgETGSECQRmZRKKU9Y6Cq8LyICE+hdKPqjB2BYeesZhLcLHTXyHilM+UzLMgzIwbT54fz0HUP5Yd4rDsbZRRjRy/MgpU5EfDbGNf9/vmXOfzK/O3SEW0lEIkkSRAzuqQTOatBlkVUFgzqTnAFxJAInADnnkiuB2nvwHhQTQsVcKMaUB2acdQRsuvoU2gvW6TY1kTxnDAVzklVgs6KqTFVvNhljzhvmPHlkSF4bY6yI0RQTD0yAWOm2k6TaH4yGmfEWLNcoFPqIhARgjMgjjyOOnqypyFTeVRHncSRixQXDeiSTJLFWmlgRkXegrcnGhSckDwToARgEgWdFRJxz7WxRZN7btBbX4iSNYpcbIofcxZKj4N77oirLMpcYJVEs0pgDj6KIR5GSUtvSOeBCWQJTGgJUSlmHlbFKKW1zYyoAYOAjzgQP9jAyKwqPvtlseqLD4QA5a7Ub/f5QcGOMY8iEiJEXzpF1/M7t7ZWVpUYtiZO6YTJSjDPQ5fSzTYicMwRGxlZFUVU2XlRZNqaC9KRaXF2zbnzzTv9gUKh0dTCZtLnDRKWNpoN+aRxwyRVTkfJUCoYiidr1WjEcgSvjGndlj0VsdTnttCRsGfCOSUZeVtb60nJGSkjizjpDjpDJ/oBqDVhaXmgtdArjD/vj5eXFRmcxL4rKkYxr+TAjR9q6hcVlD1SWepJPGEMUcjgeH/SHtVra6HQ8Oe9dq1FjQLqYpLW422oM+yjQSwHNNLGC+yTaWFuPlejn5jO/99Vf/uWfQ8Tf+Z3fWVlcvnv3LmNieXHp9MlT19+61mo0z5xqfO1rL/ydv/O3n33m24sLC7/0F3/cgY2k+PXf+P3/y9/+pd29u947IN9s1Pr7O3feeHWx1nz4yXeVu/sFDsaOf+tb33r3e9432s0sYTx2W4e6ibBx/vGvP/PC3X3/T379czs9qDfgy6/2L5xsY1ZEUfTatf0TJ5fzymrrFxaWjPV5XkohdaUjxTmLjDGnTp2YTCZOlwI5ME7kQp3TeA8GpJQ7vcPl5eX7e3vr6yd6vd5kMtnY2ND5WGtdlqUQYmFhYTKZHB4ejkaj8MkPoZtzrizLUJZpNNM5zs6HmEK1nTFGM5JMQA2PD2AXjhRV5nH398L2782WCYHzd/9qPik6R9hpY9PaEGXDrCEcjhAJIYZZcoYkGWNSyLIYB7Kf1hoAwgxUURQB3MMJ8NkhpYzjOLx4wND5ucWxLHJTVWWSUtKMPSFq60hLIaelaWJhPwTGiaG2Jpyec05bY61liJxJgOBNgYgAzqP1iCgYhrqZMSacTxRFgcbS6/WKosiyzFonBA8lGsaYzov5kh5F+TnZ5mgmhIhwREgff+mpM0SuzPIsyyIlms0GOTfsHy52O95q5wx4YkCMsSiScRQlkvK8zPPCA5MqFTwyzleGWp32jVu3a7WaB99oNEpdtFqt/f39ThU12629Yb/w1eL66v5kePd+T9WgXq+vrSyXk+xwb7+VJI0oAeOUkJbboigcAZeRdTTKSwtcxmlmvAdpiJXWl5acBw+InDUEjYaDxU5bV5libKFZK7Ph0mInGwyajYZS0z57lmWcy+7i4s72wfLaan84uru1zWTClcqN4TIqdMVYKDcDAy8EQ0TvLGQCkVSEw+xweWVhMplwzsGyTntx8+79xW7H26qe8IuXTlfVaDIe1NJ6npdlZRA5eVYZ64FJGU2ynIgKXWljpJS1egoMyzLnTAkhRuOhEGJ1dfne1v1Wu314eNjsLASBgqoyeWmM9YwJwdXxzhLnfDjsj4d9zoBzJjjWakmv14vjGJkoqlI7j4wzxrT1OnbZqOJatlSrxkVT2tPHorOn5HueWHjyXauNZQnM6t2BqdTtm/tl5k8kk6UTG5AXk+FhvVWb7G3VEn77+l6rzRdOX9QmrZKN71wb/6N/+4U3tz3FtdgBA+Cc1+MoVhEDNGWlq6Jer/d6e8657tJirZYUutLWKKVqemI9CCXjtIZCamcdMhkp61xpdFpPvLe9g30hRLNey/OcMaG1Pnv2dLtZv3njmqvKleXu6Y2N4eBgMug36/G7n3yXropiku1ub509e/bOfu+w1/vYxz72W7/1W+9+97vfevPazvb2pUuXjq1t3L59e3V1tbfTE0L88//phf/9X/vAJz7xiX/w937lAx9436NPXPrjL35u/fhikmKrHV+7dvXHf+STr7743OOXLg129nbubK50liaHg5XFlT989XZ3acUT3zsciKjeWVrfPZi89Nr1Z57dtAiOAXCJTDoU2nlnPXF0RB7QEXpCAu4YQ+CWplrqPAR3wRiGwFE+D9CA5s1PZq3lfBrlefcgiJZg5ph4tOH2jkBvfohoFoy7B04RwfqZzYPEIxitv49y2IPnzkga087nzF/h6LvDzNszPDicZABZA34eQc/rJziTe5y/DszYnCo4SSEG+775+QSkxgdV++lztXNKKQgCUwAhIQikFAyzkPwBNcg5J11lDNRbcZaXC8sr4yxP6/VSa601TkXuiZEH9EEwsypK5yBJZKwiXRnGmOC8yKt6miZxbTIeA4B3YK2tp2mWZb6eHA3Y5+2QwWDw3QgOAEHWZX75Yd0YC38P08ZsSAK898YY5mi+h4nJZJRGMWMM0ANAEkWRFJFAq0uOoOJIICNviRwHAu+8Nug0RxScKSUY5+iEB7+3t9doNNrtVrPZ3NndGg37w8FBrZYiB2IkJfcQERE4X0uxu7zc6XQYeCtEp9WOmPCevCcytqiKLCuyDCpTIINagy0tdduLS8SEiGqG2E7v8Na9rVE2SdJ6s9WKsYp5S3Jaai1ydM00GYFGYyKBzFuJEhC99/U4juNYAhV5du/WLR5Fj1y6mDTab928NTrIuktLkTZVVXHOGYciy3VZKSmdtd1mpz/oFbl2hS9HQ52bZjPhnJl8glZPBoN6I44iNRqNuDSNdiOJmygkLzURWkMOmbXTLCwofwrOpOAMiAEmSjZq3e2d+8sLi1LKzdt3y9I8cXmNdEGmCpwp7jDhImJBswv3d7dPnz6drixVxXgyHkVRZC0NJ2PGWEXIAB2PEMETlsYWhW4kSiMgo1jxVqPWTXmzLaOY9g4m27vjKG4oCYVmrfOXFkav3ZlsZ/mAbXqlVK1eBwCZpJaqehsPRm6hylS7o5r1bp82jq3u5Yf7owqj1HlPnkrjgTnJuGOMuCBgzXaHEJmQo7zStorjuN5oQcF9VWXW6crxUFMXLBCK+oeHPFK93sHpM6d7vV5zYdHQQU3y3d1xf3+vmgxjwY1nHGhvf3ux3dLFuFGvv/XGW6Yql5eXL116dDKZeGullN/5znciqY6tre/t7Dlt8kmmdfnEo498+ctfPn/+/L07d//yn7/w8kvPxRH/83/+p5aWO5/+3d9qtJJPfuwjL7z4rUcvXTrYvbt5+86NN66fWT+5u9PXll+7ef/iuYedECunHx2OJ3HaPHfs0o17O7/x6S+9ei0jDmlTehLGMQeCUBIwg95zUKD5VFU3fFyReYRgC09s5iRG6BHQzWaKvpthAvPJIA9ADGfNTvS6moNs+LSHp4fZlHcgOwAAsSmXIiiDT7WnEAA9Apv5yAPgTKvgzxgu/Z9zhNBSKRUwaL4bVVVF4p2VnwDxR5H9aNQfXDARZ6d5RD8LICzzzJptlna4uXxumDBFRMTQt5wvyzy3aNbqpTFKqbzSVVWVZekBtdZCSaKpnrglB0HRFrxS0mojGH+w4SBKzsuyROBaa8YYB85mft+qXoeZYJm1tqqqwMEPlMd3IDsihhh/njDNL2RO+wkLNde1b9dbOFMfEyxYdwN460pXVFXBWeSc2dnppwk0awlIHtrEwDk5cmCAnGCI7IF6GRHFcQwAm3fvLiy0h8N+q54C+HPnzo528yiOa5yEtwBEztXT2trSclVVkyxjgJFKhv2+KapGrVarJXpc1Jvt9oKY6uXLKJJM52PnWWEOJlnZH+dUlDXOBFmfD0FSt1XPR8OFZjIZDGw+VowE+DhNwFnFyBhXTsZxHDPA3t7e6vKC9TDJi63792TtEBG63YU4UTKJdnYmBE6CKIsMPcWcM0/jwcFCs7a4tLG1dVNyWliuLy+u7O8feGc/8N4n+/3+fm8bMWm26mlNbG7fk1GdGKLg3k5nlK21RI7IW2u8d5FScSQFRyE45wK8effjj29tbW5u3jy9sXFvc/P6ay+vrKwYY4wjbbwGsuCNBW21c9SUCsxYRdFqt1U0FGMsK/L8IAMeGWvJe+uQgJMH49ARLycZs15yzljJmEjSRne5fWyjHqvhseMPq5Xa1a9/4ctfevE/+j9fWDtxvN1d3H7m5v17/VNnzrG0DlWh0qbRWW2hOza90usYtK2ySTZg6CIOYKyLGQA4cpU1iOgFofeELNOac4aIudbGVA7IllXl+g0lKgJCFgRXCdEReGcjEaVpGv5ouVDOQ5aXaa2RH+ycPnG83W6++PzzC536qeMb62srzz/37WYaLS10X7/6WpHrX/5rf+XmzZuf/5MvraysRM2k0+q88sorGxsbpjJVUbTbrcHhoRJ8ODo8dXJDSba3v/3eJ9+NZHe27zgzRH5ukvX/5t/8pc/+/qd/6OM/8LlPf/r0yWO9+zvvfddTo8Os3V1/beuNDzz1kf293svfeVk+9KHVMw/duHn3H/6Lf/naPVhsQ32ptrWfCdGqLBkAC4yIIXLHkRiBtQDEiIX6KTDyQAiOwTScCg7CD/qWMyF1AAAkRKApKBFA+EOi8JRAWDwKoEf/fwebe/4rB0SzjAAACIHNbJcRA77PCuJ/lizMn4Lj+F3P9d4H5cGyLOc4a4xhMJ3WmT93XjWeXwg7QtkMf1QAgMjIIwEBPPhtWB9AjzilzweFqzmm41xUS4j5s+ZZAiJW1jjnjJ1uMJxzyTgolec5IgqGoVIdlGoQWKwiDTMTqzADhcwxFoS95nvSPCMpiwJme9g016EAGA825qPg7ma2TXSkUYGIIRGZ1vRnlxNcq+bPFYqLEFQGU0FT6QqoyLLV5WajlqaJRPLgvWBMSikkG/f3w1N9UG6zZCxYC73Dg263G8dKCnbm9PFWoz4eDxV6WUs0eYvkiExRVEXBhOAWdFYe7va89xxFlhX1epo029b7tNWNpaiqajQe5LlN06Lp61KGGY0yLzQn6NZiEcWAnIgm48OVhYZGG3PcHfUyazvNRi1JG/U0z/NapCa+NLqMVUTOHewPl9dlrdYAhr3B0JV53Gh7a3d2dtbW16uqAk8sSTmg4iKVkSYUEU4GA3C5zqukKRUS6bwaDxc6y6eOrZhiMpSiliohmIik97bUlbHGOu88OU8eyANZ64IFAEOMlIhVMPQSURQtLXQHh4fddpLIjVoia2dWms16b3dnMskYYxFTSgiQ0hNzJIgwBl8OtuJ2+8Rap6yi/YNeCVWzLvOq8s57y60D5zkyIXgkaxFURZTEEWfgJuPBaCSazsZcdSaZ47wFyfLOnv7OcwAOIVEKXBLz3V1odlpkLMrUM6mSxI5BNsaZN5IRCQ/oOHog20hlRd6DDy7mxjuwQN7DzPDMk3VEKo6UYMPJ+GBTnzzWUEqlaS1OEsbAOee8tdaUZdFdaE0mk9Xl5d7ONiff3+9dvHhRox0MBrVInD99anGpffXVl2PJr1y8xBn0ewdLS0vew6d/77P7O/sXLz68uLS+sNwSQgwO+2dOn3nxxRc3795dX1/d2+sNDveNMRvH18eD/vFjSyqCpZWmc25tvds7uP/E45ef/fbX33Xl4Re/88zP/uRPffrf/TspxMajJ954/cbXvvH1n/u5X7p6Y7PR6n78p//Sn1zt/7e/8k+u3iybKTx8YWV/ON7pV43F5XFhDYEPYlBB3pV8mKIM5ODpwL0PJAJgyKbKusD8rPpNRAAept6YsxGVQJ1GP/WEdz5ov3LknAhm4ZubefcEwAoR2xzf55BhZxS6uYK5x2A4DPDd+P79G6dz2Pp++A5v31rm2BQIjkH2/SiI45HG4FFAnGck09NmEMyWYaqQzgDCdgJhtYk8zIygGIMoSmgmCgYwl5Nh83B+zqMPb5fnFSAgs0IoABbJCBEjEZEihsQBeajMgAfvACDmEtAFYiN6AvDECQAiqYLBHmMsDI55AA9QjrOj90UgSi5RzFZsJmU2u/XopTzKzX9HZ5gdmSYLLzhvIRDRNEAuyowxVk+TRqOhJEcyYb5fl1WZT0xVRZJHUcQYRIojMmRoCK0n74CQcw5KqZWVlVp6fHvzXiJllY/TSNgy3xnkWuuqqhig92AqHQHLR+NmVO/jYX80KbWJEuyurMf1+ubmpqlMo1mXjPMoialQSjFEsJVirL7YWeeqNGYwnhRljkJGUeQUSrCJIImu26iXRZYqjl4ziJl3SBAJ2UhrjUYjSWr1VI7Ho/tbPe2Bxei1OJxMiCuHbDwee2sYohIsabY5YwJAW/djP/pjX//ql/Z6u40ELp45RV4nUbpQr2/d37/60vO37+6sbiwudhd2d7fTIlpaWioNk0wAM6gdeS8EWTtVTAPwUiqlRBRFkeRSCikl+CKJXKOelLJaX1uOFKslKj/evnPnDucSkFfGZ7nOC10a6x3wIkeCBo/acX2o84RrLXSZGVcCU1qJmHOpLTjvFcMoStJkgTEAVxqvOQfGxoeD7TfeGP+tv/EfHh4eXPvWH/3BZ1578xrsbe/HCY8iriRyBlCr7d7eWl0/ZRzyhbbOJxVXDJA363x55UzVXH5ll7+130wbm2PDGBOMAWcemfGOrHPeCsaRIXl03lnyUkRcCiY0MIoSldYTKbi11pNB7wX68eSwlUqTjetKgKnqSVKCT5WojAZrqiyrJXEjTarMV0XWaabb29u1uNZsthmJL3zh2ePHOg9duJxNiq2tLWtto9HqdDpf+/JXFhYWNjY2yjwbjQePXLr43PPPXrly6dKlDx8/fvy//+9/5SMf+eBhf/fRK5cbaYROT/oHp9dW7rz+5smV9Z2d3mc//YfnLjx64eF3OdFgjdXFUxf+k//bf/nFa7DSgofOLVsHu/2icpzHzVyTdkTAGEMhBONA5J0x1loD9m1QiC5IvTrvPYTgehqyhXD3CPVwpr1OhEQiEFmAPAuGbcCROJI/ogl+tPJ+NII7irx2Zsbkg7xSQGqYVWM8IIaEAvj0if/LFMS+Z+Qe4uVQiNBauzAIEvqQ3xWusiNDsEe3hwBnxlUAFoABIYDwDohwtpkRsmnKgRyRAzKmlAoF/cDcn5d9wgDRfMUApoUvJrmUkgnJuSwq45w3eQUAi4uLjADIMe/JW7KGcLqZz8sX3jrkYSaSUDzoeTy4+Yixih7kCp48TUkvYQML+yvMt1UiLmbluNkcU/hVUGUIP9daB+aocy5KHsz6CilluM5ms9luNmr1hAFxqjMgJRGsISNjwer1NI4iAJhMRojIlQSPYDlhkGJnx44dQ/JVXvT29yS3glG9luz39rfGljxJxpSIOLBGrZ6oGCpfmmJtaa3TMlt7e4M83z8Y5M5rxidVHllsdjvt7iI67XXpqtLo3FaltsZKwbnsJKomhXHWu2qx2ajyoWJgq+zY6mI2Vs6Y0WBQFUUYQpAiqtVq9TQVKlpcXOwXoxQoBiicyyujkkQm8Sivtne2OBOCc3I+TWtgbTaeuFJ/5Uufb9bjE+vd7XsHo0Gv22nGklFlbZkXkyxRUIsUeCs4em9hOkOB3oMmb/yUeqy19t7GcZwkSSSl5BhFijFmnb5/9+alyxfBVvfv3LtyYc3banSw9eQTjx9fqQGAd1RUbjwp+uN8Mi5LrVXGsjwXNDCDanWh+953PbXXH/3RF57WBQBCrIhJZS0rKvJk0elYyLIYVVUeJ3DiWHxstUPO3Nu884//0f9w/a3rZQ5LS/DJH4bltRPO9flivUBfrwFMJnmhiUeG+zhuWBXHncWkFoNgUBVxLa6nSZ4BE6UHjgiESAhEzlH4i/WeMSUFIyxyXYzHxto4jY+fSNu1KEkSIdHowlQVkucMBYOFRk1nw5jT6GB3cXGRiFrtZn9na9zvnzx+PC8mO1ubacLPnVldXOhev36dAxcoNu9tX7545fHHLjDGb97cnExyq/ezLFta7hbrxxhjS90FJXhnofXI5YcbjZqUuLrS7XSaUcyOn1isNyKNbJL3FxfWNm9uPXHlEqTpP/ov//4Tj5+/cOahRnvl6eeuDioYlez2zvhfffofPX8DTm8sjsfje/d7Mkp5FDPOHBEQl5Ijhl4WQ7DeavIlWO1C+j/l7wFiSHLQeQsAgIzAAuMEQEesqBGRIREA+jCgB8ZqzhiHwDJ2gOg9Q8+J1+jI+OgcwubAehT64e0Rt2fIZ6cUTOcBEWaPd0cGf/5X4PvRbwEggGwIJedhuxDC02yzOWI5NA/k53A2X5kjr8kBkDEkQppPMT6oVIRYfjoIOn+R0JOcxfXsaGIRNhsyyKUiIiGEmeSIzBgjGR/1BxxQMFCMcQSGwEAwThR4vggAwdJnusVqrYVQxobJak4IwBAYiuDNBEBvXyU6AujTNZ/er+k5hwxj3nMuiiLsWEd/ON8mp8sbajKC8Xq9FseqqipOXjC2v7uVKInkrNaxEt65qiqqorTeSRULIThJS84ZUxlrPbGqPNgv66k6eXyj2VBel7297WvXyJ2AWCWttC6Au7yKuIqYLIvSe1g9ttFZiEFGeHDQH08OsiJp1rvLx5w1W3v7nKzwTnFqJFG70RzToChyk9l6vb6w2E2TeqFNlmUafK/XW+ouDHq79fVjpirJW8HRasMYs9owFJFURV7pceacl1KutFvL68eYjLYPBllZ9sZZ//4BEZw4vuQqPRmOIuSKsYiL5bX1F1+/9TM/8lS3U3vefmOhWU+VtGVW5oUAF6fJmbOnLdBkMqq3a8RsnmcgOBFqa8qyrCrtHFmrjTEcWa1Wa9SSEJVIIby3+SSr1/jNa69eevihjbX2ztb1xXZ9bbmxs/lmkiREpITqtlvp2Q1kMiurPCujyej2nTvbu3ujfJBgeunssSvRQ1WZf/vZl8YVaGsZGeSR52AtgDXaaGtKb4AnUK/RwmLiSltluXWwvHJ8MhomCdZqeP3GraRWLrOGkri0VNve2W62V1DG3DNfGFQpZ6a5vEhcDHu9pHHuxMmNWL6Yl4ZJFbJI7732jk3jJk6IlTHOmykhl1EURXEtVUwjc9ZoZ7TgFHGG5K3WqUBrSXBmGQdTtlstKeVgMFhfW/PO3L93d/3YarPe2N3e6u3t1JO02Wy//NLVxcXF1bVjL7x4dfPe8Md//IecF43FCMDv7+9nWba0tLS3t3dwsN9upgsLC7dvX7908byx5cHh7u7evZ/8c5+6c+dOXowuXv7w5PCw2UhuX3vr1Wefe/+7Lzx8/vLVN25du7Z99tyjWjYKI/6b//dnCoB3Pbp2f7tkLK7X6ijVpKxG+URFSbNTL3UF4IEseo9AjLQAA2hLIQFCXTvIidIU3sEDMULvCAEsIRLZkL9PY73wQfUOKeC55cSBgQD0QOAdUijmT6mN7O16L+6Ie9HbSigztJ7CwcynNGw2RISAR/eD/xXgfvSt5nATx/FwODTGJEkSlHCms/U0RcOjRfb5uwdoPvqTGfIzIIbICXkoy8zYMgyRjk75hHQhgPX8FcJazXvUNGu6EpEjT0RaayaU1jpJUiFEEsWD0VACKMZJiEQKxpnknAFpT0hTcZ4Zq316O3B22h7BQWjCEhmLoe96BIthRuYJ/ipwxKX1aPnIz6yapiqb80HiWW4EAN74eelJDIfDsiyTWDUadQCoilIwiOu1ZqMRK8nAG10ozqSUuizG44mMJBcegSNjRLaqzDgrtHXHj23kQJyz1bXlOzfeQtLG0NkzcFPErVaz21xwRTUqNDmvdTXoD06feshZPzoYJEntypVjd3e337x1a9I7lN3I6FIJrKWpYkA6s9ZqjYKxRj1FT5b8oHcwEkOllFISueQIy4sLO5u7g8ODg95ooZ0sLS15Y4VQjgCZQJT9wehwOOScL24sv/r67b3D/kMPXxqPhy++ds8CdDppWeq11dXD/V5v+6ARlbVGY6G7eP78eQGmzPJr+5sccWlp6fVXXrx53Xe7UK/J/b3J2jHe6jT2+ruj0chSsby2MswMIg/b7BTHpZTSgackSdI0LYos/NxaXxQFd6ON42veFVUx/ND7PpQovHPjreWlhXoiy1ITacltI+VCKvKmnOhHHz4TC19P+Fs3b926ttVeePo9H/zoD33sw3t7vc3d/s5+XlYTJhwHRcgRUaKI0pp1Y4aQZdVkfJjItNGovfrq9Scff2J1ad240cmTjRMnTnE17B3eW0njpJ5cvbZ75cyjIBUH3h9PmEr29u6unToOabvOUVy6/EFa/fe//8yNWz0x9WAhcKEKiXxG4M3ycVmWURx3ms2kFocpgUrngcMlONbSOJWyKrIyKwejYmWp5Yw5sb7++uvXzp487r2PxeLB3u6pU6e241gX5d72Tkhxy7Lc3b129uwZ52Bra+eHP/mjzz33UlWaoigT5Y4dO3bjxo2qqk6dOHn1tZebzeYP/uBHn33umSSVQKrS2alTJ6RgtVo6mYzjVH39G1993+NPWMnffO21hXbnzMlTt2/e0kV5+tTZm/c2r++M//WnXzl1Uh6MzfU722BrKo4cYTUpLFCj0fJE/X5fSk7gGVjPSDFCcJIR51BxNiec8EClY4SILJhAACGB8+DIkwciJ1BQUAkHYGEQ0BMCpbESjEvGkRF4Ij9l/hXwICp/J45/r8r4tMQxC10ZYyyA+9sf9v8/rL/jredDSVEUJUmSZVnQOzxaSoK5qvAR8t/RsJSIHAUWow/pYkiH5lV1xkLkOy2TAIBHP8fE+YsrpYIH/ZzHOd9dkjhVSmltvfeV9lJasg5j7NSbHFAicACOhB6ct54ABMOwnkEdbHbycRxHURSu0XiaX06skvn60KytOp9Imt+g77n4OJNEllI2Go1A+MnzPM/zUCHw3oPHeZdCDAaTxaXmSrcbSwa2EsySs9nhiCPLRxljTMWxBj4aayIh2uuxx8X1jd1+dmfngMVJ4S0T+vyJxYN7tx47u6DzUXHvcKW5cHuXeqVMm0uPteH+/fvcMJ1XPp+ki0tFUdQW4rHdW1ta60bJjRs39m4Nzpw5fvz8wtPf3IL4bktCjcma5nWl4lpknZuUIyuFYVzWm/e39qyD82fPCx7l40mjswR9/MOvvn7h7PGCjEhptz9eOna63+93O0uSi9tbezv72xUxD1GR69evFe2F871iot/qD3qHl9bXXZWnETt/5eH+/v7FY83oPjz1yLEXXnhN+piPZKI3TX/PGzi9cWYwwt6kUcbZvmscFIq32Y5JG6Uc6USqZGlhwxUOYA+Ac0EqJZu5bJJb62SslFILi63+4X4S8fX1heGgR644dbJxsMsGhzwbFI1offN2efb46krr/O0333rXY5cZK5qtxkG/t3Sm9caNa81m8/y51aLMlje6XtlxOdZ2//7Na6lKz59/9P2XHvn6+KUKneVJloPHKJJplum9Y7a3Pe7WhRvbVVpZbT58eP/mairPve/E3c0XXAKPv+9UYxHVGbF9bWftoZNwuHf/7t16TdD4NvJRlOXWWd5snrlw6a2d7PyH3isMQtYTi3r1bHVvn46P5d5oRPWGqTcGtkIVMfT5wa7oj2oAay11fG21Vm/m1o+NJS78wSROkzhNyFM2dBl67yVBp7O8dDgeTIbZw1e6p0/nk9HByRMbb7x+VdXVne1bK8c2itLfvHuo4ppImmVJJ06vPXLlwv/4r34bYexN76l3ndCF7TNYOr908+ZbVlQGzOb9/Xp98czphz77ma/98Cc/tnnv5ltvvvTIo+ffeOWln/6ZT924+foTj59a6G1/4+mnD9EvLJ9847X7n/iJn35tggfy5LH3XP79rz3/B59/8frdnEsYj2Im2wSkUz+Zaol4zrkEElLUIhGCqWBNUXkg4s5x5wSYqd0ym8rtIQBwwFQ1LXrvvSNvgyl8kP/zU9+GUEVVSiFiIDUTkX4AhdPyixQ0r7fMCxfhie+gvc+KHW4ewwa8qKwJM1D4zgMQUdrvXXNnM7gJMAxEDIBxbvj0Z0EdBQCklILz8XjcqNVbjab3vhhPvLWKcQZoyErOUHDrcRo+IyFHZz1xBsDJhcJXoKcwzqNwkcgA0Hs/lQYLXi7WewaMcSlEFABUGuIonHNmUsAsoLbGk7UGpmz3GAWqaaUIuSi15zIyxrXqyphKKAZQAgdHziMqpbgQDqCqjNa6ATVirNAaEbngyDkgRpEERgRGRUw7m8TSGJ8XA6mkp2BgjeFPgXEE4PSA0Dmdp3UzVjtrxJxzY4wuNRFFSiKnyhSTyTCAu6mqMN8eaKZKxmFuQDstWu0kiYKPsGfeC8YY48hUpQvGQXDBOSfkMeOekBhOxiOzeS9zfGdne2l9bTTsP3zq2KVL5+5BEf7cJ4MKzLBWb4y8TWvxJOtbR5NxXupKqTgMxCYAjMPd23eSJFpeWWo3GwcHB+TtlSupTWsSGPeeVRoIrbV+JjFRGWutJYCqqra3t8tcj/qD3sB96MOPPn7lR7719NcFkBS4trZ27do1JhWPUhHHlbbjrCiMj9JanNZqquF0NRgeoq8pyVutRsTqzVSZqhwc9p597t7/5pc+9uyzz3784x94/fXX+/2DtbWFJG0eDjLnzB9/8bnjJzqNRqOzuJyXutao12oJkUckcFRVFRfAmABgpiqdDU7w2jkXK9zYWK83aoeHO9qYLMuyLEOyAPFCO3XWpJFYXV5oNaOyGClJly+dTWtScKGU2O9V3pbdTmNpaTFKkvFeYR00m40TJ9e1NTt7g93tu3FSazQX6jUVKacQgbHBYOi8bjeauwf9dj1aX17cze67Ui8vLsYu39u83tvpRwl88IOPr51c2j7chLxaWloqiiJJ4lqzbsoKOQckUFwQJ8mBw/L6MpjC+cjYqnZs7S/8xZ+7ffdXb3y7t7aycm844k5SVTlnBadUqRNrSzWyDc45wGQ8zI23yJmM540gImJhYgyYc77f73unu926MSaO49HwMKTSIop2du7rOm0cPytEvHV/p3/Ya7biP/zDVzc2Fp944qQpi93d7RNrG7393ao0o5Ho9w5Onz4dlCWPnzx2/96tQX9vNDzMxv1f/IWf7R1sr621Nu/evX/3frNem5R24+T50aR66+7zD1++CFx1FtoTn/3L//HXvvPSnbuH0G5ymTYPDoeFHjdbzf7BqF6vLy50A5rkeR6C0FarNS3sBvqKc47Iei+Dbp/3znsAhKCBhW8b15wVLwAAkjQJWgJpmgJA+DpJkrlQ1NED3l5+mce8MKM/H4XjaZniqFOPECHKmxfBv/vxM3r+9ziOvh0eKYV892NCyIlHkoxQGGGMMWBHC0ree0Sw1gbG6HTo6cglz4PcMKoaMuMkSUJZZh4Lzy8hQhlI3/PNbH4+33WlAABe+9kELA+7IJuZjYRHGmPAuXBiSqkQLx/NnMK3krF3rMk0oLYP3vS7V+zo14HBGfbd8Jp8dvqBvRpaDdNCEyBHFniiOFdm7jQakRTWVFWROaMBAr4zRhAJKaUk8gBeCCYFQ++QfJZPWo3kzMn1C2dPMW/2du+/9uorSomsLFQS1+tSxVGz2ZQMB4P+cDxhQmoij6zeasZxHFrYvV4viiLOeTYaE7l6rZamab1e73Q67YVOs9FScUoIlbZFVRbaeMIwQl2v19vttlIKveOcd1ugEK3R5EyliyzLgLPu8srq2jGUcpRXpdYWUDsorXcoXJU7W7ZqyepiZ2VpAZ0tstFkPDzs7Xdazfc8tvjMM0+vry5dfeXlZr22srRYFFUwjNVaXzjfvnevf+XiwzeuXS+yMZLPs6x/2HPOAXprjeSCMYHAjbHeumAb64yN41hy5oyWDFutZqNR45xVxkwmkziyjRq1m0wpbcrDItvlmLWbctTf4lDFEaUJiyLqNBLOXJUPOwvNJBVpTSwutbqLdWRwONjf3r6xvta6/PDxlaUa+H491svLqpmaSIzXFhb0uJrsH4CBwV5/795WPU4fOnVmfXV12Af0uLTQPXPyDFgv0jbzHCRLG/WkUSfBAAkiKSPhiKI0aa8uGVvyRE7KDGx55RM/+MRTZyRBI2bSldwW0pfMZBHZbi2qCdZOk3osnS2rYgLWKIaSUZJEQjAi571F7xCJwHvvl5a7iwvtbrdbFVlaiz1ZYypjquWlbhyrssyrIkMkqXizWT9+fOPMGbG1tXnl0sWDg/3z586+8srL/f5BHMdf+eIzJ0+e3N/b+fCH3nfv7o3bt95kqC8/fOrMyeWyHPzxH/5+mY8W2600TiKlOq1uZ+U0qXZvaEG128snQNav39n+T//zX3vjrTsykcdWYqEUES2trhw/cTxN0xMnThw7dmxpaalWqwXUiKKo0WgYZ613jnwgv87M3P38Ez6vPITP3jymnoPgFMhmKokBrUJ2T7P5yXkwPsfToz85+jpz1RQ4wh8/uhO8A1kehOtHfvWnHPMHv+OLo+czrfocec15V3D+CmENYdaKJArCTw+qNHO5czaTD8OZzjtOPfMezN+zmc/1HOPC7UDOuBRcCuQMGHogLgUTPAhhhTtlnDXOHr1Tcyn5qejjbPgoTB4RUegSu5mk8Py58xZoIFPMrULoSDNjfkdCX2FeyD26CXHOwXmyjhFIxoUQSOCt896Hxiw5H6yew8VKLqypwj9ntWjUUvLWGeOdZZxLzjiABx/8CRGh1BaYF4gIDMgd31i7v9+bjA87jVarFp3cWBFUtRpplR1IJOd9vdmcGFaRqzeS4d6AmO92uwBgrU1rDeuoLDVjOp+UZ0+fstbevX0rTeOV5UVjTJZlw71eLYoTzjmijBKRgAdQRLk146zyqoqTWpqqRNUVim5nsZaKw/2dl597aW295YxQSk6y4sqVR0rr7m5tb27v5pZU3ACFhqA0juWTJFaL3fZyt11mo0FvxxYTqiWp4mvHjg/7h6+9Wki8f+7cuXv37oF3nU7nc5/f/MmfuPK1b7y6sLRw4njzrTdf//jHPvL0t54xVVFkI20m3cU2Y9waY62kqRUZJ3KMGDnDERq1VDB03kjF261Gs1kv8mYUcyGYYJOFVjtWzJZ7uWWdpU4kdTbeYWTRR2CoHoEgQy6vJhUwJJVIRTUUUtU2qqVJNtjenRz07o+G9x5//EyUsK985enRZLyQtCoNZTlJumdM7yBGZAyyQ7h/+1b3wqlmo3Z87UokTLNWzyfF8sYSAAIKcuCsJiUEgkfg5EFy76FyWkoEdIVxMuEYs629rfV250d/+idu/clvvHl7uxlB7vOFJLbI6rW0rkQxPKylieTMa42ekij2jGmjZSKIQqHRIiInQO886fXVM0U2nIz747FWstXtLDirGWPGlqsr3eGo3Nq67xw0m+2VlaU0Vk+869F2I3716ouXr1yodLFxfPWFZ19eW1l9z5OPjobDYX/wzDe+/pN/7ke+9uUv/fiPfPilF15gWPzV//hvfOV3f2fn/r18cnDy5MmL56985t9/7nj3RJI2os7xJ594z1u3t/75v/53f/T14fmLyf6ganYXpcWDzR1jq4XlWEo2mpT1JComxWAwKoqiLEsikpGKosg77458Mh2RJXDI3BEx8Xno6o/M6Ux/xTBIU43H406n470fDAZxHB87dsx7v7W19d0R8RS1/dtKtHQku8dZ5/BtEWUkj5Km5+Ayp06+I378fnT2+QnMv50DHBzpfB7thXo3rS/DkRLz0XPDUDSfr8ms14qhhsEYIurKBWiKokgIEXBz6nr2vc7QaDNH/PnKhNc8urfNTzvMB9BUB3jKe/GWkkQKjoEg7+x0jGNugTLfxugo7+XIpdHcNsMDHNk753shHjnm4E5EkVRznjsRIZF3zjsXPDYcuCmyAyIBIHhriAi8RyJRi4UzXgNDxpNIJZEi57TVSglEcM4z8ETIEYXgUvIsH4LVo/HgeKe9e/+mQlNkQ28izrHd7oyHI+BRXuqJs93usVzbqjT11kJVVbbMSu2sLcPFLC0tjMfjMs/iOK6l6WAwsNZ2Oh3kSiIDbbWtXKkZgieowMXNliMoyxJQMObAMmNMHEW7m7e995GATqsVFmX/8PDe9s7uwWBrZ/9g4pOaqrUaHJixzhGutOtal6Tz4aGVSAr9Qre52Gq9+cadKr/6xOOPvOcJ/dprB0+9p3Xvzq3BYa/Z2UgVfPNbr66sNH7sJ39yee3Ef/Z//a+efeZbzUYDyFflBNBKwTiySud57jHmyFBxBU6HqahaEjcStbbSzYtJMUFry6LkQrLl5qIQomZ0LI2AkkduqZUsdeOaZKa0GydWiVxZjgQaUw5dUagkaXVX+4fbURQ10xoRRYlIUpm8df327cMXnv/aJz75Y089eY5Ddv3anf5gMhqWSQr3D/ceWltaW1zYuXOrv11Ja8vR4NVr9x557NzP/NSP1x49t/XSN6uiFBkD0vlkonTFEYWSjE2n0QmdJevRa1N5kHk2arYbw3GZ97YuPPXEj37y7rf/7u9unGVQmKTVJqHStA7ORFpFAr23zlsOQnDuyJNxss4dIRFwD8CAcyIg7tje/k67mRqra3FUFVmn1SyKvN1uHeztNtuLCHIy3DUWOTpdZj0z1HrSbZ9ApFoc56MxU+LY+mpeZIvLa+jsX/6Lv7h594bi/sTxLtnxo1dO3b1z9XD/ZlUOOLMfev8Hnn32+YUri9lENy9dePPajfd/+KP3D8b/9//Hbw5LWF0HUeuWB7vDnQMQcau7aB2MxpkxA8bY1tbOPEJUKg6fZ11ZQnCOjHcA034lIUOOQcaEIxNCcECG6L235MVMMyRMOtIROJjDzdEP//dDVZgRKOf/z2l/c5B9B4TB2wPz7w3es8N9nwewQNr7roLMPIiGI0F9gML5C00Z5QEN3YNmpmAs8EEBwAdqo/MWHgDfnB8SDKeC5FbA96PIOA+9ASB6oM/ztjbvvMwyX9X5OYf8aQ7NzpFzAe55KGQZ57ynsKOEbePB5nEkI5kf85xMCGH0rC5z5BYf3QvhCLIjouRs/moA4IwNgB5JZa0FJMEDq4rIOuCgjjRUBFiN3jDvgDySI+e81cZUaZIYY5z3QkgUnAEIxlQc9e7tNBtNofjaYvPN69fqsYIKpICiKJmoR2kt15ZJJRk3topj6THyTOY6rypn9JgLTGupLnLG+HA4rIo8jhXOSmDGGC/ivNTFcKjHGTifRjFX0iHGtXqUJELFDsgZw0mTs+gVJ9tq1K9cvmC0AyGff/ElQ1DS7v3tgSGIEhHVmtpDYbTzwFW02o0HQyPQUGXa3Y5XzWYaKQYcoBjDpfPn7ty49sTjy8986xuOYGNjfWtr66/98id+/zOfl4pvbt79489/6b3vfmKS6939vfHw0Niq3WlEUjAkwZEhISprrOTKoc/zfqxEu93kzHunGfoo4oBUFJmxVpEssvHJlfRwf9+QOb62srzY4FCRo4VWzKgEAE6uVU8SKUoEnedQla12gwnhrc2LSkX81OljaTNZWd25+uqbN669eHzj1GOXT54/s/bmG9euXn2z14MUCl/a4rBqJ6jaMDns7eKIrN68cx0/cAXQd9r1pF2fjAdmogF9mGhHYCg4cA7kkCiSPG43oVbjxPYGvbUTncXW6vate2mj8QMfffLcb/2uSJj2vplGIBPOeVHm7WaLWa1zR4iMcy6kkkkUI9FEMAZyOoPJg90hyK2tu8ePPVmLN5SAbNQ3thoOBqvLi6oGkRK6qKJYcgNFkXMBS4stJLa7s/XwhXP379yOZfyVr7780R94NFHJzZu33vfe94A373rsyosvPP3RD7+7yAbeld127Jw9e2bjuWdfeuGFFx46d7EqvXfcp6sDu/3ZLz3/D3/1T6SEE2cXckuvvbWZNDtKCEfceQIGaaMezIRbjdo0EOOMMUYMQ0ZtvZtOoga0DkEcgLOOcw5TzSmGU+ghFgZVYS6JMv1ANhqNLMucc8ERdHd3dz5defQ4CqBHgfsokL0DxwEglGvYbKh1HnK+A+XfHlZ/b22Zd+wKD953Jhw2R1siIk9zfS7GmJgjOxFzGKAJQpgPPOg4CsZCeYZ5cPTA0COWyjlnysppE8omaRRDBHN4DcWQuX9s0N2dP33+RXArPZp5hC/CjNXRjZZz5Pj2RETK8BgiCnD/DsoNImqt+RHnvPBbIQTA2/bCd2w5dKRuE37i/bTwwoVERODEAFFMRXwBkAuOYcTJe0IMc7Ohby8YaQAvwHlw4DmSm99yYwwBJEkNEbOy0Fo3ENfWVoUQIsuqfNBO5fnz51rNtNWsf+kLfzyYZEuLq/feugGi1u4uvnbtTqe7pD0MJvl4POEMg5tdEtcO9/fI2+CmnWUl5/zEiRPGmDffvH4/32UE3EFdwcpCe21lNWnULOf9bKziRCaJd2Cs8d5656qq3FhbJiJXlv3RSEQ1bcACTLJ8/cQxC0x7Ki1VVeX9VDi0yvt1iQudtikmaUSlsRKFd+aJR9bq9fpXvvz5qiw7J9al5LdubTOgKE1u3779xBNXrt+4m08ycHZ7826U1iX6fjZK68lyt51EwtgiSaI4Vo7F+aSvBGPgdVl1FhorSwt5PhkPelzxSEnBkMipSMRxnOd5PUmrNCVTonfZaDjReSwBTeNwr1zqdgm5Egq8U1yMR6ODrb3uxZPgnTfT4ilXcmNjfX19fbm7cPv23e3NG/WHxPG1lXZyvp3StbduXG48+sZrr+7vDNcWxOIqDA+hKvTJE2mcwuuvPXvK7XWPdSFmfpx77tK0FieprkrmAQjAOrCGEFWiAAB0xWUcC+6qnHOVSJEND/5/hP1nsGRbdh6IrbX23semz+tNuVfv1XPtX3sDNAhDGBJmwBFNKCSFRuRQmpBC+jURcjGiFEFyGENRohSMITV0QwNSEAdg0wFodANodKPR9vXz5c29dW3e9Mdts/RjZ57KqtcAT1TcyJt18uQ5J29+a+1vfetb6ZW9P/sXfuJXf+0301QJNmyrbJ7N53PVblXGOEIZxoyq1KwQgigqshOfcCE5dujIIQARsHVpErdb/fPjx0kSFUVWVjkiJlEkSDC4KBAUxwAQKGw1EtEJynI8GV1cvXb513/169efa16cnV69fO3w0QF/7MP97mYgudOM3nrjuy+/eDVKI0QeDMbddvsnf/Inv/EH3+v1553u5n/2l/63f/Xv/fY/+pWvbPYhSKC32X33wcX69mZv+8pgMkmiWBfV0ekpAGxsbCilZrNZK4lKo6uqKrK5toa9e4kU1k+hkUoIAYKYuTLaGqNWOXesNYjowd05BzUoAwAACapFtM65+XzunIvj+I/C1kXj6gouvx/Wa2QHAAtP/L7h6Vx+FeaeiRnv3+rC5jOrARRPBnvWeTR7P2H7FP9Q411dCUAi32TqvOxv0Y6Egj35tFiUCCF8br7a7LqK4PUKBhG9xBTYMS/a+r35Ay+C6rNX54xh5kUv2NIrWCmqTxgRV99R8JPLtNbWUwM9Tb8sMSw2Y4xYiKKeLHHwaWc0eGa95dg6BwBKSCKy2jCzIsHE7BwCePcbrbVjRwyV1fUdlo0ocs5pIRybUCpfvfFlBOsWykrnXDadWWvBGdmIyjIPiGwx2+o3I2GGZ8df//13d3f3Tk7P12T47h2dNEcf2b12elpcu959ODi3bp5r3W00EKxSEhHPz7N+L5jP81AJEUiUCqVyxo4m0OoHEjBA0YqSfrcXJs1S28l0kltjHSsU2pZZlhUM1XSOTGGXGq32d793q6wg6dAnP/mxd+8+fOfO2c995tXz4fjh46PpbOQAGklTRSEinj2+2N6Mu43186yaXsyz2Wyjvd9pd4eD8047PTs2N25cffjwQbPZ/NhrL52enq5tbAoh3nn73edfePmtt99AUGzd9sbaOI7KKuv3u7s7W2WVDcfTUISBFCxCp41FwdY5q5tx3G0m0+FpHPWkJKtdpQsA11vrX7p8udPtKjna3UlNMcvG50ejYSRsImk+mnQaqeuA1tVsWjorwrgRypAZs+GIfBdNrw/GlNOpsS4Kwxc+8uEgCAbn55OLk2o22drY+NTHPnBtf1OrF5+/1Hrje9+tslkjiDa6M0LQOtvpr6nAWJ4XWmQPjlRD9Xc2qmyGYSzKyhpDTOBsVeasVBhH+uhoZFyysdVd361m82padto9IAkl/Mwv/uw/+7XfDCKpdckaxqOsKIo4aQCTikIpw6LQk3HGrkiTtuQ5sw2CgK3VzpLzXxsLALPZJA3p8ePHl3e3qnweByERHDx8sLG5E0iRRGGr3RNCzOezweCk1YrKYr63uX9+cqIr+Ikf++Lbb7739W98/X/8F/7CGz/47tGjmy+9eDUM6It/6k/+6q/8wxsvPNftdjudVtJozOdVb33n4cEZqv7f+Xv/zX/3leGHX7k2mU4RCyNbSVcdD3MVsCV5eDoEcOsbW4iY5TNE7K/3xmeTIAiiKAqCoNSVc46klIEaTcZIQkmpgsCPS7bW6homFkJs9jbkYlGYWSLgCj7O53MvcfODeKIowqU14CraPoFUsLjCgdSPa2KhziX9poTAZR2y5nzqRqHVnN3/av8IsQz7JcrTzzAwLW1bVqHKOae19uAuhBBLoDTGBGnwJDAwLDhr64AEEQlEhid+wv5BEARhGFpri6LI8xyWlc/FqCmAuiXVnwwuR1vUpAcsTQ5Ww9LysqHec9V2ZhXcxQrrwnqRwvv/tUufAxUoz8iDIC9LtdYqpVz51Arp/an6KrIzsyBiduAW1VdTVtZaJ6VYckcSyUO0f6Gq/SmJ5OnxwdbWVpTGjUbjrbfeiqKo0+9lZbGxsTGeTc/OpqTkbDz5iZ/4iX/xL34jDEvRTpkhTaIooDzPHt2/M8uy+ZQbzbbB4Hg4ufRc88796be/94OXX71yPhgCyfOLYbfdssCj8/MqDXVZBgGkaZqmMTNHSdzvr6MMZ/kk6UiMU6dNoMK9S1dOHh+nzc7pxcW7d+9v7G1t7u4dPD4+Ozlba7d1USLi9atXGzBJm61AnqsYXvrAB+Jm56VXWo8Hv//V3/3d3ctXTk9Pk2ZDKXV2drK9vT2fzbcbMB7kvJdfvbQ9Oj+/vN0XBOdnxxJhdHEWRerk6HGv32UHp6fHnU7nvfv3m43W9vb2aDTqtVtV5a5e3Wm2mm+98boDK4iTSDnLwDYOw6rMZ6WRQmSzObDe2ugLclUxf/76pVarcXZ21uu2Z/N5q9u5e+/B6z94+6OvvXb/4rTVTEbnJ51mUM5shboS8IXPfgyZj46O2u3O3v6VynCludvfFCrgUDnnysIpW1IYhM0eWGtNJZD29y9vrG1enJ4MTk4nI5VsbHabjbHNPv8jH95al0cPH05Hg2Jmd7bXi3L64itXWr007TchEZFSTrHORo4NGJYyBEtQVaYojNGgnSOKwqSbNMq8On/wAFTcbPRgPgcgsAFe2/25X/zxf/D3f6vZgtFocnhst3bSRqdzcHAQN0g4Haio1W1cnI2EVJEIWq3G4+Oj/f396Tzf2tq6efPd5597DtnOp7M3Hj/63Gc/86//1b/+6T/5hfPT4zhMKl1OxiNnRZykSoqHDx49/8K1RjO6fevNV16+/vjx4fb62mc+s/fWmz+Ig/Ty3s5sOtzb3bqyt3Xr5vfZzUxVnJ7qz312/ejoZHv78tHx2fFZtrZ1rYTq//Zf/92DQ9ja2TwezhkEB43hrNIsQMWFc8wYRDEjZJUmZJISiYuiiOKQiAiBpCAKtTVa62xetptNt2idscgO2BGwXHqGeJG7RPIdXgLQmMW0YUQUJICdH/WghKyHfNb9hzVBv4rsi3x8hXP3Gy3bL3llgHKNPm4paIGl2M7vXKN/Laqhpz2EV3FwgdFLiaFZZrtSykJrqIUxvKA+0FsWL5mTOuuXUoJjgURSWfZVdj+31IE2PltHED7LXgCuqaz3MdAaAOIo8oJFa73fJRNRFIY14DI9qRvzcmQHrQxltdaWZemPVjPj9T1USvmXB0Hg66u+eMBLl10JVEuAhBC0ZGkWoSsIRKD8+RZFNR4XsRS+IFxHF1pax4jlLGu79G2XUs6K3J+zf+soivxlaa3FMk7XCiIiYlgkE8YY2Wk3lZTD4aCqCiGECmNd2Urbr/7OO70ebG2vbW5u3JrM7z14FCbQ6XRana4zOglRENsKCBDjSHfc2XAyryA3UGG4ti3W1ze11u/duo9pv9lsIuLx8bGrqiv7291Os8gmg8EwDFUYR9rivKycCDBIu2tbp5Ph/t4eWfjmt749HcO9B4f99bWd3d2N3b03b713cjbqtEKHoIuyEYVhpIQWzrleP6UoyfLyZPQQgmjv0pW7Dx5VVSUIyOlmEHMjjNF0+41kNthcS9e77elkVJUTbAZVWU7HF9evXSvL0jrtSdEwiiISRHTp8uX/36/fvLwLFwP41Keu/vRPf/Hv/t2/P5nw1k7bsgkFsCmtrpzWpioqXSgZTcaFs1oJ7rXStX7HmqKYT5+/dunO7feuXLl8vyzv3LkHKF5+9YNvvvnO83H45pvvNhMpL63rUr5wdf9TH/9gc38zf3TfkQzDWMWJACE0g1Agg6wopJQiUI4UOkIkEEKoyGZFVtk4ivcuXZOkLk5PFNLmzg6SKLKT6y/slPmxkEFjf388PNu7vBE3ZZhKiBFCAMkkAQUhSyBe/BMOUYLTbBkqp/NCBnESSoHSMKI2gCWQLDEPudi9uldZKIpcyvDypUaj289LLeK4s7FxfHA8d+byzuUsq5ix2UzPzk6SKB6Px0dH5/1u+4Ovvvrw4cPz09Ev/Kmf/e3f+o1vfO33P/vZ144OHgvC+/fvv/TCC3fvPGw1++ubWwePjp+7fu38/LzXvXL75mh/Z/iRD37oS7/2bz/52of63fXv/OF3tjf3Tk8O+t324eMHn//cZ85PHv7hH/7hX/7Lf/7LX/7y89dv/OCt2531fZn2rWz8y1//F39wGz54PTyb+HlcwEgWwCKyIGC0tvKrYgJgBPJCDkTWi2+1p6KRQUopQSIAMTgGwYiABAQoSKgwVAAAjgmQGJY5O1prnecEEB36zMw557xBID7NBa/C67MZ9PtU0u8nTFYPtVqyE0tbQV7pv3/m4LzwoqzrtwgMCJgVuUcfRAQEJEJBKIiW/TiIWBtPIoNzjgB5OY26XiVoXcFS6S9JiGBxPqXWAsAhsFtwJx7iffMzLbWeHqOZ2fvX84oXjd9EoMBaJoQlo+KnU1VVpZ0tdOX3RymY2QGY5cxSIsJazcnOOQf4Q+zMnlwsLawf/UcQJbF3Saus8eAbx2GaEmiszxmW7QiI6O1GeNnTU19L0kj9A7Zu0YMKQD5YAgCARahL1Z7688UeBpCnx8NWo9lsNtc3tlSYjqeTR0dH0ym/9onn4zgWQiRJ1F9fL3W1v7dlGfPCOF2gpZCMKXIGJ4RK4jQv9MHZZJg5FoGS0XhWZvN5qaEVBPP5HJxNo7jRbZdlmc9of39/eHEeJXEQJQ7JOJwUBmXY7G+czMZ37t4TBo2Fz33+o3fv3g+SxtUbz3/njddPTkcWIMvKbFJutZPttY3ZeKI546wI42T78jUN8uzh4Wg47W9ur62thVI0osBUhbAKi9nj09n2Ju2vhZ1WLAVLcmkcIzi2utNqaF3OZhOlVKPVCYJAyCAvy6OTY9Ho/Ojn1onk/q5ma7/33W+3GvFsknUasWXjR9xZUyKYhXBbgdF5qNBZTegaqRoPx4Lo5rtvfu4znz54fDSfzR7cP7l+47nf+eo3g0hOBqbTDq2z7905eeXGpdNh/v23bn0iCkWUrMWJcdYKklGqNBeVDhAMOyKhhEISmhksSClIKI2VCGNGBBX217bmk3mpLagwioW1GjuNS9d3smmDkFXiNvfXSSFECJKBtXX+G4SW3XIoAaNDVA61dsxsWGeVTC1SEEllHIFl0AYIw/UYuLh641KjDcrRRm+NVGNW6dF0NCuyjilzU5hc5/maZEZn8ixrtVrW2tlsfuPGNa318fHxeDxeX++8/vobL1x//lvf/Mbg7KLXaT24dzcI1b07dydjs72VOm2uXr36G7/x1V/8xZ8NFL/0Uv+XfumX/s7f/n984hMfjoPw6ODwF/70z3/p1//NF3/mRw4PHp6eHlflFWPMKy9/cHgx/xM/80vf+N0/uPbCRw5OJ1Fr7f/0V/67hyfwysu9u4cXNgBE9kaxlsExWmDHC1HewrVrMdeHfWb7ZAVNKIRQi0zN+p2RHSASMxEribj4GjMyYI2/Pon2TLsH92VOXEPGKr7jSs3th4J7DTHvR/xVZEfEaskB+2OKFTdd+KOjyOoB/T4eIuuscxWn6qyZav0JoLWWV45f4yNZQET35Bnhdyt9Ks1g39fpI4RY9KOueJ3XJU1YmciBy2WKXTHLrW+mB18AqNHWLZsMFpe8UodwztWMDa3AunNP6hmriyQv0NRaa/vUpEC3DG/1Tahf6F/iIxAubdiljNk+OX8iWpDvlbYLgzms/2iAAZGW2M5SSEjTdJbl8/l8MBgMxmMUwYuv7DbavaIojk6P0yRhFNN5trG+fnp6ejGcsC1crCBkXZbGaCtUZiUn8nQ4n1a0ubPFjLfuH7CttrbXMm2c0UrSxvpaMw2H56fDqri0vxtGCSPlRTUrquE0K7SVURynzel0+rlPf26zv/7lf/9bt+/cmxdFxfjOv/sNK7HZTuM4ZGeFtb12J4xUaXSz0bkYjifFvGeckyTCaHJyoeLJeDzM5hOdz2IJlzbbl/vh2dHB5Uu7TVlarct81kijRqxmk1GZZ9eeu3J+fp6XRZI04jg2zhpnK2NGk/nl3cuUZXvbe++89fbDRw9fTtLRMNvaVIFCRlVUxXQyBGIlKVCCRFCxkwhxGM4m0zybVEVDV1mk4maj+fjgYb+/eT6avPDCtXmmtza33nz7OJrB+tZGsyGtHu9ffTnPTlQShP31YnwWNCIusso6mYbSAM8shxSJUEjCgIAIGBjJEBGzSlLRaM0G59PBoBnHu5evVNkcHI+LSbffm5w+bm2ttbZ6R/fuXXr+qmUjowBDCSQ0gAE/vwEsgA1C65AAJUkCVIzExkrpAI12gTEgIykFsABAYMtUINDejSuf/MS173/zriQzn1zkxoaRkpW9GByvr7dng8nx4d1+2pPOWWuFEPP5vNvtXdrbv3nrzmAwaDVTrbXT5o033vrABz5099Z7w/PB9tYmW302GOzurt2/e++jH/vUxWB84/rVB3fvNVvxlUuXH9y99+lPf/rk8OAiP/v8pz5/dHi8sbH1+g++9clPfLzXjbMsM8Y5K2/dut86K1TY29p/aaQf/6X/9d9vb0LUg9sn40Z3TRdswTGgc85YtsyanWNstVqOjXNorWHHxhoGCwByOXhUIAokAkcLO0D/3QJmBxbqUZa551gco18RLe0HViEV3qfZqAHoj8nZn0HeOjasBoPVxH/x0z3VV1W/sO7YrM/qmTXBM/j+/sXBYh/xJHOH5bgo9GP84KnL9LvVnjOGXa02YQAC7zPKNb4vztloCJ0AJBIM1jnnrHHOEQPzsi8XFzAMiPppm3svpPGrFp9Q49P2kN7voQ4Vi1sEXu3zLBz7iL9ayK3faDqd+qy/Ntb3WB9SVN95j+N1pKmfrG+OX2HUhyUiv45kBIeL8CN4scjw7ysVLSwygaVSaK3N89wiaWsZZZw0+utb9x8+aDQajBJQlMY+fHDEjNoYhgAsAFCoFIVVwWyBrKOidKxSJcOg2WfLFk+rqkIRzC8GmxtrjTgCcNZU/W7bmmoyGRljs3mVFXqm7TgrsspGKTYp2t7Zy4piMBwJFRweDNbWO61O7/HwIohiB3Qxnmyt9a7s7IyPTx7ef3Blbx8EWZTv3hkdXXyrcGBQDad6XlRhIFlXkeCNbuO5nX47CYa9cKPfuxie5fmckMFZBsvMDNZam6ZpUWoHMJ3P5lkhgzCMk06vM5lMgiB47713yrKUhJLghes7WutAChAwnRWziYvSyAdjSaKyTkjQJhfEcShDCYp4Nh1Jhf31re9+99uf+fyfeHB0BhT/6v/wpWab2s2Nm/dPr15e7zab947O97dbL3zwxazIg0YCqRKomR0kEoxh45y0YSgssAONAlUQMinnwFqWUgIKK6WTUoShlBKlgDjJspHKslE2a3Ta1GgknbaMAlcVqpmKUIIiBCMEgxJAjM6VITIgIQklUQipBLFVUlZEBtlWRaBCoSJABSAA4GTwcKO9Q93en/zJz997827gysOzUdSKCWGz1zgdDvo7a6oUF+Ph9f0bh3cfpWl6cPDYWXj++fWbN29nWXbl8uU8z7PZaRCEk8kMHAqSadyYT+atVsNa0EX50ksvHT8+OT8bfeFHf/Sf//N/8ef+7M//1b/+a//t//vDZT67dev2L//CL/3Wb/3Wj/3IT4wvxp391s1bb/70z/zs2cFhM9n72u9/o9noRI2o3V+7effsf/pf/P39KxS0t44fnIxLq2MkztmhA3SOHcPi+wWwhBQHbJ+k6l5yUVtuecCx1hqz6Jj0FMJKj6VBw7wwDgR4yguQkJxzCySqHb1X8BqeTuH/o/i+CvTwPsm5/xlFC++R+r9q7Hv/+oCfLu7V0MzLCuci2V7x5DK8qsp/cua+u/KpMLB8fnGvrLNLTmWR4y93IgYEtPBkWVNjqFuZtvEEcFduhXGWiOTKbBD/qrwolFJBGHqa2y10nMRu4cLIy8ydiASClJLwyR2rz0HQYjxeHVRXb50Qwo9lrkUztBwrWMeJ+orqtlu/g/8Tm5iSmdFfpnNWV0VVAkASxd5amwHF4i+WHTsCekLL9HtrZVnOs6zVXe/00NJ4PM3efPud/vpmGDeKohJh2JCCxNF4OtvcXJ8O5qbUVUDUihpJGoZhCBKNPJy6Rmvt/Hh8/MbNZrOpoiYBTqb5Wr/rnLFGJ2koEAC84wqTUFmlLaAKohADjZqFcqT293d+8z98o5rD5rqSCh4+HD0+HQ0L2G6IKIqGo+npydkLV67s7e2dMkspcq2vXH/h8Hzc7K8fnQ5VEPU3mioM8tkEXQFFIbkanRxALEjnx3ePChEESgmBw+EArOv3u0kcTiYTIWUURUDSAopAOeBCVySDB48OPv2pT771g7sf+dCNwdn5+fn5B1/9wP37940xMhBWVzOdk0IZKGe1YwaHQSDn44tOK9zd2Vhf7yUR3r9/1+pqb3u7010viuJHvvDFv/X//G8vLuDlVy/3wqsXgyNUHLeT9Z396y/tJJ00nx8nacicV9JIKUCUla5KLCtnJAWOHaOSgjCMUEpyyMZp7bTWcTNudzugq+npqQCGdrMZrY3Gw7WdvdzYlKl9/YXRgwedzV1rSpASBDEbEEBSMiJDpWN0CAJYslJSQiCJGaQICXIHlXPIjhBQIDACirQhdDUKH9++fnX7Mx97JQnWAnpzklcPTi5am2E5s+PzR9Ws2N9ovnx1a3j/1mhQbKxvDIfD+TwHAGCaTbPRaLS+vvnee7defumV4cW4qsze3v58Onn48OHGdicKU4ny3r17ly9dPz89W+93Dw8PP/2J+PT0dHB+fv3a9SiKqlw/uPtge3tn65o8+OqdL//7f8cWX37h1Reuv1IZ8YEPf+qf/+q/+b/+nd/b3QJDzeFFAXH70uXdd+/c3pAlADCg89/ihZkSVWXGCOA8SjIJgUQC0LqKCAmAFl8jBmZkRmOEEJK8YyA4r1Orv/YMXq1MC1dYBAA/qGGBX0QL5dv7VC5/PMSvAsT7n1/9X48aNVXyzP6r+6yi+RMOlxaUvd+6zaanNXyccADM7ocO9qgzd+Qny4v6XTyPvMB3ZvBuuIjWee9McMuk2OOmiiKf7a7muautADXM+l/rQdKrRWkiKsuyJkB8rPLP66qqaROBi5qq8ssRXuA+vs96/tnrRfTWQKvn6VN4ibKOprBSmF197WrF21sQAy6cJ6HWVtHSWsb3NhM6Hz4An4D77u7u4+Oj09Np1BjNiooZUcjxdF7oYwA4OR698srlG89dK7P8+PixUmGnH88unGGrtSbyd0QIGQSRTGVYHIwenU/6hd3udZK01YiCzV5669atMhC99r5CLPIMkbXWeVENp1npgJKmdTArS53r0tF/+A+3Awk3PrQ3G02vvnjVOFrf3jwaXLx351babG0h5NPRYDC4urW9vb09G41ef+ve57+wnpd6q9nSJ8PxYLgVRtP5rMrnrRi5YjLV4OhQtsIXru6ePB5WqMoydy5hZl0VcRzHUXRyegpVFaUNQEGM7SiZ5cVkOgeAtbX+G2+8sb6eTCYTrfWnPv6Jt958s9fuTKelIGG1zQ00tIFAeJVrUWbtViOfDVrtZrOZxlFw5dJLaRptbm4FYXjl+ovb+y/8f/7xr8zn+Yc+eH04nr7x7W+0W6nETNvu5layt98Sp7NOiyCg4cWYBHfabYdlBaUIwZjSsCMiUhIlW9bIyKRQEpGwbIM4AURbZjIKQ0GQZ2GzlSIlnc5sPHEMJEKZNKDZtaMLBAWIILxZnGJ0CJJD1mCNc8KyFAoJARmEQCnJWSEkqkCDA6MRWUmRxlSN8+HpUNrkYx98sRVudpPWe/cf0v3bg2zea4HJc9Swf6kbQNFP5dGg2NjaGY/Hk9H4hRsvffe73z0/P/dagnarOxqM1te6+XTy1lvv/Nk/88uHh4cf+dCHq8r+yq/83sdfuxFEqda21Wr/w3/47f/X3/6fn50eHjx8+JEPfejRg0cvv/zy3Vv31nprv/7rv/4jn/uRv/HXf+tnf/rK/UePPv6xz2e5+yv/l//6S783+NiLraOJnhZwlhVbV5+fVFbELShPvKzPoUV2KEgQM2KpK1hMSmICREIiJED0IoeVtngSKAXpogQMpJKKBFvHhM45cCwE+cwdnGfvF7TDk0QSwGe4iyiw8rVfxdz/KLjD0zHg/fvXy//3owktp4y+P3Ov9/SaDV+QJKJWq+XdF2p1x4IWWPIMCyjCBSHD/JSm/Am/4cxqJi5wYTNg3VKDCE9FqSgOai1K/XwNoM9UawFAKcXL6Rmrb+290jxFU2fitUJ0GZGf+NVoraHO1peMCqL3b36KoVpm8MuFBSwIlsVizz4x+akDcI3pq/OhfOzkkJxjz/gLJJIkhBB+zWetp2hgedEO2LolKcMg33zzzeHYGAvr6xtRXo1n+VwPx5MKp1WaBlLB5ub21s7u8fHxu+9WwLd+7mf+k6OHd83sFMDmeVlUecH5xEWqvRepZH1zh8J2GifSmUDh9t7W9OwgUDIK1HA4lOC2tzaqPPv+9x83mjAtQcTYFEqRQFECMJDc3k7Hw/lsNjs9Hf/YF59//fU3bt+6+3hwZtDdv3+/0Ugajca7795569t3OjFECHuX+pevXvv2D97sdvppej6e5XGcVlW1vtHfbCdmer7ZDs34JBDw3JU9qGatdO3BgwcIrtPpTIYuyzIG5139wigajaezokzSls9H0jQ9ODnb39931u5v7dx899b52dnO5tbVq1e//vWvCyu0hrKCeg2FbLMs29len0+baZoaWxVFdv36x3e2Nh8dPi6L7Ozs7J1bB86BMS5R6u7dkzjZPDs/vXSpn7Za/+7ffy1t6F/4uc9KMQMliqqIEwFpSNYGbII0LCuDpiQlVUBOgnbaVBbJShEFSQwqAGPng0GZZb2tHUA4e+ddwN76zt7g8eNAirJys/sH65vrkFUqiFEpCIgIQREEChAirXOas1ROaAPWOJReaiwkKCGdRBVQqKzjUmuJLGRwfPRoo7HebqWj4UyQK7PxKy8+113vvfyRl7/02/8hSMIiy+bnk14rHp0+7qTh5cblt9+8SxLW1gLn3HA4ee21jx0dHY5Go73trVCKo6PjRhw7K7/5zW/+mV/+T7/8lX95cjL6yZ/8GEIUROnv//43PvGJ125cv/+Vr3zlJ3/iR99963tf//rXP/XaJ6JmbK19+PDhz//Cn/7n/+RXP/3p5Gd+5md+56tff/fd927ePPjK7w0++eH+wWC+trl/cXjS6PRLy49PTi0KSeAbtgSABYfOWCAmrktkT5DRskMU0q/iHVuHREQikFKSKGcZSJZISkgkdkhsHQhAP2lo8VVfHM7xAnTqJBl40VDzTOL8H91+KOg/EwxWD/VHqWWyLPuhx69TSC8fDMMwCAIhxMXFRVmWeZ771LiW99VJ9DPgboxBfgJnT36C8DXqJ3KdP3YJ4rWJtZ/Mah2Vlk6Tq/DaXK4wfMdTvUMURXVBdVXTGagnCT4/MVj2LaDL8bNP69zf/2ER0Syb+2sHsThJH42Ek9Y+saapZY7+utzSep6ZvUCztb5eW5X5lAsRUSAiMqLzM2T9HDT/b2XD/90Xr2ZZVlWVkiIOlIcoScjW3Ll9AhY+/7kb21ubX/va1x4/cq++2vn8F2/0ehvf/MPvv/vOo8tXrhkLDx4dtjrN47Pzl199AUj84TffGU3gtddearfW3/jB2+/NBrMZ97oNQWG3veYsvvPOrThKOt02OLu9s+5Y339wMwix126dDy4+9eK1R4ePT8+Ly8/tX3/+pX//m78dpq3tnUsXF8MoTI6Pjna3NglRIT64dzfLymbcjePw8uV9XeU3330zTYIr+1t5Nu1301DBdDzYWO9YXSRxOBwOWs20k6w9ePDghRdemOcZMKVp+u6tm1euXCvLcn1j6/j42LKbzWZhEJ2fn3e7XUiw2UjaaWx1WWRzkmpW6IdHZztXrkdx85vf/GavlYbkNlthBDafT2y/aUz1/IvPfe/7b//UT32ys9YqdbF36crp2ajb3X34aECy9/zzH/4//h/+2snZ5MH9i2BntzLGsm00o92d9Reu7L10Zefyenu/EzWwbAW231OQgpkcZ9Wk1W+dz01ele12s7XeBmes1SIQjrAyOmo0QQWsWVuWMgQU1rIoZmw0sBXoAIw1VVHmZVl2ul0UAQYxqBBEDCgMCOuY3ESbXFdzdhmhEcjIxI6UbDgrnUUSigJCwdqVxlbQbNoSVCndxP3mv/rNg9sPX33x1fF0FMTy2o2r02z+6quvHtx9/Du//Xtp0Pr3X3pnEEG3GxHJyWR247kbs9nMGjMejtbX++Ph4MMf+YAUfPPmOw/uZT/6xedu3Hj+7u2TbrszGQ8PHjwcDS/+z//7//Kf/Pf/KA5Us5E2GolU1Gq3792/8+jw8Od//ue//OUv/4XXXvmrf+N3/6u/+udFoz/I4d/+3rd/7be/0d6+elHB+aQYzksQSoSRYVfkVVVVoVLj8bjRaDQaSTabCyGCUE5H4yRJoiAgoqIonNVeHOKca0WXH96/32s01lrp+dEj4fRmt+V00es2r1+/+v3Xv9td6zbarffu3O6tdwcXF6bj5pmtKvB2C8aitkAsiUg4EsCSUbDz/h8EbiL3nHMMzjnD6IgAyYEAy86SYz99gsAB+cpuUsjVkFDDurW23++fnJz4imWapoPBYG1tbT6fP8maV2wa6ybY9yfvsEJzr/IJYjk4gpZ+Bh6b/DGJyN+0Oif1gvQFxi0tYupMv/7Jy1qi1tr37tcv1FobWihP6n4lv/nj0NJ8xtftgyCY5fM6o6+Pz8x+kkZVVc651QOGZY51TUUuzGRg2TbslqcHsMiXI3rWOngBrMv7YJcGwv5uWIq8nN9aC+hokYujMUbgogXMGl3XV0MZ1AcUQvAyaFVGL6SocqF29y/RFNTnI4vKyCBiFM5UDqmZNoXAssim0+n+pW4Uqkrb88HF7t5+qzVmEpNZcXx6++GjIyQyFk7OhienpQbX7XfOBhf93tqnP/ux88Hk6Pj89R/cOjoyeQvW+pFS6vRoMBlOup21zY2eImV05VzFuux2G1mvczEcWFO+cG1PV+WrL71Yap5l1XBwHirZThO0ZjYa2bi8ur8bh2oyGodp0mklH/3wq6NBcefOrdu35uv9brfTCgMRRUEz6SWxCANsRJJtOZnOwJpuu9NoJhcnF+vr60EQPHz40Fp77fpzu9ubtirHF4NmMz08eDid6kuXNsbD89k0/9QnXwsSNx5eTAcn1mhENgWFYfzyjRcmuZ7Pp81mUykRKSwrzWga7Xa82e12O2EkLu02k1hJcJ1+PyBc63Sef/65t968ffXq/j/7x//w7OTw9Fhf3m1/++CQCUhiGK1JKY8eH7z3vT8w47Oeguu7XcVzNtWnPnP9p372x1r7z9nxeZjETIyCbFkap0EgAmltpAoACRxYRkTBQMBorENGUhGRA7ZgK3QQhKiCcDSaOhJCFSpMwxRllEglJQrWGYN0VjggBIHICIBEQhAhoZQoJEoEAgFsQdgo0bYKIVS7vd3d7d//rR+cn3xtd7cXpuEHP/aBtN0ajacijP70L/2ZXmOtrP7Jv/3ue9N58eILz4fhaDKZrK2tvfvOOy9cf34yGc1m5e2bt15+5YUrly5d2quI4K033mw0tv7Nv/3KL/7iT1y5tP/u2289Ojz4xV/8+f/+H/3DMAqOj49lIFQQvPaJT/2b/+qfvvTKnX/3Hwaf2Dj+z/83X5xULqj4a9/67v/wpW9gSgCgixysVeiMKaqqsNYKcE0pwyhUEAeBMOU8n1wkSdTubHbj9fPzUySrgkDFJCDy4oqiqJAn632VBM7xeHe3/eJzV6XVf/D73ygjzmajXq91585B1KCNnS2hZKfTu3lxUlVgHagIJAXLaXjk3d0ZF/JIAgAGZHJcAgKAJeH5EAZg8I3mDiwBMYHz1OuzPojPJI9ElKapHznke158T/xqLkzLVppVouaZQ/GyrsjLudUA4DnlZ+IBrYyv46VN8Wosef8Zvn+B8iTxX9py0dKIxjlXmqqmL2ClGlwfCpccep3Or65j6mTcq1DqUjCsCCh9Ti2lREF1pPSvsitsOOECVesTXr0WXvoQ0HK2rX+vasWOwEs5DGtE71HzlOlb/QGtVhfqg/vCuNbaVCUsSbMgCCr95BykBRGoiJHGeaFtIVUAjiejkTW6ud7udNtFkc8vxv1+v9vbODs7effmAwAJIkFp7z08PhtkQJCmXSHk0fFxoeHa9X7alvrwwjKvb4WXP3S91+0fHh6ZvMzn5Wx0EYZxmWdpmloD5yePZiMJqBMFrZAuba+/953vkeOz88Hdh+XaZthrpGz1699+s9WWm3ubs+nFWntnVM1vPrz3wvXLcYBlSEo4dIWSrttphgICAc5UVYHnR2eNRAUK+71eHCip6P6dBzube+PxuKrK9fW1oihu37wZRdGVK1ekgKNHD1pJ0IxVJCFd67z8wjWusm998zu7W2kcCCJQUTid5eNRBkzdzvrdR0dJkiC7dqdVTC+0dc1Ov9uOu+3k4aN7jYCakVzrtYWiw0f3VJD+we9++Zf+1E89fDh+5YWr44vp74/e2lpv/U/+xJ96dPDg29/+w0cPz1jP+mkUg97ZWB8/Prv13jAU8NIruH3likgTcJaTqKliVSgAV1pjnIuiiFSo9VwFAYB0jhgQRYCktGXjQIhYSgECwWkAQhCKYhAUsTLM1oFhQGvQWkkGBGAoFSpnpQUFDAiWULADZCCBSAIIAAHQO2fJyXzeb/XNsACdf/hDLz34xLvvvf1gPh32Nq/evnc3bbV7G1tJZ63VWg+a/Z/4hV9+/keKr3zlK/du3zs/HzgDe3v7a+sb/fW16XS8s7O+1u9cv3plNB50O43hcDCZjl955QN37t5sNOIf/ZHPf/Yzr/32b/5GNu9evnp1PBz83M/93N/6W3/vtU9+4h/8g3/6V//aXzw9Pf1zfz57/rVPD8aTOUZ//5/8y7funnz+x177R//fb//5H3/lO7/ypSAJeq12EARFUcymmdZaGTx8NJEIsoWhUludoNdrd1thURSDMq/KvAIQAFKCEFBpyDIYwrjfxShonD+eHlag3Nne5kavA1eurM3nZ7s767P5WDuLzt589/Hufn9393KWFVlRWEcWwBpbGgtAQiAhELBDJxgQGZxfVc/e/00GBiJ0ANISo7cgX4xCgh9axFweodVqHR8fCyHKsgyCwLMQq/hekzOryFij4SosPsOoeBrBT8xwT3uQ1cepU84a43ilwFi/1zOnXR+Bli2yNT4ycySf6rmtG2VhWSkVy8EabqG7xfoqnHN+fAAyO2OISK3M8fB30x9QKeXB3S0cY57MC6lP3m/2aUNKeLrnwJ/zarzJiwrgqZmryLBqP1yHUliWYevVEhG5uhCyfLu6XLG4g25FoTSe57OiMpXO85IAitI6Nvl81kiig9Pz0nCgxHw+Nyzb7XYFcnA2bTV7KJvj7GJwnjeayfrWZhAHhc6Tdp8peHh4XJTc6q531var0pbF/ODRw3feuZ8EsttuXJyPhZTMJp8M9ve2SbhQ0d7+RlVmd+68950/+B7MYe3F9gdefvXl88E8145xkmX5dDTPyjvv3vzC5z4ZBVL3G2nIb3z/wc7uwd7ujevXLylBbHWezeI0icOg5Or0+LE15tUXrwuCi/OThw8PrlzeX+/3Hz9+vL+/X5ZllmW6LANJrUZy59Z77Xb78MF4dzdSgVLoGknSjIPf+Z3vVEP43IfaO1sbJycniNhOVDytOJJJIy6LLIqbWutmp8OuAi36mzuBOE8D2N3oADb6jejKVn82n+SxTBuJ60TDxw/M3H7yo6986V/92v/yL/7yV7/ytW9/83fDMFzrNrpN1UrC2XAwHAJ2Z1c21fxC7+zBT/3sz3z0xz8DMJ/peWNnC3IbBYKtzasSGYMkhUBxqZki7YhBAimSEZIEYJRaELHwkuPKsQChEQEQko0GaG2sYyBSSigFQgAC+MG+QoKTaB2CVyt7DxPhBWnOGocggBABhYBGQ5+Nq/E0ScO1fvq9DFTAP/7jX7z3+DDu9HavPJ+01vOZLVjtf+ZH94Oo2+/9N3/jbzrEMA4uxqNr164Nzi+CIOi2+9tbfSKSAgMldnc2t1xvmo3/8l/+XwC60fg8UsGnP/+ZN1//fm+93V9rF7r4z/7Sn/ub//d/FiVwej5IO52N7Z1To9Lta//5f/HXwxhkgt95650PfmTzq1/97b2tVqvVWl9f7zQaRpezydiZSgmhuj0PN0qJVqvVbrZm88nBwcEnXv5sWRZVWQJAHId+gpgzdgqD85NTW1ZXthvKQqfZasZBr7EDbIaDM3TJWj/VFkSgkgDaSXKRiWzGs4wNWBTSgEAKUKJ1zoJDcgLQADAwOkZwqHPfCkskALzHHzsHApRwCEDgyE+A9tO0zbPTT5ffcee01s1mk5fikGazmWVZTbI/k7nXhjC4UpZ8BqpW8curXFYTZM9glGVZw3ctUIGnWZf63b1zb33Oz2S+q2/tHwghQqngaQJk9SUemuvJGOSNWZYvrxPzGivrHq76V2UXoeiZd6nZ8Cc3h3xSX494rYvkACvuZtY+NVyFSCGiH0oO6ACArePlUJf6Q6lP9dm7t1ysaG088aWi0C9lvCpBBk9WVPLsYlYUBaBL40QIzKY5Icdho3Q8Hc7nxWkjiYqimMyrxjTP87zV6R2dzfNsXFYQJK3e1p4Iw8PTo06nsbGzHiXxydlgkk0azdQ6PDw51zQipukIRMcksQsDSmPFTkiM1nqtqsyAy1hQXs7G5zydwkdf7hfz8uzkNJtlDw8O52VVlBoAP/3xj2it79x8q9VqDC8uzk+qn/yJlwBA2yAy5JypciOlAHCI3Gw2y7x1eHDx+Og0iYPpLL8YQKczU0qV2hnnZlm2UEGhQKHyvNjaWH/ppY0kDpn52rVrg7OTyfDs6qXG1Y+Kl5+7OpuOx2fHRCJqddbajcb6zr2TkULutpvzIvd/ON219esv3jCTqtEIru9d/8Eb3377O1+P4SONduPGpz42euemiuTp+dHzl1967/a9yzudh7e+f+utY3Vlw5Y5VBPQ2vE8JdjbgRf21yPUV19de+7GpZ39TTAFpxKjuAQdBgJAoiNFgKwgTEAIppIpsI4YhJSpCBJApQSTZCGFNcbZClBREKHVxpZsjABmVoDWW9eCECAJpADtGBhBECoUiOCQLTgmAhQMYME5x84Bk5PoUMoUZpl1rtFKAKR12VoP/pP/9E/2ruz2Lu1Bo19qAVEz3tyCWQVBkj1+cO36c3/6F37+61/7xnwyOzs7aybp0dHRZr8/nYwU2dHg+NL+JhuTNhuTcXZ6dua4unb5clZU775370/85E+RMEcHh2+8/oPvvT56/oUXn3u+vba5Ncmyw5Ozbrf7m996/Z133qMWyDRodPpR3BxcDNd6nd3dXWesYCv1LEG31o3iqJXG0WlVWcvz+ZwrjlnEjgDznbZKgqoCY8gpJZJENhphFEWBkEXC4y0MZLjR66OB6cXEVkZhfzSa7Wy+NJ4Wp2fTLKva/Y3L+2unJ49tdIWNkBgKQY6EY+sn95AkAGBES86b/zIigIusZS+x9NUyXIA48eLBUunme6fAiB8O7t5XK01TT0avQm2dSz4DKPB0Tuq3WmRSwygvm49wOYtuNR6sUt411PoE31PndfzgpfPlH3X+7mlVqH8hO4t+dsdiiBfXNQNfpSRCJhSEzrEg1NosTDiRAEEIYlpZMbCDZcLuaXevxvecUl2fBFxIKsWKFN14kgbYa8xxqer3hXFCsMCWndcykic2iWIZ+w/RkzzGGKuNtTpN07pJanEEIiGEKbVdmffiard6Qg/ufu48L8ZFgVhZyUmQgeaSUAmVkIB5VgGAigNbaRHFubHj8wkyNEFNi+nFxfyy6B0dZ46h29kAGR8cj43T2hQlY8bQbJpZXk3m5SS7YBbDadbfTDc3NqLk4uz4bDbPwyiWYcDW7GysE3KRzwXas/OTwflJrwef+8xzV3Zefvuddx4+OGCk2TQLorBwutFKEfjk+Oi11z56+PhRNlfXnk/Oh+cb/bWLweDs7IwQ9/Z21ztbF+endx89ajdSKYPzIcxeP3n+ufbu9nacdnRVHR2exc3WwdloNpleurQfSDE6O4613dzdYxFM8lEQhe1m+/bdO48PDtfX+3uXLu31wgeHJyeHj7Thfr9dGp4VE6NGR48P2u1mp92M47DIZ9bpfr+9t7P13Xd/3bQbL778hVfyy9lsrMz88L0Ha6OztZc+8OD77+ztX7//3uu/8+Wvv/bKjV//0td//PM9s/uBxweH06lMI5lIIdmkyE2Jexsbn/zkh66/fBVaxIozqGYutwXuqI51Fgg5CMCys0AkUCWWYgdEIhJRA2QIIIFJeUiuNJsK2ABattqUc20yKLUgByBYG+MKIYowVCoInDDW+b+sUEIArMFZBoNKAjCAAWKBC00WkACS2hohkcsc08bHP/6BzbX21U9+GGZTWN+DMJ0XhXEiFWEhpbOYpCkQvfrBV770pS9NxzOu7O3bt+Mw0qZkp62uqiKPgl0EEyvBaRTO1Os/+HajGTaTeG2te3DvPQLc2d8+Pj6aTqe/87XfC+Lo7HzwxtvvTaegAlAbl+8dD7f2Njc3tmUQDobjF198EQCqPC/KeVXMHQEpQQRF7vSI7p8f93q9KIqCQIQ8L2eZZHd5ozkej5WwpEhKQs70NMMygDC8GL3X73ZbjcRV59PRzORVGjXbrcb+zuU8M/cPTtqdF04H45PzcRKJMrcWMjCVRFBKshDCuMIBO4ssl66zZJEY0KIFEKEoLQAi+FnRXmtHRA4EIBETwMIqnuCHw2KNg3mez+fzOI497e5W5h/V6fMqvj/DkNS8x+qv9eOaoYYVsbZzzjtbwbJl3y8gfJqPK2a5Qjzxt6pPePUcVmsAq+D+zIPVE6tPw3P9zxy2ToTr/f3KAxE9CSOWLml1ql7r9rlm5FeKxsZZa63Ep+YI1j9X3d/qKEhE42m2krkzEaGUS+7oqb6zmoyq78AqLSPUopBuloYzQRBI6SQ8KfBKCuK4KRCRRaCdcSJkZ+a5AeQ4TMuyqJyNoqACWea5JXh0NAIMgji1Ip1n+mI4QbKtbmMwmj0+P1WhJJJ5poHCKGzIKDk+Py8MEtCktIqo2U5LYyOljs7OW804TtJOO202ImbWOk9b3d/9xreZ+fKV56MoGuffJymUcWmjmRdl2m7fe3SQz2dZWQ1G80996qOnp6dnk+lgVgiAZlagUoPJ7Ox8lsYzYNi8lHTbnY3tzco6kaQlzHrbjbdv33nxxefS3tbx8EIK3Lv8fCOJHj14sNPsyLjZ7G82m823bt1ptLs7V66DdceFHZxlFpPdS1e63fZoMp2cD88HQ0bY3FovTRXHYqardhomIV2cH/7YZz/28NH90d33Ht1+u99t6Vl5fX9TxvGDr32l0V6bnx9e2dr+wqc+dHI2+fEfeXFwMdm4vlFd3Fdl0YpiW82aSq41EjOftKIWVxPWM2ysYZOgLBy5ZrcDWlldIgopA11VuWUlhYybQqXASsiQwiZQ4AwgEajIOMCQRejQVWytq3IOlMAIQStybIt5Np7PMmabJlGjkZoQ0RFhJBULJGANtmJbAjt2FYMDJBIKpQAKgESj0eKiUEqMTk+6+aS73h4OwpO3f7B57SUIAnDcXtsW7c1CgwmjRtKFNkGWvfnG9+/dOYoUdFqtal702u18nq3320kcBzLI5jNF4XymOp1GdfDox3/yxwIlXv/u9z7/uc+MZ0NkZut2Lm1dDKK3b96M4+bFeLS5vbO9p4IgysJ2FMdVpUtdaGvKfFoWydnJ6e72JkiEKGhGKg0Vap1ns6LKEsWNEMMAhABTzE6OHxdFsbW1tb257qdKOKOn02lRFHEch6LzoRsv5PPs7PiwKsqdze3e3k6ZmclkbMri7HwcSvXiiy9NZuWd+48Y5d5279/9wQEUeVWBUSDCSCrVDAMK4kk2s0COERw5BAZBTA7BoacdEBb1UhQkLJBzfgoGkG91BftHkO3LL7aUeZ77oX1ZlnnanVd8ImFFQb+KSs+QITUzUKf2/teqqlaBuC5s8tLO0Bcta/sXr6H0ywhemgCXZfkMrK8C5SovUQO0EguArplovz6on4RlK78HR7UUmD+hOADYrwyMcdYqpQLv+uKc1lrhk1IEwhMBfk0frTqsCSF8tr0aFerIgUunRlgSWcxcVYvJXEIIEkBEQkrEJw4/zOxXJ/Vp1IG5Vsv4zN0HJ+NsfTJSSrIr4D6ezMMwFCRybZEhiBoM1moDAIXhQnOQNNrtzmQyyTT317dGo1G73dUVnJxNVBh11raMLbMyC6PQWs2GAVxprQQoSpNlRWdr/eh8EIeRjJvddoekenT8sNdpZZNxrrWzlb1XdNppGitjqosfvCNg7eLi4mJ2s7Lm8HD8oQ9dC52Yl64cTR4/fry7uz0czUiGa3trU+2OhpO0txG1e6OL4d2jY3l8aowBhZS0wLrmxs5kNs8PLipd7GxtX4xKrTXHzaNxtbHe7+33wdlhWV3kmWpv/O633vyRL3zmZDJ96/aDwoq9rSu3Hx7neX7lxQ8UKaHVh7PyYHQqBDoVz/Ois7be6/Vu3b7d67bSgLuNWLjszrvfG+N9a6pImK1+e3uzf+/urX4jPnx4b6O/ESby0eMDATgZHOxu7oArtjf2Zzxu4HhtK95cX5sNB61Q7W+sZWN59fLa/nYbZQWjI8A4akmnYhAMMsGyYiRSERsyFiRGQZwABuiUCFJQDWBh2AhUQia6tCoQkgSwsUVurASQSiboSiksG4llwUCILgiUSuOyKhAFoJQiAPKDXXIE0CZzRjtnUYpQChQKSAJLo/ns+HSnnXSv7MFklI/PKaTNva3KmKDdg4I0KEBRIcowzEHj7XeinZ3vfueb25txu9nNZ3nUbOiiZFNao08eH66vN48Px7TTy+cX1mxtbq1tbqy98cbrnW6j0Yhu3XyrmaQbGxsbaxu3bt/+zGc//c0//P76xsbp2RhIrq9vzMeDOJBb62uPHx8nSevGJz5y+PBgrd9IAjHNoTImyx04qxBJRYrkpZ02M08mEyKK41gIDEPV67TKMiciAiyrYjqbGGNajbTTahbjKRhIVJLKhBydH53N53MhFHAeKG53mtn0NMvK565uqDA6Opb/s6svHzw+vH33/tHx+WhWVLpACWTD0DkL0rF0JBiEBXLMjMTYdM6xt0kBIpIOPMYZZGByCCzYETteZO5PpG+rm+d8i6IIw9D5AW9ar+6wmoY/k3uu7lO329BidAat0jj1CqBGz9lsliSJV/F7cA+CIAiCZrPpRZN+ZrQfa5VlWZIkz9BEz6B5/WD5Ls5aa1dasfwpSYJFqxgzgSNwkkgJ9C2v6GtH/oSdA2ZntNWGGVA6SSgJS210WYRBQEtbYAdcSww97WNWaww+p16yYgxQm7owMwJKIUlID81VVZZlWVW621tn5qUXmDHGsHXMNkkSz8Z41rO+ZKNtfZOdc1Dr+ump6FvHhQCfgDt+Yre3uHGAJKB+rHWFiJKemI7VgQtBIipg5Yk/h4ah0iaTIUtJzKy1rTQ6i8AyQy2ljKMoiiJJwmlT5HNdlHEUWFPaqnS2lARehQEIEruwKJ4gEDKz1qUxJkqjqqoqo4XAIAhALP5KKGz4JKIRJ1LKqiirqgLmOAirykgSSRhZa+ezmV8zQkxBEBCDNiUBR4EiZF0WSaDYGmc0ghPIAM4ZZwxUjc0yn+6td6SddxuBKWfb25vWme762he+8IWv/s5vnRw+fO1DL40HBwHa3c31zehsMDh75aUbF6dHbO1av33z5uH6enL5tY+b83FusLKysBg1+5XD23fvaW50u93hcHBxfrq+1tvqdSOiRiBbzVRtdiENIEToRJxQEaBohiprAGNVmXlWAQZJox1FbcZIa5QqRREZC0XlHFMUJmEcl6g8i0jgBDsEA2wBSqjmgBUUw/HgMM+GcYCNNBIBTljGUapUDIZAG3AauGQ7RVnZamJ0BoSBSlElwAEbwN72wd1bTWnbCsGVp7duHz8+/eCP/qwtA9Hdh+a2Ey0rExRJCW6eFxv29Lf+6T//2u/+/nSYTYZzqzkOYltWSRQKtkEAa72k00nY5f1u88aL11tXrhVF9oPvf/fFGy/oshhdnEspd7a2gcTdOw/ykofD+Q/eeLfU3OtuzPM8DGWSJBYwDKIkbQ8Gw+Fo3On0slleFJXVJpRKEIE1gVJRFA2zA//3EEVRr9dD5DzLAEAgMPN8Pp9PxwDQarVarZaUcr0TR2EoJdlK58W8yObGVs65KI6dA0ahwkiEESLlRZFXOmpszmf5PM+Lyk1n+aOj04eHk8EQpiWkTZBRUllhUaEMS21m06y1sc3M1gvdvWkZM7NVgoA1OQ1sJFhBKMkJpHn5pCD5DLj774Uf9+E7YnA5z/L92x+lSqwT7Tqjr3H2/fk+M0dR5FNyH1GSJGk2m1EUXVxcLG3Y9aq6ZjWo1EfGZdfoauTwO4sAa9al3tOteOOsWrcTUSBFvTqpyetVYc8z75tIWZvVeCmkc84C+7DklksfYwwQSilDFfl9qqryayM/S8QvSuo1DS7VkAzS69wRUUhERLbOOeOck0sJvxRUB1GnrU//F2sdrf1ph3G0iL7AdWXbORcuJz0BgPTLjbp5DBgAvUkEAuDC1mjFAIj9MF+vxMJlFx8SLI3JAABREDCjAEAWyiIVll1pAgnMYCngAA2SRWeE970BEkAEyKDNwvBagO/BsppJg5CsDIJDcoDGCQKyIKxQTIElYOacSVqsmIyTzIysNIADRRgwuZI0I5OIsrIKLQM6qwGAQ+uQnTU8rSpnNDhLyMIXvh1YC4M86KY737rzYL0hqvvjn/3xD4WxVIJRwPde/3YUi49+9GXFhc6GxhQvfPrlBspWI2oksWu1dFUg2yQAV5XFg/sgwiBMtC2tZeeyZrP9ysvXFcUO3AFMTOYkzdvt/tbaGiSJHZwBluAcGAQr2EpbMedkCk1CWScsKHDSGKWtRBGIICKZAIXMjtGyA82SjGAZ+M/SsQNwyEqABiAQDICMAYpQyoCkc8BkHasWUwyYABKgA8HAGaJzVjsgRwIRLSNZZIvOUTme9/vrcUwwPj25++jg9DiIU7CucJyARAod+CHRGQIEorL3b7ly3E6kqFQ55XmeOwbBVM7njTQMhHDWsjWNNIriMJtPN1QQSPrEax+fTUf3797e2d3c2dq+ffv27u6elAKrstIFIrRard5aP5jNoRhUs6wstQ5i1HlIopOGYHUSq1arZS3PZ1lZlowyy3U5mpGqUlKSiLUdzTJjdD7PhBDNNF5bW9vc2Z9ORicnJ5Msn5cXQRDMzubr6/1mK81n5XA0AjSdTrPbawwGZwAOBIGwKA2hFMJGypj5A6h0hNBqp7vrrWt7rfkrLq/wzr3HFzN9fDo+GtiCoREHa921vZ3tHzwaRlEURKG2nJWVdlaFKgxDFguGmBBIeB8tW7EBaP9QsK6BzDm3qhb/oTvDigs8rohk3EoK+UwS/UwAqB97PPFgp7WeTqd5nnswdcv+flzKHH9oQbVOQvFp3Y5nseVyEEfteeCT616vt3oVsKRrJC74GWYW9ITtYWaAp67Cl7Rns5nvNuKlIkgIIQK1uoKpkZCIpvPMn5hSKkpSRKyqajSZeh26d9L2hkVEhETOPNVrxkvbg1W9TX0TYGkn51b80fw51I/r6qv/Va6MXZRKLDvEwAIA1Ku9Jxs+dRfIAksAA4DeQc3/bRDgwrF68fYITIAUBN7bgbV1zJaIUJCgwDpnUDpi9rYdAp1XhsqYGBBBSBRIzJYlLcaCAbJQxlmnYaEVEwqIHAlrbaXZCjYODQMzCgcWCAglkAOwJMGxBcEkNfoFh1+jIQFYUHmlkQU4QGJJYtHKSzyDqJybsNEfVsMXru1kFmJBk/EgjoVUZn93/bMf/9Bf+yt/sxzD/+ovvgbVLOqGiJ35fA4AQRCAMztbPWYusry91nKSoLJpGodp0Ggl0OrAxcToane3mzbBArfXUuiFUGQuAiEZwAALcGC106V1lQOOVCgFhSoIjZOMAWMkRAwYAcaAigiQDAIghoAKV5btDh2CQxAEAhSBYQZFMgrCVFIJ4Ky11EhBNRgjQAUCEB2AAgeOM6Jw2TMvrEMHEjBgw3GvB1QBwnA6qwB39y7PtNMiCmUiZYxOojNonSIryYjIrTVVI3AzPUc9Fw4CxVEQZNNZQBgIslrrEoNOSwmaTEaPDw/73U5Vlffu3On3Oros7t15b2tjfTA4d7ZMoqCRRu1OaqyYTkbHJ2c7DS7G01KDDQsJrtnuUUin52dBmKZpKmSkjTWAUgZlWY7LSmqMHJFQFkRpwBq0KKQKZ0XVMK6poka7XxrA8dgYA4haq+nUZvm0KjOl0m6vESeqMqVxgMTEbK2pCvZ9iwJA65Ety0obtDHphsAwFTKJw92Pvzid83BSXozyxyejw6PB4OTxyMJmd18IAVJYRXHYsEgyECJQ4+mF7y8nIhAA4LR1xsIPz9trX8MVgF6V/b1/W82dVxF2Bfue0tI8A8o1Ks3nc14ao/tn6pZUWGH563fBpxmhVbKoDgC8rJRaa7NZtZCL+PU9EQmSpKyuYMlpgFfUAAlczp5BZABC8oMAV8Gxfju/RPGSHn/+YRj6/zLO+V5WWpHV+/9K09SvJHjZtFWWpda2dpz3Aa+ui3r10dJCDhD9rA2fqz9xnazfQvmJp0t2iJdyT20X+npYTGxcaOoFrhZUlwC9lNDXHzbgwmwTeCXeI1l2nl5CWtR0GMAgOUJGxz49IJKOkR2BWlp6AhM4XMhO2SuEHCOAdOjNsZmZg0UIYiFQIAKSIGWJiqokRAlomI11gCCVVKQYHADRkhwkIl8bsUt9qwUL7BajdxFISq//JymZHSNaRyy8sRGDEIBoAZGW6lcVTCez7nq7F6cf/ND14dGdCc4FVPNp9plP/sh0dPK3//bf3FiHv/xf/vLB7Xe29nez8QCFPL8YRFKEUlpn+/31PMtICoxjW5SGTbuVqmZq2EhXWJ1bZzvr7dZGe1rMgkYKis/Oh2kUKyVBKRYSKWILusgL1mEiFAdSJVIG2hJRIkVMqmkrsCgIFSMqpRhIqUAIpX31nMmPB0ZwAGIRrVlaFiRDgZEkFFgBswibIBLHMdhAAIIAwBCsldjyg3Sstc4KcJGiJlEcSgTLbjgkEp2NjbTb33ruxunARHEHgyYIRYCKWZIBLMFkgGUr4lTZVJr1dlSFiKwIUSQhO2u1JYSyMGUZOg7Zsi2qbDbTuiyy/LUPvzqeDI4eH1x/7uq3vv1dxxqR4li1munFxXw8zvNsJlpNImgkUgURgpME1rrJaNjqQJnPggRUQCFIFAgUtF1azHNA6UfeJUJJGQRhHEfBbDY7GwyHF2O/ym53u6bSRVEkoiGVsq4CIaI0abTbjvV8OgqiGNECOuesLitmRmIi6vbaajYr5yUAgM2sya0hB0FRlZGMn9/dSF68NplU795+cOfew/Fk9mB8YStgIeO0IdO0YhpMR6cnszAOSIAUSEjsnHUMDEJ4Vc0P2er8dLUA+EchO6yA++ozNb6vZuurqf3qM37z4IUr+hBcNnk+c2QPiH5o8x9zejUphAsT9uXovmWx0UcRXzRe1aH7B1VZ1fuscjLPqH3qd2k3W/P5vCzLMAybSUtKOZvNptOp340WakvyCCOEGI8HfqCud6oJw/Dy5cv9fv/mzZvwdMisMZqIiLyEhnABfOSco6UKk1duhVvpUaL3tROvfgT+v+zKPZTOPjFLg+VIRgDw+k1AXlIw9VEMe4EpOAbhJ9cDWD/gEIERhEBBhA6QEQGMA8fIzIyM7FgvrSfYLYazMBOzH5JMzhUAjhCdI5QogME5YieBEckgKATHaJiRiUCwKRRbwwYBBYAUkkmysdZaJFTIgq0DJ4gXI9TNYo6CjyWL8gjgMkshYLDOgQU/M8sWk61uUk5OL1197uLk0Xo7yqenL964dnh47/Nf/Oy/+Md/zzFsbDQs670ru9NsCkhhGFAQx2kUImYTyw7m8zwI49BaywgonEDLrtB5mFPQanNZQBA4iQZ1lYZxHGNZlSCiNCUZIymImsKytWCtBlYMijBCGQEJxwFDCBQBMmGIEBAiCwYmRv/p+A90+fXDRbwGZ61FxySEIhESG0IBhCBTpARczKSYlM91gHJQCWDhjLbWWRBSRiRSkA2Qlifno9Gkt56u7+1X2kJnDWdzStpOhKjJOSfRARRQjtz0fPL2d6Ec7661YhCzqR6cZZNR5gy30mg4HKKDIIi0dmVZCNFNkhCZHtx7uLu93m40J+PxWq/Xaaanx8ebG/3jk/PxdG41K4lCYqsRdbtXYzCMgQwDZsyyrCgK4wDBxGFQFjNrNQgpgPN5YS2HksJ2GxG9AZaOIqWkc85o12g0pqPxxWwiBDabzTiKrLVa20pWaSMNpZpNzHA20pg3mlGQRsZUBMI5A86nj05YdMjzua4qYJShUkoEAIBWIFJR6aLMR6fzYjpwGOz0cKt3LYyTN24dn51fPDg+PT0bFxY4xCBON1vRcDbFKFQqBCCrtbMcyFBJsZShP7vVpi5upTvfy89/+AuWSPoMztb1w3qfH4os9eM0TetEm1cUk6vETo2kf3yweWa3JWe9IlVc8Yb0hgG1BdCTzdhF9l5fFDEQI6JPYBfX6xwwI0BRFD5td855M7U8z41xUtIz5+Y3KQJBCpicBWcBmAilkmGgInYLyZMgRSgdOwTwAU/SSldwXa9eTnhxK4HWl8Gf0EFLGsfXA3BpGV2fj+EnQVSSW3ojAPKipkwAQLDsTgTEFe2kIOvAOStxcbMQARAdoWNwwIuxnkjoWDgENjnVfzEI1lo0BowTUQgIyOyYiBZeqMxOiIqZBbAAVCwEIiA7dEiWgYkFIoJAASQQBAM4I4AlAbNTyIFAZtbOCufbKBxhZcECWWBGMBbQOgvL9YvlxSxab669+MtDZkYf42F+url1udnv83wQxc7NdSoN6+kHX7n+r//lP/385z994/r2b/ybr7x762YzxCuXd8fnF5FS3fWNdrMJCFIGKAWSmszmYbuKm02OwTFrdkESB0kIOUEUaSUqiRi2qiSyUrl2G0FQqw8iBFYQpqRtGEqyLGQELJ1FKSRhyCycFcKiUBFgCChpgdsIlpmtFAoWDTK+7cXhYtxbYZkAFZJiRwAIQkAggVKGiCkGCgECIAfOsCMGaS1Z46xDIkUiBBEBhZCPdKGVDABJhCmA1qVR7a4RMUHgDKMzACWYKcxOqovH5eRsvd0IuC8sl9NBNR9XmU7iJrGzlRZhEKmAoUDEKAqiKLo4uxicnueTycZGp9Nq57NJls/7/S6gazVTXbGuiigKorAoCiYwWkQYS+u4KItppqfZBRGFSoKtyqKqQIRxhCiELREgVGHaWjfGsHNaa7bWMFdV5WTZarWiIBSthdJNF7mUspnEzVbiIC+qInczJq0BNYgoUF5IAZbZCUIpPb3LNJxm1qBEiSQRkK1jmxNgq9FSaLJ8ls3mlgFQBVEcQPG5D6zP8/bRoHfzweGth+PTKTszUwFmXElW0jIzOyPIAgIRBQDmh4JjnbmbZX88/LGZe73Daopdw/EzuLb65PsfrOJy/darmTKu1HVXQ8Xq29WnuhohpJRZPq8P6N/Ip9K4FNHDkvH3PEainnKPYWYkQAIiXACpH1NOQEiImGVZmqZxHGutx9NJWWqlRKvVWIhzliCLiH7/tc31siyLorDApGRlzYODR/cePuj3+4KV9MFDENPC0z7EhbW9q0emMBA9GdXigRCX8qGagKqLwIurqHd+uo7i3Aq4K/lUwZoZfQq9GAUJtFzLLzaBFpEAKmYBLBEFICNY8hQ2MDorhEIAZETGCKwf/ssICOgESAAjkIgNMxM6vyuwBWYGiYaBiZ0AFMCKEBkcOCLHQMY5koQIlokR0Fl2WhA5dOCcdKgAHTutcyWEFKAEMlsCK/ykHceBUAYMIyghAcCXN0QgisL6NZ6rxxoQCSE2pe1F7saVrcnxnet723fe+W6nFVTziyJxjO53v/rlK1e2/8z/6CcDYQi0TFIZFkiy2WpDEAK7oNUBdr01nMymDhBIRmFQCYoaKTQbttLzsoobqZXSRZR0GoZgVpSu0QxUAs014AAqB5SghDhJGzKoqAAmRCUoFCIALRAlOAFCevj2PF4t/CJABk/JCPYfICCAQ1QIgkkyCzbOWJ0IAKkYhAMFECBFwAGwZSO1JiZwjh0gqSCQDSEb4CJwCvIcAeI4zufzoBGotDmcF3Fjo7IKSAkRYKVBl6AnMD03s7PNjS5ETbJ8JqGVhJ1GrAuOApUVeRSKfq+bNoK8MHEcB0GQZVk+V512bzo9393d7W5u3Xnr8Wh4fvXF6+fvvNNI0rJyF6MpgYvjqMhng8F52tyTMrDOGlRB3JhPJ86WSZI4U0hPn5ZGRWHaCgHAGA3OKSGSKDJEgZTOGQkskMoiA+tCqTxOW2sDpdI0FaGeTEd5ngeBjONESNS2cEXF7JwxbEGyECgECmetMS5pb1ujCVwkEcFal7EzDtzhwf0gDIMgUEICSSTWbj7PhsPDt7u9tVeu7N547iMPzyZv3Dp8887J4em03Q40gKs0OFIgABUa0JrhiTjiqc0t/dlraQq+jyhf3VaBo0aTGmJWaZkabp4BZf/AD6quj0lLAeUqWNePazJh9ZlVcPdH8DDt0VBXhf9iemKRCKUkKWVVVc6ydsYnth43CTEQsr4QB4vLISR2zG4xlhwWywIiJO9d7A1qPMEbhqGXABlj3PJsnXMOGBEHg0E9qttP7vYqPq8Xqm9pXdb2/VDg2FprnWFmSQLxKTkjLGukiEj0ZPnlb1C9CFveWFi9w4affMQylILZAys554AdwGKkCvIC4mElcwd0sOBtvfrCn/DS3s5ZL8BERAGIyEIs2nAdwqLTXYUWuNIWCS0DLTh9P83FmSoDAMeOLDkhnUBkYEZFwi2CGoRCGJDGryCACZjRGTAIAI7AGNalkrEiEORNdhyiQ3SOnbHojAZYOHYuuplZ2KoEIZwUAMT1jUS8stXf6qbTs8cvXtvjctROVDatnvvU7ub2xrt3br708g0ix4Q7z12rRucnZ6eb/Q1wDrSGsoBKe9krps122phPprMsFymiTCBNQNDp6ela95pqNStbFM4pFWEgpJBp2jKFgyQFLcA6QAUk4khAnAp3YQ0LkiAUiFCBYFBA0mmLREje0OtJnzfAqrmUD+QOYNH3CETs0Drf7Y2E3gySCCSjZBDIbB1oa9G/jGQQhiJsAKZgAyjJc12IYjwe99L1oNVzs5EjYR0JGUiZAFdQWqhy1iVyCcjgKnCm22r2Orvd1ujtt+9PxoXVptForK2tkbSVnidhRETD4bCsmq12c2tzZ63b+97Xv66r2dp693tf/0acJo1WD9z49PS0rLjd2VYyIqEmpWvFqZKcps1A4fmpnIwHzWbTmSoKA2OqPJ8rlO00NMYMZqN5NojjGDyXCgyAQog4VMaYosistWEYKqWQuSoKcG46PpaKWp1WmsZ5np9fDCSJXqcjiJxvekEhUQCTNU5rV+TMlhUBoQgJBIUyRoXsbKmU1NbMJmMHHCUpSeFctb8RT2eDh7fPIe41uzuf/cSHX/2wvMjg3/7m701zznLtQCgZEklb6ao0ovnDBTCe+fS4UKtlVtmV94O7XY6qgBVvdP5hJdBVLH4G4muPgRoEPWD5ztW6LlofYbXMW2fudVCphy7VeW6SJP7crLXe1YBX6rd1rdU3nUopydg6sK2euX2yOXwy0Q/iOK6qyhMySinfJZBlmZ+jVF+CMcYtpnCoMAy9y0JZlp5SV0rV/vj+8pfOBdJPgILFhDzra4RKCWMMrgS5eqtZpsVNXva7VqVerCFoofVc1hVWVkI//eLm4hKXJVp/rPpzXRUtOedSmTrntDXWWstmGShcGIYCUBAIJAlIDMCOmXNdEEkUZJkco0UiqQhFVi7GuICz4JjZ+nbqCzaSKCQZCBmTVCgUkgCUUlbWlNZYZE1ggQurS61FZsIwlFIazy1K4avG8+ksiaJAKrQOHCtvw8d8BkMiAkZmtNYCkBSBlMF8njljwzBMwqTMiyzLOq3W9vb2evtUCNzot7fXu+DyYn7RjGh3q7e50QJbKukajajXbYdR6JyuqioMc583s9au1M5Y6QcpS2WNqxw7EhSFKo5kFIMUU5iiaDBtULBD0R7Gaxg2XRgYUTm0ICwiIoTEgeAIIXD2/uJDpoBkxCAMk7OoZIogERSRIhAAwtcPgEsAYTAuUToW6LRys9ANwV1AdQJ2BHZuTZkRcdqMGt2g+DCwAShZaKsKi6WFuYUsy8dgywBcIlUoFBiGSoOxoO+ADLLRVDO2N/aAxDyrkkajzHMpWAYKhIPxWXF+TE4HaQpTLCbz8XAai+TiZHT/vYcXp8N7d46badxqd1HQLMuCNNzZ21VJMJlMrly5cnh4GAgRBEFRZs8/d+3s7CyO47W1NRmo+Tw/eHw8HE3vPXh05cqVw8Oj8Wy+vb398PBgd3dvOByOJzOtrXEQxUkUJfOsEEKtbWzleX50dOyAL+9cGgwGVVU1GgkRjWcTrXWchFESAgApEkJUVaG1juO41WnrUVGWea/XU0odHx0i4ubmRqiEtdozJtYa55wQGAWBUmp08cgHPyXDQEpg1KUxpVEq9GtHa4xzDp211lZVNcJpu91OopB1Bc5KKZ3FrDDt3vaDw+EP3j66/QhyA7JBFsKssAfdvWI2k8604zBCdtlUOteIQq21dlw6rpCcijkInQiYKOah9zPxGEGAzjm2Vnp9j3e5cssyIIBZ5mp1odJveZ7XmFJn6LgUhHhyv0Y9Txx73Pe0z6pF+yqmrwYJ3/TkPf6stXEcx3EcNSNfSlngl1skuUWW+ytSS0+bRebrnqLI6zgUx3Ge574VwAc2nwsnxAtFn5AOwAFaRusgLwsRBI4xr0rHqMIAmEqjN8STFcnqA37aRaAG38LmT8XUJZg3knQR9pbligW4K7V6x/xjj/j1TVvd5trWMVXWR1ktKPOKRAngqbuzGJn4dFMD/DD2pz7sMu4jO7bOGsfeCnmxLQoJi2avWCmBKBygH0jPDICWV7ufFycspQQiLhfaIO+6UGunnvhFMHjTNWZm5yrriACYnLOGgdlJZ5WtKm3jOCYSk/mMjW22W51uTwYBCemcncyyKJTthmq2O+1YBWGkZChCGYUiTkIhA0BkICTpMyZCQiFIetkNAApnmWQQSOm8dhOlJAUyaLZjwASoC7IDsuFUbFUARIGKrLCIFgERAoJYcACsSHYcMAAxEoKyDOzAGpB+IguSX356x6lFu4LnYbzICQ2hA//PGshzwApICBWhjAEEsP9fRAESBQAzWHY2DRQ5J8CGCOA0aA1ag3XgvUHYAkiw2jIAOEQMwxDJATvIcyjLxV+DrlhTFEW2wagpCFS33yHGk6PzIJDn56dREjfarcLoBw/upZ1Wmqa3bt2SUu7s71+6vPfowf3xeIzEa+u98/PTOGk0Gq1GozGbZ5vr/aIorNUqEBcXF2CdH4uYxonqREByOp0ppRAKP5YeSMZxFEXReDzUukQEay2DC4IgbcRpmpLELMucNnEcdzodY6rZbHZ+erbV3jDGzGYzY8x0ljXS2DlXVJYA/GQ0o7VzduGfxRxFif/iIKA1zjlwDkA8kfcZrZmt/7tVSikIreGqMoIdOrDaskNieHjv/tbe9f0rL928f/oH333v7iNtMI9TRfPzqxvrAmF4dj4vi2acCoaj4SiOY+tQMzohgC3r0urSAoehQ16k5GydQyTPbvgvr4fXuvsR0VqzmrPX33c/pu4Z0IelrN5fXZ7nYjmZz0sJYSnA99tS343PHMrvNp/P/Q5hGCKiMWY0GrVEK8/zxRAPXJCoXlkoEKG2FPb9M0S1lKBelPhtPp97S3cPmlhT9qZyAALQOIcoGDx5A2EYopSO2bByzEpIRmAgo8vVsLSSQT+5XatY+kxBuwZ3j6urnJh/YJby9no3WCo13/+hAACRqDF8oVOsT261TFE/Xl1eGWvAz/+FVXCvFUWwoHuXGLw4UQ/u7Kx1Dhw7Q0r61woSgLwYPuNcFATgGMAtS8fgI1RpNMNiwrfxkwkFBVK6ZYMALUk6j+OLRRkSE9OiFQssAMoEEH1xgB0wowF0IEFC1GiD43leKBWsb++s9bvW2jBJwRokLisDGLc6nU6qpGCLMomitBFHoXDkCm2cQwbSlZXIQviPDRmkN/YjqTCORRwLVJadI8FBjHFUmUIIRTJEGUMYUZCSikEKgwbRAlgEIlAIAaECVADdpQJ1scS2wN7rG1gCIrAEJLeY/0BA3rOXERwBAxpgDWSADZjSae9BG4VBYmWMELIwPl9BsgAaWYMpWedFfhGQQwGWmRwge/4GoTKgFx0M1lbGOEQEdCgRgKAqdDa3uhIqFCCc00RkjQHgIJRBKIXAIFCtdiIxHAynQpVCoC5Kw7Yfhd1u5/jw8SuvvhrFwenp6e3bt7e2N3Z3d7X2kxbQOeOcGY+GaaPpHGxvrufa3b9/P47TbDpFpLiRdjodB3h8+DiO42aaWGtNpYViZFvmuRLUaiaIaNlZa6NABnEUBBKXk9h0UV4UBSKGYdRqdbh0JERZVT51TdJUSFUWuRBonTV6wRUo6by4Q6EEBG8n4GGNSAgh2Fgv2LJsCJZj25hTFNZpXVmplJTge+2CUG5ttvJ8OpoWnUbrx7/46fNx+fZ792/eOklRzx5MpIJmnHAjKSs3q5wJm5WM7YK6dUSArIXV1lpQ4aI0Z92ywEgCCQBwUW5a4CGt5NG4QmjwstBXYxCs5H+reF3/6iUitBzlUf+sS501NtUA56EWET0JDgBlWZZlWeWFrTRbS0KAAAIkJCFEFAQAy4HmsERbD0dLYmc1f/eRVawMGvSXw0DIaBmBgdFaRl8wdI6BHTOw0Q7YV7Hdipc9rtjWr96fOjT6EyDxFDO2Cu6w/FbXR0NEuzSN4BURJD7dabzIHhZyx4UGhgHkalG7jgD1M6u3o37gKwn4RBrPAOycIyRYagrtEnvqoFxrotgxANYjEGlRil2MRnfOsXXo2IOjEEKRkELkeQ6IDsE4Uznja9MCQSzRHJZvV0e2haIbEQUSCXTMzCRiAGBGQIfk51qSZQAZVM6xdRSEjWaj2W6RkkVZlpVppHEcSimRUZAIgaRjjSJQURKnaSCxKLO8KJ0zRKQotMjsfN4QLJcohFEKQQhBBFISEEiJUQxhVOYDgjDAUFKAIgQhQShG4RgZyV8Bg0QmYAFAQM06bgIQIUthEJiQEP3spEW49SVsYgZ0DIbAMjiEEigHLqAqAB0FEmQIKiZKHEcIoVHg2CBr5IpcyWZOJhM6W2skAAaq3MzH82zOzglAAowSx1UlkJUUYI0FB0IxszGVEmisqbQWKFQagK1MZigKysFwPs+ChgRwRTk3pkqSKEka83zGSPN8XlVlf7O/ttZDAVevXt3a3nj48OHp6fFofNFf6yglz89PEbHTbc9nWRqHWpfWRN1uFwAtBA8fPuz3Oqcn5wBA4NjYvKySOEyjiGgxvC0QRCym81ncbiZJIKUsisIyeobdOFtVi+VtURRVVSmlojBJ4sbh6YEQwk+xjJNGnDYQ0VhnfHaCAEJKRBKCAS07XVRqoeIg5/u7CaWQBkAgAqBkiYgkBQkEB0rE5Uw7axQSSbKGgV0gAxKc5bnOc5XIbrPZavYbUbC/1T06evf+AZzPADkTCecgIWo0Gp15rp1zyFqwlqAFa8WVY2059F8ZB4i+3Mog5ILzfWZDxEDI1V/rx9ZYJGLHDh2s9NlrZ8XSPrfGTd/quUpQ1ANX2TxJ5OvaIwCgUmma+nlPi49AiKTVHk4u/Ld5IaJf0tmwHHdHq+30SzV9jez1hSz6V6X0xNGKnwEhLhQkDsE5y8zO1wgRHYJzjhAB/dKBhXhCea+C8iqorl4gyqduc/1LzbU/A8V+hcQrjm+85CdqxF+9XuFF58iOnXTAniImREBYpGPkfV1gaXrJi8U9IcIiR2Z2vhJhfcWS0XqBNTzhZ56pDhARMUhCYKysWX1+KdTz1vWMjpGBiXgh/sBFmZiAGYnB+jtlrAAAx0wLeYBbGbYrnLMEAKxwEUMs4UJyz+iYLAMDeR8PQTAYTyRBK03TVpJX8ywfF0WhR6fh5b2Nfi9UIKVnfqSS2O32O60kaMTgKtDGuNwYIIKkuViG+x5aEgqEACFBRUDSgnAQcBhRFHGYoBCNuIGUgOyC6oGIGaWzaKwDJRnI/6WyEwAhOwEgARNm9rb1iMBg2VvIioVtAyICOL+09nsCM4ABBAQDUDBmwAW7HBVCkIAIQIQAIbsAbFSICtAQa8ElcSXRAjIIhtEAyEI1q6YjWxZBEERxgEIAsdUlogxCYsHoGAmNqRbxGoGUVIgQEpRGs5PGRHFYzLPJfFSUWbuTpkE8Gg6azSROVJaXJGS7k0ZRUFa5sba/e+ng4OHFxflLL91otpKLi/P7D+/AgjZVRQG7e1sHB/3ZLGsk0Xw+FzIMpIgCFUeBJ0HybDaZzC7t7kgZzPLClJmpTKuRhM22EpgV0zBAIUOpMJJhmqaOYT6fs9Wl1lVliKjd6iqlqrx6OHpoKttsRkyWSwGCrOECNCMUWUECpSQpBEgHABaYjbWldY6iwJMYzjrLhpk1MjgCEISWAMCBdRasNlqmugKjrWTNipw1goCdkVJ1W0mjIQvt5uNjw7Idpusv7HzsMmeFfev+yTffnh4NctlpBGk8rVwJaBmgcoI1QBlhJUErhswZBgeI7Jy1Bvzy1TIBs3e+wgVE+jRvtQa7CiVCPKFQeCHwYERoNpsLYYlzHsFrhF2kosvHnmJeqqCfHNy/pCgKXI4h9TyML29KIl9U9L7qzlhk8JUDD68SF7KfxUxR96R4W6NwHaVq25Y6QXQr7fvsoQgcMwdKMDMjiCBYgjgIIbB8oh1auRuLza1olhZU9tOYWO9b30x6WpVEUvob4nl2etoH//3gTowLEQewRFhyNG7hf48gCIEd+n8A4IEKlnGGiBwwMTF41g49hCCzg9qt7MlJAzxJzRFRkEAgu+wDJvTNuBIZmdkIRMcATI79n0XpWBijlHIIwnfpCKJF18HiY1otAvvP1ecFyIwMjhbTwS2wEqFfZyEwoahrWUKg1rkMwnY7jSKVz0e6KqSUVucKXasRdxpxIFwrCdqNqJHIbqutQgEkgFEiKRJICgC0p7kYHRGTVBQgkmUpZaidKJEcRqRSFTY5iAARpSIRIaUoYhAhYgAQIJLvJvP3EkkSC0AJjACxL7YzGOeMs0Yba12pghjALrVM/qtGDExsHTCgA9AIFUABnDFkLDQCAAUgI4CQbUAcEQQF5ARGYSVRC6iALXAFthwfPoiFtabIiikRCNVA9J0LLs+mFMah7KJAKQiFNFarMHCOEVGFgWANVtvKGGfzbBr31xqVPnp4xA4uX7vsSn7w8H5eTEudG7A767utfnc8mUznk42NjfF4mCTJ5ub6+sbaxfBsNILBxZlSant7ezobW6uNqVrNRFdloBDT8OhslMahqapGElXGMKOzBpy2psqzzFobKSmAQyEUMphKKkYyhFIoJGJjqqqqijwPoziOY+Mgy4qyKMq8EkIQybQZN1rNsixlqaUUha7QYBwGeTkMlEQMQAAwAltrGcAKR+zIWPB2S845bS1WrALBCGydtoaZyS006YRCioRAAAKAU4oChZEKolAVlbFs0zCMQlVUNi+HWXFxtZGv9Vut5tVWa/id2yfvnczOj+c5NNLuGrCzaAQzEUhBISqBbm6dc4sFPjtHAF7dL0n4Tpclsi++Wm6JHquL+Bp9eGXz+6yvr0+n09FoVJaltdbP9MCVFvxVIANvRLgsPMLK4kAppbXO89xDcBiGnoWPYoUMgkgsQZz86FljmZiJLS5cfxdamKfY4yfqzNowYNFVJKUPGGX1VCctACAIJN/WZBBREQm5OJRS0hi7uvMzP1fvDCzYrafUqPXtFPWwlKfvNq9Yyqze7VUifnUjfjKyT66+pr6/q0uA+swWT3pWi5B9rdCvO/wnDQsEt8gC0OGCEQNA65y1YIyz4MX/K06V4O1oluorL770HPliPeUMQCjIFwiJKJQh8UKxU2cWdcB1wA4YERywcY4AkFE456ytjI5kbAitA/aD5QWiZQQjBHRaabsZN1LFJquKcSCp04x2kq1+K2ko0YpVHGCsICSW4PLxWMvFcHrnjEQSUjBzoQkBhRAkFQWBIzLM2kAIgQ1CChIKEw5TE8YyTFAFOq/YhsQRetMfIVBIAcGyEkoIgCyBEZAAyAI4BmRCFoAGkJEsOe3XUQBoPeYCOfDOORaAgS1gBZgzFACFhVyGYAtwxihwIBVRhBgiKwNTCQ5AE1RgM8hGMDmDbNgOBQgEdtZVldXFvMrmg3me7+7vz2aTkCFFBikVKSBRFpUCqEwFxihB4MiUxjgrg1CIHGxlTBWGSoUyiAPHOghoMDjv9pqGIQhFFIXDKVtj2r1OOc47ndbGxkZWFJP5ZG1zbZqFUsq01Xjn5ruXL18+Oz+Kk3BLbRT5rNPuHZ1Ndnd3B4NBq9XM81xra61No5CdNbqIwjjtd/I8DyQiWLBV2hBRQFFIiKIyrixmxjgiQOB2syVkcGLOhudDbW2v1++1u9P5zE//kVJGcVSVZVFkzAkReR+9JT9hmBkBFAbWALMRQggEr1J16BZkgTWV0c65xXwfoKJySoZSStaFcRAFKgxIEJydncRx2my2hQxm8zKv5hHJME3nw/NMn6nW5odevNRZ3wxev/v2g4s5V1aPpCMgEBITGQQiJLCELrJYZ0K+CR6WSgRYYvkqM+C/7/y+DVZ0gbykIOocs3Zl4WWTkSe4YTk+OwgCn36VWb4KjnXN00sPaw7HC8+NMby0HxBIjp2PQwIQiIDZ69v9agCZJZLDJ9Goxjr/uPaE8RTNAuJ8gwhYZPDFZg+4hOAcM1oSCBadc0ws0DE/kXKu/hTLaSRupQsJEc0fMWKlPqs6vC3QzDm3FKe+f5/VYOkfC1oBdyZkQGsdeHU5LZqpDDsHvJgIgECEDgGJrHUISExI3iR4Qei4qmJ89sQd+nNCdmyts9ZZQEbyk2cXVwUsFpJr8OssWC3mkF8csU9wgJBQChIS0FprrBMgGBEdLzkJrCkqIHSOff6onXXGaGOoytA5cIBCghAMDNaA0czQaCatJCCbz8ZnVT5PO2kjbFzb24iUFDZHDUTSOZtpW05NIQnQKAFBIOMkDMMQhQBAIxNvShxFEQYBADttrLYVBCJshs0OR00tQiNDDhsiiEPp+XHlWBkgxxa1BkQlYwACRnZITMiLMmrlfDB0kqwgK8kJck5Y5nJhLEEIQJZxsVQCBWgJNEOBrmDMACqACijUbLLCBCpIiVAFCAIYAXICkGAEF1DN7Pg8P32sJ2chVEkkQJhEUSNtQacJBM1sbstynmesQl8CAClBSCgq7WxZlmiNCAUsey7CKMK2mp8PhqNht9NNRDCfXMzGmQrQmOKVV16a59XDx0eZqWZ55hizLNva2prNJl1n0l57d39PRSocXly9dvntt99+8+03btx4vphnm5vrksQ3v/mtUIpmo9FsNqeTUaORWKudc8wQxcGVy7tnZ2eEEgBMlSsBzWYjkPh4/MgpEhQIJZnZGafiII4b52cXRZGFIcdRsLGxVlXGWT47PpkWWVmWzlmPOFVVXVxc5Pm83237pNDbt9ZfaefQOcualQKKhFIK0CuXDQBYZm2ZGchbJUm4OC+SNJaEVWEEaUUohDJgO53ObDYbnB3FjWYSN4IgrUptXBY222B4Vs7nJ482e9u/8MWP3rh/9P237753f2gJnAAZJMihQ1mBcM4lK5a5tcTZWus7NkE8BRaIi0mhNU4xQ40wzjljwPoemaVg+v9P2X8GS5am6WHY+37m2PR5va26Zbq6unvajO1xawZYv0u4XRgqQoQQEslQQAIoKigCoIRACIyQBIYAiQgKJBckrLAAiAWxs2ZmZ3dmx097U93l3a3rTfo85nOvfnyZWdkzi6CYPyruvZXmnJOZz+ue93m63S6bWnPMtK4AYDQaebOOGbL7frcr9SRIWDeTx3LOZYhJkiRRTERlWRbWBkGQRPF4pBhjHKejS18dSskZ8w8H6yzRbIprvPrrXMFB04GtMWZ+fRcmlBX/IwOYcg0ZMWBCMHCGaKITYJ0BInD8RxPoWSo84wXNwJ0xZukjG8UzIHd22hr6KHbPs11w2juaTVPxR2+kECcFAf7E5aX5ADuLFVJKz/fyu4J2qnAGpU7TVBkjpWy06sNs3Ov14jhUSnFEjiA554TcyxkQADgidEDGoZtQUxAIvZOhc46sIesQKRCMc54T+Waen9cxP90lkFL6AYAlcpN1VnJE0qAnlmlrLBETHBhaa8uy5JyLiYwbY350DiCJuBTIRGHMqChLrYghE7xWTdJISu4WW5Unj263apVaIldXlj+xs5Rlo1o1DRicHD6+tLN5vL9rTVavJK12baHZSNIojOMoDsGrJi2u+o8ODyUAaG0c4xjGweIqENM8grgBcQ1kYjEgEKj9W8W0JUeM8UjwiEFoLecs4BggMLAOPNMUWeGEIyJXCl5KoRjk1o2sHgIoIqOMVkoRChGEDpi1rhXVuABrskL1GeYyAEdlVhaNaltpYw0LWAUoJMMFiyFO+/jQQBGaUnVOWvVK5/233PB8oRoDlZANh1nv7qN7jaV2baG1sLWhVSlFkmsDXIbVFosqyjFNAvw8jQCMQtISLKBx40E2GsQFZKMxWJdGKWjqn3XHvRFZhg5qjYVOt//hrbsijPaPjl/+5KeOj49XF9dq9UpcSfJ8rK1aWlkMQnl8fGiMkkJs71w5ffxEoCBLvU7XGdMvpVKqUqmcn5+//fbbzzzzjOTSS/SNR7lvFPR6A2NMrVbTWodNft7tDwaDOE7rtYZSbpwVgoeFNsNBXpYqCFPBA6VMnufWOplGq6urRVF0u91qJQkCMRqNwJkoChh6jgcaXXo5byGE7hlAhwhCsDCSUjLGAXGiCmAJxuPxeJQDYCWtVSqVvf2y1++sLC8062nnbD+J+Npys8hHgUQpuUA22VkXEohZaxWFo9GIiKq1RhDFpXLKMZDpmzfuvXf39PAcokYAcf2kkw+Vi5JqFQYeeoIg8CwUpZSfGPsMC6c94knfPIxmCen8DacbMB5oPD5YawvjPFFt1oSZ3fwTcs5nCjDGGFuoWRN8VgQwxnxndf51Jy11/pF2B5/IKyKfbdjOTWgBQOFTEt0PoTCfKjXOnJsYY4NRGQYBnwQ5CKQEcNbqJAqIyDmrVaG1RiRvQmK0V719ml/P2j5PEXyuI5+bbHb6iBhw4WsIZyauszg3ouCcZ0Uxn5jPFwczxKbpwhdjjMxTHv1ET5KmuRXM9a/5nEMVTolNURh65S8H1B30rbVRFMVxNF1G8OvODHzHB3xznxw559A6cOgJ2k81E4SUTCIicS+KprVDFMiQM6/eIKYMXAZoZ5mDIy9thogM0MA0s7BADrSzKLgD8B5UxLnkgnMGAKIckWaWcXAkkCAQXAiUrBIHaRIstqrnR7sbK0smH2ytrrVbtUY1XF2q59lo79H9UJBEV6+EjXp7e3NVcMzz8cnRUVbktVplZWUlaTaVSBDJT52RMZnEEMUQRGCRRMzDKkZ1ElWNkQFJwARwQ0hkjVUOSKClqeUxkmfL+GVgAiJg4BgwsCgsBw00djBmMGSiGI86QkAguZQMGRJzqlTKlNo4zjkXJqHSuYIDgAApImVzS5LJiPEArbBakbZIWqSjvH/WSJPKUnt457133/huO+Sqmqw9cwkCqEYsOU0BmfZL2yJUDpFJEaYsTECE3HFAjlzKMARnQIEuS2cMc8oZA46UtWEcBSIAYsW4l+eZkKxabzx5sr+wtEJEL7784ltvv9deWNjf32eCa2fPu/0WZ/Vmy6ImwcI0uXD1CoA9eLIHjGQShUwcPN4HoFar9fjmY8ZYvV6t16ubm+tJErVarbfeeDsMw+eee+7NN9985ZVXZMCTJHl0/0Gz2SxMsbf7ZHV1aXVleXd3j8tgob20+/ggCKNGrRLGaRhGqnTD4TgMBDLWH2fHRweMsUoaC4Tu2bmxqlGrDvq9OI6RnDUOEeM4REdaa59a+C155GDJGTOx4GFMOGAOOBMhALPAlUFLjFA6Yg4Y8gg5EotQ6EIVBOA4WDchCyASoFNBjQxyMlLyEApmc2kMo8FPPL+suqf9Y6CxYkGexAHGUVJtt1B4TwlELIs8z/MwDNvt5mg0QiRfq3ttKkfOkdOl+kjtPx2/WWutNv5/J+QNR0hPEXOWt/rHeXzA6Yz0KWA5AiDAj/ha0NTnCKeNFJzKTDqc8sHnOkgc8CnbhzP+NE339kwfGXX+UKx6OuoEAIB6rcIA7eQN4pwj5wIcI3K+dTwzC2QMZrCJc9zEaYnz1H98HtyjKGJzO1MWJtcEZ4zGuXgwi0DzkYnm+lfzYQwmtn9zeu5FWc7QfOL/LSUAaGP41C7defKNc9oY7axSyhdWw+EQEeM00dZMekyThNrjOyJnZOz0hMk5IDZx/vAbBIgYCC5kwBiQ1dZaDsimNZc/RN++wfncASb4/vTa0eSa+la7dXZCUrbGgWOMEXqFBODMefcsT/CVXCBnyHkQRIxBt9s9Pz9fuLQhw0YUhlEg83xUq0YslrV6euXiljWlVcn29rZgDsAxwaMk5lKESQJcgHVP9var1WqtVgtF4ACtttm4NypNY2UzqKRSVkFWgCUAEYAEEFIGRJZAI6Jzxqs4CmCO/GTDbyOx6bAUGVMcHAdDkFszItsFOwTIk9AS2FJpbQB5EEaVNI7DiI9ODiGWoXROj6zJnEAZBBgk41HJBAsivwNgAJQzihsWyX5ab40O7ufnJw8+eCeRePHCZlUijPogGcRJvb1EkhvHlREyDLgTQkgWJhDEwEJAIGLI+Hg45kikc1vkzJYBEgMKAyl5pRwOR6NxyEQYho1Go8gKpYt6vdrpnl28srO7e7CxvfX9H7y+srZJSsOSCIIgrtbSel2T4pKxagoBh7worQHOlNZpNS5UudReEKFstBsnJycokBM/751vbKyNRoP1zZUnT54w7prN+tHRwdWrVx8/fKhNwTj1u73nr18djbLO+enW1kavNzw9Orx06SLn8ujo+HD/iTUURTETgXNklGnWq+PxMJBCMux2zgaDQRQFWgVLC23GmCqy8WjIGKvWKmEQMATBU0DHGCJ3jINzVptSOwriiBySBWQICF4IczjUXNaFDCxhYZxFYZBpQuKBViVYLK0F5wTjjE9q0cygY5IjR0boSm7H3JYCg2zQ+/kvXL92efjb33vy4HDUXF9cqrc6oxLI2lIBwyRJOKIzhgGQdYL5rasZxjpwzms808TJx6dS6H+tVtOiKHw1g0iIHIAAHGNylg7P+IW+f+X3Cmm6CCmmzqUwpzqJH11lclOPIZyt4IjJBswsY2WAFsBqPU3tP6K3zuiHQZCezjafnu3s1Z0qvE8pB5CcAsEAQDu/ZDsVKeMMiLQxVmlG0SwDBvhIiJrP3Gf4zsTU+9QYzvlM2GUWaWYhDT4q7D5/m4XMCUJOJ9vOuWCOainCMJ70qgCmfMSJRoEf/hhjiCx6yXXkRitrbVJJ0zQ97ZxqawAgz3MhBFhHjixNRoEOJ4T8aRB7Gsr83oF/+x3znFBGAEQUiMkgBQgsOJoO5H3wmBy13zkGfwmeBi5/wgwRyTHOwVpEL18GAOA/uFwKn837gYB1pJ01pV7f3hJgb3/47kq7EcWV7fXlrH8eJdVHex8enZ4sL7bTer3eXnhw/zYQGKLeYMARpJStldVKtQpC6KIYZOXSyk4oOXCWl8o5h0IyLpMkzjPFIyZBAAXkAmQRhwhBIjEixRgyTo6TsdpaZFwiBEjwkaVfJEAS4AAMQYFQMMy1Hqn8XKl+q1l1TjttrCYmHAtihhgiH7i+KhkYw2zhTImKlEmcAWMYIjBLJWhpHELJWAlAg927zZ3Lx/c+lE5dXFlMxBKasj/KKtXE5i5IKssbF5wQu8fHg9xWZRBW60AITIDjAEgkrCNdmDwrAgHcOrLOGYvMMS8ojdwYk2UZyFBGcRhHRZ6Ps3xpYVlp1+t2l5aW3rnxYZRWzrudpaWVYZZvtBeqzZYmpwBazSbEYnx+psucBQHUGxqeAGc8kLV6/WB/f3l1qb3Yeuutt65fv16ppYYMF3xreyMvxqNsuHNp6/bt20U5KooRkW40Kgvri4eHh4uLbcbEwcERAl9bX8nHQ2tJqTKORBRXq5W6Meb4+OTs5Jj3I855vV7Ps9Fo2F9ZXrxw4QIDp1ShytwySOJIcgwYciQeiIBFzlkHdlJ5AgEHTlwGkTHO72s6kMZarY02utkMRRAqS+NMlcaChlFpBOcyqRtdlnkGzkYRl1wCorZqkI04GRGA1sSpBFICLAcdIKEaXNpc+JXG4vc+2P3B+6eD89Ol9S1wskRWFmVOEEVRrVJVRmejkZTSEM1wE2cLSuzpwNDN0e/8DMAjtc/c/dcZ+VMNFt968sA3y+hnUP5DsDXDdDandzLr9vh+jjGGxFOwhmmv1aMBR+Dw1KvCQ55fupwPBrOXmwExTWmaiCgRwjAI4iCKojiOvRpMlmVnnXN/PEIIDtwhOmDG2XA6k5i/OLNCYR6C/c9KKzfnSOXzfUS0UzXH2cWZ4TV8tPLwf/EDZ5gz7PZ/9wbrE3CvVCre83BCC9V+BkVSysm9p4fiL3oQxyKQlUolSpMoG1JZzEddQPRTPAfEiDx9njFkQNzLR3q1TcBqtep9HTlOmkdcSkQ0jp6e2Jz7uJ1zTplRtRDR+33MPo5cCMvARy/GGAjBEIEzS44cOWMLbg2gRe6ktMQLR5lSSikMKkqPeVRpLq3V2ksoI5BxtbXUqhhj1PrWZquW1pvVTaSlVhPIaC7JGWCgWTDWiI6AhZgEShkiiqIojlNHVGpljDPkwiQKwxhEDE5a4iADiYkFbrR2BEKA5NwAOKuc0cRB8gaDyaYAIRA4ROeDlIUcqZCoGQeUYHLt9Pj8ZBBFURAmUVoRMgUWlONinJf1KgdbMlMK1CAJHBhjDekoqFsRWAJmrQDDAwPCgNPNy5fGb71+5/XvXrt0qZMNu2Ca9VqjWef1etHtBpyz+goLItbLtA1YWAUZg3FKk7MWg4AJgUjGqjhJI47cKcc0FRZt7owmrcbDjDPRai5wgjLLs8HQGBPFQVCrmu6wzEsLgggR2MJCW8iw0K601iFjgRCMQSABsTSmWm8URQFRkFYqyEShSgcwHI2dZS995jO/+3tfy8v8069++vDgYGN7Y2/3SXOhVRT51tYmY/jgwf3LV3b64972hY1hqXu9np/5+4+xKsp+v1+rNSpJRET93tnJ0WEcx632woWLm2+/e4MhBQxlKE0URYEIGBFBv9cps0xI1mo0okD6L5QQDIAsGa1LRwbQOpzAZ1mWypAqnTYIKIWUyJAJVxptnNNFXmgG6JCzTLkoElGSqNEgt5nTxIPAshAJtHPcFgIJiFlLCgiBO0YW0CEvRgNSrF5ZfPW5C80kvnXvSWd/N71wRSDrDQej0UgVZZwmgnEDxjmHNM2ZpnoyAGCMg+ncb5ZDAYAzBpxjAJOFLo8UxqB8+v2d4VcQBB5GfSedT7XmtdbhNO31l4XchMgrpSTGLCISsSlQcs4zmkhZTBf5prkdMs+S087OZ+XzXYtZ8JjPjmFaW/i/Cw5SYCREJITkjCFwBEDynQBDjhD9JBoZZ1xw+8OsGJyK1cwj8uSYibTRszSfzVG3YRYe5gQM5kPF7Bl+KErNkNAfv3v6aiBGo5GdKmTO7uGfV6mJiclsPjldImBFURRaZUWulHJEQj6d3gI+jTMWic1gFxAcEDI3q6cmam1Wa+0c+t0qZyxNwx3NnoqhMcZTf+dPlc2dsH+MfyhOLy6fas5pcowAGHbzgsuAycAxqRwWQCUIxfHWgz1ny0Zt4aib12rq1p17G8uts34uTFav1zSTJZfnI8XThhLBB+/fvrC9LjjnHLU1g3HmAOv1emuhrZkwSnPOMalyRlGWS+QybVoMMa1CkIC3NgXhXQNCERlLnBOAFsC9CCQDr8fpYLYMDo7QIZAFBc4CGEQHYBmjOBTcRarMBPhdW+uAkCM4xiEIgtLmOULhuzoAyJwlgCSuaZYYYIwsRwdgoBhANijefOv73/nWs5d2LnzsubOb70VRWGnUd3d3l4Xo5TllZSItS8Ko0k7rLVlb0uO+BbQE1qEgJngoODpCo0tDlpxB67jnzQIZZ6SMGE4WsKSUURSRsSovwbnxeJwktdv3Hq6tre3uv/MTX/qpD2/eXt/cipI4TJJgqQ1qVBQZcoiqqazVR48flyenUbWqC90bDJUxzXbrnQePmvfu/OIf+6Wvf/3rz159plKtnp4eN1r18XB0b//J5z73qtbl4lIzTePt7U0L9uH9+5VK5eSso5S6dHEnz8qjk5OFdnNv/zAIIsllvV7TibbWnZ8dHew/vri13ev1pODNZiuOgpOTo2H3rFar1SoVkqW1uhiNjGTOOSl5FIZKE1hHYJ2zxAgRkAMnbgEZQ+QMLViHxqJW5Bwbl0NjjHNGBiwIhAEYlYY4CzQVFhUJSy63IBUJZNqyRqARkYElIoMceaCtIEd5Vqyvb5XK7T+532yu/PJPvPxwZ+krv/Pma/t7cZrEYcCxUpalKosJMk9SJGBsjjw4XYtnP7Je79XWZopgOB0hztjJT8t0xmZD15k4AZuSW5IgnsGFzy9hjiWCM+bbdH7oDU+eIt2Mam+tA0Ln9FS30jkHjmYVA85NgHHa5Jl1VGbj32oSBIHgzJVFVhYZcmYdGGMYAmMMHVkHTlsmPAdTMML5EDLD2Vmrhz7aC/KghH6IOnXv01qLmSbMR31RfJN89lQ0t8f7EST0U2XO7ZxtnhiMhrOoKIX0fXYiKorCGBOGYZLEXrIHrQmi0LfXR6ORssaB1VprY2r1yrR3hhx8f26qLOFBGP3bjNY3x63LsmzSnJq058irQvKn5hKTuOw/dn6y76UYcPIvEUx1JGZvMTnnJpsRKDiHyQCHIfIgiGTQyQaSmGDcAi8clI4MC4Dh/f2jWDIh2p1xzxlj8kGlUr3z4OC5q5Wo3joZjBfW11v1ujNFkY/qy2tRfcELqjCGPDXWubhSg2pdarW3t3d8fIiIWmtl9MLK2s6V5+LaAlgAvx4IjGFAIKy2KGKBmmwBHACUNQodF9IBzmS/YBLnwAEQgeWMcWJaFaQGpEccXBzFcRQAodZO5Rp1GSaVUMSS8zzrgy4Ca4EzsAQaiMtABpxLxwQBMkfIHOTj8mz//Hi3uH1rMQ4vrCz3P3gfyVY21iCJt5r1m2+/HaS1RhCNtalqTBtLlVrLKRyOi6RSjZPYALMgHCAwLmVY5kXpNNMZlFmEWnIARAEoKjWTF2WRcQch53Ecq0JpleXD4cLCwq07j4QQN+88rFQqjXorCMK0Uqk1G0F7AaJQjfujooiTIIwScNYB9YfDVloddIdciiAK4zheXFy8//DBT/7UTzXbjQePHzz//PP37979+MuvMAZxEhoweTG+/vxze7tPWq3G/ft306R6/96D5eXltbWNvb29eq35/PXrH966df3as+fdztHRSZYVcZpWq7U4jgaDQTYealVoVcQBr1fSMk/LPE+iKIxktbJYlmV/0LXa1uv1JEkcWcRJyYvMOfR62kBgESXjIpDMOaRSF4XKcqu1JWE558AQGBdBpG1ZDoaFDrO85AKJSRSQK0vjMuACgNWZsuSMA2URA8F4RAyNcenSQmdUcoLt9dWIsdHenbYt/90vXbj/XTMYDFRRVmrVOI47/V5ZlkEYknXAfOcegbzauR8zepAlRJj0OBEQoSjyWTvXC58hgpS8+GiyOQO+eSdV/5WkqUbNLFGdPZAxVhTFDIhhvu8hnzY6mCPn9/m82SaRBTfZvfFzAv6HSMnPuiUzTJ/q+pBzrpJEURQJIUptCqWIEBiFQnodSobCobUEWk+03vCjxtk4HSb/ECI/RXn21KFba+0A/bDTGTvLqmfP45z7Id+s2blorWeJ+Dy+2/nM3essz07Yx5PZ+tZMqJ7mSDVhGCprwMJE+aEsOefGPpXuZIiz5p31yzV+N34y9vSqlhO/U45A1jlnPEz7XpIftHuui3WWiJIkIaJJUTu3GScYx6mwp3POW6ZO+oDELE4cT7y6cxzHKAOUIfHAEFN+ORwFchGmtWa9kqmiVmt1+p2Xnr8WB3KQFc3Fi8rRjfdvrq6tra6t9c6yXJlnPv9jwNEdH/Z6PcllvdHmYQiMA2PgbLVarVQqnoFw++6d89MzYvcvXE5qUY68ABAkkQEjQLIAzBVFYe2YB7m2vSIbMpQckyjwe0ge392sJuaAEhggK5Ue9npOndciFCkHbUAEMkplGAKvAI/AMK1MWQw5uJAjMO94yLjkPEmccSQRkCEjsM4Uw5PTw/1Hd+uj/vbaGoA73Ht87ad/Cors/d//vRd+6qdHeXFxayfd3FS9MXAZJaEjODg6ktLWZMiqjcCRKoy2XnOGNZtNW4z0qDQlEPllAmuMMnochZEImm48GvUGKsvIUqVe45xrZ9Nq5a1vf09GtXv3jupra/oHP3hycHi91QAhXKdzeHwUV8IkrTpSgLC0sloJQsFEqVWz2YzjeP/JweWrV887p//mX/3LX/rlX37jO9/hnF+4cOHeg7tXLl1+6eWXHzx4sLzQZgzSanJ6fHJ4eHj16vL169dHo9HZ8UkYhqPR6PT0FADu3b/DUAghkiSSQgA4xiCKAub4Unuh1+ucnJwsLLYqSYpE2pT7T06vXLmy2G4mkUDExaUFa+3+kz3lmCPjnPWad84Z46wyxtqC85hhiCgZCkLrUxpHRgiBjGQoRSDLcTEcjbIil4LXapVKEjlgWhU2K2wQSinJjJwjbchyKXhVyNAiKmussqkMAiaczotxIVQZgONEv/zLf/6rX/3q++9/AADVes3zxNM09Zbu8znjVEIgmM8QZwmj5/OxqdM0TFnzefl0ODlNqa1vmk+I7dNn9uwXo8x8VwSn3Bs/xptoDMxJwE8I2TOks5O+OfctAee4RyHGkM2pxEzpKzPyiNdsmcxgpyIERHR8eFCv16Mkdc4VpSqUUsYaS2ESMyEEcu5Ia20c+OmtzdX8QJWm7aD5GeEMrADAknVTdUxjDDLuOanj4Wge2ecv+PyTzM9O51/0aWiZ68uIkSHnXBzHnPPROEOkMAwBzXg0MEo7QBEOpJRpmnrFJZYV41JzKWImXFZGxIIwNqM8iELOOZFV1mgCITmisNamFhgjQEZkHJJExxlgiNo4xph2lKvJ6Nwgd9aZOQNcJoVAlJ4fmuezDw0isqm0RZ5n6BARhUAEJALmiDOmlZFchEHoUCrgDgGIW2ISRMCYIEcqF1mWWIriNIzSs06PMstEYDBcufpyWVtsrqysb2x96wfvnJ0e/c2/+V/903/y32Que+XlV8rTh2enw0YzLdNaUK/FaRVFMNYGWBAlcVd32dIiFJlGrK2uvrCweH7eNRDWr1wDUSfeKFxVuQQyGUgZhRKyX4uVAZYe3e3dfXi6efGFC5dfOO0V4fIycGbIWVcgMxydg6IwZSZ0BHac7WWnj5vcNGIO5diOSh5IYBZSAFZAcQQBAzDUP2sUu8ACSNsK4nMXlNVW1FzmLK1DXUNHDrtBCHD4aPjm98Lzo+tkRvlZvbYJnaNEiPGD3a511z/3syCb7Wc/1SGH5/32+gqQZYe7pig36ylULpE2dDbCIAqYCIwiO0ZWAiuY6gWQx4kjTWVeqtyiSwTLgANYV5RDA2VSTSIekWXIgvGgjMLq+emo1kgEABhejZr1zrCdl1DmYzU+LHqf/vyPv3fj3Rdf+Hh+eNBoLx/evn9+fLS+ulZbw3HCTwIVds6eeeZaYOEbX/6dII6CpeTS1Wdv37yZG9i+dPXenVssCI/PTlWRcwHrG0urS+1Op1OgA9JO2WpaDQTs7R1U4tSLgo1GmbEUBdJaq3OXG5frvDRUZOrk8LzVrFfS1JTFytLC3Xs3t7Y2L13dGYz6Z9kZMFCRThgCSO2YMUZrMIYAueAJguj0xkYXaZzEoSjGpIkCGfZt4Vf8xqPcKEtEkkUhk84Y0kxghAGOR+VoMKhUkqWlpXNVkVLygAcoODBheOAocqjzXFlj0EYBj0JJSaisMcasDv71n/uUuNFOvvXG6ODxKF2OZbR6OFDDLFleXi5G/fH5yXIjaobc2ExI6mLoS2fv7UZeLQTRWsslx4BzY3WplCqJgAOgCKw2nHMhOOehMQ4YOHDImHLWGU2E5JVpkVmCkDsHzpJFn+3BZFQXSw5AzBoi4kRgJyjeqCQfRTokYMAmKo8AIASXQk7mpdYhtwAgOXp+NiICEIBVRTEDYpjjp0NU6RnQ570gCIioKHUQBABWa82dE0JIIgZWkAULjJiVERE5InJkJ61wTpwTIk0Fetzc5FiKNAjCfr8PLAyTkIhYEHW6HcGYECwMwlBKRCDrPLPFajXjxQMwkNI5p7VlAp0FYx0x5Fw6RGOdVYbPidcIox3BpEqaqCQLi7NpuHWesziLz1ESe1R1zhkHBH5xdWZ04sA6h+AcQ/RuI4yA4UdqoqnzFuMMnkrhEH5khj4rxGZ5way6oTlWPuNerYABgAC0SAAMiWQSCiE4Q88cJWNNWRRe2MERcedHCKSMNqUduY2NtfNu3xpVTRIg6p2fPfPMM7/w8z/7b3Yf37r13l/9z/7KyeGDP/pHP3vnzp3nXtiBWgBZFwS3DAg4ARNBwkXAZbhQueTKwVDtZUWPO5ARLq6uBJVVgBRMBbAah40YBIHTrjsajxoi6O49IZYmcateq/Q6nTIfLq6s6GKEUnKGjFmG1mcgTGBuh5xTOwzqtRrLekAGwpBbW+RlYXUKIOupAzTjTEiM0ipU1sEyq2FUGB5U0yAC7RzkAxovRCGAze/e6z/8wA46CbO2GMe1FpCASlo1aCwttJccWTXsx1FAAJIjZBnoslBGMAQuwTlkzBGCNf5bi94kBBGAOb+kZggcCcaQ8VBystYWChHDMJQoyZK1thgNKmsXs7uPDw/o0qVmtVr7H/7BP3jhxZfzvUf37t27urEUR0GjVndGra2sPnlwe63e/uAHbzz3sReZMUQUhlIplUSxUebmW2/FcfrqZz/9ZP/w7Oxsc2fnmR/7sSevvw5RtLGxcff2rfOz4xeee5ZsA3Ft98FBpVIZjUZaq8uXr3Q6vfNO5xOf+MS9ew9mH7bhsN/pdNI0rdfrpm+t0YhIZPNCDYfQZLUkjc7Pzxeara2trSgKdvc6Z91Ou91aW1sbnWvrfYOthx4RYMCEzMZlFEWZNZ1e12i0hhmny7xgCTPGKKWILGeMyAJgEARBkGhdnp6eS8mllK1WS2t9dHTSSI0hF4lIRIwL4b/ajIkkTq0prVGGrLYGkXMhAykeHx9vbF956YUXcnrw1s3Tri7zYUfnkEapNQVn1F5otmqxLQfakZSCI3duqkeDCFOx3MnXFhl6eQDmV1tY4ZxzzlrNvLyCc4wBuMA6g75+R/BmZx5zJE6wFeFp+4WcM8YIvwTPGE7LgllBMOurzLLjKfyBLwiekmHgaSUx/8P8kifMtTtmzWuYjgZnXJ1ZD2Q+JYeP3mg66iSa6CfidPvH3wQIJyTNDwb8wRD5FjxZy7y36CRWiYn+pe92T+aUXpp3ymGZy3rlnBOWAACGE31O5EwwHkURR4zjmIiKLLfGIRovJMA5Z1MLWuN8g9syL4I8AfdpHYEOEMES8knhYOjptfDvMc6NjD24ExHOXTL3I8pnOP10PH2T2BytFQEsMiSLEAYCER0ROcsQiKMjW5ZlGAhkwACjwLdq1Dgviyy/d+duEIXbFy89e+2qkGF30G/Wqusry3/qT/3xO7dvPN6995nPvHzrzs1XX31xOB5XQ7DERFIRUQhcAAoBXBs7HGs3hlgkcdoIKghSwyhTIypKjMIG4RJB1VokPkTekaJbr2T57b0HD3ZrtaXLz2xurAbHZ+PTo8cLzkbNJeAanAOVExgApbUqyqzGM7ClCFGUZe/oECQE9VQVhYhCV5DlgZRRNhp3O8MwYNVa0j/stBdXMaxKElFcZ2HCpAwwBpeDGmdHuw9vvDU+uL8cszDmshKMbf2t1967/tJLzYtXyLmR1t2T09VLF5lAP98uh0NV5uBcEIUghHWai5A5KJXm6EQSAJdQZgBA1llt0Ro0ABY4MsEkRswMhnmeB0yGYQQOnbHO0aDbK8a3z84GKytwcHDw2c//2Hvv3vjed771xRee7Yz6uzc/SC8sX7ywlY9G7XodKykqa53u7u4uv/Sxu9/85pVPf6p/8EQwlFJ+ePPm1avXwrW18Kxz597d9IMPLly4sLDYvvvBDclZs92o1pLBeHTzxvuXLu4cHOxVq9V6vV4j6nQ6Sqk4ih4+fJhlmXGuXm/s7Owg4u6T/f39/ZOTkyBeCIVs1WuLzZpRpdUKyDKQiwutWq2qiuzkaAiO4iAoxllZ5s141TDLADkyZrQxTmnttEGUUSTzvBgOO0pDmtTDMCxNRoRKGa11ICRjTCnjZWoYY2QhLzIhWKNaC6NQaz0YDFIZKjIQiyhiBKwoCmuMZDyOAuNIKWNdWTCKAuGX/xuNxtnZSVhZePG5axaTr333ca5GFy5sdQe5yQfkXFiJHMIwU3kJPOCTvt0E1cA5sm4yFyUiYNzviHLG/A/grNfzAXJ+M1Ewxhj49ilyhsCIyJCz1jpys6fCeYqI5yaCJ12wSafXczQ+uvA5++7PBrlTHPzI7YfuPPt1FjPmOYGzUOE7CrPxAMxlqNM89Snc/yjQz+DeW7X6IOGUk1z46Gis0VqHMvAn6PtYkxWcKQtm1q2aB0D/u1+qopkZ0lTz4Cm4T5poxIBmqmGCC+apMkEUcmSTCSZnKLg2/jwZISdmCbidXBs2wVIHSI68XrR1xJjDpzJkzqfxyGeu7bPjZuAsAJm5td25fycz0rnRtr+RMTA1g3YEDJGAgBCs0dPUX3Dk3nYOQABpa8k5ToGUwklRFIU1qllLM6Uf3LszGo22L17gXP7Wb/zr3/vqb398e+NTn/n4rTtvX7688+zzzxEXGATAGI8rkITAOGlriPEwAgHOlNVwlcFwPDwf5aOQZ+gQRCuurAFfdKqhlQBRiHDEcF/nd7U+jMTFheaKBd7rnIdJ49lrF6GxAkxCdgLWWaMRHIsExJFkKB0cvvH2sHeehKDzzsHe/Va7unXp4sjoha3toBKH1RqIsCCugHMmLAU2WXPpChchNxDJKgPushyYAjXuPrgzOnrEi95KPaoLW2R9Evj+k/EffOv8wkthJBJEsrovOYJWYSUB52xZjIuMjI3CCIMILFruOEcANMYQJ8EjQE4FoTFkLFgHznujAHeMIYAjozQZYhEDzkFrYwwiW7t6+cF7t6xWv/SLP/u1r32ze3r60seef++9Gw8f3v/MT3z+MOv3zs/bn/xEWHb73U4sRXbWbdaqr73+/Z++uF2ppuBs77zzu1/5nb/8v/2Pi6IQksNgsLGxRgj7+/s3Pnj/1Vdf3dxcj1oNGA3BWXBm1O+ddU/b7bZSqlarRFFydHLCGKvX6/3BYG1tpdPpeTunMIyBbKvVaDQaJycjhy4Mkma9RtYMBz2wJhCsXq8D2qPDfUumvbTQajc7nbNOrxu7EWMsFCKQUWjDLCuUyvJcJWngDDjngCEKYFIIGTRC2Rv3nHMcRRAEgYyUUlbpslBKKcmZ7xX4FVNyEASBts5ay7gpjVXWjUdjVZSC8WotBWucI7KorTHWCWM5x+WV9XuPngyGanmrcmVr5cne4b0nikYnseOFQ0NgStct3TgrHGCBgZ4a0Tki65y31WSMGWPIOuIOGJ8hEREFUiKA4+hTK2uJM2TgJEeAydANiJhzNFEJRvSGC55FQ5P+eBzHABNtTKQ/PEeGH0kEcc5uyN+YmCNqf6Qx4FFlUpNMYwoAoTEmCAJtDCIGQZibnCFHYEA4eW5vNQ3oHCH74WPzOTtjbLosOaGETKQa2FMHQasnVYUQ3kiNGKBgDCetL4Tpjr2fW/jSaVKQsKm8I/P7ZZOhrlX6KbgrowFAFAUiZuOCcV9ZkFIqECIMJRPcGT/UtMaYwpiACyklFxIdd0Y75xDAgmOOAQE4IkDfB0eHhmCS1AOS3zOFCbsT2Y9cFGccPX0b5qIUAE7kgtk0mAMAeDSfhnskAO+uBIycAXLg13sF54zBxC7SWO/xGJjABUjIEQIBRpWRkL1x+eDu42w0WNvcqKQ1TvTa69959PD+X/7Lf7G10KzWK0srbdGIQOcQB8BRjcvuYOyYrLcrSdSoh1yPLZNCBhVn6lwmCAJcE0QDoho4ySwFMUBkIT89ffzmwf67K/JXKmmzVm/KOAEZQSSg7MJwBM0FGPd6Rwfdbsdo7bQa9LvdbvcCqc75cSWRMnCizKvRQlqvBQi5tbxSwbTuyJGIaq3VWiXmQFhZsMiNsRyREQfl2HAAo8GNN76vh2fLzXitGteiEJg5fXQ2yMobu6qroXXxue75cVwNG4vLUAm7e4+bOxfAaleMbZlxEQkZAnBdKFsFb/Lk0CIwmK6VkV9QdMQBOaAjS9aBF45zKIUQjMNktmYnbqJWHx8ftzWFAr/1ze+vrS587vNfcKOz5JWX3De+9ub3vj00o2uvvFhvVsG4nFyz1djZubj39psbr34WDg+KfLz7wHz4+uvXX34ZgsgOB+fd/vHxsXPuyjPPPHryaGXlU+BcqYru+enpyVFzodlcaFZFk3P+6NHu2dlJo1a78eGHBweHzz33wp07d1qt1srSojK21+uNRpn/Ei40a2VZqmw8IuedsEUgQikOD/ZrtQoDRwDMUiJluLyy0G6ePu4j58SY5FJKDhEaRw64MWY8VnlZ8oCTYdoq4jyIohrWjNF5nnvSFyOGyAGgyHIXBEEgAo6IE2USKQLlCnKgncu1ZsQKZUttBVpZhoFkIko4Ome1tdqQI0snJ2cLrbYhkfXOqkn7p7/wycabH3z97V49hVhwDCNFZlwqFoSBrGnEougEQSDCAJ0zypCzKHgg5GSRkAAc+QGY/xYKh4yIIXr7uhKNc9ZpYn533Vg7RWovRSW4YIwJxmfcDzYjywFYoHnmNptK5s7DN0wnijPgnucmziR/p0uU01+51xR3NC+EyZhxVhkdxpFxlnMeJXGhSsYY4dxGJRAwnL32D8UbnDaOYLYBixNA9+AehqGXGjYM/FYUA7K+Jc6F5JyxqYP2HJ998mrTU/NdLOZt2WebXIyxKHwK7kJIa40l58mLRlNW5FabojBJIhBTmO3UGme01eCcnLhgofdCdQ6ctV7ilBxNdcR9GWOs45z7VSYCRtNOi8OJdcoMymdv+SwKzeO7mNJjJ+/fVGs0CmCiVUeO3GQ5lgNx5i0rALzgrQUiiwABZyS5N/Fg5BgX1TgOpegNho1Ko1mvZUU5Go9vvPN+pRJvbW2FavjjP/55Y8tqI924/uzxozuxDWrtxrg/RCkdk1G1iTLBIFUgANh550GjEUsRVqqbGIdgWDmCcYFpoHg14KBovH/+5I3e6RsqO666SDlcXGjKtW0IAzjYu/X2m7u7u0VRAFmllMozTlBJ0nqtioip06lVKLEay0ozgbBZ31yDdlOiJAJWqQOvkNM8qEYCw1C6PGdh1VmdNqtAdnD75sGd26rfMcPO/t2by+2kvXQlGw4GualtLi9sbGIgd6B67+ir/RxEpR01YsACkCLJYNwHrXWpGBBnzBIY67QBwcGBtQRMCI4crAXyVtEO/LSLCByAQy8M5FzJOZdCIDIwM/sbAqurlWTn4ubek+MLW5uf+eT6k/2DahLuHff2f/8rUrI/+Yu/mAuyRab7tPd49+L2Fmi7urr8/W9/Z+PKJVhs4w3z7/z8C7du3bz+ysum3zk77551O48fP7x09coLL39MFwUuNKHfDeO42Wzev3+32axXKsmD9+9vbW3Va5XBYNDtni8vLlpr7927s7a6JoNI67LX7fcGQ0SMoigIJFoBzgJZcEaiZIF0ZExRlOPRmLk0jYUQZT4uIplUYsHClcUFra0y2ihtQVlNSCAZz4vSL/FZ64xxhXLCOutcs9HwZhfj8RicYV7hSwjNeJ7nRmGj0UiSBBxl+cga48BKLghYXigGHISUhM7YTGlkoQwC4I7IG19bhwDKhgExMKBNYONmrfXKs1uC9O0H45wsUAEY5UAYhBgkg1EmpyD+Ebc2RCklETHyGSTjXu3JEWkF1hJD/wDurTWtTePEkLNG+FR0WoRPKICzeaaHLSIqlZotJ6IXm/Kr5lMgm3QCprIwbIoPM7j3D/QqjLMWCk67K77xMnv47BjI2JkbhF+/mj3t7P5sfsOWfljghabd9qd/n140xpi22ss2hGFI1mqtlVJkDcwZhhA9taXjYn7YMOPRg6OnhPZJjTLtSj0Fdz4x+OBSCqqkfoJRYBYjIkIx8ZBlTHCrXalKTWAdGMBAGg7+zSAOSMAcAk7aO85vLwGRsQQIkysHzgI68mZNOO22TwLvJBlhYh7xZ1cQvKrBtIZyU6osj/2EgcAxZM4BMfDDEMcRGSNvk+VIT6MFC4UkLryuJFgjuJAyIiJVZoBsZXFx4fqzeVkMBgMp2cWtC3kxStJgeXnxwzdfu/7Cs6fnJ9ZhYZFxHiWVStgEkBm4YaGspcWVgCP2O+V4kNfTOK22w2oUBqkqegH2nRmcntw8enwLxuOtxavN1UVofg7KPHv46PDw4Phk/+TwoMhHSRrlw14UhGnMmSVOGSspDkIechhmScKDEEWIQT0hcK7XU1Ear2zljhOQZHEc1bhWoIA5GUeN+x++I4wWRfbGN752ePvDKhkz7F1YX+DjMY2z8XBsma1pwOoC7Gz/xM4nvvy1b//2N773J//YT0MibLdnhqN4se0GHUuOA/IgASGMI8ZFkKQkvO8BE4FkgNYaMgqIBOcAaJ1zltA40ACOIeNEKIQEBh7ZRRgCOqNMd//JeDyyBoTEwycHr37q04vt1ptvvvHKJ669/f579ZXFjavbtVrz4Gi/ubTQqtd0kUkmHj5+oEz5+Nat7Y9/3Ch97eoz5dIYnHvrrTeXllcuXbqUpOnFy5d656fD4XCzGgPHd996a6HdfO75Z7Ns9Pvf+Lo+N3k+vnz58tbmerfX29jYevHFF7//2mtKaVXmMoh2di4wJk7Pz4+Ojk9OTqpRjXm7H6eQeBwF1mJZZO1mo1C5YBjHSakLUxYmEOPxuBW1C1BKFdYYbayyoEutFKnSeHPQwXhYagqjlAksdQkAYRiGYZgNR0QUBIHzSp9EplQ8kkEgAiFHo5FnXgMwEYSAPMtLJBZFEQqptHHKMe6AK0CySjlnZMC5kNUw6na71tpGrc70uH80XIgrf+KnPv/733n9w4eds8yKQDHOrSNtXWGpEoZAYIwhhlJKRtyvNAoh0JEjYrMc1hERcQ7OOnJEFhiTjBxDQuScIRKXARB56toEsPS0Up+B4yx+PIXpiVHwLPOeR48Jms84mohPRQkZY3r69x/C99l9ZpNV/0c+7bl7bPXqNzNwtx9ltX80cf9I5m6M8Xakvi1O0xWtQhVIMByOnHMcyVqntXZGR14efLLEO+Hpcz7RQHOTxaWnB++ApuPGp0UMflSNUhRKGWO4lGEYRlEspeDIEJFXUJdKqUIZI2XsA3VZlrm2lpxxtiw5InJkgkGAXHDmld0BDAAD5jk5ZMgiIGecGCPfhnfOR85ZFJoPO2I67f1IJASYrcvOLqu/iAIZMbQEGi1jDMmbz7GyLJEzxjgDMGTR/8J5Mc4454DonCuNBmBcCCYDJLe+tGQJ9g7233/vAQFsbjavXbvWbCTXn3tuY2M9z/PL13Z6/cHi5vZ42G+vXjC6KA3LjHZEWWGQBVGcWPNYiEoSpxIaaXUZgsTpXOXnUezOe487J08gG22vrzXiF0CmQHL4eO/09PStN1979PjeQqu6sb7Urkda5VBguxalSWxLlY3GNu9bF4swtClLkpjHHFIpGhWKYxuGUXNBAz8bjEOFS412HFRAjwAIoogGJ//87//qjdffW00hMfDCVvulq1eL3gnp8uTg8HypHdYrmCYDLbqD0fZ2HKxf5En9tTff++KPfbauKK1Wi9NuaI1TJTAM4hTD2BDTBlgQBLW64VYZw0hIwZCYLQtrTAAAUjDGtAUyhmlglgnk4Ptp3paTHDABQgLTtizjStxeXP7uN7/7zKVn792+9/Xf/+qrr37u4oVNFLixueYE+4Pf+9qXfuHnAoC83x9k4/rODoRRlCbbOxe3P/Np92R3ZWXp7u3beqS3X3j+6pVLjZXVw739w6P9nc++WkN4sr+b33j/8qWdaqO6vrUOSSSPjz73xc/nB5lz7uTkpNFobKyvv/POW51O75VXPtEbDE9OTopCjcfjoii63X69Wrl+7Zkbb9+wFrK8KHOVVsK15eVGrZ4mUb/flVy02+1KrXZ4tO8MpVEccHH65MgYZ5wl5IJJB6g4MNTO2jhNDQl73nMO0kocRsloNMqGw1qtFgdhFoZRFMRhMDZ6NBqBtY5cFEVpnFhr+4Ou1rpWq2mwXIbOuaJQRMSERIK8ULVK1SHTBqwzWmvGIeAyiNK8KIIg4ggMyZYj0ppI50hf+tzLo+zbo0elQhswGDkFEIdhGHGnlNLGcM5FGAgUmc11oVkIzjkkQE6cwDHmi2kZh845MgYJEBxjzAsMeD9xxhhOxGomOMBENN9dwWlDN4pisNMhpNdBoYkK7HwMmAFZlmWzpHCWXxP5JvDkPjgp7BEArLFP6Y9+VGudcy6JYkKOXFpCRkjIzcTcDI0D63wvfNIro5n4wY/crLWeHDTtnJDfFvKsTY/AQggphfeYk1ICTDTRnCOvVc4Yy8vCXx9jjHPkJSKsnfaFZkn+7BrOzZJFo9HKsswYlZdlKGVRlEROCoGMkDNEbq3Ny9I5h8grlZpTyjk3KcWInLNMBEEUW1Ua5ziiDCMGCNYprY1VLJDaOAIz8czlzDqw1shA+u4RQyIgZzUR+dGML1X8+FtK6TU23dy67XwlpZTymY521hhnrdVal6qMomhiYMaYYMzaCXvSWuufkwBYyZR1QITOJnF8dnpaqVZ/6ks/aYz7H7/8lc5597nrzz67s5RUk4WF9qUrO1GtAgJAu7S9bJUaF9oRI4u1Si2UsjPsMwCjkZPLcxOJ2KoMTM6rIeT9UTE6Pr6/WK8m1Vq6dOm9f/aV9erWP/pv/tF42QG4pcXW+tpmWQz6nX69HhWjUS2JBWfZeJgPB81afbLDxky4sVip1+I0Oh/04lqVVauHJ731pVBGjUo1OD46W2psqH7/D37zyy9euVKLg7/2n/+fdh+MPvFcY7vZKE9PLiy2Gxx7zvEwyJJKkjYPOr3F1mrOk2RpBbAOPPiZn/sFk/f6veG4P1pfTtLV1eGTe4yTdrZRqUMcZedDg2EURk5TWWZxXGEiBk2mNIwxGQhwjoqRM44zRgRkrFIGGXIWATIyGhkHv1dtHQCE1RgsjntDS/qtt1976WPPPXmy//Zbr7/66mflzvKDJw+1s9ubG7fefWdxa731wnPmwxsQBcf3716+euWD92/c+953L1+73tB0fHiCxnn9WJuNVy9fWr18iU6Ozjvn7Xa7VMWde7ebzTpIBvkYOSwstcd5mKZpnuePHj9+8OBBFIZrq8v3798FYEVRhGFYrSRhKIMgKIriwYN7tVqtLMurly+lSXL31u2To2OjS7BueXnx5p2DixcvLrRazrn3P3hPBDIMw2qa9AbDRq1eaTR7/dGTvaPeKFcOwiA5P++KMLn2zDNHZ+cPH+1XKtGVq1cPHh455/b2dy9dujQeDqy1URycnSgZQK2ShlKMxoM0TZHo4vb2gwcP0lbqFdKrm/Xeee/8/LxaqXEuSq21NToQUSijpEpgSgtmnFXIW6Gh04qTiyUX3KIduSJ88dqFUXn33QdOgZOxsE5X05SXRRAEwgnjbFmW1jlLTnreOGM+wSSiifUxUZkXAOCX6Y0xflYKAAEX2lmtNYJlYqILZowROOEF+mTZt0SklIPB4CmVhaZmT4D8D8dS8P0T/zOfuiBZa7XVbLokNX9/NieKMLuDX+VJ0/Ts7MzLNfd6vWq12u/3ETGOY8ZYURRa6xmYCAxnpcYMnWgiijWVXJ8uwQKAtlpK2W4HiMgZVKtVJBAMy7JEJI6MzWkm+9jmtWGIyNMWnHNEKIKpjjz4tdAZVX2u597v95VSiChl6CYHB9qaAKUHzWkwMW4i0DNJgQUXiAREQgYyDIwxDBCQLIG11pElIOTSAUNAH/3Ij5zntBdwqgczYz3iTHV++pazuUIJPso6QkRlDXOCLDoHzjlCQCaEAEsOkXHOuJQAzEcL55w3ANNaO0Lvq+KfUxd5HMdnp6e//7Xfe/nll/+j//1/sLOzs7m5ef/2W1ZZyaUxDoCN+v0gjoLQEmG9tgiAmoABGqfqSYUzPszCElw1qchKDKTP9h83RCWKxe7ewfVnPv7+W2/e+P4P/tHf/d9cXbyqOibrZvI6tVqt9kKTy0CaKC9LMdIhD49OzurVeGWxXRRFkKSXL+/0ut2VrS1VD4gsS9PFlQWo1sCyuBmIdHmQ5Y10sXlptXfw5Nd+9VeffPDerco3v/LlD555Hj59NXpmZTEmV9laTZg7PdpfX13p9nsrG9ulY9WFDZKNkaLGwiK0NqHXOdp78ty1i89evwZmcPDwveP9e5vrS53uaZgmgAwsxmnNYADErJv4F4BDa8B7tRISGcOmNF7BpQgDh4SGgdEYcy8a4QkHgBY4AbJhtxfH8UsvfexrX/06cOts2Wiu7j959PjGd37sl3/5g2988/LVZw72nty9cdM5t3R5x/R6SytryBgw3NzeBsb6/f6VS5fffP0H1O/U61W+uvrgzdd3rjxzenbSaDX7g8Hac1fV2cmg3wWgw+Oj4bB/9dOfio5Vv99VSrWazUDK45PTLMs4l0KKYb+nk6TT6QyHY8YYMrawsPDkweFoNAZnt7e2Njc3yzxXSuXjYZ7nUZR0u91Krbq+vn7WOT86OtFaV4RMkkpv0H18sCdl2mq1ZKwOjjsHBwdJWgdHjx/c743ytdWW4MG777x3aWtnPB5evXwpz/OizOpR/ez4bOfSBkeIoigIhZ9Cx0mYF+MgFEoVUrZ7vZ7APE0ro+E4y7IkSSbyXg5KZQANkQUAxjGJagjOeatRMkAApJFcdn7Ubi49f+3iUD980nUlh9yVKtMWLM2pEZDfDwcyPjdH5F6wBdlE3supCcYBzSTFAJgxigARmHPOKDttiXM+kU962oeZfbUJZ47MSI7As0L+LeD+b7sRMk/fc0bPJBB8ogmMM8bAczQZI+cIrZfF5VyGYcy58LRO5yCOIyECxlgQgP/BhyLJghkozdjslhxjzI8jENEhzEoQQkLGvfoxR7LWWm2sVpwxRGLT6cOMLROGoZ/BcM6lDIAxa63W1k1fE9gEJP2vXqZ3Au6E4AMpIhKhNkYVhTEmSeI4jOIkZIxZbZTyXSoXytAn0ROev3XOuVJbR8j4ZG/FkCU7vc9EiYAmEwNEwolZ0jx2w7SY8rPpyQnCxNyApiqV0wmIDzO+NONE6Bwoo60hRLTkHIBkXFtLhOj1hAgJGGNcMDTGaO3tbDgD4V9lOBwvVapbW1vnnc4bb7yxt7f36quvWm2uX3vu7t27H77/4c3btz71uc/wUKS1ejHKS6PrYTUf97PCaGXzslxaXFGWWovPA5Rlf//08QdRaBY2llzW+W//P//4hRc+/Tf+07/VPS3/8r//Hz968F+dPfzguQtX7+/vxnUcDIfGqGtXL29urOk8654eG53vXNzZubCRjQetldVGo9YZj+JmQzn9aKTbzUa4sOSyzDqU1UZTNlVRCghvf3jr4a37N1577Q9+88unD+FT1+HP/YkXkqjfrtcaSZL1uiEROGsJWBBplNV66/HBWevCjsSoWm/woA4ugpj1T/YaH78GzgCSMebsvHvxyg4M+tVaE0CoPOdhLQorxn8NgMgaaxkZ5FxyiWAmbmFEfm7OQEjGCDKy2jLOAch/V32OwxCQk0wCEUYnjx//+E9+4YN3PrxwYev06HjhmUZ7dfl//O/+/r/zK7/y1re/+8of+dLaL/7C2R98vbt3OFTF4uZavLy2feVKGMSjk/Nc6cXF5S996SeQ83w0Cg+edDqdnVD6L0lRZuPD/aLIwjiAenXZLSF37vwsWF9t9fsHjx6dnp7XarWXXvzYyenZzZu31xcWiFaXl1f7w+H9+w+Gw6FSpl6rtdtt59zJSQeI1pZX/EextbC0t79rLd178PD0vPPSx19xjvKsSNN0OOjUGnVCCFTQardEWOkMjpRSL1x/7v7jPbJuZXnZ4Slom1bCrbUlVY6NLsNI5sWoXq/pMpMBrqwsScGM0UaX3UH/7OykUqkMe91mPe2MBhxpPBgKEaysrJRl2e8NvBGVEMIBMUNeF0MIxhnPlRXoJJJAFISEBhljzmhdpug2Vxczy6MnnQcHXW3KOKm5EsCLteOE4OCmDWhAYIgCGUcmp2hAXHiMnjZPp91XIQVjAExbo5QCIM55IKOnVTjBNLmcMN48rrspAY6mbd//WTefzE1IK1MyOOd8JmE262lM0EVw4yxyFkQhEWVFbq11QNoaUpMyxQO3NVZbI+YkdmEu9bTWAk3ubCf2J9Y5x+WkXCAiC8455yGUscnJTVot0/6EA/L1hBBCysAfuXOOCW4NEREgE4Lj1AXFzIO74AFDh5M1UmBM+CWo4XDk5X/DSKIP0ABEGAehLxMA0BlblgURCV5yoCAIAiGJgbEIgJxx4IKcIyDnCGCC5gjAGFPKCEaMsSlGT5UoHHkd0Rmj0/9dhiEROW+zN1WMY4hChowLAjCW9ETGiLQlGcbOOqutNs5fXM4l50KVmrz+uH86JO/et7S0dHJykqbpwsIC53x/f//rX//6o0eP/tjPfsla21ps3bp/+7vf+s6oyJ5/+UWZBHlRPP9iMB6Pl9Y3AcSo00lDfn5y3i8irQeMssWVJQgy6O194xvf+vV/8q//5s1//bM/8+O3b7z11//63/5P/9p//nf/i//7u/ffW1tfWL+00O/333z3nTv37r5w7fpCu11L4o2NbRFFjtUxZPudk7DZojSpLC1k+bi6vD4ulTrpC8BaWgPWlCEcPTl+/71bf+P/8jeoLBfSSI/gz/7xKx+/ful479HHr169d+euYzwNo2G3U20vyIa8d3AYVxvnI3Xr0V69tNsgX37pE/3js/KkE66l47N9abLe3iPkam11lajsdnq11iJrLdms7PSH9WY1jpAsiIB7A3RnDYLgDEFIv71ClgAAOfNOsEBADLgMDBhERDGdoTlnnGOWonZ9eHTWWmihha2djXFv1FpqxkmgivzaC88d7+4WRfG7v/bPv/QzP7WweWF///HYlI/ffPvVKK5uX4DTjiNcXFh+8vDRzidfguHg/PH5effuxUuXAaC10CxUubC09MGH77dajZ2lC7Z7zmvpSn3n4Xvv097NnavX1tbXT05Obt682WweRVGSJBEQLS62w1Bu1Teq1Wqv11dKnZ6eRkltYWnpyBwMhuM47ptScWRra2sAMBqN9g6fnHf7j3f3Sq3y0pZmsLnUqtQrjIn1rYtJWr9z7/FwONxYX7946crb795Enr/48ithEO/uPSnHI8bZWbcbRcGjR/fX1tYubm++9957ly/vINhO55whEtmyHGcZLbTYSS9vtqprK8uCYSB5pZIKxuMwghqRcwjAGePILBlnneQcuQAG47GWDAPhJHMBY4GnMTIMk7jbOyNZ3dlYklHa7XbzkVtK4MRwDzHIuQPylsYwlRFHAD+i8xm9p2ZMdPymvXG/0Mi5JATnHDkEJhgil5JJQcbOvs4wZUlO0BbIl3dmxmkhEvSR7sr/5G22hSSECMNwtmjqZ3huTujGn5RjnmDCPGGmKApEDILAI6xHMD+A9OIwyj11qqKnND9QSs167sSeBhUuuTPWyzIycJxzyYXg3BpDXgBtmrn747c02a5yzmmtzTRICCYdOmvtNOZOlodx3qzDz9wRkRyyeOJsa63unJ0ppYZExkRhJDnnxNAaG6BwQI4cAnpHZq2NNQYALJCvKzzxGSYWqBzIEJEjZt2UAO+rPK8JN63fiQidFUE0qWV8OwmIccYZs96wm5wlR+ArNvTLBG4SBsg4h8g9GUdpaxwA44xzAaCNsQ6UtrY0UkoRCADwkpaICIyJIBI8GPRH1kGlUrl8+TIA7O3tffnf/Nb29vYrn/q4gACdGA2ymx/cPDk72dhaH49Gh4eHzz777IXNrWxcpBxCUJkdLa21wfCT++9+95tfvX3zg5Pj894BXFipnez3dUFvvPfBH/mJ/c9+6fPds/0b7769Fa3UWW04HnXOhq+/faMS1y5ub8fpooib/+o3f3/74joLbEthfzw6N+X29uZxp9xeX2tWm0AOxsXRrYf/4p/967/zt//l1lblfL+4dmXh0tri+otxO3b3bt947plLB7sH3fNeLIN6vd5aXk9bzf5g0FWu0Vo4PD1zTHz44e3+qHz5l/647fUkADy5Mz7pQt6vLa93h32xvtEqFx/vPb72/HMgE4vGkSTGgAl05GnsZC0ZBuCAORAARDBtAjLGnCOrFWmSGEIUOtJsIg3Ep8bI2pC1g7zaroOIT+886Pe7rVrTJRRFwXe++ea//7/688HlK8s7V8C6N7/9nY//u39mSZVu2L39ZO/m3XsvPBfDwkKtMGABkXVuftDa2OwPupzz9upy2e+EaZJWElhduazGjUYNAvHg3qMkida3NmqN2vmj4dHebqVS2drYCILg8PD46OjEWOucW1pauXnzZpqmxrgsy+rN5r17B62WqldrlVpNct5qL/Y63WGv3+n1uBCE2Gwv1Rq1OKmkUhgHRyfH69ubrVYbSACKrLC9Xo9zfvHCpX63V4kTEUZgXb1WeeH6s91+780377aXk9ForAtYW1HVarqw2KxVk8FgcHC41242KtWk0awFAtvtVrfb5wK2tjb39vaq1XRhoT0aD5QqarXa0dFREARxHDHGytIZa6wF7/xJFAEhc1MlJofOkgEnGWZZZplpVRpbK42rm0tqdKgHPcTWBKEB/JfuaffEZ+hTdKGp9MHTtimA78oSgLOktVbWEPkGtCBgSlv5NF2dpM/AkE3qc99TniZ5k237/3ngbrRTSk80EMPEw3RZlgwFAidHRjtrLQnknHMmrSHnyIJFdMYYZ0FKEchIg/ZBSHApvHItwzBgaOfs9GavihBF0cyOYobsjDFLk6VPInLk5ukhs5Wu+eP3TSScgOTUaD4MkTHEp+QZRPR+3+Ij8gOc+airlGLcu/Chcy6tVsla5ymHRgCRI2utNUp7KBdS8iDysZGI8jwzlkpl/BoUeN8gAgnggNGUsmMdIkzoRP699IMA5xwZTX4FBgiI/G4uEXHOJZPWaH85CCfKJR7is0JLSYwxSwiMe5cvIFdowxgLwsjrKGRFnue5Li0YJyRjyAHAkjaOEEEw7PcHtVoNGOZ5fn5+fn5+7q1Yzk963U6/1+/HtWTzwvZLL7xUaaaHJ+2dyxc5R6dyUAWVeS0SiKYiwCV9APzWV7/yD//e33//9Q8qYdiqL9EwZCx98uDxs89eXOyc/Q9f/qeXL23fuXfjZ/7Uzx2f3wnjeG1jq1bNsqEa9Iu33717686BscXLn3hJi/Nf+BM/Hdcl1JNrr7x0461vv/jKLx4f7X94/3bC+Fvfe/0f/bf//fHB8NmtZru1eHr/zmqjff3Spay/LzitbC47yLNBfvnyNUfQz8qLVy4bpJPD063rH4sqFRxl25d2Dk46924+gof39dkxS0IYnK1UoXv06MKzW6yv1dkpcrG4ul4aR+PcYJDUhAwiYIIxa4wJwAIhWUvOr5QhWGOtJesmEdindISOI5cCiAMDAnQIBGCQHAJxNKWFUIBSi1trD+7crSbpwd7e5vVrX/zJL/7Gb//W9ctXn332ud/59X/zM3/+37v7la9d+cWfSR/bVz7xcQMwzLNqvX18eiaVu7jzzPnRbZDi9PT08pUrxWDAZQAAEEXu8LCxtgrOlMPB4mK7KLPz0+NGu9X+7KY6ODo6OpJSPnPlyqVLl27c+PCdd96TMnj++YV2u62Nu3fvnlJqaWHhU594dv9wFCVxWZaMIIqSap263e7u4z3Oea3ZWFldr1SSx092iSHj/OKFnUotXV5ddhaf7J+cnj69FM8AAQAASURBVHY9PW53d3c0Lmq1WpJUBr1+p9Op1muNSvXZyysyjd966+HWdoXA7T55WE2Tg8O9IBCtRr3ZqmutdJklaYSMlpbri4ttpYp+vy+EiEJ5fnpmDFSXk0EUd/s9KUUQCJ88BkIGgQAAC4lgiMwBcuXAGMusRTSUF2mloQmHvdNqY/n6pfV80LnxQema3kECnO+WTPctPR4zAuAzaqCHeHDA5mgk5AgRkRhzaIkQkDEuuJjMA4E/pTxOK3XwCSJOLTYJJySQacfiD7nhv6VjY4EskEMghig4Cg7O+roGBQcitNxXOpwzQLTlRN12Koop56nu88DlM3rmZheDZhtG1rk0Te2EsG3nFqlAa80A/XN6BwufCQVC+IEqR/QbqpMTmLbUrbVKaTdxt2ZuuitA88kxopnT4xJeYtcY47Sxhox3MVYqjkMk8tg7XX4FAipLba3lHIMgEFywINZczeJuqRUp64eigAiIcuoS6IDxSe/FuYky50QkaBJ8fDSzlnvBGQDnlRYA4EeHLVMCrHOWEQfigNyPJAA5OgS/EzsZ4xN5FXVGGHCHoKyPqIwxgYi+PiiUKsuyUkkXFxc7nc5wOEySJBtmxOj8tLcUyLfffieqhC9/4uXPfPJTucpXL21devkFKEuQEsajw3u37966fSO7sX//5Ju/9YbI6lc3Pnu+PzjbVUuNZ/dOH4YNGo73HR89OS3Xd5qdzHzlG9/4pV/6zHCYq3KYFeVoXAqZWoTDk+7m5vprb9+MK+w/+dt/6zf+xa/+d//k7yXVYHGl9f3/8G/92V/55eHJ+de+/OXDh3qxBuvt1tFe58GN7p/+0z95+fLGw7vvBGy42mwxbpIkjhfXFheXB1k+6J3nxA0ixdXa8tpoPDSMLa0sX93ZuHtz7/CDd3SeZa5MGuwLn76+9+DOx154JmA4Go14HC7vXC7H47wwPIyStGIcgFaCS601MIcgOKIFR9ahsZPVbP+WEQFjQSgtA2YZWBJR4CX+rLXOGSLn147TleW9O/c2Ll/t3L7/6T/yE9/7ra8aZ4HMi5/65LDXbzabwMRLH3uxe/PO0tLS7nd/0N7ZjGothyxNEhjnh0cn6/U2NOrtheeLhw8ZQ8bYaDRa2FiHtOKGgycHTxqtJoANQtHY3ABdDs9O8zyvnOVBvbohxP7+/oMHD5IkaTabL7744ld/9+2y/IOPfewlR6SUCkPZ6/XW19cNjOIgVKXp9zrdXk9wLkQwGo+XlpY2NrayYtwbDHuDkR8dvfyJj0dpoqwZDfPT09PhuGg2m9YNHz9+jEyOx+V4nGttTk97eHC0tb2+troytmpzK/3Yx55P0/T9998NpCzLXMpkdW250agf7O2ORqOVlaU8Hy8stGrV9OS0G0oOhLoowbnRaDQcDuMk7PVAchEEAaCzFsMwCALhnAMKGSNkzhE6MtZ6LiCBs60kRmXOz7ucWKPevry5rAa774z86pC3Q4Lp/vHE9pIRIAGbzt7IOifEFA3QTf01LSBnKGTAJh15ZqwH9KcK5tNhpCMEay2XAtikZEdCP5bEqYTv//83mtKsnXNZlnlzDCLySe6sxwLTbBqAQq86XjrGeBTHjDFtjCNnJz0ia5z1K06hCK02sxeaNdYdkDHGlxqcc5j23CcnO7Me9GcPjsj33Gnaop74YUyQc+6xOHWwAoYAjHM+k5z0LCPD5sBdKeX7TZ5j7rHed5Qk51IGzlmj9IwwRMaStQBiFsf8E4VhWOrSFMoYAxwCBOCMCIlJYIjuqekUeStCKR0xJEvTpV6cU0Gb6fR7TXrOuW9+sbklY/9sgknOpI+rFggInbPG2jCMldFFqZQ2RGTI+SE1N2itVaUhsIwx5llTDvrD/tramhBiNBpzLmbWVJVKtdPvDofDrWi7c3p2+wd3v/uD7378ky9rk7/wwnNJHL779lujQb8Shbdv3rp9+3C4Bte2Y0TSOdeywnQsdCFABBgijDqdgazA+ha8/d6DL/3Uqx9+cPe8e8YxaLebWrF+90gwkVaq48w+3j9eWm39xb/0vzvf3f9//73/+v/5d/8f//Wv/peXrl26d0P/m1//jbvvH1/frv/cl3buvPfh2WFnudn+Y7/w2Wo17p93VhaXlhfWK7EKWEbcEYi7Dx/X2wuN9tKotGmj1lha3T89NUaNxnmjku7sXMy7Z53D/YCxR8eHl5/bfunlFz/8Jx/2z09bl3YSZ7tFDoRhvVl0uo6AkGfjTBhbq9YZA0AGU/2O6QwMGZtIFRERFxzCiHOA3FiteVWSQe0KY403BGeCccbBmVqjXpydKmuAsU+/+ur3v/2d/sEBT+LP/4k/8ejb379/48alT7/66LXXL2w81++ehEny/u3btYWFS9eeg2G+tLS0uHlZ7x3I1eCNN97Y2toKgiCOY3AOGtXB/u7i4uJ596zVasaVSnF+HsVhdWHh6PFjWQg1GMgg2NjY6HQ6BwdHMoyfeeZKo9n87ne/d3JyYqxtNBoLCwtvv/1up9MpbSWKolqtVhaFUgYDCKLQ75oORsMPPvig0Wy+/PLH4zR58OjR9tbFZlMfHZ08eLh7dHgehbWN9YuVatto1un0hbDDwYgQNjdXGo16WZYP791f2F795Cc/vrW1dfXq5QcP7u3v7V67di3Px9aaOA7TNG0265ub67u7u1EYjkajOA43Nzd7vZ7WCgD6HWXMo1artbjUbjQaQsrReJBlI2ttURilVCCrzovkIgPkJASCQ2IyCCZdXV1m40Eg5UKj+qmPX7rxnYGbtNCJnLeLIfLbVc6Bdb7VDo6MMc5YIQIA8uRFD98OAYhUqT1xw1oqlZrxKaI5j9ZJBorgnJOMwWSpBX254EuD/7ngrpTyz6yUGo1GM4RRSk3I2dP2uic4hkJ6qXdPygzD0DmX5/ksBsxGl75hMugNZzA4GwgT0HA4ZIJPJAdwgqjWWhEIcBPOO0fyPXfOA2etb9pPeS+T45cy8A/0GTObYD055zy1BhlOFLSEQMSZZhcA4AsbCwBQFIXfAgjjhHNujOEySJJEW2uMC4LAWpvnOTBcXEx1USql0DrJhWDS76kWWcml4JwTMk8G8hVoKJ5KSTDGAJwz1lrLBRPIuLdKsc4YY6yy1i7EIeeccQF+Rup9rYBpa8mrlU0WkSfuvSmUs08GEnkJPQDgDIQQg8EAwDWbTVOqsizb7fbZoPBX3BhTFIXXdvAnOAsb0xrLAUBrqX1+fr6+usY5j6JoNBo06vXz8/O9vd2f/5mfjeP4n/3aP19ebL300kvvvPNOEATDQm9sbOzv7zPGqtXqYDT03FhrbbVRPz4+5pzv7OwcHByMRqMvfOELa2srjx49Wmi2Dg9Px4NcK2gvrO8fdC3yD27dfHT06Pe+8zu/8Mt/+lf/8f+5tih/+c/8Z1sXLkprxicHqbEXFwIzUKst+LO/8rOA5fLaMhOolAmCSBUqH5aBkMODB81m0zrNOV9eXnbG9Pv9UPJe9zwOQnKGWXr86GEo5HPPXt8/ePLZv/Bn7nzvuyenp63lxY0L2+fD/sXnnoVq+vj2re0XPwZG7z98mCRJc2FBF8VgMEi4kFKKag3ycffouJLGslGH0WjU7wrOpORciKl11kRvGTgH50yWe/cyAEBHsprScOQ//fdu3rp85Uo2Hn//+9//yU/9MavVqBiljUSju/vkwce+9GNQ5jfv3Nna3hmMioWFNdlY6O8fI0jGRDb+IB+Oqmml1WqDIzAOpCCOWKsBQ6uNGuegTACMGwLtisEAkQ06g1paC0X03W9+p3fa+6k/+kd3H+9Za0/OTg3ax7u7n/vi5xqt5u994/fPOg0iYlJcurRzfHp08+YHjWatyDJd5pU0blWr21sbO1tboeRREC4ur+ye3tnf31eajo/O6o2FrQtXTo47Relee+Pd/iD72Isf//5rr9eqLeNodXVVCGF6D37yJ3/y6OioWq1ygTdv3nz06NHP//zPvf/++2EkW61WGIbvvPPWhQsXvv/999fXG1c2P3t8fMilkAG7f//uo91OvQWXLu9sbK3fvX//9PQ0rdaSJLHGiSCUUha9fcaYFKExpijKKEyiKClLjeip1pgkSRhKD1hSyrduje4+PNgf2JMc1i997LQ3IutA5wupYOWATG7JWRkYWdEi1iASt2+McwRhGAdR4oj1h1lvMJIyYFxKGXJkAF7dXhtjEl6G4eT7aK31G/KWHOeSEIFxQG4BPHHZOFfhc6S5aS8bET2Iz9rfs3/5dGUfpimw77cEQaCUMsZIKZMkYYyVZZnneaPRUN5UGdFzwWd9GD9T9WnuLDAACiLyAnNxmvrNGxFIIYS2ZuJNjTB7yOyYAcCLQiAiRwYwacXQ1DPW3wQ3P3RST+e3c7cZamFQoWmDi0VREEVRGIa+da70TPLCGmOs1t78O89za63kotfrDYfDfJz5SzPhdVobhiERlWVZFIXnWuLU94SmjPX5UInTJV3vxEhEDIX30qPpSc7+BQAp5cz85emJWWOcM84ZY621xjnydoFCCBl61JYynOX7ni7qnJv6F08G6O6j2sITKs40pCPi8fGxj40LCwu9Xu/s7CxN0zfffLPVasWxXFxctNaenHS8a5VfHfDhkKzzqliMsWKcWaWttZ1Op9/v+2jBBSKzgA5Qray2W4u1w6NdR9lw1PnSH/liVIv/wT/81YsXk1//9X+1sLDwl/7SH9l99FAKtrm+URRweqyef3bti5//dBAEly5dHo/HlUrlk5/85PLycj7Mdan8ZTLGqNIUReGXLZVSZVkOBpOELorDJEmybJTlo/X19f133rn6yU+ura11u93BYFCr1TrHxzAa16rV0cFBdnbebDSSOB50u6PRqJKmcaXCASHLAKBarQIAjEYAEMdxGIZcSsBJ3mK01Uo5bcEYMMZN2rLTWb9SSinRbpMxFy/tFHkupYzj+Ph4n0tmyIgkjrfWP/aFL0C//97bb0cySCvVJEmUUsBlfWklStJOtxcE0cLicmtpBXjgSu0IgUvnQI/HtlCTvUHOiMBaW6oySpKw0ahUEyICztO0MhwOv/f91z788MPT80692W7UW0qZ99670e3219e3ut0uIhZF8eDBg3ycMcaOjk6KokjTdHt7+6VXXv7MZz5z+Zmrzrnd3d39J7ub21sLi8tKqWeevQYAh4eHT/b34jheXl76xCdeqdUqFza3kFG72WAMOMdqo76wvFRrNpQ1D3cf/9hP/sTy2uq4KJ772AtchoUy/eHYEucyvLCzurK28f0fvN4fjjq97g9ee+Pxbufqs6uvvvpqvdF47bXXer3ehQsXGGPD4TAIgmw0RHJbW1vNZhMZ+Zaxx6wwlGka12q1SqUiJdda53me53lZlsutSi3hAUIlYOPesS1GjFQksMgGgM45U6vVfM92OBxqrXmYyqgqotQxWRqnrZNh2Gq1arVaEsVIzmnldCHAViLZqqXGOePAeLajp1cxZEwY5/zmygRACIgsn4o+zr6kMyiYocqsQzBPf5z/Rs+6ArMh5wyjhBAe/WZPSFMD65m/6zx2lWVppyYh87ALcys7c2rsANMWt51KY/3osc1aF/MHMGv4eFieW2v6yM23OmZdB0HOcY5RELrUTVb8J0LSE+dWo0rLpT9bKeVo2HHOTaUpn8bDOElMbpVSxpEMAxFIIDDOiYnfNU6Fh5jjDL1xonUTuieAYNzLYCKp2bHSdC0NAYWU1gE6Zxw5QAaeawcOkMh5xWQ2kxsDJhAJmBQhoGNMcO6EcNYSl0Ip5T3IZym830YDgJm7t9fAJ6Isy6SU3fNOs9l0zlWr6dnZmTGGc1mtVr/xjW+8+uqrh/sH+/v7QoC1NgxEkY85A8GxVDkiyoCzjIQUZVlKyaXg2XDAiJbarXol7fVPtzfXzs/PG8201arnj/efe+Fipdp+670P680AhLm4s9FY/rF+fvyD737vxedfBPu1W+88fuX5lS9+9rk6M5vLdQDYffSYXJHW4vXVDWPM7qPHQoiF1uLBk4M4ToUIfNU5Go0YQFEUhTNSSmOMKos4kq2FZn9wfnC0f/HixXw8BME3L2wFafTw8cPnXvpYrVbtnJ82ms2T7nkURY2FBavUMMs454wIjC3LsizLNElEmtrxMM+KOI25EFMdEAfACB05cg6sNQIE8/IYAATA/JXWjhjCeDwaZtV6xSgtK5VPfvKT7752b3l7rSpqRpdqdzfZ2balWltcPj7vgXa1tKYdp8FwnGsZxFtXrhRDEwoJXNA4VxajJIEwKPq9tFYHKTgCcOVQgdPWOa11t3PYqDX7/T4HHjUWnn/+eQbcaeccdDs9QpZWK+3FlU63s3dwMhwOVaHPzs663W6haXNz2RkqcnjxhWfqjerVSzvDbudb3/n21cuXVxaWjDFHJ8ePOg+fe+6FWr19ft4pjQ4iunLlSlkYRKpW093dvYXFZn/Qc6SGg3x5ebUsFHJ2597d733vw0uXFvqD39vavugIn73+Qq3eevfddx89enTp0uVS2d0nh43mQmtppdM5z8ssTKv1BSmDaP/w6Kx7Vq03iyK7dOlS+eGHt+6cbm5u1urVPM/TNHbOFUUBxNI0LIrSWRvHlfE4p4k4CXn4CAIBINda4UGK0cXG4sXn3769/97th5aL9e2tvD9GZ6q1lHOsVqunoxwxIHKDzHszcOfAOc05j6OkUomyLHNkiKwy3iiYEBEZGUfMOgcTeShgiOCdfzghIE3IOIAkiBOCVXYG6/N1NpuXg5/+fQZ5s3/ZnNf2DHZ9z4Qx5tN5N6Nmwlw7RYhpA31iQTGDdY8k/l+Ph5OBBGNBEDDGPFXEP+d8JJip4k5C1IxJOb0zzalCzp8RzNnvzSM7AJRFOQsVgog452EoglCUyvheEvq5hxcMIor8aBvBH65zjiMLpQxkIJh02vhO2SR4TpXpaXLVCKZGJCDl7OICTSYkiAKRuBBSSM456ulyATBEiwDe6BOcm2rkADnrYLLbahk4hxbAOQIg3xjjjGlLzFpgnCN3FhgTQpC1hHIqYjbr8c3pWsyu0ex65Xleq9XCMOx0Ooh4cgLj8Xh5eRnASSnff//GhYtbeZ53Oh2/mB7H4Wg08hWbynIv/OSMdkDgbBIGlpwq80a9srTYzrORhXxpedNRXqp87+D2rTu3ti9eFb39UvfvPRgAy9NYPNjvXH/x2u9+5Wv/x//kP/q//vW/+jf+2t/snBwvXL/akpSEmEasVW8OBv1ao3Z6enp4eHx8cHTp4uU4CM9OT69fWve6bzAeqdIguKIoimy0stwu82zQ7aVJsLW+QaC7553BuL+x8wwMBzIMV9bXeuOhLpWI4sRZJmXIRCgDINBFGckgCAI9zlkYRVFsjdFaiyRGJpQZRTbQ2gI65jMgDoxNyhfjNCICCsacJc9MQIfgrImq1cHJaaVaycbjJE3VeBRsbdcfn4/VOF1ql93zW7duLPXPWgvtheXVhe3Lg5Ozx3vHC2tbqy9sVzTkw4xkGLUW7Whkc4WEUVKFah0YgshASOAcyFlCAiZEwCLGUZhsRGSLIi8zFQcVdCyKU8PtxUsrP/jBD8YHJ2sbcnPj4mhc9rrj4+Pjzc2tJ0+eBEEghPMFZb3unnn22a2NjbXPfAoeP/zyr/+rd99//2hxMQ7DtFIZZdnu3sHGxmal1vjEJ5Z+48u/vbW50x/mC4sNwWE87u/sXEBw3d7AGKhXo8rKpX/0T//Jn/yTfxIFPzk+G2WFDGPj4M233x2Nsk+/+oWXXvlUr9f74IMPWgur3X5uWPXJ8Qlj8My1y2Eoz86PCXSapkdHR81m/fbt2weHeytLtWa9VpalYHh+esYYEwy5ZHEUCMbLsuQMEAwReLoHAknBBOfkXMLHm4ux5vXWcrq7a57fWVbahZjzEEe9MqyEp91ue2Vt/6zbWGwoh+MyYLPGtHaMW6CSnJOMsUhWYskAnC/ilLJWgwuklB7RAYBxjgQE1n/9/J4tB5zKhoGaDv9m8OfmlBpnQDmP/vNf5/llTvF09jvp8ARB4D1aZ08+n2LPosjsDs45OyeL4lFOa+2AOOe+Jw4A3pkE5rQn57N7/4Mxhk9Znmyu8ghCMR+05o8E/rDbDNmstYIB+t1N33dWhSnLEpEFUhZKOWMF41Ec+CGk00ZKCY44olcoFkwSMsaYZ/gHccS0Nc4aY/wF9krwRMSYtdaGHt8RrDHIgAkuvE6Nl3BE+NF3BREZkrHWEhlLzjnjAH0/DiDXk9YQOBLIDCJjHBl34Kx1AhkglqXmgEAszwuWMkT0J+tLrT/0czB/sZxz1Wr1/Py8Vqudn3eqlTSKojCUb7994/r1K9/5znfWV9c6nY7PhSVnqiiSJAHnkIgjWq0FY0WW+YKrHOVWQ20xFYD3b9/pFSf/8l9++9qzcaUavvzyi//Lf+9Xvvnt7x8ddx7tnz55OALVTyvy+Wev/Zk/8ysnJ0d/8PXvfOmL/4sr24uRKQedc2Rm88p2GgdK5S8+/+LB8cGbr72Z1mqXdq6YQt+6dxsc+WxCiIAJWeYZZ+CcG4+Ho1HIEZCzQpVpLb0Y76CASi3lUkClkh8fn/Y6z7/ySq9znvf78eoKqNIaY4oSYsMJGGEAjHOhijJeWEiRFeMxGMeEkEFkCRxMvBkZUIACOTAmPAuCSwkEbPKtmNjVW+cgiOJKyhqNJAj0ODs8PNwOgsuffOHmO+88u1QJl9orneXz09NIyMF5f+WTn4lZEIexcwAWQYYlFJIJETYoszwIuZCgFOQGoihtLubjzHHUWps8Fw6qIuRBxHjY2BJg3KKh8SDTWmfD3FqbVquqtNYxY12pgAc4yrQMbRjWVelMqZqNVqHybrdbrVYXm7XBYNDt9/gbr2fDwdrmRjYaPLz/oN/trq+vQ0zDUa60C4Lo4oVLKysrSRodHB+1220i22pVGLqVlQVrSyGqRT5stxc+8clP/tZvf6XRaFhyJ8dn159/4crlq51Op9lafvjoyf7+4ec+97mbt+4/eHC4ublx2imSehuZu/dodzzOGs1o58JmvZHu7R9df/65D268F0XRj33h1dPT0/0nj5vNpspGcZz6FLUsc85lEAql83a7pZQqisLapys8ShXO5kvN8Lg/ePDh66OTzisvv6IUvvPOu4sL7Qo3SmUBQq9znAYAaiiZlEHF444AJ5glq1VRluORYCyQGIcyCgMhUTDJuHMGHa/5dNh5/WcOzjnr7ZonFHJijM0ywVmy/EPf09nMDOdoF4g4KRE+2raeB0c3p/WIiFEUzXpBbm6p1Xeq3ZyTH872hrznqDGglO/VCCfjOJ4l12wqpkJEMw0cIqIpNhLQj0LQ9LD/p/UW5oHeR6zJotNoNOBc+p77ZKppiDGGgY/AJIQQjDtjyRkCywAtOWMtEjgmUAivdFMUChGFEARotDPeUInhVH2AwIFz3DgnvCaM0YJx/xHgiERP5WX8NbUOrLXOs12ZcG5CNTKWyG+3O4eII10Skbf4QsY448gEME7OGGtREDgoizIUEhG9R8/McNaXnxMdsR+p5vzPcRwXRRGHkZSyXq9rXcZx3O/3rdVhyAaDgR8bhGFYqVSOj48rAgG8OZFLkiiOY6N0rZLqsogCiYgMIA4xiUJdFqfHRxTqX/j5l27eeufizmUZwPd+8I1nnr3KA/gP/uLf+XN/7i/843/4q69+5tP/t//ibz3zzDM/9zO/9NprP/iD3/2qycbXrl+7urkW6HEtSXudY2fHg8FqWZaM8WatHgbB7oPH56dnFza3CzVpFxaFGo+yJJaMMWvp9PS02WxUKkmh8qOz4zgKuBRpoxJFget38jIrigycDkMZN+vQ70IUlaNRMRxW41gKkWeZIScajaMP7qxYCMPQaaPHuUyipFYDIlTMGmWtRvRa0EjW+PIWOAcA4YQBYMCJLBGFSQxZJuM0PzuNl5b7R0dJWtXGyVo4dsWoGFfajbXtjX63k8bxYDC+9/vfuHD1+uVnnjs7H3T2DyrtZeSBSOsw7hFPRBqBpe7Z7mAwaC+2KstLITIDzjpwWFprlTMRc+gIVAZESZKEIhqPyuE4H2W5o0ArF8SVrDfqD4r+WGWZJRprrc/OekqZbFx0+j3t4PrzWy+99LG0mrTbzeOjw173vNGobV3Y3tjaOtzfz7LsrQ/eeeWVV7Ql0vrNd96+cu1qFMWNVuvhw8dlqVutepb30rS6vrZcrzcfP37cHY5Go9Ha1uaTJ/svfvwTlUr1+Oh0kOWf+aM/8/Xf+p1HT457veG3v/dGb6jWt3fu3HuwsPJspvuj/mA4ygWHpSRVjp7s73/6Mx9njNVqlcsXd/IiOz463N7a7HQ6iwsLo9GIMRaFMssyBBeGYZ7nQBpIIziGLgzCIAjKsrTaAJRg3EI9TarhOM+6Bw9KDdXAPntxLU3TO3fuyDh5/e1HFzcbD/d6PAQFwjrDCIRgYSCElBqddsZZXViniqzvSd9sWiinNT99McYioiBmLSllrHUeOjyT2tv9/VAr5kcBbh7HJ60PoD/0PvOV+ky3yrnJVtEsisCcb9/sRSfPzBgASMlnS7B86rwqw4CInLVezcZz1f1/zX74COCgN2OaHvTUtomIjBn/oSA+r7U1e0IiUuapEZUA55TOrC6jMAHOJBeBQBlEAAAyoIQ454zAE4OSKHbWKee0sco6JMAAOedI4EUPtDHGzuj01mknuEBkXICUMpi4khvwxCNmheXWWsO5mJorCTKMMQLmI6p3UgIHgnPtKTLeutUvqKL3aUHrq3sg66A01qJljsqiwCgCZFpZKWUcBIzxUikCED640VRXnvPJ2/AjhY/0g3hH1WpVKZUkCQKMx+PxePzs1Ss3b969dHnT6xZMztoY/65bbZIkkVwM80Gr1UqSJBDCGFNJ4iRJ4jBExHazuXu6X+Tqr/yVv/pPf+2//8pX39+6CP/0X3zz9Td+q9PNMgW/+Zu/8f/9X/+H27/2L/8Pf/mv/NzP/0y1lp4d3hTOLDaqjUqasqiSROVIXrhy/fatu2k9Xl5a5Uw+uP+oyMrV1bV6va70sCiVNXo0zAb9PsNaGPrlaTcej6u1OCuK/aPDWq1iyaT1WpQmJycn2pjFxcWzk5MoSSAIBqcnNSFq1epoNBr0erVaPRQSLIFxSKx73qs3a2EYKatQaREFZBQPA2JIGhAIGWcIxnEgskTMATDmB5sIyLy0dxCWwwGU5XCUxdUsiKNaWoEo6pwebF/dzspxJRsA2Uoax5VK3Fwqbt1VuXKD0WAwWl3eDJpretg96/XqjPGwAjKCYjDOnbGsNCjGRdSqBehkGAZCUlZyY0yhbalsvyNFyJgwxvb7w4PD48ePDkaj4mMvfDwIq8Ps3MJAacsw7A/Kbrebxq12q9rpd2rV2vrW+s7FS1euXqsstcteh1ZcrVY5Oj741ne+F0q+srQcp+kXv/jjfn62sNA6OPgwyzJE/Pznv3B8cvjkyeOrV681qg3nIKiFCwuLtUqkBP+N3/jNSqWyf3D46PHulSvP/Pk//xf+X3/nv/zWt19bX99YWFxJ0oYQwd7+qVLw/PMvvXfnaG//CBEuXlhcXW5V0gBRcyMajcbtWzfybGSs7nXPhITFdh1JL7Ub+/tPkiTZ3t7u93ta6zRNiEyWDxAnBjpeAopzzgUjwctC1arJYn0laba//9q7466tRcipWF1cbVSeK4qCin5abzSEGRe5GTmtrdYaS2LEmRABWSEoqdSMMYVWSmsi9CtFnuLMpmbWiNwKYYxRyghv9k3kyCKCA8MsTmhX0xRwBsQz0J/Pf2dAPA+Cs9vs77OHuymdfAoJfP5pZxnhrDLwx8x5MKNu+x+EEFESj0Yj7fk/jPFA8qlA/HwKC3NTAcYY0lPYYVPvEaM/st8z/zPiRxJi/1iv2Dvhniy02rVKNRASGXEkDsg5FxylEHEcVZI0CkJk9P9j7D+DLcuy80BsbXf89fd5n95nVma5rqou1wbdQDcM0SAB0Y+CA5IhjRgaxvxQxEiQIhQjicIMGUEzJBikqBkSBAESppuNRvvqri7vs9Jnvnze3nf9cdvqx7735q3qxmhOVGS8eubec/a551trf+tb3wItGSalqOB53gCjpbJaGpFz62tjjOGc54IrYwAjBSaXwp4oo67r+I7nUkoRIlJrKbUQIhc8z3ie8UzwXAqupFJKyEFOPTq0EpRSZu3bAEBro6XRUitBHGYt1jDGxoAYyHuyOE2TLM+5FFppMIy6XhD5fmhLi3aTBcOp6uO7thGy2zth51VyzsMw3N/fH/X41uvVw8PDixfPbm1tZVnm+/7W1la5XE7T1G7N+kkshEiSpNFI0jimGAshsixjhBbCCBkgCM9MTQdeVIjK/+M/+5d372w//vhEuVwslaDT6aRpGgTwjW989E9++x/9o//+n8Ud+OYffTeP0btvvcETrnm+tfaw324FrqeE7LS609PTnXav0+kpZfJchEE0OTmZJTlxXIOJVDrleZxmObdSUcyY2+v1e72YS6W0Ia5XqFaLMzNZyuu1yaOjFsa0WqkrZbY+vlmsTxmuCnOL1Uq90+zk/RQXytjxod1bPn6iUCiEQYHWJhzHS5Ik7vU73T5gAtiaxBFMGBBKKcOMCSWV0WCMtqbYGAHGhDAQwnG9lOeTc3MyF8WJ6STPeNzvpJ2JS+cSniTdFmAzMTVpshREtrCwEJTLTqVar9cJdUCmnSSJimUW1bBfBqAZR45fnJpdKpZq/ThLurHMBULE8wO/UHDCkLkupVQLyQihXuAFhVKlOjO/UJ2YNIjee7DONSDsCYUPGx2pMCDX9YpAKGa0F6fTc7OXrjy2d3D4gx/96O71626xcNA4itNscmK6WCymudBgiuVKpVyXwmRZ/uqrP8nzfHp6ulKp3L9/L4rC9Y39w8P9qBTFcW9nd3tzc71YjCoTk//Ff/m3KhMTAqA8MXHq3Pnf/f0/YH547+H691/5yQ9+/NrHt+++9uY7+40W1+jOg7XDVqtUK567eHJhadFg1E9iwKhcLhcr5ZdefqFWq+7ubj7z7JPHlha/82evCJ64jDYOkjxN5mYmF+dnq+WoVPALoRsFrFwMK6UoChyClJZc8VwLzomDgsJRt/f+xx+Ui8FLzz9z7cpy0jN3b9zaeHDr5MI0Ff0Xn7y0WGZffubikycmLy9Pn5urLZW9CpU06+luS/W7Kkv6raN+r5tnQgPRxAW3gL0yeGWCDB6MXEWEEEwJdRhhDqUOpg6mBFFCECYIYwz0k0n0p/LocbXMOK/yqed69IefQlLLZljXFxjmzqMfjZj9QeqmlJVOWjWBlfxZVBntCSzUjLQrMFae1cNjfCcxLoaxrzPCfTwU9ozkNKOtyTheGWP8wC0Uw0q1NDlVR88s1TV61CpmjNEGGWMK5Uqv15NS+kFIKU3T1CJ4VHB7vR7PcowxaK2kCTy/UqnEaSaNzjlP8zzNcw0GM0oZC8mgZus5LkJIG0kp9V0vTeO418uyjBBk538P+Kw0xRgwHrb5Di4NE0Iocy1jJZQZ0WS7mVBKaescSYitf2MDyGjPcRzKEGgtpFKKYkIpldSYwYjxwdqNQvSnPjH2vkolEEIj32qAQUut6zLfcQkhSguj9CiY7xweOGTgWowt/U8IIQS0DoIg6cfWJRwDqtfrFy5cOIyzLO++/9GbSyuT3bixfHxBYXjmmRcpi/7e3/vHYQhzs8v/4Lf/URQV/sbf/N9GUbSxev3ksVrV8x4/d9bT8tj89O72w5UTC1HRv3H31tKxlTiOGaJLc/MHOweT1Vos++3W0cHuXqfdnJ+Z8T1n8+F9SjGjaHp26sOP3p+Yrl+4dH53f+/ChXPzp0/du/5Rs9k8e/5c8fix/vaWH4VbO9u1iYkoisB1gVJIkqO9/X6/XytXork50+NJngFGYSkCx9EizYXABPr9nuuywPOQ0ZJnSkgMiFIKxD4kgDDWQkrOETKMOTzp2145SrDnecjaBih1L9meqNZMlpccHwsDqXxw697xc5fSTtrLzeRzL0Jm2t2kOLOwcXCYK316ZRlkbrhAnBvJhcw5T3LFa1MVg5SSXOWJowwCgFxCmoJW0Osn3X6zlSSx0Ibu7R7duHk/6YvTp8/34qzV7Ozs7M3MzHW7Xc45ItggtLS0RBhe23hYKBeOnzxmQBcKIUZGiLxxsJ+nyfLSwsrikjFGCPHRRx91+p1mq7Gysry8vLywMLe6ujo7O/uHf/jH7XbnxRc+/9xzz7/x+lvf/vZ3nn/++d1usrJyfHp6eqI+dePGraOjozu37zeb7VKxUqnUPvro+ubGgecxrTVjruM4bY4xAs6TQuQtLU7zpPtLv/TlV3/4Z+VS9PhjF7733W+fObEyWa/Oz879u3/3b5cXlyartXq9+v777xdL0ZUrlzqdNuecMXZ0dNRoHGkNnhsIoXkupdRZxv2pyU6nw7nEyEl68d5uS0qIwqhaqUdhWCkWAo/xpJf22qHL6rXKQXDx1q1bQRRJKb3Af/WNN1c3GszHbqG0udcKq7VYKGD+UTeuTc3Eaeb0DiqVaj9N0owHUZFL1e12fd9HCCGjkVFaCSQVRsqhlFKsDBl/ci3YYYxHO+9PHRQeQbMZo2JGqfEIcy17adXSeExvPQoeds6EfaOhzJrlXI1OIOMcADzPc30vz3PbyGqMAfIoJlkG2L4dKI2sXBITALC1z0H+OqIQdDoAkNFobAAA+POu1y9VRpEDvXBiZiyeIWuDYDTKBU/THAi2WpEszYUQiOBSOeh1ulmWOZQihEQmkTWyIdSSZFzKVHChle2ypVIPh8NiAABtLHfmMidJ+pJzxpjnORjb2cLginRczQIAQAb27iMVzfiib/UGUlNkgBBMLcNjNMaYEYQBWeYLm4FNRFdk4/ujTxWvx3dJ9pA8h2F/AUIIQFtrziTpu5RhjA0oionVPGmt91stMtJTIsQIcRyHESpzbuMsxtgoDQArKytXrlwp1mcPmvuv/uQ7m7u7sYC/9Zs/d+7iBSnJb/3W/0tp92/89b/z3/7WPzx9fPn06bOvvPLKCy+8sP7w+4HDPnPlse7+7tmlhbTfOn3qGIDa2t9MZXbx8qV33333/Kkzl85d/OaffOOXvvJL7954CwNSkh/s7mgu8jRN++3l5UUp8oxnmGENShn53Auf3d3fe/rZpx/cuR2GYc75qSuXAZk0jv1aVaaJlQFgjP0oAkx4t9tsHPX7/ROXnwApQCttFNdKGYld4rpunqeEYooRBjBKGqm0EqCNJoMNE8FEKyFyboxxGRE5VyK3mgHXcQgltiIbV5DMuUxTFWczi8cgzvbvrkVRKazNHh12auevgiaSuHRiOU27rV5vqjZBkAFtgOc6SbhIASRmhvoUkJQik0kfc+EojYVQGVdHTSEUJm4vztY39g72Or1+3ullDx/uRFHJc6NSqbK7s1cslnu9XrPZRA7e2u4+99zlv/gbf4kwvL2z6YVepVJqHOzv7GylSd+lBJTCoCmlSkjHccrl8tr6alQMhcg7nfbTn3nyw+vXn3/+ecfx7t27n2bSYd5jn3nu9e+/8tprb3i1KUppuVw+PDw6f+7i/fsPlFJCqHpt+vXX3mg2mysrx2/cuIWAzMzMHBwcTCycuH375uLCzOL8DEbirTc/mqxBIaKT1dKVy+dOrCz0u52pifruztbh/sHR0dH5E6empyfb7fbm1trkZL1SKR0cHHDOkyTJMo4Q0QqlaU6w4zgez+W6AMlziknoekqoXruXpZJgx3XCpcVFUDLttiuRS2W68eDO/h5nx84jhHpxvLm5+bmf+1JYKr/z/kcf311t9JKoPq2c8KPbqyQsGydwg8L+4eHxQDie12i2uv28Vq97USHJcgDgnCMDGLTRHIREIBmx/U3kU9n6CIh/Jthh/QnlzAjlR3ob+IStjRkHdz3Uv2MrtvtZSWGc5Bbctdb5cIgHpsR13YGuxBgr9bHvi4fSdTOsFGKMMdjJ4INkfFQsNsYgyH8a3BFCQoifeb3KmpoZY4yh2prGDFNWZFN4BC5ztFQakJFKAheSSyWxJtZEAlnZO6HAkO1yIswBgjEhVnWopBFSCiW1Ajas1hqjKaVK6pwnJMK2h5Ux5jgeGfoHBQyNIuojkROhaNj1i0Db8GbXK3BdC+7Y2J3UwC2TEQQAWgmtlDHKYIwowYwYPrpWgLGt2XjF/KdZGv3ojg7uR6FQwAbsFgsNLYHyPKd2wNCAUwNsEBgMiESlchYnruvaRjAMyPdCRt29vYMw8p9//qXb9z4ER126+PjO3v5//d/8S8+B3/q//h/n544TgDzlb7z2upbqf/93/u6/+lcbMsl2dzaOz8xxnh07dkxr3Yu7QVQoeJXNrZ1nn3uep9nX//OfTk5M3rxzO+O83+0ioxlzgzBKmJP1424nmZyqNzfWJmcmC5Xig7WHp5554db/999845vfmyr6C/NLQRQCl3Ga3H+4unxsxfE8f6IuG41+HBvAQbXqlKsBl3HOD+6tFitlrxBgTJHRmDoYI2W0E/qgtLEWntRBIIzWUgll+1QxJhghoIAFKKM1YEq0ZsTeC62NBDBGKVkIyn2lmRfsHTSBUXCcqFbOUhEyrAgCnijjKqAUtO96Wcb7KQ9dnzIKymiTa4WYw5hLAWmgwIABpSbPtRJICqR43Bfdbh8QzgU6PGhvbu0pwxw3mpyZaTVj4gCmbpyKZnvL9/16bVq65rMvf+6ll18IoujB6n1DKMJ0fXNrsl4rFAqMYgejLEmzJO534zTuKWlaxVa1Vjk83E3y5Oq1x3Z2diTn//pf/+tzFy5+4fNfSjPJc/X262/4hbIXFZIkcxwnCssT9ZlXXvnR3t6e43hawYfZjbNnztVqNa2hWCymadqPu4uLi824u7gw8+Tjj92/dyvwyC/8/NPdzmHoEgT8nbff3N64X62Um4d7tVrt6tUrjUYjaXVu3bo1Pz87NzdDKSYUXI8eP7F4//5qpLTRqNdL+/0+GIwxUIYLxUrS7fRarXbjkBjwWFCMQkL9JNPf/cGrpagwVS3mcf/ahdMz9ep/+vevvPejG0cxTBRgrwfp73/jq7/y8pXTy3duXu83TLu9U5wonD+xjKPy9VsP23G8Mr8cr74nXFIKgqmJugKys7fHtZlbWLTPCEF4IBjUgJHBgNQYso+4FPhZ+pkRmo9igP3OSCP3qd9EQ2qIDIdMjGKGTczRmA5nBNDjYhvryGjZ5tH8CWOMgUdIgoc9Uxhjhw64eAuqeqTWH/4ywKAF0PxU2eCnz98eaRqPQIzCsJfEvh4YDYCxgUJh0JJrUzakjUMoYyxPU6OUZSqGeEcAIMsya7pmEBagpVJCSaWU5/iu61LGpJQAiFJqCOGcp3kmOAcAoZSjlBkNzBXC3gkzznMpxRgDJcHeSEIQIK20UipikRrOdcJ2sqytSmMYpveACAIEBhllHvUXmDHCzkZpNJQ92e+M7qtd/eH6DhYxiiJQWghhgDFCMcaWbTd0EDkRDEY4SmuBlvEkzREiuRGdTlIuFyh1ut1+bWZ2d2+rPl1+7LGriej/4Ps/EgaeenImzbDnhb/1W/+3Y8tz165cu3375lHj4Ic/+LP9vZ0zx45NlsqHW1srZ89QSpeX55udViLShzvrR83mux98eGLl2G/8xV9zMX3z9bemp6dvHR31u71i4AelikNZ56iZJNnBfjPPVLuT1mcWc4lAs0p97lvf+tbf/qtfax62CHHu3rh96uyZy4890el1mOMDdb2oKAELY7J+4lJWKFfDYvn+h7cYY9RhGhtDkOM4mFGhhdIGIcCADRhQUmtjNAJENMhBVQxjhBBhjgKuATAiiCjQFBk1sAAEQJjEvcRlnhN6STc2/RhhggPP94Ne3AOHgucSTftx7KZtA8wF6GeSIkUJBWCIUIypUgJyAVQxBAgTh1FgBJQEo43RDDuddv+o2U0y0Wz1lSGYOLnShHqZ6PQPG55fnJ2f63R61XLl8uXLyxdO+YFbrNcQMosry5ThNI3TLD48PPT90GfO/u5O6/Ag8P3I9fN+UojCvd3dQuAjg4mBYhitrz88e/bs6bNn9w+Ovvf9HyLifvb5l4qlGmDWTyUmXr0y+cF7HxSLRZd5xaj0/nvbS0vhE088hRDa39vb2dkpl6orS4tLS0txHO++9a4QYnt9dW9ns14rlIus22y4tcLiwqzi8elTJ5fm5zbWH3744ftJ/8TMzNRM+djm1nqtWikU/aOjg26vjZGSIq2Uo34/0QqZwE/9lOdaCYkR6rSOGMblyDcUgVB5pna2tnb21e4hlGuonfRu3W/oGF754YNzJ9iTz5+7Vpm9d+9eqVBcXV29cSu+9eG7V64+/tUvPl+qT//knetvvH/z/s2eBpibm3bC0vbO6qnZUqvba7V6ab/nRcVSIRAKsiQGbWy3KjEMMQQKEaTQwKTqZ4Dsnwd2YxaWn2BcxzM8GCNqYLibh7Eh2gihEbiPfqSH+nc19Iu3KTwAGAlCiHFaZkRFWLpca80Yc5lDCBFCSDUaS/eJYPOpHHScsfiZFzs6eXsM7A6s3mjU82QAx3GspAYAgoAQ6lCGKSGEJGl3kB8DCCGUMjbWKQMGI4MQIIQRppQaBEAwpQ4hDACk1sgYhLB1lBwIXgwAYPsj2/sgtMFgMBg8MHMeLPFoQzSAfi2VFJxz6gVo5JqGkRm6yxlnYIKMMRjrPaCFFgowRoBgNEtg5EHB6OhrG7ms8zAjZBSAje2FRcgY0+12CSAAoOxRQ7MxJuGSDpoXEBgDCrRRRBqHMkwcg6gSwvW8udnFmdkFz/eVSv2A9Xrtg6OdybmJXCpAbH5ueWHp1Nbmjud5588cW3t4r1BwX3j+52/efPf+3dbzT0+UXHfy/Nkzp091Ws1XX39jY2vNLfpBseBHhZe/ePHcqdPXb91uHzSeeepp4qtms8k539zZfnDvfuh6lah44vjx+w8eIOJNTc7Hfb63116/ea9cmVw8dupg77BSqxqNtrd3u724OjVRn54qnTyV7uww14nKFbt1TS0Vps3J46cwo1zmnTRGDi64zA0oA5SmKWMEU4Sk5koYqQlGLnW1kcYYwBgQBoKo1sgAgLbuehhjAIyRGSZm0O32w1oNDK7Var1+vzgzhzLBmNds95HnA0OAGOMapETMwUoZ5BuDQAJQh/gh1jrNeMYTjYWviO8g0NbGUBspeJb0ujyPZa8Tt3tpkivXixBxu3FerdSSXK+vb+7u7i4vHWu1NjY2NhzHOf/8E4yxTAqEUFivQ7XsNo9KrdbH1z90MSbG9Lux5MoJiOd4xSAMvECWqmv3H1x74urO/tZ//vo3irVSqVTC1Dl74cp3v/+jufn57/7gR3lucq6/8ku/eu/O/R/96EcIoRs3bisJQsDzz59rt9sPHz4oFsu9XjeKwr/21//y66+/fuPmR8VikYKamqmVi/78TH1qoopBLC/OUgJ379zotuOnHr+8tr66srT8+utvLC8ucM79knPl0iVEESDlMFIpR+Xy7N27dyuVSreTK4mKhSJBtNPpY+QQQk9NhHkSt/baR40DzYE5buR7pYpSLvrgXrqy7C+dObl662NS8lBx5us/vDl1vHV85Rhl+NjJEyvH5Z1bt//jf/jel778+Pbdmyhu/I1f+dLMyok/+s/feeODOzJuTVF6sBVXqrgwGRy2kzzulSZmNKJbeweOFwwtqRBGGBChiCBk9BgQmzEp+v8C2MGYr+0o6x+nNcZf4VN79xG8WkfF0TGiSghFo0YnNJTAG/Qoy8YYw1B7Y4ZumqM3GhVRMcYIxt57BMUD2Hnkj4J+xm89OqwZjn07apQag3UEAAYBGMiyzFZBMaV2dXgmlVLMI3b6rVJKCwkarGw5iiJrnawQogik0VhJqhSSyPY3jcQnGGMNhlJqYFBZHoUkMiwKY4yxeVT0wEOPF0ZtdB2o3gFAc6GVsE7K1v1SaqmUQtixpD8iQAwyxkijpJKAnE8tx2jJRgsHY3QNjFVgjBl02w4yewAAsEUYWz3Pcw0uM2Rgy2yH+1oFfhAWbKU3UxBFzPUDZQAhsr5xf3p2AjOGWiaKojnPOWp29/c7f/if/rjXzZ588unDw70wokqlreZWmhz86q88/exnnjrY2vrlv/JX4gerH7zzdq/f/+Wvfe38lYvNXuvf/97vZbno9ZN+EtcnJn744x/104M4jo8tLp1cOX64u9fY3d/d3d/fPXj8yac2t7eLpdrGzrZSaG1tb/dgv9vljuOFfnTr1p2p+tTs8qIXhdXjK/HWjut7iFFMiAbDKMNKpWkaZ3HIiqCkEHaauYcQErkQoAxCQDAiFIwYPjYECAONwcZpBIAQEOsdiiQXGjDCBhk70c3GR+RopjIJmaSOo3EGUYj7sUIYe45UJu/3XM9GBAQEqzR1ynX72UGYgOsjJYjo61wRB4FWWiIMGjABgo2SIs92tw7TVDgscF2UiRQAA6II5M7egeMGs3MLkqtisXj8xImlxcVf+IVfeNDZn5ycFFJtbW1wkZWLRZ4luztbALC1tYWUqpeK5ckph1DQkhHWPmxJmTPMdra2g8g7efKkUPzg4ID5gUak108azW6pUm910pt3Pk64Xrtzf3pqdm9vL8+gWPSyLFtfXz9x4sTk5OQrr7yysLBAKf23//Z/0lr/3M/93JtvvtnvxNVSIPK432n6jkmT9hc+/6Lg8bnTSwQj3yX9brvX6zz77NO1SjUIgt3d3WKxIGQ6NV33fVcq41Ur5XKpUimnaSq4CfyIMRdjxnPJuTzaeuBSUgtIfWnCSJSmZm0vTrN859DMzNc2W9n7ax+7AB2ep9BemDv+1vUHu61utVxcWZyfn56Looigd1TWX7972w+L8f7D65urrH/43/7tX3eC6I/++OvNstzeyRVK6hW/L0376EATNww8Pcy+NBjQGiPQABQhMixOjrAYD1uEfibYmUey70ep4fifj+P4eKYMY/kyGmrhRzg72t87rmf9S8bfBaxHoxlqdcgjcFdD816lVK5zmypJIew4wJ99CX+OocLPPEb7DwCgo6rrp/Ddc1w7ClsrJYaeNUoZxzija2CMAWBjjNSaYWzAGDuOC4HRCmmltTYIDyxrMDVGJFmGjAEwwBwptDYStFGKWl2tMUZIYaOiRgh9UsmE0SASjKRClGAQUmuDDQACirEBQIhiMNiABmXAIMAIG4MAa9DaDvx7tECj9RpUQob1mdFP7fqg4ccIYOCf7Ps+HowCl/Z3tNYIgeO5aGjzBtpQihmhDJMsy4zWIsu11hST1dXVNE1PnTp1+szK9vaWV3CPH186ah/dXX146syFv/W3f/n0yUvdbnzUaP0//7v/+7kzJ7Y3V3d2V59+6loxwu12c3l58a1vfev+zVu/97t/8vf//t964td/HQ52vvndb7/8+c/5vr+7tQ0A73/04aljxzVNut1uo9HQXPfbHd915+YWQJs844w5H7x/vVAtT08v9vsZc4IgLL3y/R89du2qF/gTk1N7O/ss9KNyRWugrg+M2G0wxpi5HlBmEEkP+0JxQ3FULDqBqwkWSipQzKVgsFbK2PlhxiitjNLIQQrAZiyDMjXGYLD1EEWABqNatKaAMTY+ddM4jYoR55JSB9KM+q40GCtNJRGK6zTudTko6tUYQyAxNpYWs4O8htWwIKIIhDE5CA5SgBJK5HmWaA1JnOVCO8zzXJxwZbRElImE834/CKLd9v7NO7crxdLS0hLGeGZh8d69e3s7W4VCGIbhg4cP281mwffsAzIYh4MQEkorkScpMSANTE9OHTb2Tp958tiFc7dvftxot6peiKnz5Gc+88d//K2FlZOUBqXa5H/+029PhsW9nf04ji+cO314ePj4tWv7+/t379yhhCwtzhOCi8XIaLm4uMjzuNU8+OpXXnr7jddF6lZLxYXZqVdf3VMyX5ib+fa3//Tpp55QQh8/vvLm6288/vjjFJPFxcWd+6v9uOs41PopSQXd/R3HpZ7vTE9P5blMYgkApVIhTcT+/uGxqQpPe0m7n/ViITSXnu/5MzPV7aS12Yrd0tyl47NICQd4v9f89lsPvva1pz/+6MP+/pEG/PHHH187f/rxa48xpE8vzydJcrB2FxGqWuL+Oz+enJn91ZeeKp86/c/++b948+OOgRT5GJQm1PX8IOHCoEEV0SitQQFGGMg4Co9nsn8e2Ekp4JNJm03hYWwHMNoEmKFhOh5z7BoH09Fbj3YMlA0cH7XWo3GA9jswbECFIf0wHoS01kKr0ebDGKOHlMsnoGlMRmnGfuHPv2Q9spEY0DIAQAb4jiyOIiDGmDxPOZcAwFw3iiJKaa/fsdfMMHFcl1JHSinTlHNux50YAIOR1XpnPPfdgrXbp5QC6DzPtZSEYKM051xpxYjN1gfqIpMnI5aDwCBmEkIYxYAGMw8551pJQgi2cdwOkyKYEALYaDBSU6H48HMgLb1r7+TAfG6sPcEu4qj5aDz6oSHXZsuoCCGEBvPYOecEkAV3IJRS6vs+xrhlsDEgjDZaIwOGIoIRYGqQEVLmQhXC0HPcTqeTxFmpWNFaEGoAdJL2Oc8uXjx/0Oj85m/+ncAv/Jv/z7979qXnf+XWx++8/ePNrQezM/WVYwsi6129ehUJ8caPf/zOO+8899zlUrXyT/7+fx2UoovXHsuEXFu7hbTp93qe53V7Paml4zilUoknPO31KXUwNpLL3d39M+fP/dHXv/krv/YX5gmJapXPfO1XIc/g3lsZz73JCRX3mze7S0vLzWarWK8eHB6WKxWnXCIEg9agNcaKOo5frdJ+L9cc2fIy0sSjXlgQPNVSSclBCtAajOFcaKkchxpjpDFUKYzxoIiBR59UbIw0tjPNGMvVKS5QoSQO9wxGrcODcr3mOD4ROioUHSdKY9VqNbNYLJaqTljoK4UxUUphqQAECIEH5nxMSSGyPM8TJjjK0jjuxd1etTq5tb3XbHejcs1xnFhwqRVCbGZm5tade44f1Gq1WqV69fKVS089tb+29va79y9dujQ1NXHr1q29Bw9saWdvbw9rFYYhVurosLEbp/VyKXS9dqtVDkuVYunevfsnzxyrVSe+/Y1vlOvV/f19jfHm7sH5y9d+7stf/vjG/Yeb62vrO8dPnIr3DyuV6vz8/L1798Iw/OD9j0rlQhRFb7/9Xr1eCoLg7NnTN25ctzOyJycnFc8dl83Pzr33/lsXLpx46cWLly9c/PCjd19+6aU47hkwaZqGYZgkSbFYfPjwIRaiUqlU5mebW2uOC+WLF6CxT44Oe72e74UYs1azwbmYqFcDH1qtTilUuWFewePY9Hv8IMviHu9yyHKB3WI75dl+ywjRPtg6szz/t/53f+8nP/5dbogf+FG54lGUc9lpHCxM1SYqpWBmSsZxLlXVh93V7fsfbz/3/Nkjo37hy1/66i/5739895vffS1OoOCYdrsVFMvKDLb7oBQYCRghYwj7RAb9/w/pwNbwRsLwUe48gnU8Jsz7VMI+Du4jFmH0yvZ37JyJ0UvpwajrRy5mWmttBvSyMcbzvNGZ2FonIQQTpLUeTV/SY6k6Rp84t/81x+jM0TPHpslwFjiltN/vp2kaBIEZaoDwsH9sECfJYKWklFoO/BzwqNNzbMKhzXY73NI+xhhjJ3mn1lQTASHEauEHLbn2MkSOATFMGCYMMEEIa8AASinHcTClBgEiGBGijM4EJ+iROefA/EGrEWQTBPDJzVcvH0z/GKftjDHWzBoNm9NG7JAQAhmDjMYGsAECCCMgBowxvusQQsRg6ASWWuV53sHYktEEYYdQgjFoY6SidgKvrU5TUp+cOHny5NLS0kKlfOv2jZUTCxu7a4hovxi0ev033nyv2UpfevlLUVh67bXXjp841jjYz/L+Z5558tKTJ9vNxrkzZ/qdw4XpyeXTx9/7wXd7zUOsje+6cS/Ok7xQKHU7ycHBYbFYbOnMoax5sF8pRAGlMssn6xNZlsWZ2DpoZIY88cJLL/38V7XrNXr9ysRkvPpeeWlh86PrrfbRsaWlJO6l/d7M7ESr3ZyanYTIb2ysYYarM5Npt8tFxpOD0AullHGcBJ5fqk8BodDrKckJAGCwEzSBp3mWcZ7hGoNhakOsQYdNXgzILBdZjjV4lCGEQUrJBfJaBjEgHnIi5BQNCQQ4ypBwcu72e6819raee/lZIEofbHaae5XTpyC7DCQCvwrSlVxRnwDqHTVv1erQ2f1Y9Y+qbhHyIFntNbdSk7MeS9fX17d39gAQdTwhIZMSYYdr5PrR1vYuc/yoVJ6ZnX/62ecKhcK7b34Up2mpVNrZ26WUHh0dEoow0qHP2ge7edKarETLC5PVgi9FmiVxrV64d/dBo9WenplfXDquDN3aOtw7OIozQZg3NT3rBOHG1ubW1hZXkhDSbKtyuRxFkRJ5p9NJ4xi0RMgwil3GapVKFAWbG2sLCwu9dqvVatFiaX5hdm31wczExNxUnWe9MydWopCdPbXyD/7f/48rl85ee/yy0vzhw3szs1NLJ0/G3fzu3buPPfEE1OvbH77vOM7EZK3b7Yaee9Q4oJgQZDqNplYSGWi1WihR7U5PYdhttAWwTDq3Hx66wdzWbrK+2c4EdtywG3cxMWfPnTx7/sztt/+EAZxemC/T8v7m/oXTZ3txgwY6Nd1Gbx8Y6sfSZeXZiVM/+cE7ly89ueK+cfbyY7fXDsKJhUaK9zr51//03W4CXgilavXug6aiqDQxf9gXOXL6qZgp9wa0LdiZRDnnXErNGGPMYY5nEJYalLKbNorGCJMRoGGMrf/7KMN79LVDRnBnB1gTQgiCJEk8lw1Uf3Lgsa61xtT/VE49HhssxzAeh7TB1mbc9jehIa00amEdnaeFIK04fHKPYoFrtP/41KFNPvqaCiHsjtKq0W1osu9q/9dKNUfEtxk2/o4jJhoJSOFRfQMN23btnwglrb7bc5zBG1n5J7bD8AYLStGja8CACcYEIzxGrgkptTCIEMDI0jh4aH6vtQY9iMnDgsmnWSo8ABwzyOGNQWZQOB2dtr0YwFhbzcafEyEHdw6MHeqmpRBC9Dh3HCdwPUbogLeRCpTWw6kgrutyJXu93tbWlpSyyeiFi+d29jcopdQnQoj791dPnTr1N/+Lv/t/+Hv/Tafdv3btWqVS2d3ZKBRCAKhXqr/wta/J5sF/+Hf/05/+yX+6eObU51547gDp999+e2Vp2fd9ABxFURSWEcK9Xi/wmFaCYqiUyouzc9gAAtja3u8292cXjhWnp1dOnoZCESOqe8lBo4nSNL19tzZR5yKz2t5+v99qOaVyiac5M5pSZhD0Wx2tZWluQRzKwbw9QzDGJhcIK6UURhQoBoZASchTLoUxiliZEww4x4HkS2tLVdlPC0itlCKgwfr2YaxHXecACBGMsDGYd47OXHosX5rfXV3jaWthrl6ZmpM7u6R2EYxARgJ1QWiVC656eZzsx42pyQoU/Hxj1/SyoFiTRXb/5hqPIM/sVHvquj5iJu+naZoGxYp9FjqdzvTc/MWLF4MgWF1d3d3dzYW4fft2oVQsl8ta68iP2q2G5inCxnGcVqvVPNwKGJmcqExNVGem50qVie2t3bX1rXfffd8PypQFrh/sHe7E6VGj3QvCsNXpNjtd2+XoeLVOp9NttdMsztMUIRQFnu86k1P1TqvVbDZcd2p6eppS7LpulmXHTh5vHBx+4fOfe+1Hr+zvrF06f/abf/qNZ5+6dvLYwt/8a391e2fjzp1b1VppcXFx/2C3/fabFy4/fe7cucO9vf0PP5yZn62dPAndluNQ4jpBFIo0l1JQ10GKaKnCMEzTHmWYEOo6TOYgFTdK52lSKkau08+4ZBRXSqUkj+/cuXvjxt0Xr9LQDSqVWmPj8PTZU91ux/OD199+58T5qXp9fnZp7jvfe+3199q10lsL0+ViwYvc0v5Bs9FoTC6f0S577MkrvR7/5rev99uwd9QshjB//OR7t1Zrs8durG9XKpNCthHSFBOE7ccCE8IAFMbEWASwhRuMtAGtJR5C7SirtZ+9EWMxfozgdfz3tdYAJssyNBRrYDNQkWitrZUL/FTur4cWY3iozBnlx4/S0CFzYM/nUyc5ztigsdLu6Kc/E5TGAxW1b2kLAjakoKFBiu0Ts1OEgmAwocnoRy+KxzSIn9o7jHgil1FjjNBKaSm1QsY4jFGHKaWUHS1oiXBj/zWO6yCErODEesBbfB54r2stpcwFtzM5EEJ6OLET2RIdHgw6kVJiu7mHTwziAPg0fWa/GG24Rms30M/aYbDDi0Iw8GkbsXJoWC3Rw/a2gR0CwlpIKSVogwGiKLKxGgDiNBFKUkqjKPrsZ5+7v3oPEXX89PL2wVaWcc75P/63v/vP/rvf3tnZm56aKRRKWxubcRyfOXPi/PnzT7380vf/4x988P67W2v3L1848/QTT67ev5fH/fPnz1994sk//oP/eO2xx+cvX/3xH34dMZorHTcOMCBQyiiVc6mUifvZ1mGnNLV4/sq1ueMngmodWACAEHO6nS6N0431h1evXq1VJw4PG2HgC6Gk0Emcer7ruH6ZEg1KKJEkAoRi9RmQ0uHC8TSowawlEoQ6TRDBgAlILkSe5TkYhTEormC4/xtIDmytJecUIUyI0aC1BKWJnV6BMDFIWu7RYIMRwQxhlgvpGHCrE2HWDwMny6RLdS8WqBAbnRewRz2PUtBKEaVchJNeklNwqSQG95O0c7Td3E36ScwNYq5TrdakBoMwkdr3fUxcQun27u78/OJjV68tHTsulWk0GnNzc5XC5FvvvCOE2D842NzcnJmZWr3/4OTx5cbhtkOAUppnOktzj3iTk5Pnz55pd3vUcfygAJgdNA6U6jE3QNjDlKVZP87aXGiEcKVcFUomSdLt5QQQwoYQEkURwoYi0EbmaeoHbtqXaZJUKiVQenZuptVuvvrjd//K/+YXZyYnHr96af3hqu+Sn/v852/d/ODD9/1jx+dLxejSpVMAOhNxknar1eqdO3fOXbs2sbQEBPX7fXX3FkJo4tgS5DwqFtv8SHAVhiFolSVpgRVJZhDBhlCuDY6F7MnQZ3GW89R4DtE+VUpymRNkKMVGaTDO1OT82tpGwQnXN9ckF+VqeWp+otHJQkSnUVStTk3U97GC86ePMZwTN7i/tn7u4hP9ftLL0U9e+f6Lzz556uTxxlF776D577/50fbqXS2Ap73Ti/NHvUwpYzd7SFtTMIQJtfoFAKyUQoAwoggADSY060+h3gh24ZM8jP1CmjGfdDS0MRjamA/S2TEkHQfZ8a/1YJI1GdEDA0A3j9j8EZMzqrKONgEjZKcEfeo80Tgj/1MHxmPgblWJWZaZoWP9iIex1y9H9jeEoKGFLwBQSh9N6B7+le0yHXDWdsm0wggxjDRGGoFCQAlyHSqEocZojLRGCrAzPGlmO3EBECAwtpxiFIBP7Qy/IXEmraIOOYxghDEghAdXbl/HHerNB4syLBgraZAB0KPGArCyx0cRb1S+GO/tGiH7cEkJIdjWAAlGaFDjBYBaraa1BqU550aqgToKDdZHDd2OpFS2lfntt9+tT1WiYnjnzt2ZxZkfvvqjf/xP/8Uf/M7v/MN/+I+DIBBCvfLKKwvzM3NzcwQhiuD2q69eOHWKKvHLX/oCTzq3Pr5+9coFkWfvvfN2pVT+pb/xN8Dxjm7de7ixfvfBg+PHThZcZ2JiqlyuuF4kJJYIB7Xqyfr83Mqp5VOnUH0SrD8bIW4QukIwz89ysbuzf+782YcPHtROnpienq1USpub67Nzk4BZ3u9jht2olOW8e9gqVpx+N5ZC2EZcxYVWgmGiDVCpiJZKcKGkMhKM0hoxOlArDbvBBpVnY9tVhh/fwcwVMIAIAMFmMPcXAQHCEKZRUDg82A19PyhUaXG+t36XGxWW67GHZK44EhQLwBgrxYz2ESbEyVtNKWOdybjd39/qtvdzwdH6/kEQBIS5nMskzRWA60V+FDLHz/PN3d1d/OGHhXLl3PmLcm3j8PDQKOfJJ5987733zp8/f/3GRw/u3y2VCuvrDwOHpFmKdO4QMjs9Mz9TX146Vpmcvv7je+12N4kzqVEYVg8arW7cdz1DvVADkcqkGdcII4yNwUYT3x1s0n3XZQ4BJSUXSoubtx48+/Sl2cmJVuuo2ThstY6effbZ6ckJTdT7b7+x/fDuyRMrocce3Lk9O/HUL//SV2sz9XdffeXW7Q+rtS+XKyWditnZmSzLFpYWHtz8eHFxcWJurnN0kGUZIJ01Gl6xCL5PHYZzHEShUdpWXEnJAEbC6EqpgGgOIKrFPO71NdeRQwmgdj+XaR6VglK1IgRfu99G+XYex489dyXr97a3t6/fvVufndprxLinutm9idrc00/V2gcHpZKr8nznsMUV3j1szK+c3l3dmJla6B/tFijpiN7PPXetVgi++f03qOOsH+xOznseVtxQA6AMIDvoASFLARhjtAalNUEaEUWAgAGpFUUYPpnPwicz9PEDACTSI+bAjGqnRruuy9gghxv9uVIKkUcc+ohUGeHveLJrs3il0SgZt7pJm/D9dJAYPAv0E0HoZwaS8WOsvxWo53lSSjtF71PgboZlh9Frja5hQMtgZEkbIDAioUZLiewiityK+zXFWmGiNcWAtQpdx0ar4bi1wV8lWYrMYNTyQC5HEEZII22wIRi5DjWGSa2M0UIqTF0CCA9U6aCVUqC03eCPxTprngMAFBkYRg4YdBvBqIds/HrtwQcnNwB3NJATGaUUJgM5f56naZryIUEkhOBpBtq4lDFKQRujdKvVAgA/CMIwpK4DvW6e5/v7+zOl0vHjx5vtRhhF29vbLzz/UhQW/vn/+Du/+Iu/SLB75+6Dna1thNDm2sOHD24vr8yVnHTr/r13337zcy+/MFEvyTw7Omy0m4eXL19ePnUKGOW7e//5z75FXPf/9H/+v9y/t7p/563picnJ2fl+qo+6mRMVS/X52sx8aW4BGAMNaZ5liru+47i4GDlRfapUKgMgMKhSnuh10+kTJyFLPS/oxTnfPej2O1GpUHU9gl3HcQBTrjMuJPM85oeUcZ6nYLTSUisBUoJRiFEHe1JxpUTo+YMsBkBLpeVAI+w5ruRcSom0YYRggkEprRQmCIwBjLHBtrANGBtMgbJiqQZa7exvVrPUUM8vF4FnMvTBUZgYgBy0ASWQEiTnrgQHu3HaOdjY7bdySoMgwo20L5RJMu5ojAh2fN8AxoQiIK1Wy/fDlz/3hedfeBmiwua9B9vb2+fPn//wo7tbW1uLi4txHIMxZ86cuXPrxoXzZ1qHu3mWEZW7IXMcRyvY3d3v9/v9RBw2us12ByOGiOu4BeYSx4tyZYKwZAArMP1eVwgBBAshauVqGsc8z7XiTk4BNMHgMHxsaSJOeluba7VK6fz5czvbm71u88bNGxcvn9FaRaGzODsVOoBkn1FoNvYjHxcjb2qivrezVZ6qup7jlAvy4KBw/vza2ur1m9eXl5cLxaIf+Zxzx/O0yLDnM4+5wmO+B1JR1zHGuC6LU6RT7jg0kFqFpFLy1x+2asUSwaC1ZEgGLop8BpK3mu0vPXnl/r1bUeD84JUfPPX0VYEUCZ1Eoa0DuXJi6u69Q2SiiIHDSLe1M1UtNnqORlCbmPn2t7/97Gdf2txa91y322pjwO//5Hu/9hf/6ub6xtu3do7Plu9sPZyanlPaHTzUYLR9kAGjAWCIR5CKlAGFjLJTYj4FhePM+KfA3QzTN631cD4SGK0ZY6Mu+hG8GmNG09/GX2QUG0Y+YiO6H8bCzKgAMOKIxoPQOMR/KjL9TFj/6YMihOwGedw2YcQE2Z+aIStECEFKjnB/aNX+iGYaRSFCiN17IGJvAqEIgBK7YqAVMpgCaKMt52qMUTYkSoWsdz3GCGNKKMUEj/k8UEpdAKZ1LrjNl0dFBj3Qaz4yZvvpWEcxHX3TGGM/FICQDWx2/hNCyMo6DRitxaduiT2UUhjsRLGB8YBBwBiz9lJaSJcN/CpFzjnnDrNGuyqOY2m0jaBWpPj1b3xzYWV2Zm7ywcZDL4z+q//q7125cjXLsubRocucU6dO7Wytd3udufnJ2emZWx++vbG5Voqixs4OktlUrY6MevYzz2xsbW6tPqxNTL39/gdXHn/ixMkzr73xFmPuy1/8eRIUoVwvNvtRBlFtzi3UcGUCAKVJPxO50lzIhGLheoSZ1A3CQlSanJxuNI7qk1O3bnw8tbTUaXULpWrj6DAXslCuVSaqRgkhdDRVB6K8UGOae34InosUYwYpmSFCjNYYNEaUYGSUwdJIbtKkr4dzuwZdfRQD2D46bYxCCDAmg9RAKtDaGGIGo3gQIGIQBsBpnHpegAgppP1e2tdcMpYzRnumhxGTJuMcmMCIMtDU1QaAtveajf29uJfKXPO0n3MSFIKVYrnT6wqu3MB3HDdOeK+f5P3s2PFTzz2/MjE589FHH0Wl8sqxE5TSDz74UGlWLBbffvvtQjFECLWbjYvnz+dpzxgTeI7PfN9FWsPRUbPX7bouO+pJ6kVRwWkctYRIgrCEMOvHXGowGjueL5TCiGGKXdd1HZ30+5xzhI1DmDGK5ykCBQ6bnZvud7ug5cmTxy9dPEuw3Nvdrdei0KcXLly6cf2jP/yD3zVKnj936vjSwvUP333/nZ987vMvVKqXu70mzEzxm/vdrU794nnotC5eudxut+O0H0CopW53O9Fklfd6jlau5wEAYASMMt/Pk9QPAz/PuBIec5QySuvpSjlgO0amoROi0It7/U7feH48VZ2qlKPrH95HGGananGqW/3O3PHFtaPmrVt7cQqng8lcJUcN7tbI0twMU02RH9GgNDURHjbby8vH1h8+2N3e2Vjlf+XXPzM3M/vt73z/cP3my89cvnl3J1P9qZBg3sOO/0ksthPYDEbWghTb7lFkNBhj99b2l39aXTMCunEAVZ8gQD7ZbTREOTJmCPyprFePGRGPv+94kXJUvxz9rwX30VmNA9SnYg/81C7kU4cZo5VolmWWzh4ZGY5e3TLvo8GAgzaq4SVZBBxtUqyvwvhp2X8ZJjZQAAJKMJAhtS2EbVOwAc72aWmtHS+wv4EHldrhBY1tiBgddJ9KLhAYjIBRgjFWVjektR7q08H2zgAAgN1uOWOzFscjoB5wQYPE3L7O2LKiUeYOQynrkJQnhBDHcQwC13XbeW6GrJmUEoYbnTAMlVJplsVxDAQ7nmulON99/aMvv3j13Nnzd9duf/nLP/8//KN/+OLLXxTSGMB51ozjFCGzu7cdBnRzY+13fuefF/Pmb/7mbx41D9Je9721B46D/+Jf+gt37twFjE4/+eSDj2/NzC5Ozc3duHN3cnb+3IXzxEjQGNxyRrD0GBSm2gI7ifZ8XwCjjtZpX8QdjSkjNOkfKlIul6tRoXTUOEj6qZL64a07URSUK8UwTb3AK5erEBZQv6MkAoV6caIlMojGuSBcGiVEnoHiBBtGqEMxRtLoXBqEMSKMyjwZJDyUEoYoIUAIIATCVjUJ0kZrjYcqMSO0xhhhbD8R9t4p0EqjLBeUmsrkStrd7bSP2r2sXq10+u2ABQ6hWZIajt2wBDzLW13H5N39dnu/AwB5ZhqNfs5xGJQNc3OhhJSY6ySNO90+Ye7E1FRtcqpam6jX6/PLx/b29l/90Y+V0Y7jrG3uHx0dlUqlZqtRDIPSzOzm+mq3czRZLRNrAgogpcp5nmWZm7O9Rl4olDBmlAVCqyw3QvJekigNXCjiJIBRnnPiMGOQECqPe4SQwPejIBQylzxGCByX3r1958XnP3P23OlysXDr5vVbN6/7vv/Lv/IVpPKDvc0zJ1ZqBT8KvcXZmXt3bpw+c2JhYaJaKd57cPfgYOfYzlbG89u3bz43NwWlGaC4UIoQw17ggud24s7a3bszMzNGSeR7LkI8yxxCgzDkQlDj+lEotHQcJ0kSCrJc9EoRPjiIncB1o0Iv9BqNvsxlOQqnZ6dfufn29HT53sPNMILX337wuZ+7Nr+8lENnazvd2uliVBTS8dygGDkBEe2jtbB8Ynd/f35+UfDeY9euvNL+tkz59Xdfd65cfubqGZ60PnPpsbXP7f7T3/+gWscxjxViA1gYKiTsY6xtuowMWHLcaIQMwWiEXSMLmlGRcxwTR6A3AmUA0GZAUWCElVIwBGs6Bq8jjB5lliOeHeATLUU2t1P6ExLEwTXgR9zRCD3MUHQ/wtLRS/0v4Pv4ddE0TdGY8mb8DWwFwOrz7XmPhkuNr4h9uYEJwXBEqs3cjTHMsXsCDeYT7WGjegIAGIKVwgIjrTXzXdDDgoM2WktpFNKIUqqHWTkhDiGYUUwJIhgYxQ5ldh6K1YoqpQZ1TxjOVUGA4dFw2z9vaUaro4cH/Gw/ImCMiVwppQijruvaFJ4xVnAczrnIciVkkiQOY4xQ13WTJLFSGYQQcZjre3EcdzrJwmQwOTO9tbO9tbmztb1NHa/Z6lDiN5o9x/E6nZ4SeRRFc7N1KXonjx97+tizu1tbXGS9XssPnJmZqbfffEdqgR238Wffm5iZnZqb/eDjW8VK7dLnv9S4d69emQTqQKke4grWjl+eBQ0Yuxy4F0QOON2sIeIjwhzkuTg9QlFtcnoWgS4VK++8/ebK4tLdu7dfevEFGgVTzFVaHBwcsnbH9V3ADuSaYNcvhJRSLaXkuVbEoQwZ3m03GCGYUgCjpZY510ZiDIViCZSSWgEAGJBCgBDGGIIwQogxpoXUUmltKMbAqBbaxmI8jK02wff8ABHWarUKoeRCTS8sy34XI+PSNPJcD1CuUpFIV2s4au4+fBhSUy9MQK5v373T7adhcUIjvbqxWp08DYgWipHr+q12lzD3woWLz332hZt37h4cHLz/wfVCoXTUbt29c79crXqet9/oay07rXarfQQzE0ap6ckJIzMleRYnPZm7jDgMg5JaCWOMV1xoHLWFUK4fuY4bJ1xoXShWMaKdXpcraQxQ6lBGASBN01IYKKWMlkna53miBa/WyrMzkwWfnTxxLAq99bUHqw/v1qvFJEkO9raPL0+fP/PMf/z93z9z9lQx8N98/cefff6Zfq/l+x6KglOPXZ5pTLaODuozU5OdpuY51vLBvdvHT58uTczv379XqVZnlhY311YRRcpI6ngAJuv3CKUk8CAmPFcIY8IoQibL0izNXIe4WEc+GJAIm3op5DO5QNA4ODg8PAij+sHRUZ6DxnDp2kzG05UTx9+5/qNybWb14dbS9ALP1eHBkeo1L58pFwPWzOXJU2cppffu3ev3OlcuX0qbrzb2oHWwXZhf2trevHHz1ld+4deu37p342FcLpCDhANCiGBABCFk5/coYxAyFDDGoIwxRmglKSGYYFtTtS3+ZswMciz5+wRQYoof0fFjjDFCaJQTjnBZKaXNwJbqEWIMgXE8Wx9VTZVGjLHRN0eQPf7vOBaNAsDobEev+TMPrccKqr7vW7N5AEjsSHuM7duHYcgYS5LENgJY6Y+dPmrfBhNsB4eOwpT9X3sZjFJKqda5fSqHq6MArGAcbNXV1qGNUsQYgkAkGR6aGg9atjCmhHDOrRAFAIxUec4BIPL8OO0h5hglMp5xLtXY1oFghinRWgtlK8CIUsrz7FPLZA8bw0a4j4c9zVorbKfFDtQvCoFBgPI8R8OhWXbRuBR5nuuBF41GCDE66BHjnButkyQpFIuVSiXO0k6no7UOAial/vjGjc9/4WVlYHtruxv3gyBsthKey/X17aTXP2w0Z6ajdvPoymPnqpVSKSrcvHVjYqJ25tSpixcv3H1w+6BxWJuoRuUKUKYQ6cTZ5auPF8p1SLL6wgoYB9wQkK+8kOfmIM6coOAABqAAIs+7AUNlF7//2g8CKq49+0QqhV8q6SxLkmR6Zs4N/JMnT0ulN27fcRynNlnz/LA4UQdQhw+b9SnquY6SHJjXb+9hMPvbW4XIJ0ZijLMkdambZ30Cwo/8PNaOS3WeSintyA5i7yhjlBApJTIGASIEaQ1KKyuIJIRJ24pOEBBikZ1QZvnMqBBoKTDG3UbDZYR6jk8pAdE8bM/U58FH+29/wDI+Wa0fbm70m3ma8tCrpBx3en0gztzyYuMoI5T2+lm7E4eF0vLUbKfb/7f//vc67d765ma1NvHiiy9fvHA5DAr9fjw9PZ2Jh/1+N5eqXIiODhtZ0mu7tF6txJ0mxcTxfIcRikATyjPDBc97GWG+BtnrxlIhx3EJcQVXrkuVMnbUQ5pnnudEUeQx2usfhWFYKhTb7Xbke26lIPJ8fmZ6frq2tv6g1Apknh3u7zxoq9/8zd/Y3dteWZx3a6Wjw91Lv/aLf/yHf5jlcblU2E060zOTJumhcvHOnTulWtlg4/k+oiQ+2C0UQsFTc5ROrSzqLANswkLU6XUnpqaAc5HnxalJEDLpdgvFYn7QM4ROzczEvU4Y+rVytdVIjICiRzXQdr/bOGj7fugQsr7R9kP41V/8y//Dv/onp6dZtU4RpkftjsaRQ+jhwWG1XI+T3rPXnvgPf/wHf+HZiu95e1vthvCtd0W1WvMZ29rcPnNmaa5Wvn/3xqZSZ89d2H/9/fbe5pde+kyc/fDumgSWM9cFhLjgGjB1PcIoDDhVJZWUQmgpkNEEIwCSpiljzPd9Y4wVm2ZZBmN894jUtYiZiAyGpDl91L+qhRCUILtHp2OJOcZM2+YV63w+xvNYFXiWZRY2LXI6xDFDdaKNNKOUehR+zFDbQilVMh+FjfFIY5EQfoosIeRR2KB2oKLrunaMqlLKuhvaPML608PQnJ4Q0k/iR5ViPBDeCyFGxjojWBzuLB5FIYQQNgBjmyAbB43WYIxVpFibeKthR8O9FiJoKMDRGECDRrZ5FZBN3ilBoDEhaCCrUBoRrJURQiBk25EoAEipPceBTypJP8Vn2QrEKD6j4dh1e2l6oNIe9MrDcLdlhgb8+bAMQBn1HNd1HAwIacPz3L6LXdKRGAkjtL9/+HB9PU1TjOnc7EKW8rW1jYerWwA49HyXQbvdr1XrUxMTS0tzWxurc3NztVrl4eqq1mpiemJyegYxygKPSxNLneQiQA6OyuAGJs1jjSFXmCrqFEPHV0AzJQ/7zVrRZ8ggl4GUSKYBgbR9eONHP0AzL4RhuHTmbAWZuNefnpnZ3dnxqtVjhcLW5hoALtYm7t24RV06Oz934/qN809cirMs7cdgTFQpRWEAkuf9dr975BCMCSMG4n5fZsZo5foeQtixBs5GGwTIGGvBqrXGAAAI9GDp7c6LIGQZOpuXAJKAKCDTj9uUOK7rOj4Dl6g85Unca/ZIkRaiCddXcn+X5ihySHO//e6HHy7OzPGc9+Kk35dcYAMIEOZSl8oTWmvb6S6E3NzaSdOcS81c94XnXzp24rjWcOfOnZ2dHdv4WigW0zQWMmcYFYsFn5E87h7u7/kOpg5xGKMEGSnkYNIXZp4nuAKjXdd3gGgNOedSaowxBuMQih1NCHIcyihIjYpR1O12J+qVyXq52WoszM/MTNUaRwf7e9tJ3Ll0/lya9QOffebpq73u4dRERcss3t167rOfeevN10KfvfTCV773vW+XK8XFlTlveubw3m0JplqvKTCLJ4/zLAujECiijHS6XeQQA+BgF1GCEEglMcFAiZECGcQ8HwCIG2gARClxGKEIgXIdPDXh3byRYdr0gtrMZK3H1U6jrRTMz0/fvHf/xOwsIr3a1GTjcB9hw1jxxPHle6sfnz8xF3nht//s67/88sXpiux0+zmHcqm09nAt43m9WvvLv/GX/vW/+KdJx/zaV6cODuU7b7ai4ubLLz7XzvOt+7fOLE2/+Nlj//KH9/f3DlIuC+WyxqTd7SDKqvValmWAhk4AQEEri3EWtUYwyhizT+uoOvgpLn5ELVhMH4A4GEopwYM0Do8xFqOoMOI8HvmIjeHG6Gv9CbJ38B001jo7/s2RdOVTdmPwSfoFxkgbQpgxxp4gLZVKFpXSNB39gR09QcijZi1rjIXGTC/tW1rbYqMf1YXxWIeuHjowoMFigR7gu0VqAG20Aq3AGIQxZpjkSgOy5RBjN++D4gN+tDqgDTZ2Bie2vawUWfRmWmsNyPauK6WE0hhrwlwAUEpJrRzMEBo0ShmtYbifcl13wBQRYkeqciGSJMHhcBo6RhghQohWBuyeazieyY7NsjeVW7dobQh79CkBMHaqugX3UdzGGGvOpZGYsmKh9GD1IXO9zc3t/f0Dx/GIwTwXCAFPYaJWJxTtbm9VMTEIH7U6t+/d39zZPHfh/MWrl08ePwGuC+UaBBFIBBoAuzpTKZdeqZILKbRSmjPsIMCMQOSzrfXVkm/qIaFSRn5w8fz5pFNv7G+1k36/3126cgmEm2ZxzvP9/X2P0crCQhRF3V4PsGm321Gp6E7OOhtbPE18x5Uod5kv44QyClK6rufOzB6t3d8+3AWdT01WaLUoD/e6e/vFcgQIMUwwYBvSB6oqKREhBmAQ7AEUGNCaUIyNAWwADf8FhYD7HpNCZVlX54RRTBD4jHBDHGmgdwi9lBIPpIi77ebRYZbyfj/Lsqwfi5grBdRgpBGyM4zTNNVgXMe3wXxiamZ6etr1fUqctbWN3Z19hNDExKQQYm9vz4lqmJJypUKM5kk/zlOjlUcJQUARpphgo7kyQiipDABJ+mmSJMagQqHkMDfjQgptCMqzRBuJQFOCKKOEYKQ1BU0xPnFsGSGUxIlRqnV06Dqm3WqsLM8/+/Svfv0bf0SJeeqJxzBG3W7rySevrd65fvLFF+d7nffff7dcKW5srjHXOX/hAsYYKuVCtVzuV4qlSiJSCCOktNAiCDzkUi5zTwnmeEAwYHAdVyrlOQ7GOO2nCCHGqBCCBRbcEWXM8zzDpcfo3MzE5vpmtwe820EsmpqYDCsVWN/odrubR3c77WaeZr2499lnTuzvbRdc/yg+uHKyPjNbvPnhjUIIngOU0jv3Nj7/0lPf/P67CNDOlvG89N33rz/74ue3Htxt9rOzF44FwSqXantz0ynWvvLzn3uwsfdb/+DbeKYUEpAasm67WKnPT0100/xgbz8qFqzuAWOMqWMUB6O1lkoRPWxAGSG41tqm1eN09nhGPEDSIX4iowkheNgM/9OcyDh2Wzgd50/wsM6ntQakR8nlT0PzTx9mTGwz/jtqOIcDjQ37HiX+9qBmqHLJ89xWA1x3MM3O/sag02Rocs9cZ/Tqhgz8i0cNV3gssAzO3gxy9WG2O/CfoQiboQIRIUSGqk8hpAFABkY9qzZ8OY6DABk9GCKLAGxCTzBg2+WKEMWgEDHaYAO5tDY+RiswSCo1iJhpnqGhX42VydqWR8DIWk2CRtZIGhGMKVFKCQCwQx8wGSifzCPFpxkK4m3W71EqpdRiMLILI6QAgdJhEFBK8XBPgDCyQUsPd4hRsdTqqmI178dHgqvz5y6CgsPDfc6DPG2fOXNqolY9bOxKbeIk8wP3zNnzi8sLiyuLyuj7q+uGUC9qlCdmC1PT4BZAYyAQFsJcxQ6lHmIKlNBdrZDLvNChbKIEImVEgWEauV5pyvHDbqoUV0Lk0GlCoVit1dxq9fjxFUpp1mqWFxd37969d3+1PjUZFiJ+uD+/uMjzXhSGUgpEca/VLEVRGnc8ikXWw9pUomKedLqNZhj3jBbFShV0ZsvWePgJwQRjjEWurFGQAYvjgA0ySo/ISMAGQAFIMMgAdihDRvIsz6QESojrAAUHU93sp2kbKwQo6R52mgf7PMvDQrHVTZSC3DBDsDFKIWWMUaAcx9MGcc4zO4uROI7jEMbef+/DUqlSLJemp6fzPO/1ekmSGGPa7TZl2HMY0lxpYYxyGQlDFymFwUjO7X2XUmsNxhgukzxNMaIqEBLjLImFUMx1lFIeJZkRSimXMYO0NoJRmsfZO+/cq1bgzJlTca9JKb588cLtWx9vrj18i+het/nSC58tFsOtzfXl5eXG4e7kVB3aR9/+9rfC0P/SFz//3nvvnjp1Qmi1vb+3Ugq9hSXY2Trqtqnn7q5vVKvVTvNwYmoSKNZIU4cRjwE2yujAc6VQ4DBAWPYTUJo6jsik55dACmEkYU4QhrmOFRaFMJioMTCyE+ter1uemps7dqKb8Q+ub/fZtsvg5Lk5D2U8Mz71XSArs1NLMzjLFTbJZ566dOvGR93J0KMOdSpTtfKH1xsug2MrJ77xrR/90lc+X5yY/fYPX3/2qVOnLl2cm54+PGw4FG/cv+P5xS8/5/+bVzulIlRny1xBJ427SQKuW6+UcykG7LRRNjcENPiUDQt1xIo+rIljsVgcZ8lHLA3gR5iLhs6U9nm3TZUwtu83xugxK/JPwb0e+h6iYQYppcRkbMbcGKyP3G/Gtw6EEJ7n9sTG/8SMMfUjfB+PMfbA+/v73W7XGBMEQbFYtJ2olpyx/AwhxPM8z/NsPXDUTGUNvAZzpD7Jb4xHLWVAA9JgSx/YwMCt3YKzQRhjihAZzEnCzKHMZcyh1KHMlkkxo5hRADCjSAAIj8y8DFhFpp1ASBCynu72drquy4YaRBuW7Rhu+5/QSoGxfmdxlsZZ2kviXhLHWSqNpq4TFCJLOtmyhB6b6jJa3NH6WuaqUCgEQWA3g6O7ONphjdoybbmcc04py7nc2NhQSkUR9rzAaESpY6mAZqPVPmr3ulm30+n1ekhr4nksCFIhJUB1cur4409Mzc23O7HjBjdu3/vOd39w86M7OpVAHG2YMrR3uJa2NoEfOtAPcR7gFPMOMf1i6PsuMYgACyWJeoKlqMQqS4wxPwzXHj4A0NVaGUAXqtWjZuOo2QCtq9WqUqJWq1Uqldt37yZJQpFOe52D/Z1+s8kw4GLoM5rF/awfG8E9yhjCaa/f3DvoNTuQqYGT+3Afah2KRg/YaPs8IMcwAmzrqPbBVQDCADc673UbRme+jwsB8agGk4NIIO3gbsb6nB82P3jt9ffeeE1mKUJoZ+/gsNXpZVKDCzSQQDJhEs65UI1WW2hDXY9S6jq+HwZpnj+4/9B1XUSw4Krdbq+tra+vPpRSLi8vU9fJ87zRaLTbbYJwKSq4rpslqcuoUaLf7/e7vTzPAcBopKQJgiAMfT9wkTZJr9ttt+K4J3nuUOJ7jCANmjNiHALEqMCh01MTzz5zVkpI+r3nn3+eUfy9736HMvxrf/FrTz5x7Qufe2l19V6xEF679hhz8NT5c0Lk3/gP/35qamJiYgIqpcWV5f3GYavTxoxyLkCKMCoCpQahqFgyhOQiQxQDsVovDQjAaESIUIorAVoBI9Rh1GGYEsQoMBcxTxpQCIJC5HkeaI3BiFwQDKVS0ff9ZrO5u7vLOQ8CCCeKRz1++/52tTbz3lsPLp957L3X3n77x+9i0XZx93MvnqSkt7BY3dqKjx0794NX3n/80sXpOly9Mnvnzp0b9+De2tbFx59RLmJRnYP749ff/sa33i+VCoKn3eb+hdPHf+3LT/gAG9ttJLPZepWASrodggePGOc8z/OMczlspPc8z2aro0dvhPLjWDnKI23JcNweYPx5h59qgBp9PaJi7Kd3ZOWChrVTOz57FE5Gh/6pYzx4fOp91XCC9uj746QQgG1FH/xHC4XCKAKMXsVGEguI42k7DG0AzLBf3/L1QNn46ZoxCluZgb6QGNAIMLK+vSCUJkPxofWFALAuLwpp22OkjFEwNHdRYIhBGCOkDcIGA8JGY4Ow0QAatAFksMGAkV0uSimhDiJUSWOk1MbY4p2GHAAMgNRqPAGnDjMIlNG54EI9mqPIGNNSKiWFEA6hdqCrbcQdxOThPbBrZT0GlFK269IYY9urRotpb7+V91sU8DwvTrIlP5qanOl0ekKB6/qlYpUASeOEUX95eWlqasplWCtSrtS01jnncc5fe/PNdtyrVKuXrl51ihWO3W4qp2bmcVAQmWh2YoNx3ck77cPDo+1Sse5XJgkOCRAQHBAWOQdGWFDwayTNYo1MqTTfE+9ijFut1nKaIox4q5kkyYMHD1zXbbXb586fWV5eNsawKKrX63EcRx4mGJfCQKscawNxDyMcOExK1u2LRAuR5T5h2qh+q4OVqp2YBowBEAYEQxUWVsNPFCEYK2UMpRSUfuRHjYCAtj2ugDQgoFQzbEDlIk2UlA5jgDCoHBRb/+hWs9loNJpcqIiFSWoM4Gan7wbECxxDUMpNJrgCgQnEcWw0QgRLKYMgDMOIYBbHcbcf28eJMba8vKy13tvbe+MnrxVnl2wQUpz3eEY0Z0g7lNh0J08H1TPMKEJaAXLsxEqtleR5lhmjPNcPPDfLEoKdPOunaeK52IDiPAt8tr29b4xaWZw5fnzl8GAvy5KF+Zmpeu32zRvdXnN+dqpWLR8e7l997Mr0c5+59Sd/0mzsGWO++Nf+qtnbPXr4cH19PSoWTp06xSplcMjmnbtBqRBG0d7R4cTFSzdf+8lkwQfPA2Sk4tJowzPCHD9wcy6V0Wme+Rg7vgdKY0rDQmRSTF1PqEwb5Lou+H6f9Akhgcc2tgT14jCstHOxtrbW6Paiknuo4qCCP//Zzy5VKjff+Hh3Y9dkcOFktexpQxVmuNfPr107n8dvxRni0tneWD13almxYPugMz8HhdrUdqNbmlz88O7Dr3zhhXq9fu/Bt9Y2N0Se9eO+6/qf/+zLab/T+fHdZiPDtDtRKUGnf3iwX6xUjBpQoxhpwBgMsmNJx+ulZtgaarNSPaahsE+oNGOMChoqXqwmclhjQ0NwQwgZg8dfZPSMM8Y454PumU/aFP80A2OMGXmTjLPt8MkNwXh6/im4Hr+KUWCghUIhz3PboTrKmADAdV3OuU2vRmVVWzWlw/EdVvlOCKGU2V8YRZvRYbENG9AYITQQFhoEgguFMR02yxpjpK1taK0RMsPJgWYI7lprbLkMjDAgpAacD8aYAEII4YEuanAXGWMGkFEaABFCMABC2D54Njzaz8HoPEexPc9za6ZmLWLCMORZxrPxMogBy5gPhokPhihas+l+HNsmWTrwuwAppXWFtCnA4KOArPxWM6aLxYIQolAunTlz5vU33zKIUoK01mmStttt14GFhQWt5cFBm4u47Jc8z63PTM17Sw8e3Pv4xs1yrXri/IWk2arVJ+cLVb82BYC5BMAMAaZFVIyzZreXyZSqnHllcCNwi0D9oFwCgwFh7AUG/H6WMsepVivamqxKDoQ4UZQkycLC3NHRUZz0pJSV2dnW/h7k+eyJEwdra1J0wiAo1Uqd3f2ccxH3K8UCQqTZaLgERdUaZF5zd6PX6iktCl6Qdruu62LXBUKoobYjTktlrJ5q3AQCDyqsCjQYA0aBlgCgbA2DuQh4nqVZv0eNcZAPYHSewUby8VvvKiNd3xdc7G7vKHDL1cpBa1tkgpsUUWKH6mqEtJKTUzNSyizLtDZZlrVaLUZdwKhYLBaikhBif38/z3kYhp7nzczMHMRxIQjDkKaK9+IeiLwUesUw4kmihByqL2xiiDE2QghttHWbUEr5nuN5LsGQpH3KIsW5EgqD1kZqKTCoSrFw7ty5Wr26unq/ebRPCel2u2qqNjlVf+7Zx1955fv9Xkcb8d578smiL2ReKpWqtQo0G6hYcNNEanXtiacADHjewcMH91dXz148Lw1wqUHw23fvTFw7DxgAYeY4nu9KbRQoz/e1yYjD8jw3xgR+ZLDWUmHf533jeD7SuYwzTJjjub7vFwowMzN1595WmoowwL7vJ5Ab082SHJWDw129ubO9dv3G2TMr/VavHFDebwdOIZHdpJ8tzC0fNnYeu/b4B+/cOX3yQmPvVaFph6PPvvjShVTfebj5R998ZWmu8vjls+9/fHtlduIv/NrnZJ4Frid5Nj0z8crrP3nm8atnz5790+/+8J3VjkN7fqVcwkQPB2FijCnBFtuN1rnM8di06xG4j3Mp42hL8KNmUTQaqDQUUAxy87FkGSM20lmOIzIZc3kEeBRjRtZcn8Jom+U8ShlHQ+jQozR/xNv8dC4++sLOq7DvS7e2tiwUBkEQBAHG2G5tEEIjUYddFM/zwjBsddoW3DnnkgurDXIpQ2MCGBh+tBEaTCMxCNllGdgDG5BSE2JNYZB9eLUBMMAoNQgZu1vEWMPAqD1NU9sANYipyGLsKJAYZJEdkAV5hIiUWkphACNqZ2kqpZQTYGNstg8GANsKKsZxmmLbE+s4mFJCiO/7nucppUBrJTgM7d9G4XckfB2QeghGgZcy5jLHpQwBSCNG6QCM6irYBnPwPI9zftA4eNaYx65d3d0/aHfSg4PmxvpuMYwYY46DSqVSHPcdhldWVmQqjXEP9htJFqdZfPL0aanV9es3nnrxJaA+ABVJBgyFQYSoand6wPvMQVP1AtAQFM/aB8RJWZlomeFyLc/ymMuoVGeeR1nqkKCwchz6Xd9xu+12FieMkXv37hYKhfMXLwRBAISA62KM9/b2pldWjDEYITtx8OBwf6paJxiAEN5pVsuV1uFuenjoO6Q6PVetlA93N/vdfi5FWIgKGCPPJZQ6ALZsLtRgtqoZFmns6sIgxCtbf9da2sGJ3V7boZQA+L7rUQoEi2Zzf2/n8O31vBvXJ2uNTmt9u1efyR2/IpEGTIVUQueEUeIgwigGrTUcHh4KIRhzisUiISRLeQbcC8IwdNM0zfOcUmYMZNbRjXMvKHHO436i89TzPDfwGNJJP1YiBW2GzKllSBHGmFCiNVFCWnB3HE+IPMsSDIYR6jBiNAoCTxumtfR998yVi5zzKIp4lnc6nV/9C780Mztx68ZHjuPYkUxa5asP7pdKpeb29qXLF+/cvNFoNFbv3VtZWYmKxXK5DBoANAh+48aNykS9VCr5hehUtQyEVSv1OI4nOAffC8MQSiWapFIKTIgfhcaYdqujsywIClrrjOdhEEllnNCj2lXJYEqc53mmQD2vPTGBBSoK4qQcoigK07xz0AICK8eK+/uHNeIUwpIrY0Xp3FR58+G6pnDh2jEu+AfvPfiNX3/irTdu7e4cPX1qaX33wEXoT//0T688/UKa5c8+/8zc9MTiTO1//p1/tTHjf/ml5958880nrl3mPFt7cP+o4S0sLEzVqufOnI7VnXaqulL0urFfLMGQOqcECDJaS621GetgH+2eraPLJ3PQAXYNsR2MMXjoOYhGqGNhfTx/JYMez1HKjD5JpIxv6zHGXDwS54yDMhqy7SMKyF6LFHz8F0a9rONg+0l8f4T76DPTx2v1ybWNdQ3AtelnSVgqCq0QAeZSxghQQ7HWWnKRc84XPMKFMphQz+MSukkqjfE8TwsROCx0CFXc5AlkGUWGIGj5VdtrShFFaDA0FQAM0gqMBqVAaxgwLIDQiZz1OU8oU2FBOF6fc5Fn1EjfGNcoCmAQlsTNEM0wlRgv7d4PgsDxHI1Ag9EYCdC5lByQAqQQ1RgDYtKAkEYpFbqPIupo1dAnpUi21GkfZscreMzBCEmeg1Yuoz5zCAYMyqEEACTPlBKYDHzmPkqlgwnVQLUuMq/APCR40u2Gvh8Evka6nyUcGeKQXpYcHIkZ5BUqxdp0deX0cUl1L8/fv369UCpPTc419w9bB/tEZ1984alygH1HeRRHk/VGozG/uEQd58HDtdNnz3/xy19GzEHM6fbjhItSpRqUK0rJOI4RpgXvgR2FGLd7vW5an5hF2L93d+PM+WuAIwDXcCYlReAQ7AImoBNEEt594DhNSLZBZIDcV398fecQfe6Lf6m2dAawNvLo49s/brXvXbp0rLdmJifr7U7TaOE7pFQvgks+/vEPpqolj0FhYgKyFISAJN5ffehQ/Pb73/zi177WPdgrLsxbOUIqeT9LJ+YWAMBqXLXWRoFS2kjluolUoJFD/SJyPYWJJgZRhZEkTINRut0xuSJOlO41P/rg4/V3ebPdj1OuiC/AyRShbiEqV/f2Dz3foaAFTxysi6HDkOYiU96cMYpQRCk2RmvDGaGux3wvVMpooaUwgpssy9NEcM5jBUYrpLiDdICNizXVEhvJkE7TOOMZZswNA+Y6uR1HwypHR0d2q94+alJKK5WK0frg4MBlThiG5XIx9PwbN25cuXKlXq+XJ3tBEHz4/gfVWuX48eN37tzyXfb4448Hnjv92OUb3/vOjesfz8xOTU5Oui7rdDpLT5396Ps/WSpUlhaXH+5trrz87PqD20sTM3Kncf/jm8vnTvcCgGpULBZd7G29/o5/cSUMQy0HWgtjDKXUq9YaDx+6rlsolWSeE0IQxv1eLyqVIMv63djHDsGOOmonzQ6RCpTeWN98593rza5pdEFAMeHBrXsHBvtsbunujZsTBXjh6snJCDd27h1fnL5/f+f48RnieotLK+vrG5P1ic2HDwtR0NjfK1aqURTleX79+sPl5brneULKVvvo+PHjN2/efuaZp7v9vpSy3+/3+33f91/8/NMfvPf+nZtrM3PTpdrCH3337Z+sQnV+5mHH4MIMB2JkEkJGsgNP9is+NKAwVjKldqSEFNr1PUqZrT1IKZU0ttVcZxljzMoFLVFuGelRqQyGDlqDshBkg9LRUOVljEHaSCmN0mEYAsD09PTh/r4NjbmSYRjGcZrmeRRFXIo4Tv0wSLIMY2rnDgmlR1GBITw2d3tQOGSEKqVGYh48hu9C81HcwUQd5d21is9Lvpip0WPz5VJgiq4qBih0gCGO8jjvdXWe+oTUi1GeSAyEUUdJk2eZVspjTiEI85wnSdbtZzHXAjxwI+WEgobIih/sgzsUcdqByFpwJaSRSmuNARAQgrEx1rwMYaON5ggkI8ilFIMemtJokDmoHCTXInMchzqMUoopQRiP+JzhPeNSCGtsYKWvajiHxRY9yNhsQ2SNa1zX7lFKpVK1WqXI6kyR4zie5zHGEDJSciW1UkZrPexKHjjbOJhQ/GgSiDJSAxBGpda5FFwqPQwnLnOqJRREYZZlm5ubt27dUsosLy9HUZQm+dHRUZ7nlhoSXCVpqjW4vhfHqZR6fW1zbW3j9KmzX/7qVznn//1v//aPXnmlNDU1s3JcKgGACHED1ytEkYjV4e6RTkxYWyoWattb+51O99SZ0439/bTfAc2RY1hAaIAUyntxM5UxEO2EPmizf9g6PGpCVHjqM09fvnw+KjhpZ6/b2EI+uXj5/PLC/Ob6huW4fN8PwzATvNU4BIQuPPbY7v5elnIolUSztXr9Y5Gk1GGdXlytTG7eulOsTWzcugMGQ7XqeV4URSrPtRQGKaAIM0IYJgQQxfbTAmCQUUZJJbnKM5HlUoj+Uau3f5glOSEOMA8ZrHPVOGy22+1+P7F5txWe5nnuOA4CYqwFmUFZlvfTbMSKCiGazWav13OoG0WR6/g2AxjdZYQIpdRxPIIRBo2MQlojo5E2SvA8ifv9Pufc5k1SypxLpRQgkiQpY47WJklSW+FP03R/fz+KAmNUmsaVSmVraysqBA/XHrz51uvlcrnX6c4vzB0/frzbbc/Ozn71q189du7M9PIytNvf/Oaf+b7/2ZdempmZeeutty5fvUopXVxZrNVqh3u7nHPo9ebm5mBycnd/T2vtrawQQnb2duM4hn5/bm7Oc1xkBhW1IAgAQHEhmk3PusoA2E25fWRElgFjg/KjlDYSAECaphMTE8ViUUrIEjBKl6LCsaXFs6dO3rl1u14vVKulo3bLIGi19MbWzrPPXm40Gs1m0zovcZFLKSml09PT+/v7Vgpy7Nhku932PE9JvrKyYoy5ePF8nucfvv+xxUeEjR+4777zVqkQnjo5j7WSeXLh1NLFRQfzOCTgIckMR0oYzR2CKQWtwX4GRp2Vo4xYKZXnWZIklny2hTTbizRKusdJlVEs/FTxE8YolxG5jzEOgoC5DkLIinNsNdUYI4RI0zQXIs9Fr9ez68A5t+HE9lhJKRljlUpleno6CAJvePi+b13Z4ZPHCNnhk+VZ+uT5UqvZToVsd2IlSW6QZ3AhCNIsVgKk0QxhF2MtlcrTVOvJYl0qkyZZmucKY4dQlfO93m69PqmU0kJmynBAFHnIgAGFDQcAgga8Cx7uGjAyAEgrrZFGGpQxhBCtEZdKIwSAlc4lF6ANNtqhBHFFQBHQoLREBGkJJkeAkUMRJYYQo6XFWaW1tCPutJ3YZgxCtlkZK+CKj4rmdmH00BFitOuRwzsBQ4IAIYQJYQRTjIwSiitCqEEwGORsQzrSWmuGMAFEAIFRSimOgGFCPAcZEHronAxGKcUwqUTFGqt1+91W0t3b25s7vhRFUa/Xa7X7e3sHIDQDXfTt6CKqtM6ybKfVV0pdunTpuReer9bqOxuba5tbc7MLL3zu8+lRUxnt+6HotdOcE0IIBi3CNIl55HjgB4UJvt1qt/phWItKkRc4gBTP2ggY8yPiIMT7nX7suD4NPfDr3mGxfZTkrb6BQIEQqhfNT/qgt26/e/fe29MTwcXHr0KvBJT4SY/nSbN5sLu9r6WoTZSnpmcp0kcfXo881/Hcza2duanJdqs7P7d02Dya6CZSGJAa4swY4zhOmsWEUeY41CpkjEFUI6QUT5VCGmlM6aBkgw0xGhul0hwpwYgLwkCa9BvdtJsctTtpxrnGRFJNkDAGq1RjBxMmOEdaUYoBdJ4JjDQjJE/SIPSUkHmaId91HMd1/TzPe72ulFpwrTkopZVEUmqlDMNCaY6MJkghg7TmSuSKczCKEMQYQ4wawEopgwjGqN3qep7X68XdXr8U+bblO8tUtcpOnTxOCOn1OnHSmZiYqFarn33+uaPWxzu721NTU8VicX9/VwuZ57kvxNbaw29961uf+9yLc7PTNz/6CEB/5StfuXvrVniyvri4iLtZ0u3NzM8BNtpA89atUqnU22+AUnbSfXViQuw0NOdWCxd4ftztoYkAuj1AqNvtViqVfq8HWltwtwiY5zkjgLDRUgI3xmjf9xTouCsJYa7LHAa+B8QhgLQWWTc5OHX65MH22upB3g/h8qnFuYXq0UHz8Kjlh2GpVDFa9rqdcqFQLheLxWLa75XL5Xv37j3xxBMbGxue5x0c7B07dqzf7x+1mkmSXLv22DPPXDPGpGlcCELfcbOsT0tQCn2fUT/yk1xXA2j0uiECbWKMWKpTZDJKkUMcKfg4AmotzYAxg4HXrtJAycA5UdoMz4xy80cK7yFVoobTitBwFhIGGAqzrQ2ibcYExlzb+SOlFkIJZRxCMKKUUmk0pZQxKaUMC5HjeJ1eN+fcJhCUUqPBAOR5LqVEQx95PKxQKqWEVISQkf34eH12nGuif+nLF+7evbe9f5DLSifmH9yIyyWgzPSk7KcGSWAeDdwCQjTPRZ7n+7tt6jBjFGgIfBZEkQbTjftZvyek5hIMEMwc5vgOcymljG8ADIw0DWgD2BiDDdjuJwAw0kijQRupFGCUS6Ep1gZJCcIoBYZhgo1GyII7MqCYUcogqTUYozFWYJDR0hgNRsEg0lJClNJaamUAQBnASAOykhsNGIytBoA2oAEDVlwiSpFBWms5nICFEEKYKiWMQpggghgiFBAyCBC1bW+GAAFCqK29GEm5QUjaNksOxjY+MJeBGfgQMUyklCITCCHHZf04FVq5rpuo5KjV3N7e3tlpIAwO87OMZxJCRrwwDAIQWXe/3z5z/hpx2OTkJBe61ers7x9Jrs6cOrVx5+7ihYsfvfHGrTu3v/BzX6wuLvYPGog5WoUurSU97Hka3OLysdNHzebGxsbC8gogqZRI8wQRh9krchNsVE/0KgwD8UqLpyj1unGWi865y6fXN7YPWtuFYiDyxtxEpVxk6c6+73kylb1exyjBXM+PCrmQWsjaxNTO+moe90GbucWVtNd9cP9+t91hjouRe/2jOxevXkq6Sa9xWJ6oMt9RSgBWWBs06M5ABgwQkCLjQmvDtQbiaEwZY5hSInPuGeyyAICodtra39t4sHmweWg0NhorCUJxhbEAQxRVkDqOyfOUIBMGDsVEAsKIMtfp9/McGUppMSz6vosNzuIsz3PXCQjWBGtJjJJGSgCuQEqVdigYRoCCQUpoyZGSBANjDiEEU2IIVQiEAamNVIpzibGM4zjPgJapffrq9cLs7PT29iZj9PbtvWc/c/rpp58OQz/P8zjpLy0tSSk3N9evXLy09OQ14NmNH7/68Y3rTz75+PzcTKVS+f73v/sbv/Ebq/fu9zrtudop7Jfvv/f9o529pYJTQIhSooyqTk0V9xvmcI+6zmSlAkEASHe77YBXjDEQUcE5YCyF8H0fDQfv6GF3JUXYEKq1zrLEaE0J0aA00uC5hAZ+7OUpj0I/CkieKyA0FZKovN/qN0mmtVpaKPQOe0nKn3/5cx++/erv/v7G3/0vL2utKSaT9RrGsLW11e/1VlZWpiiL4xgADg4OlpeX9/d3u91unueT9YnV1ftJP46Kha2tLSFEqVSs12u9DtdSqDxjgCIKVR9PBHifQJ53c4GJUyBE5lmGKSKUSSl814WhkHaQ+hltQFvltH3CB8kv0ggbq23Xw87NcQ5dD+WSMEZ2Y6M+wZ7bqiZCg70CNo8qtwQjShAQrZTregihNM+CIPCCsNvvuYzZNmmplVJK5jJDAACR59s0HGPsEDq6TRhbPccnqsGWe3gE7ldPFWUHMQmnzl+ibvH38De8Qm1rt61zw1xQDhgEPO4KoRh16mGQC6dYLLgOzfK+5ClkiQHlyJx5vmKuwg4HKjXNgaTCGGEmkR6VIgiAQRq00QDUBjlj6x82VoHWIEACIYZgAwKDsYYiBsAOy6Y2jdZGG2WMJsYoRKUtymIEgAlCQLBRBDACCRhZdtGOakNKg+c5w5TcABiCwU437fVS2wyFEWIUMzoQz3T6uZZKao2MNo7C4BJkCCGAkTKGDNuX0LCATpR8JFVFJkcGMYoJUUoRMIRghAnW2noSgDQGI6MQdVg1rLmuCxgtLs5OTM72e3G/3Ut7XUp1mnFQAqscAaxt7V69evXqtacKMzO7qw8++ujj3f29xcXFnH90tdU5dmyZYnjjRz+aXZi/8thjAIqRiuewdreV89bM8jwrTE67oUbbq2sPKpVKEIZAsethgBRAa4hrlek4b/fSrMAIuNVwglKnRR26vrE2MVX3Qu/OrY/XH9y9dPbU1MnT0O3sbu3a3X0uhev7lNb7vdZRs9s82EVan7p4+d0fvSKmJ6fn5978vd+fqFVlhhDGhVKx18000bkRVhLgOBQzjLAWmtvFs7srhyglpBRCKKOlItR1XRcQo0LrnAMiAA5KtY5l/7Df3IoBFQwoqWQuhQSjiceQQlgaw/NcMIKk0IRhMAQhgrDruVhyiQEVi0XqkLifaS0ZcymxvhMYWRZRKiEk5xynXc9zPMaw1pLnSnGGgToOIUQZzaXWRhhMMqniNM94jrEvpSaElcskCKI0TfI8n6iXt3c2GSEnTp46ONy7fedOfaL43HPPTnjla1/4m/fffVtrvTg3j7DZfv/9vb2dbqf9xS9+vjIzu33/Thz3PvfiS6DV9Y8/unDhQrfbDVm4vb1dDHxEMIoipEW9Xo8392v1ilJqcmm+xbv79+9WgJXL5VxIx3GAOaA0xEmepKHne8xROUfaaCGVEAwTRAhWynGcftLDmGBMjUAGaUAaHBIVAs9x6xOV9Y09kMqoJHQKJxZmpyqitd/vpL1isehAvr3f+MErr3lU/cavn+BcNhoH5WJxZWkhSZIbH3PfP7x48WK73T5+/PjOzo7jOEKIlZWVd9/96OrVi+vrD8+fP48QareaJ08cV0q99dZbd27fXZyvzk1P+57T3D80Qtar04+dWjSwIx/227wNjLgu7uRKawzYUSin1CbdWGsttQbQyBBDiJA5wtZcVstMWhdujDH6pBGYGfp/jVfpxgkQMBJjTBAekSEYEMaYD5l6PMgCB5Pa7GA7gpmd4Ka15pxnWTY1NZVxGcdxmqZGg+d5hUIhDMMkji2rA+NqGWIDySNQ/xTK24PGzZ2dtTtSQcTUwsr045fPIqcIZo2SbrEyXarOZLm6d3/9/uouz7jD2OziaZ4mWdpFWpVCzyEmTdqCp5KnmgLQgLkRppHSKBM6zdNyiLBByhiKkQHA2ljmPYtTjDEiGCNGMCIIawQEQCPAjCGCwBgE2iUE2zZioxVghRFBmCDDDBjQBBlNkMFIE4IMgEGYYoTAZvUImYFM3xBjkNKgkSbaGDO8MWM7mcj1EUJ4oEzHAICUAa2YLXFoJaQErShGLiPWtEAZI4w0UhEMwBg2oDWEmGUy5UoijABhCTpXOSjgnDuEWmoeG+QxD5RGUkUTpWZHtfuterGWcy6FOnHihOcXmkd3HeYZV6b9o/X1TY/x+ZnqwsLcZz/3K0dHR6++9na5XKSU+l7ke2HcTxeX5g92dj96791Cqfj441cxxnc+/HBxcdGfvRRhJ0k5Aq1zhQkGhGYXV+QaxxQMSGMMFwqIpNjxfSxAUJcy1+OxcIwDBucqd8NodpH0k6Pd9dVmc2tqoji7sgTEkwcbe3tHKytLlVqt20GUkhzjeH8XG+il/Nql8+2jQ+z4q+ubP/7xT6JyZeH4yWRvL8+zSy98/tVvff3E2ZVqpSZyThj4oQNUG2yUFlxKAwYQxYQhl3pSKaG0EiZNJRZYcCIYOIwkQvCU0QATb7I81Sy0HPNAKlCGKKU4l0Ib5LiIaoSlBgKAjEacS9C2lRqSTHhusS+llIPulTiOKaVh6CVxLqXKuBRCcS55LvOcc84nUEqkYtSAVtoIowUmlBGa8VwonSupEJaAMqniNE1S7boez3NKnSgKtNZxHEsl8zyfnpkqFvzvfOc114Nf/sWXrly59NprP4migL955Pv++TNnf/jK91dXV//6X/+rc6dP/M//7J+89MUv3Png3dOfeSpZ3wgK4X/6gz84efJ4FAWtbnemPjMxVZ+fmoHIB4LTOPYwajQOliamE86pQ0UsOp1OvTpFwjCVwolCQEAx4t2O5LnIM0ppGvcZwUbJPE+jKALQWZZE1SrJkVEaIUMZktgYzREmwIjmebEYRKHrOiJNUq26QRRqCmdPnrij8jt3tl0Kc/8/tv47SpIsvQ9Dv+vCR/ryvqvam+ke07OzM7szs7MG68GFJ0BAIAhagBJ5ROKJkkjxkRTFJ4jiEyEdAgRBgvDAAlgA6xe7O37H9Ux7313eZaXPsNe+P6K6psHHOHUqq+rkyciTEfXd7/6+nxmH19/ZnBuHL3z/5//0j3/fJtDrthjBjUbj3Dl/Zze+feee67pXr9147NyjYRhevXr1+PHjJ08eQQgdPnxYKbW7uwvItNvtMAxrtYrrukqJLJe+41Sr1SxOBq3dshs8fe7YIHnv9rbiomu51ZQiDSAR4cje9xRDBsAQhOABVzXNM4IBk30SHdKmsDDSSh9Qyw9A9oO2HT3kv/JA6yQopYi+z97WCApGtjngXOL3nXuLBy5FYWemjM7jGACGw6EGTAgphyXGLNfzCjnkZp4XJUopZYo5rTGgTQHLoAd5IgeV/WEWEL12fWV1FZ56+mh/wNFGy3ZKnQFntj+/MG4F1bBUzyUaZroXpYP+UCHc6fbyeGBkWvVwYNujNb9eqns+u3Dhvc4Q2lGi0sSuZLZXcS2a2MA5RggRhJUGXORiGYMMZBknhFDbZpRgTAwmSCNjTI4VRliBlgYQRoCQ1CAzzhAFwAgoQgRhQwwnoBEy0gAxBdxtNNJEPxh9gAEAhhHDtBDHKmmUMgYEFKT4ByGoxfcgCPavltk/pFJaa8sNEEIUE9BKay1kjrCFMVCMtdFKGi2lIYTS4hNGoW2BFFoqg7DBWIBSUkswxTKeSZlz4WAaWA7BINKsH0dcyXY3QQ7d7bbjPHfDyvLyzd3dtsdcCqAMkspoRv1SeXxi+uKla6dOnRqfcG/evN7eazVGaosLi9vb21cuXh0daxw6NN/ttr/0xT967PFzTz33HHAOaUpsu1QqSZUbY3gcK527lfLs3JyQuRA5VzJN0zhNwjD0rVIH+g54BDxFFGAHsBunbSfF1siEHDYHg67v242gJNt9st3vbg92draCwHNdl1Lq1Woez1vN5j4nj7jLa9ul2sju7t7NO/c+9sJH/HI10KzTbYGmvUHMqGsM6vcHzK5ohfa9QQCQ0UZLpQEpsLTGCFixz9LKKANS6VxggrCQWBoVJUQrMG5olxthfSPFDBhVBEthNNJKQSY4B8cxmFGNTZpJScG1CdZYpMLorPACT+JcG6WUsm0XG+o4OM+FEIo/ENBSSjC2famx5iqTBSmCIYRhf0pmENaAhNHcmFxKbQxmBSU3syzLGJRlmee5Ycn3XGZZdDjsRzF86Nmjzz77dHNv9+69G67rPvPBM++9916n1eQ8W1xc8OfnxObmrVvNF7/5tQ9/+BnIuXd48dLXvmLbLB5GY+efrNQBHKdaq7VaLSS8UjQkhCBAGGNgjBojO50kjsdGRrAyILlUEgBBzh3K8iyzLctoTTDOs6xerwspeZbTUlnlvNfpBpUqxihJEoOkS2zMiJEaaQ0EsiwplYOJiRGR4+ZONuhH3LT7e8NbabtaLSdxv9WWEtEzjy8EVP3H3/jNkZIzNTHe3tvZ2Vyrlkvnzj1y995qlKSI0Pv35fPPV6KIDIYmzbLp6en1jVVkoNncqVarZx45c/HixW63Xa/XfcfV1BkMewC4UR2htN9p9xjJa7X66cMzu+2VZqKZm9uUpIgo7KSgHZUZAwYfdOL7+on9/AktARCl+zNjhJB4ALI/3KGbh0SIBRdDPxDKGLzvhAJgABvQgBAGTIq1QOp9BTwUT0CkYFdLqajFXN/jnCdJ4jhOpzO0Xcv3fdd1CaEIYDgYDAeD4XCIH/ixg3kQxKrNfxWWgb84XKW3V5Ic4IOf/el71+/udgapLN28fzvXBNt6e/lup3dRGiSFHiapAqSUElhNzk1N1Hwdt/bWb+4M1NEPHP3Is4//3E999vK166+9ffHW2vZQmtwknUQYkcRQQYAUGAKYgsFGF7JUYYwBIIANwhqoUftgk8CEYGyU4lpjChRpLlSSCc+2NKLG2BphijQChLBGAIIbrJVRSGt5cA2UUohgYxCCwkKGAmAFRmO9nw/4gNIkH/iAIK1ASVCKIGSxfWxLKYUZxRhLio0SmcgOVnJECWgAhTRgihBGlGAMgG3KRE5yCYBAETDaCK0EaMeygRLFpUxzRHRoeRhASc2lqNRrqUzL1cr6zsYwSetjk8Nh7Dq+xWyH0tCzZ+YXPFvX6g1mu0fmj68sr6dpSgiyXa/T7VOCHMcZHT3c67T2dnb9wG3Uaq3t3dvvXqw3agMTz8zMUGak5sQOic34kCeDDoBRRlKLBX6Q4nQ4HKaJdC0wgCUYASiKdaMcgkvCcm5VLODtkZkF1yPr9+/2O5GVMZSi5mZramqqMKVAiIDjA+fNVjdL+elzj7zyza+df/TsrWtXk0z85Z/86Tu3bm7v3Do1eYhQ73vffNFzysbg1m5bosyaYiLJiIOpjQ0oUFIpiZQykli5NFwRAxgwwlQLA1ojxbvtdrVUBsvJBv327jZFfjLgDvNshyClpbGESqVRwmAhhNTSGOQCVgRJxY3Gts0MIKmg0+0HQcAsJoRUStm2TbAlhFJKZUkaD5MojoUQD2yTkEuNlLnIBULEogwRqrXheS6lxhajzFLGGM4REOZQmxBiPCk5pVRKDlrPzk7NL0wjUI+cPf47v/0bP/FXPvjBDz75W7/9n199de0f/sIPTk6O37h6oVwOfd8fbcw/+tg5SKILF95eWqwcObKEy6Vsd9cho9FgODM1OTk5CUmUuNiKued5/VZrqjEDYYjiwfLd2zbC4NhWpT6I251ua2ZqQrWHlFl8MAQhQacUE8156HiAEMFECwm2jZWSQgBCnPPhcAhSaiOTNOYGU79KGQVQYAxo5ISu5ZRGRrvpUKXDjsxEyXdUxse8yu1794yBw0v1dj/u9rJPvfB03itVbAhLrki8ku/JPNtYXo9T/uRTz3z9m994/APTN+/es23b9fHC0uE/+7NvPPrIsVa7eeTY8c31tWvXrlmW1Wg0omjAGBtm3GIBN2a7HbkUzx9ekkLfXV1fnJ16492V7Q4glVPmIWMLYucgXJwBMmCMUbrw6sSYiiIOU+mi5aLEKlyk9kvBQ8r+A4S9+Dt5IEU8qKQa9iGCgnYBD8pLLnIlZUHLKbAdjLFt2znkBkGeZoXUSgiRJEm5XHZdihEWWZ4nqVJaPIiqVkq7ruN5HmMMkf34jsJhBcF/icPAQ5FPCCH6pW/tPfr44h/8/huvv/XOxWsbVoDaPZMbcEMmpAbKCKPGGMCU2S6yLczlztZq1FKPHJ1yJkpLE+GF126tXb/1V3/y+WR354c+fvb3/mT7b/z83/vdP/7aF//k7QkL1q2w2+1SgtJBLwy8su9pyaNBHxuwbIaQAdBZEm02m48+8uiNGzdYUBqfaPQHTUJpkgxKpaDfH9qWJzSRwDJpGNcMSUqlRQgmIJSMu4llUcuyhMyLjz2Oc2TAtpnr+hobrblS2miEEAEkiw+6uE6MUosxAMjzPInjYivU7/eF1mEYKqVyqfOcSy0wBsaYEMIgbdu2BiOElIITjCm1ECK6uB4IwjDEFutEgyzLkM1cxzUILGbFcRxYjhcGOJedTgcpPVKpxQh6/X6utDKaUhpFkW27WussFUeWjl1+98InP/687UClYp99/PEb1y+tbLxHCKEUM4swQi3mGi2U1lEUE8KUMo7lTk1Mbm1tXLt27fiJY/X58o1b70rJp6enAZcBiOUwqlC336+PTfEsyuI8DEeVpDs7zXpl0gWcCRnzrFoZBeRBrrxgxKgEORWZZZmgjIU5Mv1eFmBvcmwWpnzLsryREciy4dpGv9+nxElTDsQWEn/7u6+O1SuN0ckoFvMLhy9evBhW6tWR0avX3n355XerjXB6bjTjamN5tTZSQtwEJZ9gsLElc6m1MmB0yrEdUM63N3bq1ZFBu9+o1hDFVS9IewPXFnFvuLmyVq9NU+y3mnv9NBRSU+Y0Rse9lG83e3EcG0Qt2y1W/SRJpMWCIADMhOKUWgBYSi2l3rd3Baw19PtDIfI8TxXPkTG2gxmjGGPRjQHAJowxSxkkhDCACbNC2+sMhp3WcGphmmtY2+yMjgcAOEkiYwwmyLYtnolur92IShPjI6+99kqzOWSMvPX2G829rR/7y09EUf/lV25srdx/+umnKSNKKeo5y5cuX7925eMf/2i/20kuXJifn4XA11rOL8z2er1+n+DREeB6Y3N9fGQEYwzDfhwPMcbaSOAcCF1fWU4Mz6KYCQlBicVd4HkSxxhjRrASuVetgla1apn3ugghhhEYVdhoK57ZjPquo7g2RiHKUCE19MuWZfU3thGBqbmJrc2OVtxhMOh2hoBCz0lyvrvXrlZLgWun3AyHSdXxtzfW+62deq0aDSAs+ZPzS9998eWw2jDEiuL8zt37zz777PUbt0+cPNIZDqUGwuz6yOjNmzcti46MjKyv9x3H44bZtq+RrjW81Tu3NrbbZ06f5JwPup0PP3M8uL3+9fei+cPeyuqeP+qVGhPQHu6PNAlysI2KUQoiyhhmjFJGGa2NNMIghBihXImD5u/hvlg9MAo++EvRwuc6L4ynEEJFlF2B2ZbL5SRJkIFyuZxLUfAdASBFeZ7nxGKu6xbOXaVSCSEUBEERYFOctjiXlFLSff5Swa/bX1q0oZQe2C2YB1lJGGOK3rfNoT/3j/7Fv/8Pv/ob3/kSARgbHc0wTXBndGJSGSOSoUZALKq0QMhoinOlpOiVPSt08M0rV2wJxybwFz4zf2JpwsJJ1LyzqgY/+blnk53rx8fZkRG4eRc2YXt8fLReLjkL9MaVy8ATwUWjEhAENiVbW3tjY7VqGI7WDm+t3D22NL8zUFmSR4PYc9FIpdzptXkGU5OjrW5iDAWgGkAjBIAwSIpMpVLLsqxoxJUWlmX5vlsu63gYFWEIYAQhjDGLWhbGOEl5gcSYgxFKscpR4nkuQiCloJQoBUJwhBBDBczPDACSQmtpAIRWllIaDCL0AMgjiBFktFaAkOPaVati5Vkihcg5IJRxCcYIIZQEC7DnekaoKMv7JitXSwuLh0rVIFfSIDIcRMagKIouXbo0Njo+OjZBcb7X3nr5ldccm0ptM60RsqhGyMKMYEwsZHTOU2rTPE/XNzZKYRgEJQC9vbVz6MwJ1xlrtptra7c7ve35+Vk7CHmWEoTuXrvieKXG6FgepyWvWjpUb261eYl4NAi9gCAKXAohMGbYCof9AWFerbEQWKVtfn97434raVf9siEDy7LGNZLKJEki8yI+nvW3W0qCVGgYZcNhpqUphW5Yrl26fH1ufmpm9tAP/0hjfLIcJXtZniHMaYO4jgNCA0ZpkmRJUqpUbdvO9iJHSoQ9nYNtLKbZyu37k+Njly9e4JzXKjVAdp7nW1tbOcfDNMtyjzJmDEqSREgT+C4iNEuFklxKVlxuznl/ELmeXWCgSGmFNAZMGcWESaEFT7VUWZLyJAatLItQkEhpo/atAYsETa10zrnUCFHoDjtcgRc4rutrTKr1uABhZ2an79+/TykulYL63OTIaNWAFDJ9+50rn/zk00Lwa9cvZZmklEzPTF69dvGHf+SH6vX6V77ylampCZhfmImHS0uHeu3OyGjjxRe/s/TCc9GVK1PTE/fv3E3T2FlcLLMppHSn1Z6qj/qekyaJZVlK8Ea5ApRBq0kRHq03lBC+50GnU/aDq+9dnJ+f92pVMCYaDFQUY0qQMe8zgKXCBmzbJp4HKiOEaGQMIoCRBIOUpLkxPLN9pz5C8wSFobeloyjuuQ7M1Se2mq3e5g4QKoBkCm0220zoXEqkdclzHYqbe82FI6e6w2G1XrPDapIkQCHKzCBJg0q91+tcu7b5wguPt7u9l1669YHzUzdvbiJMavWG43ppB2Q/sxjKeYTdUlitXbl5+/Enn/jff/HLH/740vmzp9vxxc1kUAp9oXVrrz1FyQEUbgrKWqGX10VmkwENBow24qD3hYccYA5QjoL4CA/mqAfEdtf23ye/A4AChMAgiKM0y3KMMWOCUioNaIQ1wu/zsAk2GEmjhVJYqYN4pqLzBG0IwhQT+SCkW2st1INYPiiEsvsjVvLAm0xrjehDSUz/4P/9S0qa8bFjCoPEGNvMKjmxtJThw0wzC5P9GQIgjESejYZWu9lUGMZC+OFPP/7Zjz7lQdLZXi75dP4zn4ByBVIxiPLnzp957nOf+upv/fa38w//2q/+6t7GqkNR2beiXv7kY4fzdNja3W3vmNkJC9Tw7r3OSABxBJmP89gfmRrxR0aH/R1Ly4ptKSfvddoIBRoxg4hEBmNksIZ9HhO2meU4DkImipExSol9AqmUWimFgBDCjEF5lnHObYsdXIyD8QjGuJhvHCgItNZZltm2TQAIBooJEIwIcCO4kkapTBys1aSwPCu8UXKVGYQpsTzPMxhlA040WI7FOWeEammUkIQwsAmzLJ5yx3MBo6BcohZjjm002t7ebu11SqUqxez8k09JqTUylVo9yYZe6DHFHozvQXBlmKEaIQxZLgLfJszOeToYxoQg3/ddP/jaV7906tSphYWF6clRIYTFCICxCVWgPNedmJhATrm/1yLgUN+3aZKlCfYNNkqrBGnGLAoEKwNheVyZWIq+Ai6VFefCZIltsRDs7l5LCz06Oj6xeAQQTuJ37t25G3plBEwK1Nzt9rqtXZCl0MMYqziuZ3nS7pYrztbWzuHDUxTXv/vS10dqJdcPeTywXFcOJE+k5dugicMqza3W6OGZO9e+Oz11dOXORddmySDutYaEQOZklWp5ZNze3Oxut7oSARcCKAUpk1QgSn2/ZNnQNf04y9GDiLFcqk6/F2o/CAJtECgDCAghFDMAnGU8z1MEOo2HWRp5juUQDCC0lIX7YKFfN4hIJdJcCgVAoTcEwiD0/O3dvXa/mwvjGD03N5dE0cTEiO2w1dUVnteOHJ3f2d187dU3FxZGr1y5VCr7nU72wQ8cn56ZfPXVlz/xiU/kefrtb39ramrisSceg3u3syx55NTp5t7u3bu3pycnIEmC0fobr7/86KOPXrx4cTgcynZ7cmRqYmy8UimBNp291ujUmGfZw72e7wZ51D+ysLiV9YmBrNVRrb6/NOcQFoyOqX4/TpNSvc6z9OqVK4+cP+8AZCoLgwAQEkLInJs4QSGzCNVkPxMNUaq0RlpjSpxSkANnFM/MzzS3e1GvjyjYFg09DyNkh6VMmmESXbu7fGqmIoTwGQmcEgEz7AvPc9d2t/xSGazg1uVr4+PjQaXU7sfxcADIHD+1OIxzhNnJUyOIWK0OvHPx0oef+dD6+nqvB3t7uxfeG3KAT3ywcu7MUa9Se+fCuz/1U0++9uYFGkZnTx2++KXL0kYjo7NcDjACAKS1QQYpBMZoZLApmHII73ujaKRgnxvzwP7qfV/f4tcD6VCB5aIHidjUoeYBPa6oKbRYHvCD0euDkl3UdEUK7xvysHxSFViQKRLoEEKADkB/DO/j+/r9wAylVEHLwQ/85R9wex4q7la5MYyjdpoTxjBFIo+4yKnWjVoJIUOIogR4lhYZmMZIbPRUCRZm6h96/NTjpxddhrNewhjLUp6leXdti7JganHpre+9OTXbXr+/+t1Lf/Kjn//Ud7/zTYbVU0+c/ZEf/Pz3Xv7Oq698N9oz4xVYGg9arc4P/jcfqVRqb7194f79lena9LC5nQ52HQvag2xiyrJLzmZ7aJcDg7As6JTIGISKegtSG1mEd8P7S5wQg2gIABhTRm3GECGMWNSm+0Y5D3unHazMRQ4W57zIRC3ipaQQiGBMCCKEgiGEIK20MVwISggh1OynuigFiCDMjeI8s4x0iIsNUECWZVVKlTzPjUHRYIgYMwZHWT4yMhLUakvzC1evXn7v4sVWO+IajhyZqLil6elprUiW5FrD+uZWo+rRsmUIybhwqEHIKACkhNZIaaQZIRTXRxpC5AzD2MQEQrC2ttZrNiVC1EKba5sizz3P41IaY0qVarVeR2AmFxYBWZAmoesYo1Q0qJRCZjACSKO2keC5JeqWAWiWZsS2hCQ2LvuN8LBbCh3r1rtv3bx3TW/RMAw9x2/vtZq77SyVa5tbSiEtoFoZRQb1lHbdIE+jnKtaNVgfbiRZ2h8Og5B973uvgjp76onT02OTne1OyQ6SQWxNVj2QSpm4lfd6PZkkruW++SffOnvyyZe//O3RWnVzZRVLRTFUKyXHcxzHCivlQaryjWYiwWCcc16okhn2jFEYE9dzojRJk0hYjNoWgOFSpjl3PGWAUUw0JmAQF0oppaUQWQaa8zzDWliEWVhJkSEQFrEMAkAECAUgCqQywDUgjWbnRjOpvKDUbLUd22uMBkLJUqk0OV7a2dmOoujo0cOuTW7fuUEZzC9MDgadqcmx3ebmBz5w6vu+72Nb2xunTp2ae/TR6PaN2zdv/Y2/+bNQLi9feLteqd6+c6vbbe9sbT7++OMw6ILFyuVyc293bn4WIRA8g153pF4FbUAqpFV7r6W4GK9WIM0G3d7IySW50vRnqrffvc4ivjA7vrR4COKYZ6lIU7Bt3u1sra8/cv4JTAnGyCmXwWiMAJCJkygIfbKfOw0aIWIxhDE2EgUeZLkcpISSucW5vebg2nt3jIHWzhY3BGPsuEGz0x30uUz4I4cm0iwZrTgu5JIL14Y0TRGhUplGfVQB88vVVKjb91azJCqVguPHjtxbvutYdH5+thT6H3nBwhjvdbtf/urdzS587tPH/u7f+Ut/9Wf/pQKydOz0G699u1oK19dWPnj+UeKU3r2zcXyednW4tbtmIQveRyk0AawxAgAM2OzHe+HCqxArUPu0jPfx64frg23bBxVDP3wwdFB8kQFCiMZAC56MxQjCACDVvtXvAfN9f6V8KLM6z3MwGANShFC6j6prrY1FDlAgjB5YEAPSWhfmWv/VIcF+cY/E0C05AKCMNkZaFPlhYDRv7224FpEq00Y5FrZtXCnXJibG+ncuPfWBs8ePLHz4qcd3N+7vbTU31+/aBFVKwcjI+Mat3epI2W7LxaOPt9rDN9+O4258462XD49XLl7beePP3+zcu/Dch85bqfrrP3ri5vXrH3ryWCUs5bk4dmz8hz/x87/8y7/8p690Skb81I//8Pd99Ml/8o9/4cI9Xg3gxKHJlb0MAQVjFICk3AYOkBsiLVoWOc/iBJDmPLNtxpiNEPLDwBjDpRZC5VIQoy3bdS1LJpl+SIZw0Lnrh9K2ika+MCfIkwxpjDHCDyx7ikMZjTSSRoJBSBulMUEIA8otIYxCoF2EKMUOYYQQlzDPt7KUx9qUSuUky3qD/lxl8ciRY1/65jd3djrMgbDMwnKpXh/pdYcbG5vHjp7a3b5/5cqVudnJICx3utuuj5VBPM0wo5RiIIQSihlljmVZFqas225lWWb7wdLSoaBSWV5ejtJsrlbXXMe9vFoanRqvaVC5FHmcuF5gBv0oTjiXlWqd+BXgPE9jvxSAVgmPkjxBMAxtDjjADhFGU6tkjDA6RX44fuK4SHe7g9VWc5hFMU/FMM7TTNi2C4jWqo2LFy8RhAbDXhz1kMp5FhtQWZL7pfD+2irn0XMfeWpz897eXnv37jIFmg6iuBPzlIO2mHY9wMu31u7euR+GYTxMXn1x91/+uy+0v/7y3nqTUdNxOo1afXp2Ehgx1KqNjmon2O4Ph8u7zFjD4TDPBbNdhCCOY8CEUivw3ChJhOCIYkwJKJnl+WAYO36NAtWYScFTyYnWFAwyJktjbLTt2A4DbDJsMoK1S7FBTD1wqtQGNGaIAaGWxkQqmWQ5ZWx6fi4IvOs3b9y7d69SKksp7y9vHUJceK4Q6WOPPzIceAipfr8fRbJaKwdB4DiO69oQRVvbG+effJyNj/PtTYZJr9+9f//uo2fPpXE0GPZaqyuNo0cJxffv3x8bGX3ssXOwOHPj26/ag1wnefXIXIkEV27fmK3UycLR9suve9UwXV2zCQVmySylQrWae42FhQsvvnj46JHQD2AwGPYHIyMjkKRASZamTr0OSWZZVq1SdW0HhFLSSKmVzAFRizJsUQQUMAKqqWtDRsKaPzo+cstdsY2UrWyQiixTOM0yqTHDCmnErMFgB9fqPMmwVtOT9V63WyrVWv3kyq07idQas84gHvSGhxfnCcF3llcW5ha2NzcvXr5+8vjR9a2dI4cXV9c3PvuXTmdD3O0P//k//ZdPPlH9zOc/99rrr1+9tPypj5197PTR9959B1En77Zmqvbi6OxWX7/0xhVoBOZ9CwFDESn8B5XUgAAhgw16YAOmMQbzwCjWPCRfOiiv8CBI76CYgkFgCj0EILzvYa4AjJDGGIM0cFH0f8YYpY0mWhlDH/ICKzbiQgij9b7aVO+3m0opxlz0QJqEH1RzbfYx93006CEEQr6PLwElVoQob7VaWutSqRR4vlHy3ur2iYXR8UZtb3uj30qcEtKJ4SJuzE488/SZU6eOddutzTu3okH3xJOPjc/Ny+HwW9/69ntf/M6hxcPV2ckLN3a+9s3vzi8cXjgxt3x5tbnas8bhl//5z7zz5svpsIWinecerT1+fPyDJycIgka1fO3atb37Sda8+6kPnXr19dfuNTvJ5vJC7SN//Ue/f3l95eq9tT9+bSuo2QBYgTIARHFFUkVzRmQOHLRxHAcTBNpIKYfDYZrGgJFlWcx2MUUGgVI647lQkhXiR/x+yApgY5DWoJSRtmthigzShGHXdxACpA0go7UGLTVoYwzCGDAiBhlthFFaY2oQKgA3bTIqEQFMESGEYmJspaUSceo4DjGADXielyuZSeNVKpOL84TZlVqQpFGSiVy0pdSlsDo2NialDsNwZ7upVS5kVCnb45OjAIoxQimhlBqMAO37oSulSpUGpmRjY+32nXtxzicmxiZmZqWUeadHGRt00it71yzXGpscnZ6eCGo1QHqvuVUulwM/aLU2qzqn1RokkYoUcannA5h0GO+lqhXWZhiZxMg24BhEm629gAz9UE3Oj8bp/P2re6sr68v37gth6o2xSqk6GCbtvU6pVMIYbOZgL8TIFzZL04Rz6fkkzQQXIs/zRqNhY7mxura9vnp08RAf5qAQtOJ2s4ORffvi/ZWVVgatDz39yOHFztf+0++u3EsPL3if+fEf+r1f/vVPfvbR0vwUKJllKZTcuuWURspidVcjEFpJoy2EtNZZlgIinod83xVapFlhdIpR4SfT75WpbwhRAJpzmXMCxqHIQkYJ6VrYszFB0kjOsGQUUc0VwlLpXHIDhGuECaOIIOrcX96u1ELEGACK47jTaQ0Gg3K5nKSDQ4cOJWm/22tZtP7E+ceeeur822+9wSzU3N1aOjw/HA6//OUvhyW/VqvNjY+/9tprTz75JHTblm0TiqP+8Pz584zgqekJm7JSqdRfvre8vLwwN5umCVQqEJbae3tL5VGLUDAojqJBpzd19vHmm2+9/fqFT/93f31v/e7ooZl0bbXk+iWHbu7uNh59NImijbX1iYkJQohr25ILwBgcR7QE5Hm30ynXqoXpFaSZkdpopLSCXBiDGBCMjBGcEWrX67qb6URbnusFLqO6riqtwZbUsNfuGssOq7UA50maiTiVOddp6lqsVAo2OpkfEkzZG9+73OtAfWSvVG0wyzGECiWlQtdv3nUsPD03P0hSLyh1h9FgGE/POCMl0m01z55e7Cfp//AL//Fv/81nPv3pZ8YqztuvvzxaK1fqVYrxI7X5r7xy8c03W6cXq5uDDIrgr/1iCgiQwUgYYVRRA3Cxi38I8sYP1/fiuxCigOMOfEr2cQKLYmOQ/gtehMYYaQxF7/NqDoSjOSizb29eWH/vc+GpMaAKD+F9tQ0AYADyUDpgkU5XWJK5rvvAMvV9F15CiDEPde5+wLMsclw+OTkR9QdJ3PubP/Ozf+tn/9rMwhNVKpiIJsvw7NPnXUYZQh/76EeSlTdPHVuCfBoYXc6Sq6+9dfvu3bffvd0bQGPSnzr8+B9+5fXN3c79VbnVW5FS1Sz42Oceae5ubty+9I//8T/YvnUx6jcdoqJee231/pGlQ3PTZd/MUmq9/NIrm5vtMh1/crr+9NmT/Y37xyZHxqv2E088Uaq/8WcvX+LAMSCNACmOkcRGYgNpHBOL2czCBKUIIUCB5wWBd/tuE9HMYhm1EKEWpRYpfGPlvlz4YFk+ECkUgExh6V507kmSMMY0AihspIwqPrvi8ksptTDIaEwYpQRrY5TOlKAIJ3lmFHjUopgggnQuszyyfd+mjDEGBBsEiNFcyWEclcsljaTr2kKIXq9HsNXrxt1OHPplUOruveV7928+++HHozgk1IReQAghFEmjpVRCCKkFE/xY/eToxLjje7du315d2+j0uiMjI2NjY67fqFQqY+MN33eHSb/VbW6ub/u9Xn20wiiyLALUEMx7vZ0a5paFhv2ury0SGM8RKY+jbAAxq5ZqrWFeDmcp0MbIFIEWiJVmb2trb3l7vY8RmhgbG0RZFEVptqE1LpWraZprJYTIjFJKZkryLMvTJN7b6R05vFgJG/fu379+/Xq95FhI+q5LMUuHCdZk9ca9WzfvT4zPLd9uGQ2HjkztbfdefUn8s3/ymMkUTwcbV2/8yI9/JklaoDVgYwiSaRzlJlc8yqC4dhjTIv4CAIxRWZZYtlvMR5QSiAChSGgjhRjGiVDaZhQBEGNIYQiqOSBjW4wSJUVKEfdsipHKecZoKU/zjOcKiAGqMcGYIUpd3xmbmIySGJRJ03Rvbzf0g6XFhcGge+nSRQO6VPIxgbW1Fc7TWjV87PHn0mT4f//fvzw2Vv7cZz515MhhNDH6jV/51RMnjgHo7c3NaqkspZyfn3U8/9d+5d89+tjZMPStubmXfuPXR+qNIAhOnDgBvd7Wu81KqTx++Ije3YUoUlyMNmpA6cr9ZZkDMKscljAyw17f9zyXg08wUHb65KlrN66HYVit1yojo9E77/AktYKgEBimaVo1VYNxv9+vhBal1HdpzkEDcKml1hgkJRiDIY4NVGikw0ro+m4c9RzLtiw6O9u41+xl2iiNMGM7O81pF+V5So2ymJMmCaVsd3c3bEweWjp07dr9za3myVPHMcYrq+tKZqHvLR1aaO1t7+617txqnzs7AVE6O39oeW2VrzdL1SoI/IEnzr13cevmreu/8N/+7T/7g19fnJtOB52ks9vZ2dm7u/rUmcf7g/j6vS6pBQ8AFgT7TrlFUUWgQYMBUMggeIBlS7XfApu/qDwv7Kf2nSAfwnWzAgbBiCCyX0yMMcYQQgq3AGNMoZI/QAWK11Twfv+OEMKU7qPzCGFEjDEYQP0XKR/6/Tjvh4EH8uB9HhC194t7c3cwMkKUhGTYNEoRAy9/9+tvvfKt88fLH3/uw1G3w4z6xHPP97t7G8vLJYs2W7tf/93fuXr1nkRQrftOUJqaX3z8fGgH1Ynpxa/9+YvffGllZqHyP//T/+UP//hPFxaXPvuRU8v3b29tlI4env3Kb/5aKSAfevqJ9XvXq4EVLs1OH1m48up3lpaO7G6vvfznbcuCQXPnqfNnnv7o82Lr9v3N7X/1r7/kNGBjCAwjipBlkAJDCaLEMAKMABACSqdxnIk8Sobj46OPnD0zPTfth8HG9tbNW3dWVlZ6/WEulW3bDOFciod3Q7AflGSMMVxJ5thAcJJnltGO4yR5NsJCqZXGRebm/iao2CipfX4lJoQwyogBLZXgWoJOYxnrrORY9aBkUduAHgwGYbniWG4x6QYCXMlmp1VclVY7K5dySqkQxnX9LDWDfpKgZG56enJqdGvrPpdye3v79Jnjw3bfsizLsoDgYmpfXOa33nrLdV3X944cOUItNhgMCCFBWD55aOnatSt3bq+ceeRkbeaQZdF+3C6Xw+3NrVqjdvvWNYzx0sljca93+87V+fl5o2g8TDxQ1Nd+gAVSOR+0071yeIRrkQrjYh4wJdKoN2j3487o6ESvN5BcZHGiNLEYUsZILozSQuaEIEopAmqzwLYZwYhS3Ol1h32VDB3LooqLVq+1ODtlpIrTFBu6vr793jstdZr0mjA7y5aXNw/NzSwuwnAYnX3k8c21O0YaAEwIAaXAt1zPBTt0Ld0YHZmc2Vp9L/NdDwDiOFXS2LZrAGVZrjQotZ90o7WmFrMsyxgTpYnQilNmU+JZFqbESCWEYIQQQpCWknPKtMWI0ZrnYHlYGZ1zrYwGijGhBjABaIyOAEYrKxteaM3MTDuOgxDa3d21HSyVPnPmWKfTyfPUsqyd3a2x0VPr62vXr12ZmKg/++yHjh4/fvf2rdtf/4rv+/W6Pzk56VWrN997l3M+c2g+6faOHz/ebrdPHjt6/dvfPnfu3KX33p2cnLRtGwh54403zi8ehzDs3brlMTTaGGGetXLx0vnnn98qXYTbt0k9aLfbI/VGnDW7u83ZJ8/C+nplYqKyvTU2MsKz3KpWR0dHNzY2DrmOlHLfBtLziBR5nuOKiymjhmBm0lwVYhSjZSMsZ8PYJVwoyWyn1mhYjtPp5bEZWpY1f+RIh99d3+u2e127zJoiXTpc0Vo7zLIsa3ur5Y3Mbi6vPTK1cGjx8M5O8+btCNC16enJyZlpmWfN3e12r5tmvN0aPv74XHN3m3M+j1G5VHUm1NjU7N317ft37/6P/8NPvfraS7du3/A8p7XX7O01XQufOXpsvZN5tVLSTUfLsP0gjkJr2K/roLTGhJAiNMIYgzExD2qCytTDNf2gBSwqe1HcD/B2Y0yapQUn8oCnaIxBfzF6WgpxgIzT0vuWsQfH/v4A3j8pQUgRAgD8QQwIABDYz/ArMHcM+6lP5MGrKaWkku8Xd55ZKqvVQtZtbfoWrvpm997q1CiQHC6++Sf/5hf/5dtvvNkd3uJSbLTvfv2V7tffvOjaYPswPlL93F/58dCxfv83/7NHiGVaXq6eOUyfOnSi2eqsvforP/PRs1L2kIQnzj01OHL6//g/fxFRVK2WqwusMfNCOfD77VZP0AGLf/+btx4980grfpdy6EnXapx+50r6v//SH31v+Ua1HJbYSMcZGApuycsGg26752HklGvNJCUGTtYEyDxu56wPzx+FH/jU4qB5670vf+OjX/hgeKhqji7dXQ+Gktxc3fr6t+9U6vFNeELq1PJMP9u1QmSY2W22ZmcOd3eHPgll7nsAZcelYsCGUYnqTO5SRCkEiIS58ZCRqeBamqFMAKRfcqPBUBMTVqr9XpwJSUQdM2osyASPctHG4JeYV3YyxvbioVJC8jyJ85rtr7x79dlTj546tHj5yrWQYZuVW/2exrSVClIKhsO+QMl20hyxKwqTq1fuPfPUB7tNAFWsZ0TmUhtJKbYMUjJXWjCCWeAzBL5llcYa/X7/zvUrjQ+VR09OZjzdVp2q0GQiYAn0ZaYqHqsHVTrS3NpYvXW9EgZL4w3qMtKP1pbXquVKtVqVMR5vTIHvt66+E8y1QCmgFCiD4bC9stJblnZ8eLvT4hznuQDkEkLyTCll9uI2Y8y2meUwoQznWsjcII3tUOx0w5KLqBl0E0acbjSUKljZNpOzJ195+bsWCe7dHYyPTA9FtdnfPeTPjOHh9cvrhw9VNtduH/uRz9zb+F7uo4HtygDJMiI2sS2PJxwAT1VLb/d56E7FcayUsu1QU5OmOSDk+p4QgiBjYWWMwUpBmjEtidY7ScMR1Aptx8YkH+b9rgN52UX1wOZJBMrUPddxPJlDnhFQeEDKuhRqnGZpbjuu44f9QbSxtr20tJgJ45dKYSWMMj7I8tHRUeaFieE0LKXAsBscOXpc8rwcluqN8RvXL9+6effo4sLaneXRUunVP//uf/N3/+6FF7+d5J3NnRS2zeTMRDwcQsm788ZrvmsHjkuQ1e9G9eooof7KSvPUI48AQjPVCpcpeHB7b/0Dj52GaHj126+OTk3AYTzy9KlWv4/SnoUIOnmo/eZ7SkjXxDrX5aVD7L51b/vukcUliJu+j0TWB6xcDNDtWRoD9XpryxW3KgkDqTWPJRfMKItgQEiATvJIYm0hbZgZ9PcqbvjBczPr11av7bbDUv3Nl18u10cFQ5YTekzLPNVu9dLW2qGxMld2WJ0UkThSHYX17fZeb4rp6VP+zbtxH+2MTs1xEw503t3W5fJU5ZBtXFer5oRvwdYa82DTPUJoKWetqLPRWX/v7AzbvPriicNLvR52neDmvc1rr9z6vs/82Bvv3Dg8OXfz1iqzpEQoNzgHLBDRCBEExEgjOdOaIISJhbCrsCM0SSWiaA+MAYMJxgRjTR74hSkNRmZpVJg1EkKKlNSa4xTF10hhjIEHIXx5IrxqVWsdD3qU0kajoZRqNpsWLjnaKoKLiEs9FhiVpmmKEEYYUYQBkAaj991skcLSGKNBYwMKIYQBCMYYKaEA4/1wIr0fr2q0Jtb71s302KFpRmFnY81G+oNPnEt6zeuXN2cn6qeOH3787JmL77y1tnLv6qUro6NjZ86cGfSHxw6NnTl96sMffOoPf++33/nea5/9/GcWZqaH/d75J86vrKwaYlVGRqaWTlLHr9ZGLl6++ge/8ZuO4xBC1rb3iEWu3Gqu7fxKvVo+srTYqFSWZmdnFg5dePudr3/jG5/7gSeGvf5UJ7pw+bd/9U9/q+zBydmaoP7FW/enp+fzTO/1M9fzzxyZ73W38yga9pPpqfJ79/vjNX9paWLYXP/sj/3YeMO9dvNGZQw32y1FULlOHzlzVFveU8+cL5e+9uKrV6um3+k3S15AaEox8gI/gArVGQdpG0E0x0YjmSMlACQYDZQZg4UBkCaTkiutDQKMp6dmltfuJEkyPj6ONMRRSjEplUousvv9fpJntkVd5gspB5121MOOYyEDSvDBYADIWI69sdP6/T/4gyOPPNLpdu8sr6Rp2mg0BmnW6/Wq9XoYhhggzTIhhOu6PInb7T1G8fxMvUCEjDGWZdk2AwAhckJRHMd5nnc6rFKpVGtlx3HGxsbeeeedkydPzsxNS6MAG78SOo61vrFCEEJARsbGaqVAZmkWR81mS2xs6AwP+r0sjdfWVwaDwcLc/MyZM41TJ+TqGrUsCALQoNOo3dlr7my1Wi2lLa0lgEYIIwxG70vylFJpKjOeEooKL1xlpNba88tSCSFE4BNGIBcSlLJt+969e0Gp9O7btwLXxgTu37976nTDsgmzvac+eOz2jZugBzDoTU6Ox3yY8QwotQAQwYhR5lAsMLUtaoFl0zynxS7cGLwflsslxkSDUYZoLQlCCBlAFGFjW8RIkUTc1pgy6dgsZCTwkDGSMUYtXPBihTDKaMbsVOtut5vEmWU5BYJBCJmZmY6iyLJtZhFCiBC5ZVmu6xpjlJBh6K+vrj755BP37t5anJv9yV/4B9tvvTXo959/9sM7W5uzs9ODwaBUKmU7W+UgvHz73bNnz8ZRFATBzevXHcs+efIkdV3g6rd/67c+9rGPVavVQ4cOEczu3b594cKFH/4bPyTSZPPixfHxcWi1AJBlWaOjoyJNWbXC8qyz1xwpV2GvyZU8fOSwDoM0TqC1d+T0qVe+/eczM1NBbYJzPjkxDVpTSqWSUgqI+p7nMGYLkReJwRhjMAYQ0sYAAowxpggTgighlILF3MAfHYWGaiDm2TbhnOeCu75XLpeJwu1OVw2VHEHdXsSA2tTvDvvEKk3OzK6trRljarXYcZw4HirslEthL4oEz1ppv+I0KLMxVY6FhMq73bbvUq2lZVHOuVaZEKLbbee58P0g8NxKrb6yen91bfmJDzz76rurUIGHaBAICm2n0aTYr0OhdDBglDEYGWCMHcAg8FAmqn6QSYcfyiItsJoDnOQAdSl+iKIoCILFxcU8z4vAr1KppMU+VUZKGcexQSC0eh9UMQczVYP2FaqKUurZRZIE0nI/9JQcmFk+bPn7UPweAFAz3E14+qHHTpw+sVivuEjOfOKDJ+anRpJhd/3etTdf/57I9ac+9uE85R86/+j/9r/9qw996hMjjdrNi29//MNPD9rNb/zB7x4/eiyJaxcvXgorjalDh1a2dnPH+vOvvvLWhXtxCsMMCtd8jSAIlDGwvNnvRvxb31mTBiYCaJThibOHnvvYC4tz0+VyuaW+V6t/+jd/56vfenHz+r0OsjoNZnnI9x2/bKEgdK9euHD06MzuXs8zgHMdzJ3pRN27PcSg9Jtfeennf/oHatOHTi1NRL3tmdlxL/TevvD6xNzc9OKRv/p3fnh6FL7zKty6OxRxz0aQcbBRJJrQiXr1ekgNowqQMaAzo7nBwoBULFASFGCtTCpMLqUEgzXZ3t4OgoASlKZpFqcWcUMv3Ntr5RhFUQQIOVaZGgRKOBYtl8v9bpcxZgD63a5j2yMjI0mS7HZaE8Ph5ORkq9ffaXXtwEcIJfHQ9X3XdZXIh/1B6NiB7cT93traWhLHoYd833ddp7jVpNRFVGHhARDH8WAg4jjOeVqpVGzbfuT0Gc55lqTlerU36Oytbbi+M1qtD6Nue7epVS6zlCdJ6DpjIyPUcddvr4yNjOZ5vt3tNXd2d7d37t2+E4bhxPh4wRNNhlGr1Wq1WmmaMsbSKJVSCyGNQchY5kHmtTGKcy61sGwaBJ5lMTBaCkntYBh1ec4psxglSmOEDLGsS5cuNarjjEG1FhojkjR95JGj4+Pj33nx6x948nS94UxPjuxurU7OjPcy23It6rvUtgBjwAgzAswNSuVSxbe7dmbnUiuDADBGlGnBc66JRaRGUiOtCUGmACrBqJLNsjSXaZwBLpVZ4NihAy4zOpeUMYdZGNM0FxnPEVDLoUmSFP/hhVrdsighBGmI8hwQCoLAdq28H5fDUqVUGkRDo3LLsl749PchhN763iuf/eTHmxcufOmP/3BivOHa1oeefmp97f5771z/+Ec/8s47b8VxPBzG5XJ1bGS81+txzquzs5Ak1967WK+P/OWf+smrly4hgmePHr196dJXv/rKCy+cz7PMpvbmxkZouYNer3T8xLlz5/pJdO3GrVPnToelEuc8GB+Fdqs3HIBjGYz8cinqd4PJqcnJySzLAoxHRkeF4nvbm7VanZSCCiIqSy3LipKIeBi0KaYRSBu1n0GKEcEUI1QQti0GjHqlcObQ5LVvb5WqxHWd6sikE+SY0YzH3Z2uhx0bgBucp3HZq7i2L2CgsDWIst29bq1aHh9vBKWw048yLQmzGMEgZa/XjSs+pRYHQQM3HXQoJXmWUEJc5krOGUVBEACA53n37q899tj5m/c2m7u7s9Pju7vb0zW4a5ABgxDBmCCDClgOtMFFWSzEjEaBkkUeDKLogOz48Hy1mIjqhyKZCsq14zj6gafYwVSzWACiKNJah2FYhDTkea6UIphijA1Cyug8zw9iRPUDk6v9lEkD5MEQFeEH9bowPxJCCOHaTjE6eHgdKpaq94v7Zz58Nkujp5867zC4/N4b1ZJ7aG4cZ92vfPFrgQ8/9oOf7nW68/OzL7/8SnPj/pPnTrgg0s6uR/BgdyNP4pFSINOoVi7n4+ruerOxcOrNa2++e+u763vGLTkZ1opwvxR2u0NGiWDOzMK0SBNK0dnHsY110m8N2km7P2h29zrdnZF6LZy6uLbx5uc//8QnP/fcH/7x61/80vLhidr3rl4LaKUrkzOHzk6EtawZNZxRRpQcctXwsI+swNq5v/ULf+9vNSbqUXu2F7cYMV7Dv33xLYqT6fnK9v13Up5/7MMn7LT/+Wdmf+uLXx2Z9+9uxKtrUPOgWgElpTG5MUYa2NeZIWwwM5atCDLaMmAjAGQ40hpj6HT75x49xbO4120HjsOwZVNWC0rcAYtBnucgUsGN4sJkOMrzchDYto0Cf2u3KYQYDIcSjNH60pWLS0eOLRyaSyXvDXrYsjzPy3lqOwwZKhUXSjDL10a2uh1A+sqVZHp6enp6ynVdLgRCyLaZbTMlDWWUsUApBaDTJLesBCF08/r11dXloyeOP/fC85VKjacDK3ABa991+p09m5RA5ttbm/Ew2hVKitxhfp7ny/fu3rlzp9h+JoNBrVa7cf2aa9mu61JCOOdScJ5nhTEP55xzrZVBWCJEVOFmr0DIPOdcKYYxllIqozjnFJFM4Cw3JOKW5TteCJwXy8D6xurS4eksyZXIFpcm+sP24pGZ06dntIqf/MCj1bJ94+blxycftRHbbm4dn38MLJZLJQERTJBl2b7nlgJmM2bRXHDAmFBKDMaApS7IfMgYCggMxkUqmDHEZwZzpZRysPao7duMEiFFTjFgjA1GyhhlQBWWUxqSJKnValLoVqcrpaxW/TTja2urjbERjEwY+oSQBJNKteIHbqvd7HbbC3OzUxPjf/qlPyJGj9Yqf/6tb+RZtHToiSzqYzD3797FoIXI33n77dHRxrFTxyil/rFjK1//+tzcHIw0Ln/pT5aXl0+cOCWyrFqtNubn//xLXwrD8FOf+tDU1JRNWRYno7XReDB0XRc4z4V4+5136pNjnW53dG5mhI5BpZz2ek45BKPTjAeNmiV4b31t8cknO7dvm36vcfLEyptv7bbaYblCGKWeHfWHQWNER30GNoApAN+igDFKwKKGEGOQQWAIQpQAGOpY49NTk5OtQSxykW9vbw8zVa7VKiUfGmWgplL2Yq4tZCvm9LnRdrA7SDsa2n3hhTrwbEIIRppokSWCGDCIaiGTnNsG8ySvVquSionGSJ5FxihjVJRGYTWoV8oORXt77YWFhY3NNdt2FpcmL12959leqWTpTAOisG86joxGRhfB0/v2ghg0GAWAkUbIgBDiQZHdF80cjEDhQUJyUcGllPAQP/K/OAghnudxzre2tmq12uzsbLPZ3NzcaVRrCCENsG/uBgYeNPsA+68EsP9+EUKO4xhjJBci58WUFQAsyuDBsw8694M3+X5xf/bcYpJG6d69la31qk0mKyWcdsdHa7/wcz+0ubUeWEArbre58cyT57QW58+dvnZvhVmsO+hWAhcEv3zxsmWRM4+eXzp6uj534s5m99e/cr86Cnng39uNJ+cWbLtLylWkiB+W8iQfZLCz1bEwOEQfX5wxxPqbP/eD926+1+42P/LsB2/dvOqlcObomRu3b2sc/p2/8Zca9W8pVP5/ful/Hg7g537+H3X2Lp2YO/bG1UsnJ4+LXPMs9+Sw19rBpPxjn/nov/pf/tfPfeTID3/22UZQVVnn+juvtVqbH/7BL1x95cUTZ04rHf7Zn/1+927wU3/jZ1995as/9Vd+7Obm1r/79a9GEnY7QB2kDOZ6f/zMKKKEESwkYoYgTByCbYKAaGQkx0SVwyAdDlrNTaTN/Mxs1I3jbmtp4fDKcMNogo0xPGfEYoEjucyTJFeqm+eNkdGS63LHynieaYkxjnv9lbXl6dn5xcNLN+/eE0q7gRelmRDCtZjnuIQQDQVHx0itV+4vi5xrqUZGG0EQFGhPnvKcp6VSUKmUGWNScUIII5bnuEeOHDk0PzcyNgpctpttQNpK4t3mztKRQwxhm1AhZTZMtjbWo0G/3WoprhqNRp5mnuNWKpUkSXY2t4rwz8yyEtt2HMeizLFso3SaprnKDCgpcyk1wpJguxj47+fUYCylHA5iTIqAcROl2rEgF0QO0nIpqFdqIh72+sNqtXqv2bJmSbczwEaPjI5v72x0ezvPPn/+1VdfLldmu4MWczGbrKOtgV8NgYKmoAyhFgVNAeNUqSjNDNKEUmIxQAQx26bIUAcJFWcZUIwQYoRgjJEBKaUGBVnfxdLyWdmjZc/ybATKSCksi0gppDIYU20AMNUacbEvEy926/sxjdggBL7jSiMdy85FhgkKfddIkScxQ/rI0qF33/oeo/DUk4+//NJ3a9VQi6qFzcTc7G//1n8OfXdmevK9d98pBe6pE8dnj46BNpAkUsqZo0fvfOtbK2urn/jk9w2iyLbtqcXFb/zhHx49enRmZubSpUt+owGOXr50xUJkcmycVWqQptvb27VG/eTp07lRSkniWGYwQMw69sgpqNQAyWwYObbd6UhgrFyvDaNBqVa1PTfLkkxkTjTIhUyyOAjnS0ooLZQQ6AG9pBgVIseRUgHCUitlDDBilBTIlBq1UinsDtrVapXYVSfTGqMo4a29fskpG+pst/Ym6o1UW1GUu6WR7Z2WOzZqlTzL87nkKBoyrLHNkm6fcyMQxhjiJEsUF2lST43j1D3PSeIe5wlmJsMgjUcIyaUwGGmjhOBCI+bwer2c5DwacEQJwsZoMGi/NhbW4ghhjCQBhEEDKAwYGYM0Eloc4CrwgNVu/qKr+0F9Jw9SVQ9q+sNPoJRmWba7u6u1npycDMPQdTsF0qKMQQRTSg0CaXQB7xjzINMIoFCfIoQcixbNutYaGQMYFxzrQjO1v0T91+whAYDuLl/d3d4aHameOjRWq4SNSsjzBGT6zW99+eTJkzaqMIsqi3Wazf5wsLa6niHvB7/wl773+itRP2rUKyePHZmbW7h44+ZLb17C5fHJY49PTsHdPSjP1MYOL/Qy6Ujd32vFw8QtNRQ22+1+ksrR6UmR9NqtPlZ56Ltzs1ME0vvLN1wPZ62ROAjGg0PA0Ot//mcf+sDh+shEnF34pf/z1+IOPPN4rdtc/7s/9PmLF+6vbTenJudPnmZXr6zMjvpPTOMf+qc/uXz9wrgr+bBjW3p2apwxfe2VV4+cfGSQiijLG1Pzc425r3z1Kz/xUz+53e5Nzxz9P/718x/83D84cWx6t50L40mEEaKUIE4EIAFg6WgIQCgxBGspjMgzpSRR0qUmj3qBhbt7Imk3R6ujfdWHNCqX7LFGSAwatHtb67vdLgQMxqvh1OzcO+9djfs97FhuKRwkKfMcwqjr6JW1pgIzv7g0PjqyvddSUiKtsjhyaNlxbNCq1+tkeeI7Lhe5MabZbGZZFsfx4tKhUinQWkdRXxsZx4gQYllMKQVIAwAh5N133oqiqFqvN0bqw2GfUnz4yMLS0ePdzdVo2E+Hw057d2dzI44iLSUowIBEznu9Xru5t0WpMQYB1Ot1QojkotfpCiFsyhzHwRgbpRAyxSanSDo1IMAcqHYRQkhKXWxIASMAHfVlueQprovYDNsNZJYOBoNhhwchIKxq9aDXa3eHzaVjMxOztWHSrlRd20Npq3/yzFEou9FyPHvuZJImqBABeh5oCzjux8n2Xl/rcaBALSYLcw5KGUGGagc7+8JAQAghozQ2QhuuBlth6NfKbuhZno0p0pgYwogxRkittSQUAWaIUG1AafA8r9frcaFc17VtJ46HAHhxaUFKSQ3GBHiUgVZgVBwlCPRzzzzlMrw37J05cYxR/M2vffPjH3uOIb27vdVuboGWvue8+uqVj71w7vFHH/FdzyioTEwMlldt24WRsSvXbiwsLDhjE4M7t8qzk8PNrbASEoJItTw3N8O7HRFJAFBSep6XtdvO/HypUjl08phTL7f73ZSLIPAGg37gu8T1AcD3vc3NjUa9Oj47t3vzxtj8nKMUdDuaIOY5zLbBd1maUouAFmDkPp0DAGGMDJZSaa0JwhgbbZA0WhPEHFslQoGxQn9ycvzqjXbM9yRJcrAps0uhF5TKzU5f8qGNdLXOeCKktsqVMZtbzcEwlcC8kIgURGpRahDkCccEhj0o1d3BMAHQSuDmUIzUA09k5gE0RAnRGuI0VyIvhZUbN++cOPXovZXtW7duHj1x7sbt+2kCJjRaa0BaAzHIFOlAWBuEVIHBYzAIDBhNwBiEuHlfWwQPuFVF1T4wDCgOjLFlWfBAi3TQ6R9Qq4vWnjE2GAyKydn4+PigO9T74IshhBjYdxcoTofQvtVj8WCMydO0GKPuGxJoo4SURhSnfoCwv69Qxeh9s2LKTGxBsjBzuBz4K8t3BnuOkvn9u/fmZqcnxsYpJmubG5PT81yKWrXuBWFt5sy3XnzNs1k/ipaX39tYyy9cvl2rwweem3jyuY+0lG37gZ2lnSjutJKjp8+1b68aYxTAIIldYlsWKY1PTk9OpV02XnfmJ47cvXmVomh8JNhYu//JTzxvWkFvo53JpDrmTtXHJ0Jnd+uaRPpzn5iYHd+emah8/Wv3/9uf//y3vvLGl7/0XS2H5xskHE2OHRr9yAfmb77+0uEqNv2tfrs5Mj116eL1pROnhkJxVP/i1/5ken7x6Imnly9utiX64rde/c5r90dnG6m2jyxN3t3oO8EYN0wANhhhAgiI1kgb6YrMaCKQsbDUEhkhKFI2qLLHfBd/+hNfuHbp4uV3b43OWTWrPuh1OnGHZ8K3nJLnj9X8EV+dPnn6Qx96vtPt9zvdgciHnAshev2+oggpWrUdm0Gn07Zcx7KdajlMMk48N8syglDgOUbLXrujFDiOneVJyfE45+12W2vNLIox9jwHADw3UEr0ej1K92/BNE2Hw6ESqZTStq3q4qFKGGxtru9ubtXKletXrpcDV/A8jVLHcpUlesM4SZLu3l61Wi02lUbvW941d3aTJPE8z7MdirExJkvSLMuSJHEbJSm5LoZCSCsFUgqhUBEnKZVRSitllDJKKGNMLskg4iLnJRcBYkqiLOOc824PZieR51tjY2Xb0X5oHVqaqtR8LZPjpxc9x56en3DLLrS3Y57Egx7yPU2pIRSIBcQChSXgXIHQAhDClCKNFEIGE4Qowsi1iJSa55ILCVpqqbSSSplQq4qHxyo+I6BEIhS3GLYsmiWp1MrsR8sghTAQhIHEPOVCEEJc1zUGxUls23a9Xt3a2bZtmyKkRI5Ba8HzNKmWg2olXFtZrZb95tZ6r989c/pIOXQXZs5cvvRunsYnjh+9f/9u4MHp0yeTKI7iQaVcBUo7nU6pVII4aoyOzMzNdtbXECFQKt168cXz58+v3l/WvV594VDe3I7jeGHukEgySmmWpvG9e4RZ2ph+rx9Wy6nk4AfMHRLXE1FEMVGB44blXBoHE64RGGPVqro/yPLc833LYRD42BhHCuBpLnMljVHKpgQYAzAmzyUXhHPMmDKg9uNAHSWNodgJPK3EXgINCkE5KFmlfpz0B8Oo158e99c343OPNHIgG2vbrteI9A7CbqJQJI3GFsI8SWIkszAMSx7Ypfpuu+06TrsXOZ5PXHt3kGNHeTijlCJsAdYG4STnBIxtkUEUj06M37l3d3xiIRdw+eI7o5NzC3Ow3gIDyiBsEDEAgDBFmFCKwWDARdYmRqaQvmPYJywewDIPj1UppcaYookuan1h7H4wR9UHHgMPZqGF1p1z3uv1siyrVqvFMFZqLbUSQhSYO2Ns3y8eHuAz5oGPvJboIXa8LjYHSiO2D8sgVBiq78M4+qHxKkbAT5882tzZ/N3f+fq9O3dtRqvV6jMf/lCtMeK4XirUkROnB0nql6pf/LOXtvc6/+z/88uvvn311kpzyPHKdg4MfvKn5z/4bGP20NLW9t5LL73SbkfYwNjISMl315fvCZGP1Bsz01NISayFyzDRfO3eLQbCwTrq7u5tr2ws34p7ze/7yAdvXH6n3RyoDE02ZrdXmh6Eazc3uxudCguYkAGGFz70yL/9xb/2B7/1L1556d/n+Z1nn6ueHDWfeWrxI08s9K++WmH5aNXL40Qbcu3a/YnZM93Ue/dm58d/9jdZ+VRGFm5v0Tdvr75zb/PH//bfTzB8773WO1c3U0XLtQmgFAhGhb08aGkkVzLj3Hdsz6GuhWxqPGZCF9d8Nho6JaaHzc4LTz/2Ez/4GUvB2s3b0d4WFcn/+I9+4dGzJ9M4S5MocGwCpr27u3zn9vVrVzY3N41U+8YGFvOCMCiVoyg6tDgdhuHG2rrI8pF6o14tj9UblSAMfbdSKvuOC9rYNimVA4QQNmBTRhEd9vqr91ZW7y8nw8h3fM92kDYiy0EZmzHHspBGeZIiA4Hn727vfPXLX/nGV7/2zltvf+ur3/yVf/tLr3znxcvvXrp28cqta7c6ra4WGmMaeOHExASlNE3TOIqSJFFKaakK1jzSJk3Tbrfb63SVUvV6fXFxMU3zPBdFxonWWkqRZVkcDx8MfpRSptBnFxRETOwsFUmSI8QIYXmeZ1lmDMzNYS6MAUkYzB2aeuTR4xkfXr99qTzVMFTdXr7BXNIa7IFjHXv80UGWueUy9VyFWa610RgItZ3ACVxltMEIEWwQUYC0wQphgyixHUSYNJDneZJkaZpmWSZzHjpQ8+xyYFvUSJ5kaawlx7gAHJDGxGCiAWmDAFNs2f1+3/O8kZGRwv+5UC/3+33Bc0owoxgVqJwWRsl6rfLNr37TZmhyfIRREnjuRz/ynM1ou9Xs9TunTp3Y29vd243+4b/+571O95VXX8IY1xojzfsrQqiR0fFofcv1vCzPq7Wa63vNq1e8INja2Vw8exr7bra7RSnd3d1d39zgUpAg9M8++vY77yCMvWotldyamkKMAjJgWWDbwzxFpbA3TOtTc4ZYqxtbM0ePZUkOvg8Y267nBX7GBUTDeNgHAKDIrlS4LIKxAAgBQjQYIYTgHB7AxIRRcGxsMaCEOvbnP//Zo9NACbSau9vbW9FgGAbBocVDC4eWpIHZhcO5RFduJjfurX39xQuXbt47fOpsdXRCANnr9e6tDFc3BEJmdnZmbmbKssD1AgmY2K4TVPqJ7CQqzQWmRANOMj6Ms24/GiQ5wgyI1evHzHa4FBPTU5jA669d/P7Pf5oYjQoPJiWRNhgAoYJpThAiRT0FAIQBI4P3wz61lDLP84L1qPejWiiltADizAMo5GAQelD9H8ZqCq5kAbkUBr+bm9sFjcp13QK1l1JijIup7MGKAg/kSFpr13ZsZhGEkQFkgBHqWHYRbPnw8qPR/hd66MCUkjffefsPv3T/2ImRL/zgDzDP88vVTEC5Nnb15j1paC/hW3v9r3/7JQGw1eqdeeqDc8ceacdqs5ccO3fGrni9ROeavXf15rtXrggh/t7P/7UTxxb7zY3O9saRmfGK74HIsOQOMSqLxLCDRYLFcLLh2To9d2LRBuEQfWJpdmd9OXSo1q0wVNcuv+1Sq+43ytbYaHhI9d0PvvBjH33qGRXladSenw+PnvCffi44fAqH46OkFGx3BnZl9OKd9d/76pt/5//1yoU7rZMf/oG3b3Y2B14KU488dfobL97xa2f+5KuXT53/wFMvfOw//fYX/+k//+c/87M/alPc32vNT1T5YDdAQxNtJs3bNN1m6a6Td46MBVokJk99hqgRab/tET1edlTanZuo/+2f/ktq2B0tuS88c/jcidnWZmJj9fu//Vt72zuei0SWp2ns+/4gjr7z4ou3bt/2fT8TnBCmpMGYRFGUJIljsV6vQzHUqpVBr7uxsjzotIfdDgXTb7d2Nzd6nXa5FJZDv9frEAQY02LM4rr+YDC4fu3GjRu39rkr1LZtl3OeJlkx39capJRxHGVZpiRXXFCELcqM1I1yPYsyyZXD7KgfbW5u7+w019Y2+v0B58K2ncAPwaDhIIqjREmdxKkQkhDqOC4hNMvy4TCKohgA+X5AMMvzHGA/J5oxVlRPzrkQQkotJUihBTdaGSB0cnJyMBiEfuB53rA/4Dkwio4sjUuZVap+ENpJHh1+7OT8oWktYr9RmlyYyUE2ZqcBQxzHtYkJDkQAIbZLHQ8QA2pdvnoj5woBKfwlCKPMcjCzAFOEaZrmSoORIkkSDGakVi55XjLsHV+atIjSWUpBEazLQeA4zu5uK+PSDwODsGW7mDCNseeH61ubCKHGSG19fR0AjFHdbu/I0cPaKACYmBjb2togFILAS7N4bn4qSaKF+XGeJ8N+z2bo+Wc/lKfJ2vrKV77ynZnJqUeef353d/fcucMwHCotZmZmPM+7funK3s7e4cceY+Xyd178brlcbYyNojCIsvTu/Xsnzp2hlMrBACzLmZ66ef16UCqPjE1kgoNlwdbm/OJSfXQkTeJypSLaLYXQoNvxxkeBEmI78WBQro+B7TLHQ8Q2suD1skzqG3fu2K5vu65W0i+VbNdJ+32ZJtS2vMBntgVaAUau7zPbStNUSUkp9asV6vuglQaDGM2UqFVL8zNjaQq1SsmxGcXYIjTwfdf1ehns7uyVaiOWC6PTM8Qh7WH8n37zdzZ22xvNvc2dluPD2XNTSc7bne79lbUzjxzea3ezjOdcdwfJYJi22v3NrZ2NrV0gFrac3dZgmEhi+Z1+lknww5rjhrbj3b59+/TpU5/5zNPf+MbX0gG3Efg2tQmmBBXyn4dB6gLyLhrnIpDpADE/MBsofpVSpmlaVPw8z9M0TdPUsqyCDXkAyBRVvvCXJYRYDw7HcYLAW93c7HQ6GONSqVRUfKVUkZgKAFmWaa0ZY5TSAta3CEXagNIEEAGkhVRcHGwODhCkh48DYiUt1as//fzPXLhw4fJ7F1uDQW+YAXF297qm2Zmem//OK99r9QZZLqbnFx57eumNt96mgZ3lArxSJvJIWhnydge5NPry1b2f+GvPs6D2zdfevvzm7ekjE2O1Rnv1xtL0xNraWrlU8Vx7kPTPHD/2xJkTw70dk/UGrd5L3/zaT/zIp0Ya3puvfzeNe/NzU5m6X6pNT84EoyN1bFtWYjE7ZI4DLSkT6o/VW/02z8X8/NzC4vzb714YOfv5ru7VarXL61vreKJxeuKZuURWJ/7jH77y0hv3T0RVTb04LyXZ8N//6h9duHJla/k914HHHn3i3vVLJw/N/ZP//m/90r/9d++++eaZQyUudg7NuLZdEUL4fqAAbWzcZQaAIAsjoAA29ahhIG2k+60dkQ1tql/81jcDl1W94AvfP37nzvKV7abIuVFACDGY5EpIYXKhQtfXNM+4oJxjzy2VSjTnXElAhUBBYkxsQjRFGFGMcb/fxxgTihjClCBGMGMOoYjEWkpCyD79NsuSjY2NJImOHz/ueU5Y8l3XV0oMBxFlxLZtLnmBMmNkjAEEGhttjOZKgpJScaWKe0VTYlHfUiJVij+4txilFiHMZtZwOOz2h6bdK250x7YLO57ArxFCeA4ICSVBaJEmOVdFcglRWoIhAKAV1hqMAYIRxaTdbC7Nzxgldjd34yhTKXjj9shIvVorNUbKmYxcnwHkEgsOzEbGMIKZBZYFFGuMJKKYMkwdY2xtGAAhyAHEBDfEskEXNh1EGaw0CFGYQGvJBRgVelY67O8MmtVy6ezJw541NCLXMgMDDBNCiAbQAK5jK4MAkVRIwiwlUXfQp5ZdrfkFYVkpgTGu1cr9fp/zDBmdZwnB4DoWY8QYRDAomQMDx7IWF+Zu3bp1796dI4cXy2H46GNHwtD/41/79ydOnDh16qTo9fwgQHt72pjhcHj48OF0Z299cyMIgoWlReaw3u6O47nHTpzgcVyuVZM0LtkWcBnH8Xh5oTIzbREKfqC2tyr1GvMDTDQnoDEoDFpryHLJcw1AGJVAGLK8sM5zqRGjjgfEyoUMShWgNFeKYgdclyhlcUEYAyENwQqAaA1aKiGUVgd6SAwCGWyUMQgIoxTRXqeVpUOjARltYQIUayWjfr48aB6ZoVev3n3qmWqlbt+4tT4zv7C6viMo3tjtD7v9AGDh1KhbqqRZfu9eCxiQSH7u81/4N7/0n5eOjxqDZC4RQhlX1HYIc0K3bBGLIbXd7Dd3WpMTtTMnT129em1y2h4bnxxEsW27J04e846M/+4ffKcDfGpqzPfCrb220IY61GBkDAbA+zZdD7I59+P3DsaUD9aAXq93MGgtWvKijEZRdFBhD0aaBVsGPWRzcjCSrYYhAOR57jG/UqlQiw2TeGdnh1KaJAkozQhFCDHLwpaFEBI8LYRRRQ7sPi+T0H1k/6Hx6f57LlKgjTHG0KBa3ev19jqd7/vs57/21a+OjU6k0szOL/b6g3trW165Hu92cmlOnDl7+eoVxy9pSnKlHb8U9TuJRtoOOnHMGKtNlr7z0uuGOt1UHT1UGgx7iFgzlWD99j2H0RHfI1okQmzdu/69zmpne9Bvwdnj8JM/9qnZ6fFLF948feK0FCkhiFDpBMT1HcsVItmVMnP9CiB8+9K1IydPN1u95eXO2fMvXLp2U6jJ5z9y5o/e6/zRH71oU7a5vtFtw0h9pRSUk/hGazclCO4331nvJVNhODY2sXrn/tL4lOhvPnVm8plHjnz7Wy+tvPfWpz/5yX/x93/i+LHFX/nl/ytJ08ceXRoZGVlZXa9VR43Bf/KlzUs5IthyKCUY2QHybIsS5Fg0T9J3334r6rXWVlfnpubX13ZmZw+5YZht9BBClDkYiMFUFGY41E6Q0ZaNAOda45xjQm1iI4OxTMFIAEoxppRgTAvUzLMK+AYXISRaao0MxcworaUyClGH2MzSSvCM7+22GLlz7PgR1x7hPBOCu66LMY76EXUKXRvCyBBAxGhtFDI68FwpJeRFxIzW2iCEDEZCGc45pcp3XEBEaTDKgEXKlVqn3R7EQ4SQw6ws42nGHcchPti2LQWixGWWJYRAKDdaS6m11koXPnvMaKONMRoRJIwRUa+/OH+WQJJFg2pInYrRMncdNjc7CVgjKRtjJcCGWlhTKjEmrosQAtsGTBBmmtiYOJj5ShMFDAEGy8WIyVwTSgEBIKwMIQYLXeyylci5UQJ4LtNIZwPLqLpXm2mETCeUYqk40shgpBFobTTGzPW5UBKQ4rlvu8bwZqtdq9WYZfUHg6I10xrCMOz1OlmS1htVAM0IZhgZJQCU4jxLouNLh3u9XqVS6fU6nmOvr6/ngh85cmR3dzsaJrOzsxOLi5BGvWE0v7gUJ8n4yLhju8vLK5ZjnTh1Zq/VGsRRtVoemxgFBHIY+Xaw0+2WGvX712/5ru1XSsAodW3VbgFjzHMg8NN+B7lUSl24ZeVSaKUdz3OCYKiJkQiF5VAZIVLbCQFbvWFSbYxZjq8BIULBdoBzzTkBw5EBMBgjMEYracAQQjBhGONCMqOV0lLDPkUEKZkTjIiBPI1yZVPmIynjuI9NdnRp9s237mdxVK9Xb2zsFLHRtuM5FJcc4kCGHO/KrbsEoWYXjpwYrY5PD+JEA1jEWt9YPbQwt766EiMtdbKGmqFnU1Cha2sFmYDvvtxpjPVK1bHL1289ef4DV6/fmJmZYdT+7p9950d/4PmV3c43X70EXt/yS3kUEd+GguaOCACAwcqAQUYbjQl+GO54uMQXZf1grFq06kKIosWGh2iR8MD//aDcH0xcXddLkiSKooznjuNQSiuVCkIoyzIAUFwUsM/7oL9USBuyz5sE9CABSggBAPv4fDH0fohMuV/cu9Gg2WofP30GCGWut7m9MzY+9drrbx5aOjI5Ndfp3/zoxz+5sr52995ylGSAkUsMMSLwSsM+KMDIDdJhjq0wA3Hn1kauQQNMTs8ylmoDcdw/ffh4r93ubG+fO3n0w+dOvPvmK92dwac+diodtj72/DNLC9N3b93sDYZ5nl+9evfzn/9EqcpEnhnIiUi1TLjO0/ZOpzesjUwvr97h2nvm0z9659r63/+fvlnz4PS5sy9l+sK7u7VKUA3H8Yhqa9UZaCzwIx94fHdz4zMf/4RIky/+3h8s3x1+/MOPnThx4sobv0HTzv/3f/2t/+kXfmB+Zv71V14Elb1+9zs/+dlzeTqYOTwPGoX5TugTLslCCG/1jWsZzoWFGCUWQlhwCYAd32v1hpuvXPzAB05HUreipH/7vueVPKcspeRCFDR2oAwI0YxGSUothzErj7PhMCaEWcxxia0LBzitsKaUYoKJ1lpJXfGCYu4tJTcatJFSSy1EQMICB5RSM0Yc2zOgCMHD4XBtdUNKWSRwosLXTGsFBowhgIzWxoDWCoxCBpTaRxIBXIzzXCAhhJZCSpPl0lLIYiA1SjLB0yzL5ejoqAFigGBMlME8l7nQXBo+0L7vE0KYxWzb0zotNNjGGK2Q0spojPdJ5QgAMayydNiouTbRRqRIZyXPqoTeznorT2OlZJQMsW2scgBYWZ7LfB8hRKhlEDJANbUII4IyhW1KHVAEJEVAgdgU28YQAIygCMei+5bdoBBoJTKGIE37cWdQ82BpbrJeCfP+pgkIIYQLocy+QasCQy2LMnuYDKU2GZd+iRjAw0jPzAZp2uecYywZsYr/JooJwsbzHMlzIXJKlDHKdqjR3KKEMTY+Pi5Efv365vETR9t7LUpJu9vJMn7yzOlyOdxZWRmfmsSEcSEQxp7nFeSi2dk5bNHX3/4etdj07BSUwry5a9sWKMUYAW3W1tYeOXWSOk7a7Wqjm63W9PwC3419gjOeVxoVSXQR5i6VEoIzhMEAECeT2sUOsd00TZ0gBK0Hw7RSLtmOY9kuYjYA1hmPo9SylCSAERAEhSqVEIIZA5sBJkAIACkUnsXIxSiYHB+dGKvfW44zBVrklu15NgGJQ89nFM9P40G/Wy2H8yPt7a0127E2292Kz0bcwKcOdcO9/srx40eOBYkXVg2x/+TLX2MUdna3QEqR9IEnbqPkWDaiLBHaoQxZpYpnl8ojtXrrF//D5X/29z+mkfXGmxfmFuabe+3Ll+8tTlWY4r29HQIwMtKIhN5L05HRusgSDYAAAwIDyABWGjTgh8RE5uH+vejW//+5j67rPtw7v493Y/zwKxwMRfM8p5S6hGQ873Q6hNFyrVoul4veXxJeBL5qo0FrpZQFyOwHvWEA4KDhYUnqQ6fW+xzKh4r78upKvVoDgqMk/sgLH7t25Vo/ipOMr69v1hojtm33+/1Op1Nr1B3HYYy5JMtY7lGJTC4E58KkGmlJdnqpXa7XgtL6+noUpXmWhWGY6mj55vLpk0ebW+J7r17yPnT0C5//vkFns7W9+qmPPbe6fPdP//iL5x9/jCvabcYf+finMsmEtgZxrBXvdFrGJGHZohT7JXb52rtnzj339ms3726ot9/btjACNvPupeEaaR+em3dsJnguRVwuhUSLyUb9I8+en6x/fP3+7d/9nS/OjsBnP/nCD3z/5995603v7HToBcdmTWdrdfPWlY+/8NxXv/wHjao1Osogpbq7EiWyEqBK6PUH6sj8dHp3wxgtpGDIeMzWWhuVIwNpLxmfqO70uhvtwc52m1AvGma8lWDbk1yluRIGwCJaq9zITCaE2VgpJY1QmmDbtWyKqVEaY9AKIYQIMsRorJRRBqQ0WkultJaYAKOIkCITTlrMwhhrLRFCWiutdbEGUGpdvXptdW35/Pnz5XI5SVIpeblcjlUfIWS00gCgjVHKaAnadLtds++QpxQYgwARTMCKo1xqTA0xQAGBAZoJnYmU2pGQYNk+xcQYw0WmNCCulSFpogEUs4g2JM85z7UBhBAB0A8EIxohjBAFMAQyorMzpw/HvRZDsRF5lEjEk0oZM4qGUX+YDcpWABgDFsxzWFCSnGOKNOBcYwwU2x4iRCGGgQFihNpEI1AEKUIRBWyDAQMIK6S1UUIqLmSe8yTWhhuelF2YHSvPT1QYyG40zHPXYFTEKinQqcgMAuY4CuFUSiWNLjIQwCAEjuP0B3thGBbKciFEnqdjo6NxMkyGkdKSZ6nFHD/wXIsgo0qBd3f5/mc/+9mN9bU8B4LZ2MR4lqXD/qAx0siFnJiafvvNN2zXnZ1feOXVl8+ePdvcWh8bGxsdHR0Mh4M0ajRGjx4/kvEU0lQp1ep26+VKfXRk9eZN17V930+VIAQhxhrj43kSC63yXj+sVmi5jGVqM4IwHnQ7cRxTQEYo+9AJkeegMIClgIFfgkFXGQyIWI7vBj5YDLRJueBKYwPMdQggZAySGiGDAQNjwJjhAiECBAHBlCCNlQINYMphUC2XqhWIUoIQ9j275HlYxS4DlUb1cpin8WhtdG5m8urtNde1J4MgHfZa3Z5yqaE280vIDnmklu+u7rUHOQdKoNvuPHH25PWL79kUlleyiYkSICaF6Mu8101sCzsUHz925Ic+Gf7iv/nWz/3cRw87/v3lu5Zl7XXgZ/76p3/tN37n/paeHQt22nspsPn5eSHyfQNAMBiIRkYBVggZ/V+JnC6OIiX1oL4XPxzIVos0Dngoy/TA8/2/KMFxnJRKJc/zLGH3er0kS/Nms9/vF4QZI1VhgeBYdkHFwVJgsx/pJ5QEpWWhqwIwANiAAvNfnOIhWCbw1zbWd3d3jx853mq1JicnsEGVsLSytnHn1m3bYmvLy4Jno43G+vq7hw4dorxTtaSWA6ozwZNuPx6mvJv1NfUGCccerYxOW4Rube5paWqV+sLI1ObyWqXsP/X4GE+Hqyt3l+bHyv7M5WvvToyN++Xgxt3lkyfO5uu7V29uHlo6cvXll8fG6ydPHA69GUaU0nx7e1spfObM4thjH3ntX3/1nWv3CQO/3ugMI6nJ4UpKON/bTFwbbBtMs93vQRhtfeEjf9t36GDR/egTYy4xX//Kn73z6u/Ua5Xq8VM2c37r17/03//9v7W3sfbqqy8++vhpTNJ+azPnEVe6VBqdmFpSibu1strNmOX7tu3K3AiNDPWEkVJz2/aSiO/1U23De7dXuQSMlWWX4jwLjBIcNDDEsKIsR9BP0yjLGmE46EdZknvMHa3UfNsRSRYlMbaAEoQxZYhgA0hrpBTWhmJktDJFf02Ke0gapROREEIoZRiD1hhAaCOlVFnWtywmhLh165ZSYm5uzvfdLMsUM1gbAwZrAwUyogCMtm0mpczzLJfCGIUIpowRQqQyhDBEmQIEhDp+kOciTVMExA/Lxc4xTVMDWAiR5TFjQZ7lSRJhAqVKWDQZgecNh0OEFIAsnEoxJoU6I4+65dCZnxrbWb/he0ACK+1LUHDkxNLo2IjIckqpG/g8S4mDmW2B40mJMMYY4UxIgm3b8bjGGNvKMIoYoy4IDZniXFBkIWaDVIUjQs5VkmZxnOZ5mmeRVrzi4dmxsfGyY/K+MWK0YvViSRlTGqQGRAiXQgM4gSMNaINywV3PU0ZLKUslVrRglmVRShHBKlNpmmqttZZKS4sS5Fo2ZbVySSkxGAwYIYYxzvm7ly4/8+wx5tg2I/1+//DRI0KIdntvd3dvZGycS0WkWDi0iAn1PC+KoqBa7na7qeRT8zNkblbevtHZ26uN1O/fvdOo18ANbty89vijjwkhOoP+3PSMSFI2NnHru98NgmBrd2fh7CngeZSlru8w10WIYEwtSgghzPK0AjAYMYcyB4iTJdwPKlIbx/XBD0FyEAIjYluOZTum5IJUKOegARECBkAryHWW5sTSlo0BKGCMCcUWAmx215pJ1AcNnutoMBSMFhlImYrYo1407NueR0BpkR1emG11o5mjJzbW7meDfsLTta3mTnswSK93emk3hUpo+zbVInVtq9/eW5qd3NncdHxaqTZ83+dJrBWnYJjNSqHf7ibMDZ//6OJ/+LU///7vf2JmduG9C+9+9IUTd65dmpsc9cry/t6gH3GvxGxGB4MegEGoUGIU2Q7EIKQxog+SkvSDSJ8D6Lzo6A/UeUUnfmASeQDCFHW/iMN+uOYe7ACEEHm/L5QEAMdxcimiKLZtCwBA6SL2miCMKNVaM4wLvB4QArGfEyKxBIAHyZ4AAOahVekAC6Jnz555+813RkZGXn75VdAwOzXz5PkPfPvb33Vdd3J89OLlyzPTM27g37t7Z7xRjXrtshqGljPIEpcowGYY9YVymsNhnBqvVEkE6rWGnmNPzs5bGLX3mpL4yBCCrbXllWiYHJ5vHD9+ZG9n9b0LK3fv3jn/xFNaMYns7VbkB7X62KIbLNvUanc7t67vlYJKrTrO08nJyUPLGzu/9w//r5u34GMfP3Z3q3n1TssJASN4woNMwMIH6sdPnmiMNa7duNps7uw2h266euG1NxfmJufHa5ff+d4jx6tHlkZu3rxuVR/xK/UXPvVRbsjydnN9c2fhxFyc9srjDZ6gSlgJajPdPfO9t66+8fqdu/falclFi9pRP5ZcYeYpmUnIbWaVx9xOt1mqVAZJ6oTlXi8XigVjo7q5h7HFEMsJNhgpZJDrWJaVAUqMBkxs1yWE5AmXcY6URtpQShhlBBEw2BhNEMbEMEoodpQWSmutlNHSGGWMEYIbSkGbYqZKGNOaKCXiNBsdayCEWs29LIlBm/Hx8TzPoayR0QQhahA2hTYPASDbcgnhAGAwkkoZpBUYY3ThbEoI4UIihBzbzdw8zTlgbDmOliqOk5RzgzHGJMtyKbgQIoqjIgGDMkwIthyNEAFQxWYdDBiDEUYAGOt8YXYhS/rYSNC6EgSN0KoE/vhoo1yubDW3ao2RWq02iAehG9iOpzVwrRxmM8vJTEaoTSwPC00sTxgEyALbhTSDJE3jDBmstZFScy6zLEsykcZpkiYyz2yCSoE/XQ/Ga76HMpUMtRbUZdo4AJgrqYx2mIuVFoIbjLRBmBKplG27ShnOeaVSyfPctu2C8p/naZ7nrusOBgOKsOM4gecOI6W09DxP8GQ4kCPj40snFtfW1jjnc3NzSimOEGAslO50OvX6yPLKyvT09DCOEMFLj5xtra9Xwsr91fuW7zqOUw5qGGPY2jLGRGlSU5VGowFGQxyPjIxUq1WkJGCkwDDPg34PECbK7rKlAAEAAElEQVSMOsQCoRTVaZpii7AgoJR6nld2fGAkEwZhCzABjAhhoKDfHwSlspE59UNgNiRxnueIUGYDQghRoqTiRrEiew9ASymU1BpAKcE5BY0kBq0LMKzbbg8GA6PAdZkQWkquRE6MJgjxLGIEQPFOqxn3B6Ozhzu9aGdnazgcOhaTItvcbXINUS+1bMczcnJ2fnt9fbTRqDhk+c76Rz/0yLC52eMmivNeP06Gg1Lg+Z5DCACyWp3u2srKj/3ID6yurv75d98+fWL245/45LXrV4Z7cTUMV7ZXBRfnzxzZjbJb9+4FpRAABNKMIAUGgGhAgAggpDWHvwi1F7XStu0DGvs+A/2hPKaHIzUK7k2Rs4oeKF0PcB6L2UqpJMsynlNKHc+ltsU5L3wOtDZKaymlEAIZo7W2KDl4DwBglDYICmOcYt9t9s0LHuiY4H3vMDo2Onpocf7KxStnz5zc2NiK4+F//vU/OHfuqFaglHj07NmVtTXLolOT46vrK41GI99cLdUaIKTLqGZYKUUYzXlseWWNWC607YUAKuOKa2k5bnOjdejQNEX5/4+u/4637Drrg/Fn1V1Pv+f2On00RSONumTJsmS5yMYdbMAQDOQNCSH8kjeQhNBCCYkBE0pCIBSDwbhgy0UustXLaGY00oymz9xpt5fTz+6r/f7Y914P8GZ/5g+dO/eeczV77Wc96/t8CyHs0UcPv/Ndj1KcXL1+xS/527ZPX7h4OQjVvXe/LUzUgdv3dfpJc322Uhmo+kOF0sDo4I6wC89854UoPn9tYeXxD3xgbEfSFdGuwwcfxglYqNlp7jt9amRs9PZ3PNZfmG/1O7rG3nP/wy+98uLTX/70uz7yfhk0r509sn/vKPbt577+tfvvv/eVi8lrb7w4NjL+hSe+fvn8dQKwfe/K4LAbKr0eJINFamL99Cuvf+fp890OVsxhlksx0xALKVOhZaaSVBKbRiKOpbEMTiXqtQPbq642e7GhNcBgjDIqUyIUSnJGXcey7LXGuiG0WHZdx4uDtL/WJMqUvYI0CiFGMcIYG2U2oE2MsyzLiVACCaGMURJTQim23VJOj80yQSllfCM6YGBgoN1u5xSrXq/zrW+9smPH4P333x9kPQx5bi5GCG+uV9zpdBA2hBDLsjiABiO0MMZsGJ0rnSRJvmoJIUqp9fV1z/OklN12xxhTKpUQ59JomVCENMH5SQLCIBYyDZO4WCwCgDFIawUG5UxcACh4zszU5Pz18xyrMAgcYg3WK6PDA0ZJQDpJEtd1ie8lvfUSLoLrJpnMpLYcApQjIgnlQG0jU8ItmSmMCWALTJbEWZoIAEgTkQqZJGmSZGmaSSlBaaO167vjowNDRUun7VRGRYuaNF5fiUnZ0wik1NoAtWyqdSKVNgghIJhqbTjnOfG5WvHSNPU8b319vVartVotABgYGGg21lzX1VojZJIkUSLBGFzXrVQqe2/ZvWvf7qWlpQMHDly+fKVY9Pfs2TM+Pv70008PDtUL5ZLv+ydPniyXy4+9/73B+rrjOHM3rqVp6rpuIpJarZZqsbq+TigihDQbjeG9e8XSYtTpHb7rrqTTs0eGShYKw7A4Mnrl1WNT22aSNC6PjgRBz58adURqWQ5sUjuAEEAkjmPLsgAwYDCIQJp0e0G15ALH4LiAdBylmUg458agLJOgpJRCZ5lRQBHOyRhKKUJ53t4KJUAgLAzVGAzhFmUUMwaOxdNMQ2oYobbneLa9urqybfvg4upaa2VdAw16XYJMJwyjKGK+qxEIqQuV6vJSi9m4PDBwefZqwbGr1SpJw8G6e+7NUwWXYYUVgBDSIGy7vmNbWRY3211k1PadO7/xrW/ffe+9b5486RaKTz755PT0tEoTzO1SwVvud5prq9gtjwwNhWkipUQYGY0MwRiRzeYcSSH/aXFHCOUDzFyVim5SFW0NVHOQPa/L+QaQ/7NvDWbzvSFKI8/zKpVKkqVZlkkps1RmmWCMbn1iPrm1ONdaa5FtfdzWb0UACa3gppq+1bCjm0VMi6fc3bX3iPXJe/b94ET1AQt2pJH96qvX2iHJkPfk8y8eeODehX7jpdPHR/ZOLiWNZhdiwak12O1ZYb9g0wkOgya1fOKgqBesXdk5YmUr84dG3Yf2jh8aKt7zwOFrN04XCn2LdW10dWoXP/PGU7u3b5uc3H/qbKfR9Tp99vkv/v1jjx1cmv/W6sIXD84cPvniLBbe8mLHEOtbz357qX313R88/G9//vG772b37E/eexfdjS68bxzeV9WPkN6y3d/28M6VztnF+Fp1wr33sTvajfnJ0UGb2N/+4rfPnm0OTz74tadX/s9fna3s+vgn/uMzT333xV4Ub9szWR1CP/gjh3/zN9+/a0JuLydWe3G77Q64o9/83HPfffpiQwxElf3L3s6ra2vX22tN1eeD9opYjd20x5IuFmuZyJxiI4GQWCmlHRHiIu7IVtfTaxCspx2FxUDBHfOdulJeuzUsxQQxVZyRrINI361jNozDQuhYBYq5lEZKpcEAQ4gDMAPMGKpTnUVJnKYZIdyxPMcqhFkrM31DE8SlgjiTEWDpelaaxZZlcULjIDYSVYpMp+bcqfM8tl1TtIwrpUlVKpkUThayMHXTxEpjHEvIjDFUI55xmlCGMTKGUpI7FkVRgpk9NjljuKeZbxUHSyPTdnUsAic0rnEGOA45kZZja+o1Eruhamtm/Eq/tpANL4qaLk8u9iJeYI4nRDqXRtcP3+eu949NbKMAvVYjDrvZ9NieC2fm6wPjJ9940/JYoco77Xl/0MI1EsTLrlgfcDML9wF1rbKVeE4X21lp6lrfR+4By94TNhT4gyjotGZPFrJWxrwE4b4IkqwhkvmwvchV87ZthVunK5NFC0d9E6Vhp8e43Y6EP0AWOj1cKDVTTWsjCx15aTkamLl9rolWe2yuIfyBKWQV2v0e51ipfhw1wmYwMzIp+pEMI4/joLMMuo9wwHgYZ+sGBUNj5cGxykvHXn/kXW/DFnnuuWdmJif27to5e352anS8aPnzV24UqFOkzszQ+JXzl8+fmn3skbcCIf5Adfbi+QI1OydGixZN44BMjkXdbthou4aNVcdqpVG52G71ZWnPgRXLXh+uZ+MjZX/I0tb6+Wul6jBzK+WJnWBsjH3VSAq4zIwHMcaGJ6nppRn4Bb9W7ekMWDXILHDGgE8YPtbPvIHRnSA1WEShhHEdR23XwWCygiwWhFMEr8BtY0w/CiNArDwUYa+dOf3M0bTILZcgbWQfdHv3rYX5+bZLYaw8bEs+XK4hky2sL8/3mplTeO1CNDtvX5kHmdHBChso9mS46PKs4NORyTHs+4udHqsUaLEgQLlFi9qo2e+0s2QlUddjuNTTQZIuri0ijiQSErJm0KaOFYv0+sJiu9Oj3DnyyonbDt11+fz1WnU0CfWZtexqU07sPESJlQaB7LcsGTtIK5k6Baen0oSoiIoAAl42nWxZKy8MsBAWYyXLKtluiVpOEMaUM8Io5OEbaZZGcRpGaRhZloUxFkLkFHhjDKXUsqyc284Yy39kS8pEOM5UmmYRJeA63LN5ybEHir5DsI2RzQhnWCsRhN0oDREFXqmA5wXGNOK4K0RGqeZWijAwCyg3hAGiBojRWCukFTJCglRIaawNfv7YdwTqa5Jcnb9oe5jYaHktUUodOnAojTMQKGyGrx+d3TW5p7+emJgOTw03uv3ZuQXEaKlSwRi5Nrt1327HUmnQeNsDd5x57eL+PbXRwcJt+3dMj1cohvvvu+fs6cV779qze9eO57/29Ynx0Uq5+JUvf/3eOw8/98wNI9IH7r9zZXH+7sOH9u7cYdv229/+UBRFb//Yx771rW995zvLv/Rnf+Z6dqPRaDWanuetLa/UqtVuu724uIiBOA66cPYCQfT110+1Op1f+Pd/VR8Z37Fn/2133vPaG1cZ9/7+y1/78leOnTp19m/+5m++//sf/8jdUz/z/W/d7qcP7hmdLjHVWRscHL5ybXG5kwZQfOX4rKjthJED35ltnGzjbPhg1Ok4hLiEttdWfduiCEqOu77UQEqGvW5rvRV0ulkUiyjBCvm20+v1jDGFQqFYLOaJ6UIIIYSWeT66wQAUY06pTZnFeC5YyCcz+c6/Kdo0uaoi/4Z8ieR8qY2N+h/MUfIJ5qafEcJKyH6/v76+3ul0wiAQQiEDRiMltZQatKGbIg2MMcE5vwpzQlHujkqI4zi+7zuOo5Tq9XoD1apSqtFodDudnL/lOJbW2rIswuiG78XGiTKVIp27cY0THPZ7lWKp02oTDBcvw713HbSYe/lie+7a3NjI6J4948PDg5VqaWJytNfrbN8xUx+qJyL1Ci5lLOr2GeWAMSAChGtkacwBUQ0EGZiujPV6zW6v4ZVKEIZXrs4pxDQmaZpmWRbHcbfbNkqODLId0wOD9QoBKZKQIGSU9DwvFZkxILQuV/yF+WtKplkauzavVUtrK0tCxFpLizEhRBRFhDDLcgjhlFmUUiGUECr/p0YIbRy1EBVCzsxswxivLK/NzNSjKFpbW0MIvfnmm8ePn3j729/meYVSqXTixIlGozE8PPzsc8/cuHHj8cffurKyIpvr7YW5drs5v7RYLBZxoVAsFqHVStO0Uqm4Q0M6TSFLc63N9zLhMgFSBkEQRBEhBFOi01RIYVmWUkZoA4AAqNY4EwaAgOUaQEZjAEIwZdQCajlewXMLWgN4HkRJP4zcQsn1SnGiuOUDopTbzLIQJpRgx7Y8izKibUYsrJBJjUhEFossEWkko6C9snT4Nr9YZJ7nLS8vK6U0gunpUYQQY4xaHDMqAPphkinpFvxypca5nWQyjOK8O1ZKRVEkhNBCGim0VMYYgoFxwhjzPMv3/Q17DIMopWmaJllWq9UyJQEgE+LVY8fXGoFlOXGaOZ41NjViuXx0bDBNlZYpQapUsAfLftBqEJlVXIfLLGxE3eWVIkU2pY7NOCVpEq2trzQba0apSqWyaWS9IUZljHHOLcsKgiCX7+WLIbfFTpLkZgEUxlhrnSRJv9/PEZv8e3IZVJIkSZLk1EkA4Jx7nmvbtpSy2+32er0wDLMs22LKw/+XCeXWdbOaiT757JmdB0c/8mPvmb18db5xrRP2mA37DtyCMf7ut56+7777qm79th17O0tBmqajo6NvzJ6cmJwsWmx5LUmbq55vYYYWlxccSLeNeiZe+dGP3lG06NL160ETH9g9El72nn/2pfFhajMKUlk2BqH+7H//3b137Pvql77wU5+4b9func898+Q7H7mr5JH1lRvNlaVDt93x0gvHf/CxX9h/AD731G+vHD3yyiuvfOCD7zl18rjvDR89eiyOABt44N7DBOOPfvgjN27Mnzt7/vs/+oOf/O9/ixlUt++99MbZ1cbyj/z4j/3Kr/0FtaBSBWo7IyOjluUcmt7+J7/9l/c+MH3gkbcmywvNTnv14vVDdz146s0LWR+/dOLyl59b72Ky85Y759ro8uLyA7t3dzqtXqM5MFC9+/bDb548mZrMo8A1ooQTm1OLG0CZ1MqAyaQxxrI21p8QIoljkWVGaYoJBYw15MRAtOnvE8fxFvpxM4kqD+TNYRO9mdGllEIG8oj1jTPaZkouAWQQ5KNZDChXhxql3nzzzOTk+OTUOLd5mgVZmjgutx1biQyUlkoRjTEQagjSkC/Brbm/NpAkWb/X6wcRQsQY4JxJqZTMsoxgjF3XJpASJLEGBIAVIGMIRtqYKOivLKta0QaRDpQKjbXVOw/wbVNTV8+fv+u27Ukv6DQ7B/bs7Dcbr504YlnUSdDO2/YCyQIVsUJFiaDZbY+Oj0BqgNpAXcN8RT2FPYw4AOGAuEq5IYDd1YuXT715QWK/m0Z9GWYiTqPYCO26dGK0PlAsMoTSRKk044wSBJxzKVMgwC2n7vsYpTPbJucXVzq9yPIKYZD4riOzhHMqheh2Uk4xUJZmWmlCOMk1ioxyQogQEmNMKTcGMKLj4xPnzp1dXV3dvXvP2mpjcWG5Ui2FSUqRqO8fnJ2dffPkqW3btt2ye5dS6tSpi5/4xPdP7tsDaXz+7Om973rnQaSPf+dpyy+YOGHcjlsdBcjxC4CpBmyUyV3qQQPDDChHiIBJE5lqMMziiDEpMqUN8xyVCWUMIA7ENohnGqeSgOEIOKcuAKHEZpgBEM/zKKGIISCeytZSaaBQsZHX63Rdt2w0QswGBJBkSCuaJwWJyAFsjJRCGYERAmyE0UILUSnX9uzddezV17Nktl6v+QW3GQSNdpdQwmzLM9QYp9cPkgyCKOYWdl2/FyRhGCWpTDO5gXWkmSHIaKE1VVooQBhjhphlMY2JxXkipEV5EEee7XR6faNktVhIotDyXGpZJ8/1hqvAXW+t0YpVICCdX7rilXitRrhjt7rh6o2+6wPL4L47D+7asX15efHyxUtLyx0T6gg3tdaWa9mUgmNhRjkj+QOYuzBuqEYwRohgQBiLreyOPEInL/1bcI1lbbgF5NvDlqWw3vSL3+rP8ifasizHcbTWQRDEcaJ0uIUO4ZvMgbcgmn90YXKTcdjYLvijv3jqrz/3FrSgj516c/Yi/NjH75wYnaxWKnFPm9QsXlk6uOvWK5cud0RnrDB8uVJdDkQUp8WBQW3Y6tVLQkrPY7ZlqhX34L5xh+prF84/8sCdX/rcdx96y/5LF8yuHTOH9o298uxTb/3ZD1EcLczN/8hH35UIum/3oWeefoFDdvet+9aX5hrzvUMH915bWX799de379r+B394t5Q0XFj48z//89GxwX/+E7935x007G2PQ3j0bfeuLq9US9Wx8XEwydry6tpyo9nqIwrb9lShOPra2a85Xvni88fbESQdmLDgXY8+zBhbuLHw318+/5Ef/4nVxvqVZTI6ctfING2ffv3zXz9mc948d/qJr69PjMKox1bbF/Z49Wa4NH9+pVDwhouFW/fsKTHWmFtECCaH63ML68WyhbRprTbjBFzfKlUqluNGlOSGbVEUxXGcz1XYTXs4aAM3ZaXn7kI3o3hm03Voo03bFDTnqyfLNABCZtPrE2OkEdIIIQJaI0w4YdzhFNF8t19b7qpMpWk6NDxQrviOawHINBKAwGRSSymVwQACCDYAGnmek6Zpmoo0TRFgQlCxWPTcQrffsyzHs51NcqAxGkAbRDHWhDCgCLiiRmNsMNea1Eq9VsMk3XrJCnuRTuF9P/Dua1cvp11pgbewfIMTPThQHyg583NXEDN2EYOLgFtcCKA4S40GiqgLBgO3wSoALwHxEXUwthmindZ8rToA/TC6dOmN4yeuXF/FyGumTirToN8Do6oVr15xKg5nOkm6gU2ZAa3TlDOUZrHrWsyyhsYmW2F0390Ht+3a+9R3nz199rKRoe/7cRIpiVzXl1JmmeKYGyBpJrRhsMmK4zw/lilKLYvbURxWq9U0EVEUl8ulYrF87dq1fj9cXl6tVquTkxNhGPf7/eNHL/zKL/1MliV//hd/ViqxSrUEWr7wwrNDQ3VorBoEQyPDwPn83LXB8VHEaLFSJpypXhdTooSklFJFAYAxxhxOKQUi3ILPbEFtCyjGiBsDBlHu2EJJIDZwjzsa0ziTVIeG2J7DEIBFN6sAtWxkNOIYQGnE/fIgCArcdgoOMCdSqUcxIKEyBWlGiALQJhWI2TSTJtMYUUoYUAOcGCSjqFcuepUKtNvd6Zn9R46/7lYJc5HjFLhlSYncAq/W60Hc6IYRTtJQWUmSJqlkzGhjMKYUkwwU0gYBwghAaQSAEFCCKSbIsimlUdSxqB9HqWu5mVCMkkarY3NqCHX8soagWi9mQkZpylwEJIuzLrPc4aGSQaRWLfj26mB9OEnSvaP1rLUaLc7vqBQmPYtRfGpV9ft9Y5TDmef41OJCyWav53keYJTHXyswRhkAiRCyLCufPeROGwgh13Udx+l0OvnzixDKSeT5w97v92+eysKm6DRv/9Gm80F+CDDGyE1G5fdGpgihf5i49H+76E/+1A/85//8ud/95G//6Mf/2cuvwfveWbz1ttvbjfbzz704NTl49Mgre3fuumX3ngfuuuPb3/zmG0dert1/IOzFK50FiFItE4uYgo3rVbvoo+nxWtSYVUgf2Dl46fSrhw6Ugs6i52978P7DWbD0rnc9UKnUXnzmqNHyxtUlxgta8/Nn5t/xtge07J149di73vHg/NXLpFDiDp+bm/P8UEteG5AHDx7828+enBgH13Ur5drDD9+TRLHKpGt7J0+8ue/WqVploLHWb3eSf/6v/p8zF65fev3S2x7/6K/9+n+bvRrt3Tf4xhtrk9t2nb84e+bUpY98/3v2PvizywZ9+/S5le+cvjp7dfe28YGiferVBZdBtQC/88uPH3n1+Oe/vXb7bfzoyatlF6amZmq12tWrs4uXL118o8c1SAnt1fWhkiU0OI49sWcSKGu2u/0wirK+cZDUKsuy3HXLyp2GlEYGsDKgVB6QjQzkyYeO523t2zk2l9/4my3o8KYdaG7inM9NAADlYiFjQBuKiVYG6Y2jGaMUjAGAobrdbrfOtmf73e7+W/dVKrVMxJ1+4LuWApxnu4ABMEpvOM4xKaUWQkmpEWaUOxYnPmeMRUkaxQGjVqVS4Y7T7Xb7QdfiNmKaGEwRKIKoAKWUAVV0bcv43WbbuObSNfmhx6aTsLe2OLd/Zufc7EK9PHjglm3nzp3Jkvah2/aMjFURN1nU5MzjlaISWaa1V6ooYNRygXtgVwwrGeIjxCnCltbIaAATXbly4tUTc1cWogRpYqV8kCGWJZFr4bHBSsnWVMcgMpSFFi1gTvq90CkUG+2oOlAGhoYnplhzbseO0VKR3H7r7mqtcPHitWK1/tpr523XAbAJIRa3GeOAKKLUJkSKrjHGcRzGSRj2pTY2twi1hQzKldqN+YU0k7WBoW6vv7S8Uq6UJianOu328tLq+lpzaWnl8OGdWsv5hbldu3YcPnybV/Rnz57etm16/NaDkIS9sDc6MQ4YBVE0WSmDY7F0Q7iYJDE24BUKvkUhX1SAkjCiSJeqFaWUAqS0IpyDxlGcemUHgAK2gLrY56WKyTIZpMTTlIADQBBgQAZAMssxWgFGYafJmVMdnFhrdEpe1SoNqjBRhEoMFEttMEhFRAIqUXFCLZsoAInBYGA2EAQEkDRghBBxFIJjs23bpo6eeD1NFfeJbXMgJEoSAOqXythS2qRpKrtRkKQqX9Amz8gBQKAJxgwRi1NKEAK1IbFGhtsuAADCGpAGZBDhtuO7ztLifKVS1YZgZAbqUKhUbyyuBImAok5lSKiaW5gLA0gTuP/+fbsmx3qdftADE7TWrs915pt23asVCsP1Oq4V1tbWekE/TJM4TpRMESGMbDn95hRJbG7KxtsYLAuRd+s53yFPRsuPwlt27Xm9vpkXv9XY5XP7/DPSNM3b/0KhkAm9VRP+KYfnn15Sf8+SgB579ewXv/x7H3r8Z+P+p3/2p+8GBfPzq+dOn3nxudl3PrqnVHSHhquVmn1p9g3HU7bjvjg7f2DfgQljry+sri7MV313eqxeq/CCo/vNhUO37u732rVKubG2lMTR/fe/5VLmvPTKy68dOXv/nd6f/tFLH3pv8eM//LEvfekrn//cjfEJ+OAHH9i2e4foNVrLUy889/zBfTuvrK/0e8n99z8iMtzvS855s9nMUrAs2LFjZ5Jkjs2np7aLWB8/fmJ6eoZxZ+fbH19Y+uybZ2ZPfuE7dz/4jt/7L/+z3YPqoN0V8OJra/ffPfXZb106vJ29/4Pf9+BbHjp75fy//7n/AwRGp5x+G15+ZSFQ8Ng9U3fdtv/ggVtue//7hve+8O3X/9PrV3qju8vc9davzK8v3ZCZLnCqkmhkwF9bD7CCG430j3/7v9xxz72/9du/+4Unvrlz18zk+MTx107wqs05x4CMMRZjjuMgA5lMjFT5EiaYEEIwwgbjXNoHm8P0LZw9H8vk/XveDuRLQUrpMJbX9s2oGAPIaKQZJjr3hpZSAeTyVISQ6/hKqSSJ+7348oXZbqs9UC+XipU0ibTUUiiQQmkFUuWOAb0kRQghghEQhJCRSghBSEK5ZXMG2iij4zgGAIuyWrkiRUIQIYAIBpohgZURmc5UqjNGYM+OkQunl6frsGtmam1hbmZizKdedbxodNJuti6ev2G7sCvtMLdGql63tUYwJ56V9PqYO365ZjAFVgLqAS0rVgbwACgGBZDwah1mLx777lOzlxeEKWBWaEUUvDLt9xEYz7bKvs1Un4iowInnUGwybIiFQaaxbVuOV7CJz13vrpk9cdI/cfzMyNjkW+67LQq609u3Nxorq2vdTrtBCLctP80IRphSZoDlTVMOp0qpMSKc20oZSjhCtNcNXadYLJaXl1eiKJqYmLj77nu/+eQ3FpaXpycmVpc7n/iRH3ruuWeHBmt79+waHKo1GmvHTxz72E//FPQ7URzGMrUMTaLALfrgOoBBY6S15p6zsrLiWrbnOhw5kHOrM9FPIlawbdfFYKk4ybSyENYIYiEsCRpTgzhSDJhbrtlBlCilsxgAmADDKAViALTt+FKbTEe9OK2WS8wp9a63GOcWLQnNtAcSBDIG2z6WfYgjyDKqU8g0xZxgKpWWMiaKGqmEVK7DHZuFEYyNuQSpg7funV+7rrEUWhEKcZpIqf1S0XI8TCFVocgMGMwYo4SCFhghpJURgjHbZszlxCIYawNgKEJgNliGADhJMmWgH4QWZ4jQQrFKLDtJE62UU/BTaW4srfmeLYVaXl4EwO0GMAagIO53qNbNlXmLWioMRqrlIkP9dre9tEJFZspjFZ9VS0OdIJhfWgziPnNcx7bSLNWAN+OvN0R6CKEkTfKpmOM4eYHWWucJlFtTtJsFTbk06Z/23fl8Lv+/S9M0rwNkM4YbbQrOt8r6/62452rFjc/aObr/D37tDz/36d/5t//230Wdc9OTUyuLZ599evaD7ztw+PCtaRKKuJ/h5OzVNw7u3zc4NHD01aXVlfba0nLJ8WxCes2uLPG9h25bmDv/0Q+97+q1i6PDQ4tLq5ZTmN4xefrC1bMXqO+S4Ql24XKYApRro0ePn7Hd8tDYyqPvvKtSH1xeWKiWnUyjNFOuW0G9ziOPvf3oqycba+G9973tmede+Nsn5h++j3/84x878dorns0WF5cvnZtNogwU3HffDGjzCz/4y8tN+P4fvf+Oe2aeffmNXga1iUGnUP7AQweTuL9z29TK+mcffvThv/j0V5955pmf+7F3vnrq//zFb3zq9z939r7bR9qRvnJ9dbkpVvrcWpZ71tWfPPHi6XWY2jN2oRe15lfusvFiU08NWWsrjdUEZnj6+LsfevTt7zh19uzR145+4atfXVxZq9b8G/OLeGm1XK10si5jDG8C6ARhgpDGxAACpZGBXPpJEM579yBLzT/0jM5vaj5cgpuSvf6RVgIgz/YFAMBmYyKPN8MENsZQlEb9yLIc3yumWbQwv7K6urp9+/SOndNSgFFICzDKgBRKCpElUkpEmNYKNKYUGLMRRkrJJE2TTs9xHMa4TnXQ7yZx7Lqu49h9FWOKOKZAESYAGBklhZIiE1hKh1rDFXj4/n1xvzNSr3EKvbnWyEj9+ZdfYxbcc//w4Tt3axy0omZ90HJrPik4ABrbrstd7pQTaSj2DPYU9jUUJTgYEFYpSAG91tFvfef6uQtpBAliCFcSiQKFoddmCKq+41CURSHFwuMsyyRWuh8GBb+8tNqeuWU3ty3Ldzu9/tQw67aX+t2VyYmhetWplvjeXRPG3PP0My/PXukZkKzqSJVSgii1klS6NhZCGVBSamOM6/oWt+Mo9rzS+lp7YGDQtrnIVLPZppR7XmFhYSkVcnxsslarHjq0p91uR2Hg+eODgwO84F08ceSOuw5DryuR7kbBzPZtC29eYmFUqQ2AlIABM5YlCZKKWhZlHLgFWQZxIlLBfZdiqrWWQlGGmWVpQMpoabDluKnSjltAzAUBgAF4wcWFKIpAY0q5UQYoBTBGS8RsI1MhM9uvasQAfLtQ53ZFpYzaNWPpTEZIZZZdhqwPUReMAcpAKeAMEcYECAkKYU1AagibaxOTI+9+587z53onXn+tE0WVaslQtdxcHxot2TaP4w0PxSSJwxgIxvnkkWNCqOaUYdASgAHYDLmcEWyQxAgbjAzGOImzLMso4WkSAeB2u10sFgkhjus3mm3LsghGhrBeFCkEdqGkuUmS1OZ0YlTblmtZThqGIoxB6cHhWrvVSsLItR1DkOVbxObttUXHcYrVGvbttuNkSmKEMcIC55UdfY/auDlc3cJOtwRNWus0TXOABW4yhb/52qrvZsMreyMXBTbnpbkMChO+cWRAaGvoCv93zP3mi9bdyr/+iX/1p//zz37/rz//1sPfvzJ3hnC4ZX/5kXe+p1zxvvzE54cHy6tLjYP333159vyffP7k/R95n5Ly9ZeOnFuHAoMH79oxMVRaW1p+/8d+KG0vX7k67xZLxCr0ZRou9S9fWXUrtzz/4omREmwbsd/zzluGxsarlcKVubUHH7mV+4XrS8urjfUH7r193213Jkn00munxvaO/9YnP3//vTsO3XHnN775neXV1vAAHDp8lwG6sNy4547bEeajw2OnT57+ypfm9h1YGZkqlupQGOZucWhiYvcrF1ZKg6SXmX43feqFI4cO7n/qmZe37do3MDz2fR94tNtpzTfDVz71J4XhbQPls9cbyeT2fW4PtyL0d1/6RjdKv/HUtw/dfuu//zc/9Pknnkg6Yd3H73zHO27cuPHII49cvHieUnro0KGVtcYXnvji0ROvC4MUEAVEAqKuzbjFbMcKEsuyMKAsy7Is45QRximlJBeJKoUBEYPAGKQ0KMVdrjcN/vM6vrU/57s33gz02oDgDYLvidLy1QbGQJYJAMCEYkS00RgRhBGjTAkdhjFASAixuAtIra91suzyLXt3GECYaZNHFWiFkAHQuQA1TTNCsOV6lHIpZZxkjPEsTgxGlHLHcbjF0zRut5uubwHBFBNCCWOYkowAE0Rj22XYnHhj5V/88L067bfWlvZuv/PCmTd1oFeW0oEq3n9oR2WQKiyrw1VvpJQlPT48DIxnqaZOkbllBRYiKAMXgafAk2Ab4EgZIgVIaLx59vSxE5bBvuWvrvZUcUBjtrLWcVvrNjVFz7IQJElAHcRA9cLMd3gamvqg2w/ao6PD7TB0PW+92TzyytlqdWDv7qmx0ZptadvWlRLbtWP0ymx9YaEXJ2AxI/UGQSJLY8ywllpoBQAGI+7YhFtRp1utDywszN919+0YQ7vTjNPU9RzMaKvTcxzHdd2XX3757W976Etf+uKP/sgPDdQrUCl15mZd17ZtG+oD104c275jR6ffwxYzGBUqZSky6jm46OOW6nf7hUqZAgKCTZqkUmRZVrKqnHORhWmaIkSI6xIgWZICQq7vJcJg2wFqZ7FQmXYcAhgDtixqYWYpKQFxACmkIYxmCmvEyoXhMAsBeKk64lq1MJB+qZqhCLQEY1nUBeYAYgAECAORAKFg+0AMlsbkjuhcVokDsrhnz64vf/lJwolmbKIy/OrJC4mE0VFULpcJUYjSMMp6Qdztg1vCQgOSEmPMCXFthoyWIRAjGaIcA0EICEKAIcchEQIA13VFllBKe+1AKZVmghA6v9yaGh+yi14mVKbBL9f8cm19tYmAWo5n+/7aWnNoyG20uqOjo1evtXbvK88trV69EY2MSM/zLMdpp+lQtZikIuy2+2mSJQHFCDAIrTnnyiCpjZJGK7Xpvm6YzfLjNWxqU/MnN0dTcypkjtjkBToH381N9jU3F+stV4Mtlp0BucWjRzcFifzfivs/YL5f+tWPNNsdr1DCzE6V+eVf/xu7AIOjFmHkF37pF5TJXn/j+LHjLy3M9+bmYHwC9hy8Uwpx6fS56ZGxqeFhj+Pb9+9qtxfjpPPW973jqa99WQCxi9VT565abvm7z55aim2HY5+aQ7u3vfuRB//rr/2vP/mf/+Gb3/5moVxaXFo6fWb2B7//nQdu2bl846qFVbvVOHfjRKU85BfqllVZXmwDsjCmhJNLF8685S333bg+Ozw4dObk6agffd97P7C8uCJNsLTWnN5zYLEZvXpy1q6MvHz8NHDfYKKEHB4a4CB8C73nHQ/bxPz5//nThRimtu1cWG61emLH3ltvu+3wyROvjQ+UVq5dOLRn/L47bnn1le8szF25eNk8/n3TH/7IRxbWXYTQlStXLlw4t76+vrC8FAayNlx5/D3f9+yLL5+9OOsXK26p1O5FqRBeocSREEKkaZrXcYYJxQQjRACJNMMAjmVTTFQm8llryFRuCa2UStNUa50zZHN2VA7V5SeyjZeZ3ALvjDF4a4auTT7IlZkAgK1VpTHbAAdR7ogktVFaZxPjw9NTI5WyFwetJO65nCKQYdhvtoLcdywIIyGEZTmIEqUMZ7YGkFKKTGmEbdsulUqe52U6AYPDJI3CDGFmWY5Is6DbszluLS+ND1Vu2TWVhe322qJNsWMRFnMgslDhlbr11rffVdleba7N1raNAEhDiOYu4kWgRUQLBjuAmIAqZp5hRYSKK43G+MAQCtrh9Yvf+MyfNi5fFElKrGpHum2orqX25aWWuvzm3YenBspMRitDFbvqo6CxHnaBE6gOVNbaQaLQnkOH1jqt0mCtFwT3H2JBEFy6OPvoY+8Ymt4+N3u9UhtutMKZ3bf+wEf+08gIE9qKIl0sDWlDOp2+R9b3799/8eIl27bHxibSNJ2fW9y9Z2cURcWib9m012slacQYdj27Uqlcmb32rne960tf+Oxb7r8n6LbGhur3vO9xaK+DUV/+0t/ddtcdtaFBr1SMsiTTqjJQg2Z/td0cGB1WnBhGDMHtdnt0eAQKpfTaDatYVL3+3OLCzK6d4DrLC3Ng5MjYmJJaaGUP1CFJu72oNDAExFKKSEMJdSjzDbAkVUmScFJwXB9zG4wBCgAgIUxEV6rQsTkFpLSWKSLgcOwhoE0LAXRQf7nqqXT2dUv2VHORIAWWBdwBhTSxsFsQQkZxwhhz42Tx0vorL80fOTLfaCmFmbHEwEj12ZdX775ncmklFJlVq9UWV6/FacAsCGNrvZtODJVci1OClxdXy0VLZCnFUK+VC54n0sSA4pTFcdRshtgt5CxyQFqm2UYcjFEjw8P9ft8YXSgUOOdpFCdJgrDBaVAsFkuVSrfbbTabA4NDgPH5i4t79oylmciVyWGcpiIrFosDA4Om3VbaSIw7cbrW7gtMse3GyqQyP+JqrTVGiBPKGGMUB0mcE5ctyyKbqdlbnjN5ic9btLyHyy3g8xKf//J535BzOvMJbU4GJYT4vq/0hn4qx3NyKj3nPCdi5Fg/2nRBEEK4rrvV/tNrs0du2X8rtfFTT3/3Xe//yCd/559P7z7wc7/wy8vrrcvznf/4i5/8+f/4U7/wG594+OEPj0/yT/z0vwzWW9ev3njs0Udv3bP/uae+8953vf/Jr/z9s8+++Yu/8vEXnj6SQSEx+OWXzxw4fG+7lx6+r8BuNK5cvLBj767v++BHgubqj/34+/7iM5/ff3D/qTOnhErsIummaaTNn/71k9/37vuuz97Yue8Wv1BeXe1v37Htznt2Hjv6xl/+9RcZhzSD2+/D97/t3a+89MK7PvgDKjOf/svPHDp423KrMTY1s9CKjp660AxUZ/3atVZ05607Gq2eyOTFS5fr1ULZY5/81J8cOjD5yd//H1949qTlFI6+/iZZbp25cLEXxWODtZXVhShqvfLilddffP6tD2x3iPnvv/bB1147/if/45OXw5FTp5c5gd27B3bt2vXP/uVPPfToo0Co0Vowdvba9dmFdi1LLLeIqZXoDGkppYRN/CQ/f5nNCESzqVrWYAzOnd5U/pV8EAqbk9W8rG8ae24A8UopAwgQMhiMMUgbA6A0YABCqAaMAUyuITSADGgNGiRsFH9sDGhDlNbG0GYrKBQCy7IQ5tzyKDWUcMoJIZbSOk1TSjBGjGAAA8ZoTMBIgwxQhinhFmdImyxOqIMzKbHRjkUIZpQCUcg4tNtc27t7ZqxeCjrN9tpCwWUFlyVxVPStobEx7hhkZQIL4Lg8XAfbEpkxxAJsI2wj4gByEXIBMcwH1pud0aFSN+iOlmpZs0ni/hOf+2Jvpa3AUQb1emlCueUSWyoHZ+PTXskhLkOk6FOURkGaZCAVcAt6YZoJhbltWVaWZbOXLiKCGw33vvvuI4RcOHd2aGQEQbYwd5nbhai1+Md/9LM/++9+b3TUW1zs1GoyjBPHRr5ttztN17PqA4NRFEipbdvutHuAdKfTmZwak1IjhKanpxvNtUuXLrztkbdfu35l155dWsvBwYF73vv48hvH19ZWduzYNj4+XiwWMcar642RmakgilNpbMctAWBuYYdLDKmSTqEI3IJeLxbSMiiMU88tGA1IGUa4Z/mgCZIKaQNxbJShFIOW+ZSdYIIxAgIIYRswIcQog5EEI7TBoBAiFMDGRBplhM6zzbFjM4Q8MAwyqUFwwEIa1en3uhFPu5DIUr3ab6zbHpWEKw1EaKUxcJv6HrQ7YzMz1vE1hFAYilSLg3fswLbWGlYWFxrrGoHFECClqiXmeOC7O+Moun79KkI+IHNg13hrfR273HVtz+GuzYxFsyzNsoxSOjhYlNgTQiiRbrm7IGQwJpgQQEgIlWSpQZAZJZFBgEpWNQ4lQQJjx3ErUhFG+eBQKZagGTfcDqKwlWRBqroQ9lBrv2f346TTaveSzLJcxqxepqIoJZYNBgM2GDACMEZpBUpjtBnxseUGnJ+88yq/QZDbJL/lc1GlVF7uc4x+S8i6NXXb6vEty+r1o7w+oE3ENW/efd9Hm7rZraQRhFAmxfeK+/ikRVlbQfKRj737uSOvKFL8wre+e+zNVnmA/sbv/ilY7m/+7l9/7Ttv1ie2r/X7zxxZwp0ze3ffMlwb/MpXv3Hi2JkLF2dPXOk/eLA4txYsrwV7Du7/+lPfdUojq82k1U36sdyzd+bO2/cVKFtYWjJx/Ju//5Uf/+j9f/pnX/34Jx7/5refXFmHa3/1bHP92bsOwbnL1x64/0FAjVp18Jb9M0dfO1sf2/vsS8c6ATTb8F9+48d27d75R//zf/zm7//BH/76fz3z5jkE7NNfeCUmYDlztkckYtSpGEqGq8U3Tr/puv7g4MDgQKnXWVtca9sW3Fhe+g+/+Et7RgaOXbjy1ne++7mFs1ZZBCtnzl5NHAb33HnwwJ6Hx8fqg0MDrW7n5Nz83700zxzSaC3/y3/zgx/4wAempqZofQDa7b/6q7/633/yp5duRBqgNoD37p8whHaCUAO4vivW1zd2bEAII4RQHocoAAwCY0AZbXJLIgQKfy9efYsNmd9+27bzc9kWOAMAUkowGDb3DYM2GLNIG0yJBqO10QAGQGqNAQwCjaQ2KH++TU4wAKoNtLuBvdomFJcLnDOCKCIUUUwwkH6/n2hNCQLMcuoXxQQb0EYBGIqJxSnFRIg0SaIC80WSaKEoYQhkliRaSI7V+MhA2bfTpJ/EPUJ1mkQJodVaiSi5c88EslQGEfUYUENKNSVjzRxNLEM8SgqACoj4CPsIqCD+yFCt3WpUqvVsfd0i+NtPfOXS6QtliyPwUkSBM0qdtdZ6o91zFNo3MwqgfIpsbidRHKWpAZAYgNlBJhUitmUXi8WBWqXTb4yOjVEGb546x6g1Pl5JomBh7prWsO/AIdfBrl9+9zv2XLw4X/RgdKh4/MTZickpUGa9uTIwMFirV2dnrzq2X6mV01QoJXzuZkJILQaH6szia41Vv1joB9315ur0+Fi/3Zgc3w4DpaNHXtm5a3sY9acmJ6rVaqpNv9EaKQ/4pB9nKTDtuBWpJWFUG5VkolQuAaNJr085A8uK47hcLidJwrQmgCxsqyg1AJRQSDJEsE1JFgeIWQjZCFMEGSgC2CDCOAKFJRACBrQhxtgUKAZCMWRIGa2UNgwBIjYABaN1lmnTKdk+FF1Qsl4fCBd7UaqBWEJTh7u2UxCEAqFpJrJMmizFUjSX5sfGxkDPlsvutl27L107l5l0qAJBV6cRODxLw8B3yNhw1S+SNMRVp9RexDoOfN+tebbsE0KwzTFSQqUxxjhLkl6vB5gUCgXf89rtdpqltusiSsEoTZBlWVEYBkGQ49R5L5yPIi3pdNbXEhGVy0XG/TSTButCubbWbrrFAra5wkJSmxCFXV9ZbhInYFCSZP0Qii7RmGQiI4wrjTUYhDAgjQDAaCOFAECbA8+b55w5hr6lY8pfbrHg8lKOborhzgkUOf0xB9+3WsMtXs3WvO3mbSCv7LlTyMZx4SaTSGq4Hr5199c//9XiemtwcmJq9x3/76d+ad/OYjdCcwudHTv3ZAJ989njnNj333//pz/z5KAdfu7r5w7scFRqpIXPzfVnxuyVvvjUH3+Ze5A9+Wqq4Md+4ge6YfbW2+4rVqrddM0mjAo9Uh2YvOWAg8xnPvOZoSHy5JNP/j//6sdfPvpSt9v8yR/7xMLV63/zl59vtL9R9MV99z+8tHYxjPXXvvH0x3/8pw6cPvPFL3/p9/7XX4yMD73xxupn//rzVm30/se2DdZHn3zym4u9lpAqTlU/TOauL2cAB/du467r+/7qyjKpFgeHB3ttU/AdxyKzl5bRXHfHDvqvf+g9R5/9RhyD6cG//5kPfehDH1heWnz66af/6jPf+NiP/tiFa4snzly83ADLg3/9E5943wc+sN5c/43/+tOvHDmWJEApFCt8186yRhgQSUQWR1EmlDKQZJkvJADgXMaGCcY4JxnKLAMAinFuv2QQaGOMkhrp/A7lS+Gf3uD8XsImB1Yqs7WScqqNNkYbjXVOacztqUGD0QAGI4UlGIwwNqABKCAMCAMChFGz3ZMqyQZLg/WizYlQSgnBtAGlsdGYMWNMbtjCHUvl500MOCd+mTT/xUQSayEIIhSDSOM4DAkgz3Wmxoajfmtu8QYzol7zVBZKJTnHgOLKsGX5FnGrdslKRWrRYjfQdrFgqINIUZMiJSWCfcAuQgyjCgLwrESsLfOCf/Tzf/fmkVfKbtEY1EvTVJNKrU6VWjl/tNlUe/cM1RwWxQkFBUolSYIxpa4tk1ARSxMAZGKhgih0XO5wMjU2TGhvbn5+cnJ8+85daRJgZDrdVnmwAibNmgsDVeeW9739u88eWV29euuBqfMXbkxM+Iy7xaIrZJqmcalUVtIA6NzVp9vt+r4/MTFx6dK5brf73ve+Z35x4eDB/UG3yTiuVyvBsSNXri7eeugWAIMxUUpJAMcvQKY0ZoghiHrgu1k/ZpqnRqZScMcGbRKZUYKB4CiJh/zxOOiDMQXPV6FKVWbbnLgMFAKMCIY4Cm0fGwJIYy1ASwkowZghTAEbAK2Rxsg1GCsAAIrAJVgRpJBJjVaAJCAEmTQyo6IJtoCgCXETMMJaJVGs+2EmtEEUWRZnNnCqwjBO+lGQlMfGYX2+0+msrSVSA8OEYmwQ7Nrmzc2HxgHbdhHokm3Vi77jobOzcwTQzsnhdrM5UCt21xYHfFsIUS76BiNARGolJdO+rwFhjKXIRJZqJTECAmCkxAhZFo+iCPL8J6NyvBIANIJYo0QhlSXYtinFiZCpUcy2MqEsA0YZrYExy7Vt2/cIYeuri6VajdsWSlJlSJzIVMhCrd5q9/KEUooQAo3AgM7tIa28fOfqh5sr75YhTN6z57tOrknMT+dbJ/scjM1P51uIvJQyp1Nvdes5+J6X+yiKtrjzebnYQPktvrXH0NUAwldPD0zuiaS1+/YHLlxZPXxb/fT5dUPw6NTU2UtXZma27dq5+8rs7I6d27I0jIPj3W587kbcE0AAHr1nHzJ6afmG8dDuW/csLNz44R/5uFJG6+5T33xifn5xdEfptSOz+7cPzl9e2zZa/93Pf+7rX/3CmxfTWh1WV+ezpHfv3Xe8duLofXfeMzldBwV7D8ycOT9rjHPLgbs0Fa+fvlCqjXzqj/6UWvTTf/3p07Pf/JX/9kWEwHWAMahVa+sirVQq5y4vFApk34EZhMj09HSpVErTFPbtqFSLnmtfunj25ZdP9AMYHYKegLQ09dO/8junrsNDD808Oj32oQ+98z/8ux8XUVorscfv37Nw6pnnn7r4wY+9+wvf+upH3/q2VKIf/JF/tjTfrFZty7FKFW7bdrPZxEQEcRTFBhPwyxXf9fph0G51Sq4PABhhislGuCICY0ycJJxzwqnBSAEYA1JrpRUisLUzb03Dc0AmP5ptsWI3shmVQrDhUmoAawQGGYNAaIOU2mgH8gqPECbYQIAw0ZggoEYjg4hBgBCxHBp0G0EQSpl6nl0suQZEliYUKcpwDrunqUggQUAwIEMMRRQAK6OVlAaAEMooE3GEEOKcUgxKa6ylYzu1khv2mgRrRkwaASBVrpZkEvaC3q5byszXToU69SIg3YoDrADZHrIKgD1EC0AKiPiAfYQcABYDRyC5V9TN5aXXXz313Hdlp1mqT611swh5MTImNTLuG6lGirB3zKFp4GDJJArCII7TUqWImROrkAPjnos19Pqtq1evMq57nX6vuUrqzsOPPh70O8tLK75n3377oaef/i6AAGYtzV9yLX3gtt0nT74xOFALElkuQqnslUtVrWFlZUHIFMC02o1yqeo4TpqmWsuZbVNayzDq79mzc2i4Fsa9MOy2WuvTEyOVajHstg4cmB6oVRDBy+sN4Ix4heGR0d5aA9mO7XiZaHNAyiCttMIIMQ6MmySLU2EbDEmWpgIwxZhiRLHnQZKCAqwwZDnzmwAjHIORsdFSGW1wBshCmBtqYcQUCKMzRIEQBwBJoNpggzAyNsGKGAIqNkIirAAMoarmM4C+aS50l6+Vy45DoVYqYsZFmsVRKnCELOVg1+LYsZlME2i0hnbs+sLffXpkrNjtopdffu3Bt91+Y+FyoVxqrIZ2iTFip0liY9BpnBphG9nrBdND1bHqdJbEUTN2fEvrjOiMWa7SJo4zAPB9P06zbi/wbQNScIwpRkqKNIkQQo5r+Y6be7zkDjBb8dbGSEGJNLIdhn7BIZQoJVSSFFyHGiTiVEYJ0YZKoyORydhCBBMLUQuxFAiRSkuFhDSp0gjlrtw454UhkqfPMIRQrmDaQlY3bDkI2QJkcvps3sDlhTtHb7YmpVsT162+Pm/J8w5+a1i6JV/PsixH87cI8lti1619hR4729+3f4bZJWIXG4Hzr3/+d7oRaAS+X4lEOrV9dG7uoudYjpv+zz/7IwQgAWoV+Mmf+eGDBw4P18e/8IW//9Y3vvbz/+7fXL9+7vf/11fe9+jkffff9eM/+uNvXoLxEnAK3FlfWYbbtsXDZVSw0Bf/66/dd/gQmKOjM7Vrs2ff9a6Hn3/++QcfeEuzsfqex9+9/74HLp84+tWv/Z+FRfjiV879+m/+h//0y78VxDC+fXRm58zvfvavC0O//qUnnsCY9vrR2mrQWmq648MXlxqsbL/7/R8wIkuTqLW29vyz3y34dpYllOIk0XECu/bUDx8+XCwWp6budl2722/8m18/wHG6bWYQwpWgk/7ED9zzlsffruYXv/PUM9988Y8//Wu/8+xv/fyBCnnuxSPNRpdyVCxWQKt2p5XF2cjgSDfoD5Rquog6Yb/XamPaL5TKO2ems/UW/MPALa21MlpqRcEYBNJsEFE1AgWGbJ6ittgy+b1RSv2jTK/82/JkJYQQzt0HEEAO5gDkwgqWS021zuUgGhmMDSANoDWhRhNjACEgjBvC4jBtdaJ2rzdQL7quxZTiOqEe0VqnmRRCMJwT1xRnHGEKAFhhrSQAEII5Z912h1KKtJEISSEcRgsudxhrrDcAMs/lQwOezVEUdS3O6sP1HfsGiSepq8FGSgMoqgkrFusZcIQ8REsE+UB8AAeQA0AyRYuEACSYoq/+zV84Wo2Wi+vdrsJVp1qPg+TK0pzoLpYLMF3BJdyjkjCKU5llUQgACmic6UQhJrDl+ZygusOjtGcp4dmgsrA+uJNy37JFv5f0VlZ3H7pl/769qt8mrr+yfGNiYvvp117at3e6PjR5/uLVkcHSWrvjOFZjvd3tdRijjBGt9fTMZJIk58+f27d/d7lcvjx7bmpqcu8tO8+dO6NBHT125PaDB0ZHh5eWFkq+vf/ALY7jUNchrbaQ2mE2Gxzrzs1biDHbzwgGpSzHThEgSny3aBBIZPxiAWcKjOacmyTJ/UkcrSktMURNFmZZTC2EEQEg3GZZGiuUaZki6lKmCcOEECCgoW+MRQwnoHP6iVYYEQpGYEQpQmAkGA1agRFgJKxeBiOht5w2FoAPADGuayXd9kC1avl+BjpJAsoMY8ihWhuI1+KsudxudwmulEp+r9+XaQbaIK0chhy/bCSPjPI5FUFPQDxSqXpEB+31XTu3L7TWBstet90xCEQcEIIyBXEUaEQZoVKrIEgGimVS8Cmltm0nWWpbzGiEDGgjLUYYIxvgp1K5QWNH9F3XlYClTi1kU44hA4oNBqzSVGcZl5IjxhSYVBClKtUBAzhT2gDVQCnDGmftbl8ZhBEmZoOqhglggwkYjfFWBwYb0WawNTPbIsJtMV5y0sTNtOa86EdRtAXFbA3YlFKQHxU2+ZFb8Gze7eVfzAGZDTjI6Ny8GCOEHnJBA6xHMFC2ulGKuEscOxGZMiqMYtuCt9x368zk0P69Mw89eG/t1v0r862rV+bSBH7vt//g2RdOuRQGyr7N9EDVee8733Jg99TnPvOX+3Zu7zVac1euP/SWtwSk+bYHHyUCffsrTw2VB+vVulLZA48+eOS15xMTB2l/cGR4ZXFFxuJDH/nB9bnFRrdPuf/EE0/95RPnfAKWjwl3ecEN0+jwPXf80Md/8NiJ1xeXVp55+oX60Ojy8vr1oN9tRW97+J6PfviDP/ezP2cE7JqphN02o6jdNsUibN85Nb1tZmbHdsd119bWxv0RjGF1bcGY2LOyfTtHLp9+tUDTB+7YD1KePnmW8uqFq6tvnF+V2I0EOraqJ8fH+kEvi6PxsZE0CldWl0uFYprGBgGiDBNiME4zmSRZmmVjpcoWopKnROaKtVSKXIWcn6EoZ/nmTG9SIf8jB4ItZtXNxKlA5+GP38v0IpuS1/ydrU2eTD7kkaSNEMGIGWSD4VpTrRFoQxE2Ok3irpbZyLCzZ/f0yHAZI+NkPQCUpmkQBEkqtNbGIKGMZdkAoA3aEumhXFsR9xAiW2Mi33M826YEhUGn12mUSvbYUDVLgywJZrZN7t+3d2xPpsFURkfBsjOtke0ry7X8qgRHg4ewj1CBIB+DA8YCRDpkjMSNQrr21J/+TvvCydbC/Mj4zjdvdExtR8zrjTCZv3EJ9ecOjrE9A4gmXVtXAaNOHAYyJZ4nCO9GWZgA457vFxnBu7aPN1evg+oNVO3xseFdh+6+eOns6MiA79BOa2mg6vkDxWB9VUqZCnXm7CW/XL/70fecOvL6rQ89evw7z0SGXrt2o7HeDsMUDCkV641G6z2Pv/fkyZPnL5x7/PF3tDtr12/MPvy2B5IkujF3bXxqLI3DfXt2M62uX76QRYHNcKVS2XlgfxwmiYHi4AgZHs96gabcLhRN6xpiFDy7m0Zgs9JANU1TnWQO4TqMsYLO0orvehpMr9ejnNs9yy64Ig0znXgV12AlkWDVYhb3U6UVECDccgrc8jFlBhHlplJSgDLnw4DqmXSMsTmzpEw4kRiFoEIwCWSxCjpBr9t449Ml3/M5Xrx6aahWcWwbE3Z1fnH7/kNQHwKALIkpR5iAyvpKCc6mLjxz8rN/8/yJY+D5MDo27vjILbJWu9HrxrXieNjXaRKVSiyKVrTRZatSG6gsLy+WCkVCsZTZ1avtwWFeKJaB0gxwmIjUII1ZnKkwTgZ9bwugkBqSLJVGY4yDMKTcwpRqMEKITG1g3PMJKfiuTGKQWa1c4qBUlpVcNwlCLRUAppQhTI0mmDJKqeNCLESzGzSCOENMMTsxkEiTKz8JMhwMQ8BAMWQwMhFxtprxraN2znvZEiuhTaM3AMitvPMGfGs/yCN50U1ZH/lIVgiBCcebiX1545+maRiG+WfliNDWpqKUUhi2NhJaqEyFcVqjyhDrLW+9496H3vKbn/xvH/6BH3jj5NGPffR9+/bN7JwZXFq4sLJ45XN/94fz//3anR/690EQ//Of/NWD+6d37Jl56P4HLE4evPfw3h0j3/zKZ//27z7rMmwzXBgqzwzd/qH3veNPv/i/P/Xbv3/7vj3ve/xdzaXm6tLqvoP7nv72k2PbR9tRdm1+6eSp127Zs29qcvr4i89H/ZQXysrEP/jDH7/3LWvnLi999nNP9MKo1wy27Zk8f3n2a998anr7tu27q4889t4oFsViKSlWKIJt0xPbZqae/MoT1y+f9zzn7Q8/8MUvfO0nf/z7zl+6+OrRi7ZrzS0uPPfSrGXBvgQ++ds/sXri+PMv3vjN3/wBMK0qj2amRs+fP3Ph0o1WD+bWFy4vgeBWN+OZsXwPLl6cLXrOQL3WbnUphqH6UL/fY3nkngGjtRQSlPFdp14bQMnGzmyMAQ3KaKWU0GojfMvofJxtCOacY4Qgy7YK+tbofOtwl1fMHFzLj36AiTEbulZsACFkMKIII4SU0aC02RzJ5tVfYzCgMBBk1FZCujEoSKJy0WNUt1vNVituNBqlouW6Vv6DSZKEYWgMsh3HGKTidHPYDwjl6WI4j4odqlaklFEYSiE5s4qeTwhO4n6WpcWSZ1l4bm5Ja7jz8La77z5scYrZSppm4FDQCghilZKMZJxK7nKELIQ4NgwhCoYAImBQP4knnNJXPvOHp195eVeRDtcqr716ZnD3gfkwvbG2FAOzvaJrDVRLpuSnMgNmIJUiixNqUc8vtqI0TqTtVTKJ2r0QVHbglp0AoISolkcGKuVUiGpl0PcK7cbizC23tOdnTRQlSVytVpeWlpM4ePChR0y3OT01JhurmOjbD96+uLjsuHalUm81u1mWAIDrur1er1wuVqvVY8dfdj3uuu6zz33nllv2aCPf+bGPrZ8/s7YwNzIydPbUkrEt3/fTft+pD2etNgAk6+t2eSBMRdgPPUKklNSyTBJihIDYadozQnKDlZRcI79YpAiD5xWMwRjPnpwdnxwDpIAZ4BZSYRwFzOcEEDJKCmmIAUINwiCo1totOFIppTIpBaBMKU4IJsAQNWAUKAAFAAaypNNqrq+usLhHbGQ7rk7DoK3cwUE0PDSYJK319arjQqHAOQVqAAQYiUwmFubr9XqpVJqY6Kep22w2d9YnkqgT9XvYMIqJkolR2kjR62gNIKC9Y/sU1vL8+bmHHrzt6tVZx4LR4aFuP0iyTAIBTKWUvShUQCzbkZnQWmswhBDCmetYSkOmJGOMWwwRltuCZlmm8igL11bEpEZSDFKLOAogyyqurWQGQjFmeZQpCVEUKUS45/VMZgBbjktTvdLsGZaWBoadktPqdJEBZARobUAaow2AAZNTG/Oym/fgeY+l/mHw3tYsLf9KjqXkT3RuMcI53+rhcvZL/v0Ms63ioDcCPbRU2rEttBkMskWuN8YYvNEmEkLQILKLBedd73zo6aeeePzdbxmssNkLJ97+8H2PvOW+k6++evX87OtHL6IMrl4Bn8Hdd8/wbbVasVx0PU7w/l3bLp47deft+65eP3/yzdeBoSAV9Ykd+w4/9Gu/+Qd/8hef+5n/38+Nq1IatPbODL7tvgNjA/bS0tVGr7Vj/6GTl69dmlu++577e61O1FwZdEjzxpX777p9IfAmp2snTj6999YR7iSxiFYb4Ve+fpbaFbe459ib85qXQ6nqU8NuxY5luKc0MrNt50vHTmjmvvDKiUtzy+NTOw1CExMTQauZ9FskC/uNJZTBv/zEB1vNtbVvXq9U8H33zIyNm1defeFd77mVl4rEH/kPv/n5l2ZhZHhQssHlVugWK61Ok1sUwzVswLHsoudzaikpVSa0BiGEQQRRohHEMouzDDC2HLtINgTHNwNkQgjO+T/qxPMbU3RdpY1SRiijEEEoj5annuMqkRqRYaMtgjjFxBhAZr3X3zi+UYIxNjn3XEnCGWwQcoy+ScAmpdySQVEMAGC0MkbZjMdRwBjLkjhJgBH48Iffq5Ti8XmE8hOlEZnKMp2lQkpNua0BCSmlMYhgwFQIkWRp1APLBs5TSuOBiluvlFWGOmtRZy0ZGRwLui1Cg3JN3nbH4FsfOZDKhu3fZnkUPAxMAGSGcmTXwRkBM5jEvl2Y7AbSKZQ5YWvdFbfg+sm183//laefPtLuZUIzDXlGhMyynsfh7KkrAx7csX+bhYiFSBzGWbKKCG50oupwzTC2vL5ObasTRo7DapVCFPTf9tB9c1cvyyyulYp33n4bLiZSajCY244UqlCuUL84e+Hi+MTE0aNHW532nffcXatXGSPUc998/bXq1NTJYye3DU6LtnjjyBmLF6lTwsXStfUVZZOx6dEb1y+oqL9zZLBEMTNm5vbbJqfG0zQ9d+as0XJ1dXlwcDBNk+pAbXrnjO1788uLlfoAc9yVtdWdB/ZDaxmMBmoBtwARrQ1Qjh27325zQhlCRgpIY2wMogQsBkdOzc/NMd+tjAxbQwPAcC+KCrUKsrkGlIosyzKCmee6iFAwZq4w5VJcoMgCBIQD9gEX+6YQogKBog3GZNfl4qlydA2HN2D92gqI4ZExtd5cvTpX84pWvQ6MgMvB4RElbr2uAK0vN21klf2KCiOSlaO5lb/8yy8ceSkplmD/vkOLS829+25989w5oZUmCIgVC9XsBp1umCayjeOyz4bL5f76+qHd21QUmCgaGax2253yQO3C5WuSoaGp6cSgRq93abZR92Db9kkZx1HYmxobvXL5WqXiYIyFwcIgYG4nFF5t8PXTF/qRcYse4wgbwBgqlcr1a/MWQ6VyYXJsdGF+3ndsxkmWJGmaUoJc17Usa7UV2I5HKY2zNI7STAptQAAYRCzHDsJYauP6XhjGvSAoFApAYYvjeHOXlschbMEpWyxGhfgW/LJ1bX3bP/1+YuTWmV5rEEpJKZUyBgGjXKMNLoZtuwCQZhnD3wvppo+9/eH7771rZLhy4tizL7zwoufA3bfvrgyMfuSjv4gEFF2ABD72/Y/VT563mffhj/7QSroS9vpl3zt1/Pjxl1/ct3Pm9OmzjMrmemPb3l1DhVInNt/8+pPXrmVHjhz5F//8p3773/2qx+H+O29ZWl361V988k/+9ycmvOlL1641GotjQwOXL531bWt8ZODLf/P53ROlRnPFKWzvt5sTo0O9dqOIiOvyPQdnJiYPtfrel75y7NjJhYnxuK/Uy2+cNxxcH77RhHoF1jowMlkzxJkcHa5WvChMkl576casxzFTiWcRy1IL8zcIgrVo4R3vfWxx6Y2xybHb7xjQqPflr5zatn/0k7/zs//5N/78+MW1tZU1rzIwNTVikFhZueF7GxBefvMopRRhAIwQklrndi560wMIYxxF/fwl27zyA1puxX7zncvfTUpp8gBpSozBZkP7IIMoREqCViw3eRFKaAVG56E/eZAvQkjdBNMDgIYNnixscqduRns2sB2tjFGxjG/6K9OPYHl5uVQqFSxLqY39SUq9Nazf+vGNoY1RGAMj2HaQEiG18cjQkOuQfj/UCbiOV985MlQbfP3EYhJGb3vk9l27K71eMDg2aBA1RqFUACiwKWIcEAYhgSNECGDwXSeO+ilFvsNdTHuvvHL9+o0kSwGQViC00BrSrI9ArC0uFoswMzUISGOEbZtnUZwkycDwSKZNu92OpNYYXM5NECWJkFIODg3khsxLC82i6ziOo6i+cf3arl277EKxuboe9COaqsnJySAI1tbWytXK+O2H+lcuJ4mqTI4feenlD+3ePTY2cv3y1bc/8I7zpy4zTG3Xro4Nt0TUintz89d918MMdu/ckXbaVMuZ6ekrVy4P1Qe3T00+88wztsVuO3Dg0qVLzdWV3bt38nIFLSyE3d5EtaprA1mnxwGBISA1IAkWxzYzSqdBTAk3xggptciQUEhLLhESAoaGymGQKhkEAbIYK3rEABgj4gQzThDGgKQQeYOJMaZaY6VNLik1BIgyRmMENuLdrCuMHOQM+15voWlWrpdR7A2WQUmhtGXZyuiksQ6c2XwA3BJHCAgiiDqOYyEKoLIss1ZXLcvqdxPXhfGRKhiTZdmLL74YiyxTylCMuaUxy/IYXJvtnRk7fmLWxOtDJeebr1x9cKf3/scfu3jmzYhjozK/wBVlcRh008zzS3v3jnWWltfX1wu2nUsEBgaKtVplcXERMdv3C7FE3W5jrRd6nletFzCxWu2VVAhGacH3duyY4oy01hsXL14sFgpA8g6XEiINQJqKLJM5pKmU0kZblsVtK82EEkIoHYZhmgqpjdRKiI2zuIYNd5Ct0ejNPMV/ejmWfTMlRm8+X1uKlptLPto0ldoc46GtYWkqMgOaAEGUbgH9IsvQ95jSiL7rsYekTN84cZQzstaG9VX4oY/eWh+eHp50J0fH9u2+5b67H3jt6Mnh3eyl51/51J//9cNv3V8placmpou2+0efeu10ErXWK+/9vscc37F8+40z5yXY3/7mhaIPIsq+e/SphWa3yGF28dqpk9d274f19tpwcWz79MirJ46uN1ddvxS2dGfJTE0XJ8eHAcuiQ4JobXSyurC4IELodmLejSx3Ymxo5iMf/uDxU3PX13rV0QlWclOIETHVAZQJVapRoRFzWKsXLl8932r1apVi2umNTtZRql3HsbA6/caJOIQJFx7/yfddfFHF4fUDd+y0HD129ZrlZJVh522P3D5xS3zq4tKlawtrK68jnWybomliSykJwlLKSAdKaC0kAM5FYtIoBUbnKRwYM0KZbec7+c3oeT4rv3nAsnUHpVQIIcB57AMyGzVUCZEiAAZAMBIKDBhklFGacUsjgJvqLMaYIro1agcAZDYgwvxzN262yTEkbbQ2BqTICr6LNjK9VDeCuYWlW3yfe1wIpZTS6nuDfoORUkpvjhKQAW10/uYYRdwh5aLvuwViZJj2RSwxJd14HWRYLJL60Ojthw/UJ931lQtAfYSJUkKmKcLAXQ7cAcRSaSyGlJFZ0udu3TFG6ZRzR8vWK6++trC4rJVBmBkEGFNllFKKEt1s6btvH9q5Y2Z9fj7TWYJ0EHQyCUopTJhScZaBU6CVSqVYLl6cnfM8LwxD3/c9z6vX64WCTy1uV+zrcy+MjI3b1TpmXErZbHdmZmYAoFqtDgwMiLl5JYRf9OSN6/WBWqVaai671fqAEOltt9/6d3/75YceeWdzfbnfbiQ66UbdsX170iAdGqx3ZOYzRsrVLIg6qDk8OJD2+wVetW13rF5vra2mQd/SgzW/GGYJSF2w3SRKuEUAIam00sriCLiLsjTqdV3XNUoopZTUSGqklTGGgGSu7ZWKEEdhloT9oGhzZJSKUswIYZhQgrSJTaqUkkoRAAsUUQopAELAaMCAMLOQjYHYiCKdUYSAM5QmYavpcmkGB8IgUUJZno+FjKKIMWL7RSAUYdBaI2xsh3PDQALSykhEhoYYhmoRhgeHwkRxShYXu5YHqQKFAPEUUStTYIAjjK9envUIzEyN7Zoa/75HS0WO/uYzX/7Y9z+iz4VRGrsOoa7fjjItM86IbbveOPTaHcaY6zpJlrqu67puHEuOpNYaY1arVW4sN71Skdm2NFD0vCzL0jRttxrdbnewNuD7bsF382KapTITmdYGY6wNGK0JoUbpLLdDsG1MiTZgkhQhLIWwbRtTliQJMOxaFsZYSQnGYEAY4TzI3uANdAU2BYz5n/zlFuK6xZ7IC/3/Z6dvjDFSGaQNxppgAMhtGACA0w3lOcqNXSHLdwGzKYMyxtDP/92nX33tPAaYGLNvP7zvX/7UT977vvf8wS/8xx233DMyNERL1cvL/T/+m7+/7dAdqlS71gnXPvulOIB+Bz7xIw8e3H/r2vJcnt5c9PyF5eV3PPqOKwtr1fLJsanJ//5bv9fpwvaZkYfuv+NbX/rasA8P3VMfPrSvf+W8Xy7cuNb8xV/718dfe+M7335JJ/D+d97Rb65WB6ezuC2TtgyzoUqBVZkb9nuxTPrhjbk3bv3Qv7rjjsMv/813FG/QghvECTDEhIrjdGpmemVtndp22YIid2YGKzan1vSQFkl7vVuy3V3bdgxUi1mS7qzY3/jCZ6olXS763SBev77w9sceErT4e7/1O2euZ8QtY0UHKw61kJTUca1mr5QlqZQSAZJSZqlQmQAAlcNqGAwieYmkGBEErmVnWZZpo5WWaabFBgCXF3cAIIDgJr1DhgAhyE3EjDEGkEGbtr65bQzCesNIBgEmcZZ+b2XkrTfBxCAppcYIA871qAQhs8mpAgC8sbQAAzIYI20kxpRZWRorA7ZtWf200+kAppvvSjBWuXROGQAFIu9HMKEIKzBSis1zaFyv1culQhZnOhMWdhGOO+1GFukVBQ8/svfw7Xu8AgUMxUINtAVIKCMlaIyIAkYwN5gDMLAYkigI21W3QCxNjIas+Z0nn1hcWg6jzCAmNShlgCCMcSZlGHRtG8bGRyybgZEIo36vLVVsObzd7UhlHMcGrjRGGKPR0Qlms8ba0uTEaKfTWm+sfejDH/ri3/4VAAC1CaZRIsDyOLPbQVcp0++HvlcsFYvbt02ffONEvV4r795x4YVnH37oLWkaj42N9Ne67mCt9dqZiZnxVmutJ+Ty0lxlpD5Q9Eue0+ipLIkKBa/q+5AmMxOT169eSSx7387dRsm1K1cGJ8d3Tk111hqe7ZSqVS9O0m4fc4YNgCFAORiVCUGFJogA4RjTNEoJBgIEAVHaGGkADCAE7ZZCxvW9tCe1UiaTWgkJke17IETO2+OEKgzS6EwqlPS0UhKAURtzDMYBpCjDgQgqrEwZgqAJ7ZalpDKgo1AYDMgwx8cozVSEGHeLJfBdk6XK4UZJk6umwYBSjBNCKLS7nBAMihHCCS0Wi3v2QKPbxiJNlQaCJWitQaoUMFEC9uwcX15c/KEPvhcl7W888fm775psNuZqNUesBY6DqI2FocQqK6WXl+YO7L+l6LlGyyxJkiigBOl1LQ3US6V+nGRGDg4OLTe7Wmb9vuSWEwUd27bdolvyPRFHBIPWxgAgZIQQKhO5v67jWLl7RyqVBtD6e3U2b8gQRkbpQtn3CoVmu51JxRgL49hsioZuPjHrTZvuf3rlMqutK8dLt17+48puDNpSSGkDGAEAQUgj4NxRSmVSSKGwwogaIJgxAjcZkNEgav7Fn/233bt3W5Y1duuB088++29/+CePHTu2b9+Btda8MQvf+taLBMP6y68Wi2WEkG9gZJiDyI6/emRmfKy51pZpTwhRLBYOHqi+euxVzbzH33HvE18/0m7DY48efOyDP/ziM9+KAEgRmv0uJKE2aa8d/uKnfubiK0f+668c/9VfPTxUG7g+Ozs+MdTqNy2ZuhYsz12d2DkIccwxKbmORJ5dGL32/POtVmtywCaOt9RoK2oqxarRfQkppVykSWKaWiolRbFcCjqBXSmvzjcKHiS97NK502zfPq3EX3336Fvu3X3HbdvOXbnwjkfuxtbY0WOzzWCx1WRxP4u6SWaINFrEsteXWsnCSJlihDChhGDGLcaNQRjjKIoMIhgjRAgFJLRCgJRScZpu2fabTedehFCSJFvY980oG2FUa220UTrPZcYIU4wRYAzaIKOFVtoYgxGjmCKshdwAgvIKbgyYTcfgjS1hw/ydbvYIWx+HEEI4D2nb+PQ4SpXWVsEqFiFNRQ7IaL0Z6E41KAClDAIppAGUy7KkEiLNtJGU0nrVKhQYI9ikSAtkDDHSIKUrFSgWYN++0fHJEqFSBFmaGIsWhQgRNoxzYFwjboBjalNeAKCO50gZQ9wALQHr5vzsK99+op45QoFB2ABWWmktoyRqNpv9brJrm+VYdH1tmTLtc6sZtEslOxEojCONQGsghFBGw6jf6Vqjw4Mjw5XG+kqSJJTz9dWl/QcPXr4yu8PdOTQyoRUGqRHhGlClUun3+57nUUr9Usl1rCSOIIldixc9uxNGLnfGJkc6qwtJFt5196FmJ0JBODxQHpsYBoIsbFzOZJYO1ao2JZBKr1Kl6Bpn5NZ9+5qNtTjoA0ZjM9OLV2ZbKyv1SoU6toliYiCNU8UYyRmwaZZlmZNmQEnBsVcWlxyb24QgKY2QOssIxpTjOOwjhJhjszjKsjQLIqUVAwzcBpSB0oAxZZRQnGiZZhmJezLLADDhiiqCZAIoRTTTmcEsxZCZsB+uLKathqWlQ3FMLd91scHZ6nqUdW3HI74PmRDEEItLRkQqsAGRSSqBUCr78fFjR5K+SmMgiFZK5ZX160ND9U7Y5YiCNgYTZJBQyiilFdiEZ2Fc9gsvv/Ds7NmLvXX48Hum33jtyPTkRLnMC8B6scBIV0ulbiCSIGo3mtVqOQr7/X7fKKEwNJs9z+OlUimR7X4/CXr9LMlsZjNEkJIjA5UsyzIhGEZFzy24Tr/fD4JgA8owAIQiShFlGm1YtWBECcI56yY/IXHOtUFok6ogpZRSAYBIU6fg3ozD3Ay6/iNwJn+pxPdCOTDGaBOJyQkwWxfBGGEEgCAfgJkN0SKAQpgQAAxaARCECd9ILTdSGWMoMsZsdIr0l//LL33605++ePGSbbtZqq9fXzUaxkdqR4+eWmzEI1XLccnQUF2IVJu02+3XDRzYPfTYw7ufe+q7M9MTH3zv22dnz1QrBSGjC+cubJsZbwfZHXfeNz2z60/+7G+xjHpC/+2XnrnnwACYVmlgcP7qVZeoWsVfPv7S7j07/8WPnZu7en7vtrcHtQJ3GAYU9VrlimuMBIBWo6UQlkQTuzS4beQnfuCXrq1AebS81u5FQpbLA+utcJDgTKF2P7Btt+Q5LidRv+NQnWYSy2ioQh5+6K1LS0sXLlzo9/sAUJvY8dlvX9x36L4P/tTHv/jHv99urq42ulfmWv0UK15GVolhYlRidDJSNeWSd6Mrtc71nhhjsrnfMsdxpFIGYUSIBgMSa623Ipb+0Va8RYPFm7EbW1/HjBmDNOTQG8q9YTBGWmqDjAINuYgJA0IcmCGUIq3xJlfSoO+B/vkbovzTMdpaWMYYAJ2HhJmNfHSDMRZCZVIbBVkqHdcPgqDT7Y+5WmvQWiswRiOlQWlQyhjYYmRqI5WWGcZgMzoy6sokM5L4jh+LpL3eUFlY8JltiwfecrBaQ1I1velter2zvNooVkeAa8o5ONxYlqK2NAwjCxGeZpHLnULRNmGAkhgskN21IhUq9bVBgBllHNI0idNer9ftJgTB1NSEUqLZXK25ltKZEim1eRAmmFLb4s1u1/adkZGhWGaNxtrAQJkyXqlUpJGuZ1+8dOmBhx86/dpxocD1S3MLiwizer0+PDQipbwye9X3/UN33Ll47ZKRanBooH35ouc5CIFf8MJOf2Ry/MVvPuuUnNpwzSn4dL01MFilDltcXmDIKhe8guc4jpPEoQMm6XUL5ZJTKkEc2zYv+rZorLOhwWq5HKQxdNvguMzzwHWT9hww4hgEGCEAk0kTBshxMCEmjbUSAiMkMhHHSCnEKBhNXA7aACMIYy1kFoUAmFoOKAWSAgXEMbVssCgyCiixsEmVRgYYR4SgXNWMEZQ9LwrbPtPIAtHvBK31okWgWM6EMYQDtQQ0E2WKvg/VKmCNGCGeiwCEVMQYpTIZZS6iJjMnjp1zLVpyJefccpz5+XlirQdJmGlQBDAHhBimmCiEDBKxDnrhY2+799Xnn50eY3cfKr7w/At337kzDvqVioWpF82vISGY0TbFM2PDV65cw3hGK6GUohh7ntNup67jLy+vWp5X8Gg76Lo2rVbKiZDLq+vloYpByBDAoMJeN4lDpZRtu0maMmbZNjfGYEQNoDjJ0jTFWlGONyiGWmKgnDEgFBAxGKVpmkmZZZnWoDG2bdu27Zsl5fAPNS5btX6rIGxVgJsbLwDwPO/mhv17RPgtVrw2kC8MpBAiYsO0gOdRUEmSJkkilSqUfL0pe6Q/8uM/3e+D58JARaWJrFVLruV22r0d27d3W2c4MjM7p8+cvjI2bvmuPVKpVNvtfXun3vORD5i40+usrK25Iuu1WyuFonXLLduIZbtB1li+7nH0H//fn/7kb/+P3/rtT41O1RWzBqpTS62WoS5lLArjkR07o+Wlx97x9jNvnFpZXrRtO5N6ZWWlzr1Or1ur19M4c7yKXSiFKbVKI6BhcRX8EqRSR6msDY8LBK1ea2xyuOi4caY4t8MwBIF6nTiGuOCBzpKC72UiWWusV2oD1cERy7I6Mtm9n5+4tHL1D//uzz/z6kwNBodG26HjVUdjTRrdiHLkeYVEqP5ac3mu7U0M58F4RmmphcxzrlFKmWWM0WYj9ZEiQJRgRin5njncVrJiTnW6ebC5dZRTBmnYtAzbzFcCrY3JBzVIIwQKa9CZUUoBg43FgQjeIsBCTmnfmNB8D9PHGCPQsGlUsLXICCBMEABYFpdSxmnmeQUhgmazjcc2LIjTVCSZyDIlJGhtKOVSZkopACNFClrZjl0uFTD0GGUMCFYgIhn3IoIy4sJQ3d69e4R7yqAQsiARmeOWo0C6oxwsC2wbWa5mNmBHaAJKZ1Jg6NrcQyoCKiFJW4vXai5rRSzJIqmFUKbbC7pBGCcRYBio01KpFMddijXCKo4CzkDpRCitpPQ5AwyMMdu2g3aQJfHE5Ni3vvXkRz78/k67debU/Lvf9faluRsTk5NCaWbZlFtXb8xhxicnJ5vLy4QzTCkMDa4cfYli4/v+ysrCQL2GjLEsm5bwysKNme1TF89cHtk+/saR47Vqgdi8H4SdtdVD+3ZHYXdwsJ4lsQQDlAhApXodkAmzJM7SYmWgsbZWc5hTcDOk0yxjnGPmgu9x1417QZaknHPCKEFKR30iU2BkwLNlEqf9yCQJ0ophRAw2KuWem8YxYGQ7FlKaApZZRpSBMAaEwGKg84gjRhl3GKEIKNZaYWJxIMQobXRGdIoxRyoCC4EMu901QgyrlkD2DWFSAWEYc8swRmwbPA90lpmEISOU3mhssQqiWGvQAYsD2L1nEuMg6sdJ1o1jFXRDXgCpIZdiG5KLMzEGPDM1kcW9i+fOb5sZLFgpZ+b2B291LIjCdQKEYI5AuBYmIEGI8cHBtU4rDHp50GgSBaVyNehHUqv1ZnfEtv2C34visZEhQ4hSihMzd2PNtmFocGB6bEwkcavVCUOJMeaMU8YwxnnWZB6hhxDhnBBClDGgjUEbLRQDwJQr13R7gcgy27KkBqWU5dgE58Yfxmx5hCCENh/Mrb7d5MbcABR/z+EdALacYGxubdV0rbVGG7oWgozBRillsNEICGY5Eqs1SCkxaJyHKiPAGHFMGaEKFDKgDFDuQb1A40AixqNWsBom00OUI1i+dmX3RG1suHL92uyhbbzgk9sO7Xrrww9O2Wh1dXX29RfGxipZxaqU+fTkPsCpZWlu6TjtpFFYKQ36BevG/NzCdW1PF4oOi6Lu4IGZYX/qU3/wxU/+l59cu3GRmJZbGVi/fuOW3XuiVJy/eGVyZsf+Wycdoy5cPDPoFs5fOjM0NjJYdHtx6tlw9OiLmEF1sHruessq1ZjjzS8sjU3uWG0tVQpekoS1gt/rNGzqlUpOteiJJCgVilPT24IwvXilMTUzdOHKjeXlZVEYIaBOfPVcvYB27RmKgriZmmYq0ySljmc4CCxilUmIvIo1YLkdIcEoQAah3FrdYIwBozSLs1QqoykVmHJCCKOMcZ6FKQIgGG+lqGzxW81NWqSNbRwhseUZgAFg0xxOGwSGYEIpM8ZImYEGg0AZrYTYgvg3mvd8eEIpUkoorZU2Wiu08VeUbm4A6nsfrQEc6lDCPJdmWdbrBQgTIaEfhIQ4UmqxEeKeZcJIjcBgblOjlFbCGC1lhkDbnJd9t926Njo4ZVN3faHfbq6DUYRAGMBdd+0fGvGBp2EYXHzzOEalnXvuikMJrgbCgdlAHEJcSSylsVTKc4tRN7CU0llIOIVu69Kbp9ZuzGle6kdpFEdxYpbXOlEUMY4YQ7ZtR1Eko3bZcRjWsRQD1ZIS0i1ay8stYDHnHBGy3lhdWG5YDtgWfcdjjz73/LM//B9+/vrVS4uLi3tvu/X00WOF+mC5Utu2feexY6/NLywRytvt1sFbb7N8Z+7IkXK5PD4x0mo3C+WSOzp67c03ZianO8srlDFF9W133SaibrnmE6BRFGgRp1Fvx56dzcUFPDAg5q+7RR9sqzA9AXHSWllwbJ6ASo0kDuvHkVsqKIKQzYHzLMs4guLAwHxjDafY2LxQKDCijTQgUyDYKrmWjFTSz6LIwtizOFIYZAKeJZWywHDX5cyCTEVCGpGFQeBoRSgCwzOdGSOwzQ3BQAGZzAAByLRkUQZadSzMHQ8YjoEy0V5aWZ2fKXAoF4LzVysHH+KIAOPc9TG3Eq25EArJIE0hzVIpkNTYKmAidCpkJpfmW0pAuTS43lSLS6vUjSs1nwmhiAElpDFAkd7EIjDQfjfARjbDbn9d+jbcffttxqSNtXVKIAoDlQhiZLVcyxRe6Xerpeqe3TsbjYbFOMW43WzZtl2qlJvNZrVaBINzRLRctRZXGsyyd0xNyaS7vNxYXW6Uiz5BeKBaKRZVqVLt9PoIoTSTcZxIKZll5xsGBWUMyrJMmNyANYdijFApRqCVMko7jpNkMo5jSilmGw+4+t6DjLfw95ub8Q1kxqj8wYeb0vIQQq3GOt40c6eUcr6hTucEthr3DU4O5YSQIAjCOMmyLFEhwlQrZTPOOU/jSG/6lNFWAOUiwRyWV1oFx91R9anWDHMLyQEX6d5yBcPhbbVb9k7defu+JFlcWg8XFhbq5VocNuqVim3D5Usn77r/dtBJFLQVwiWPrK5dm5jem9UtmULSD2/dfdvZk68mCX75zKlyubC8lhw9evrDH3h32mrUR6bOv/nm3oOHR0fVymo7SvHMRL06NH7s5IUde3a12u1uujYwMoOZf+nKHOZw7UarWi/3hMnzxX2/uLo6HwvFqc0chzKn3Y92Tk9cvnhjpO7Or6zHEp09v7r3lom5hUW/XLH8cuhEDJPJ/TXL4HYUxTIEmfCaazwIVE/aQulM6pTSLFEmjQDjmsMtKWUchxqwZVkaTBTEcZxUqhXX9eM4DsNQYUoxRkp7nre1+26xTdCmOecWHrd1awuFgpRSpKkQOYl8cwSKsQGtTD7e0fnOjxBCYCghmFKMNqp2bjGx9R95Td96/ygKcoWFwTg/Q+RLBACSJMkPhqVSIRHZ4Eg1ShOjtZSZMYZbllA4zhJjDGVcAyoUCmkcZmlSKhab6ytTY6OYwIBTX19ft1AWBRKMdG0yOFC+9bbRQ3fsn718tN1fHh4fm5yelqoQhpFXrAPpAsaAKFCOmMuxncP0vU6rXqqGa+uOMWC5C7NXW6ut4drIscvr3V7Y62dSUUSIZXvGpAqyOErSNHW5rVSkkUHI9Ls937XDOEUEhNQ2tyrV0tzCjcFBPxVppVJaXLwxMFCFxmqpWjLYxL1uZXDgyvUbt99+B6G8Xq8TQpjFi+WK5bkiiUfGx5Ik6gZ95lhewYE4nNmxE3r92uDw6RMnPMcfu+MucW0uiHvbJmZwU8/PXXvw/ntV0Hd8B2ol34yqMATPAcBpHFZ37Tz21DemR4f7Iq0M1tI0TYxiRS/DCFHKCz4obRx3YnI87HX63V4j6ru2VfAcIBiMBGODTFwkKZJEKq0TAggMBDbzSz5IFfb7RGqb24Tgubm58empJEmy1YSUPKtSxgbSNE2ksFXkj00wQ3VfANPMAqEyh0pQHU4EyDBJWo7HEpQknRarVqM0sycnsxvzQdDnvl8cHU2jiFe8gbIPngVJEkZ9kAoc3yJcG3Nldl4pWF5ZL5VriQ5OnLnEfR8zGsShQiARGKE0AGhOMAPAMkuKLo+F0QY8F4QQzX7b5ch2HIvbzVZAsNk2NXbijYt7d04/8/TZHgfPgUOHbm2322Njo+12+8aNlZntk+vrjfpgsVyvtzu95cXFNBHl4v+fr/eOsiw760O/nU6+OVau6uquzrlnuicn5TCKIFAALBAYP2yDCcbghBO2CTJgwAaMQRJIQgHlmZEmafJ0T+ecKsebw8lnh/fHre5pyX7vrNW1btWte9fqOnd/+9u/7xcc3+u57Wa1WkilUosLy4ZldvtepTKkM5p27Cjhbt+vb7ijo7n5pXbKwTt27NAJ1GqNXq/npNPNZntoZLjv+esbLc0y/DC0UinD1DY2NjCidsoJw1ASBXfEMCmlbq/iO5u522A6/aFB66DPUyqXybyJyQgR38J5QiUkuhW1igjGGHCIEOm5LkKIEaoQAEiCsBIyCkKNIIwxYUxRSpmGENYJk6mUTBuWxSiOIybjSsasZNgnPvKB73/3ayqq7RnepXurKYZaOgLht9sRw0jJoL7RiuMeyACYMhEggrhQFIWI99ImPrgLzgbad77xnSP7Z559/uWDOyZ37xz78//9pUeP7QNpBiEwqnbuPvTSS69u2bGnUMwYtr203qjVO6Nbd84trVWHhphp+yFqhx3XD/bsyb98spVEbhyj+vpSIeOsLc1PT453Wg3bdubmFpCIt4wNNTr96R2TCzfni8WsF8vJbUN+LBKJLCezUWuIHPS6bSaRJsGmppHLRrGgmuHxQBAAKtHmeFMNwGkZxTyUhBDTNBFCMZcKlOPYcpOdGkkpB177GFQShYq8iafDICoJBjNuDANrdLi1pUupAPy+DwCYINu0CEFKqUGV3/xwgMQAMGjPEVZKUbI52InhTW8KfEeU12ZxlwoUgFIaY4NuQipFKR1sNpxzjClXSg2IDgqw2BRD3zaPHiSKKaUG9mTtdjeTSSklHcdKYr+Yz3XbdUJIkLR4orBhRXGgZJjNp6amKjt2TN68er7dr2MDa6ZBDRODiZEOBgPLAcyA2IANUFQpQiTVsdI08DtNW2eQyLUTp86euoikYTC976/7IY8TqQApRBUWICkC5rqJEEo3NeV7SoClW0IGvhsolDIsvVQpRlEw4O1ls9mh4XKjUQtC13EsILBt29Y4jk+dOZPJplKZdCqXVkJphu44jmmaVNO6vW6SRIQRQAprjDBCdANMDRAK3dAwrLGxMYIZxH4kw0wuZZeySvJ81ikVMv1+m5kWNBtASADKMUxQEqUdoMQu5JVl6BRj01RKEKZhTZOawRlRgBHCiBFq27aUIuFhFCiRhAGnAFgmzAXgCVUJqIRHERcCCCGYNBoNyUU6m7OHyuCH4EfASL5SBIoJBl1jAqEoDpTHlaZRgjGGoFaLE8k5kyhIJDPNPKRMiAF4CN1eu7HEIXTyWaNgg9ftCwHtdt913SC0dU1JrihOEPLDEGPgXFimI0MBzS4VKAqSrhf9yI99+PNf+lo2PzK/UhcIL6y4VhYUHRhcg0SgJFJKgURKqUIuv7G2OFTNri81q3sKbj+YGB5qNpaK+ayUMk4Q09LddtsyNSSTSgUMYpXLZYxxEASEkHqzrZs0DEMnnWo2m41Wu9PqmrYBBgMlsEqiSCVRvNBcymazQsnJ8fHF5eX19fW+K6oj+VIxTwgplUpB4EkJvttzedLpdDDGbq83cAXI5/MI0yCKLcuimh7Gic40QEQmHIQMPf92A377QgCE4MF8a7AsAQYkOQQg4f92KXVbUKIQUgAKoQGYA1gBkgohQFhKCUghQIoNvOMBADAAKKyUAoWA0jftwygChoA4lk2l1KWyDTI+OjpaSHfX55RbX5+/ND2cJhL0uJdGKb/bW6l5SgSBz7PpjM4QBzw6XAYZt1bXhIwN2wBEQ6/V76TTmdJD95af/8zCY8f2d7ttJFXXi77w5e9un8h9++njqytLW8dK+3bNtBut+9/1/trS2vX5RdePLQft37//6tWrtaY7viU/v7RkmllFo4xtPfLg3mJ18eZKa6nWA13jinVcf2n2GlLCItLQSNouYMLWVteEVFYul2DWbHV0zcjkc5PTW69duzYzM3PBXxMJLeXLiRv5QRLHqNnynByVGGGNIoYRNmQcKMmQUgwhyzL9MMAY6bqRCO73e3EidNMwLQMANoNRKGOMKSmTJCGY3cbO7kRgbpNkbuMzg6GH5AIAiEKUDpizKI7jKAoQQomQSZIIBYQghbFQIKXElMAgHVvI2x2BQpsWEwghPDCeuUW2ZWxA18EEIQBIOE+ShPPNAY2SA+oMlmpzchPHoZSDsY8SgCSAAEQUTsSAXY51XU/C/vBItdnY0DXqBQoEUBUlSVAoWXv2btkxMzw+UV5YaVaqw1bWyBbK1DCF0hDVQEegG4BNIAYgUwkiYhHzBIR0sulmrW7lciDUmZMX3jh+QfjC7Xn9kAURTzhGBGFMEEZSCYRI308CP6KZDAcmZaJRLYbYDwSmVCZJOp1tdhKlVD6fN3WtXC7WNtYpQTPbt85fulitVhcW5rr9juWYQ0OjYFnQ7xuGZlgWoTTs92prta1btzKdYqISEUsVhwjTRCKkiMQQxNlMXiKAJLQcU8kMiIgy5KRsx7G6npd27CSJWbmIVAKWpZJY0/LK6+dHRolMTNtADGPJma4Rw5JMTxCLCcGIUmqAHoEAQ3BwURz5URjHMiEiiZUwKcKUUE1HgxgvqYBi2zJ4HAbdrmlYIEUiYmaberkY9vtU16ROBUZhGIokIpahm0YcJwgjjZmUaQmXaUvXDcWbS9SyIfT69eVea0WqBDQNTCeMI80wOr1uxKNECieXAUwNx5I6CfodQ9eVQk46J9bbiRcbTsFdbh0/uX75+pf9CBZrC34Cw5NjMa0babvtdgBJhRRIDApjSZUEkOTy7M3tE9V+vzE8zPbuOzRSsU4df75STM3OLQMAwUwzUvMLy7qeAhVNjhWfPtsYHdUGkm/btl3XzeVyEiCTTvtBpJTKZO0oTHw3ts2gmM0WC2UpZbd303VdRGg2SzKpFGCqae7k2HgURdevzCdxWMhmMMZev5NKZx3HSafTaxvrBNN6vSEB9Xp9qunZTCYRsu/5lFKESJwkUspEJLfnW7cxmds91m3qxK2GCTD838VN6law9WY7OKgVCEANFDMKFFJKIZCgkABgBAPggXu7kkigzfdPos0YE0CIpg0LuMSEWzrTkUoZ1NYAC88xVL8XLc1eMVCwe+tIpVz0Wus8CZcW5qYmtiQatw3TNDQnn0rnHbe7jgCU5AwTzFjWsi2KNcN44Ohd7C++ff3M2epowdS09Y1mdWx8etfWsLP2re9efsv9LgCMDlW/9jdfmJzZURkaO7Ztpt5cXFuv+0E8PDx58cK1mZkdiLBGu71r25TupKvlw7N//beNxbgyGtRqfHi0AJppGEatUc9lMpLHa6vt8tBws9l89zveXq/Xz/fOYUb7nS5CPREpGYcWKia8S5J06HsqEsQwVSKozIZCKEIIplIIEWk4kZRQQnTdcJVSXIqER1woSmmcJL7vp9NpqbgcuKtjhUAqAAJvmvSqW75ug7trWdadYlFxKyVLp1achDyOEog4wYbGNIwQZQghKcJkMMvFapO9KN9MWFUYKalgYAx9S1+EbxuE3hrmEDTY0xV+U0EHg7QgpDAmCBGKbh0VB+cGhClCWCElpZSAFWChQDNMP4yzjtnpdLAQjGKMFEVg6ZVwEEhkkZkd48fu3ZvLYCHDialx0AF0AphKYIpirEnQEoktTCgQHUBHHIkojoNAxpFjaoWUDZk8uLVW06vVg9AVrXoUZCHhSiLKMAXMlBKAOABFAN2uy0spjWg4kQAoiQRRIAF7YegFAefcMc3qcKnTrXfbzY3G+uhYtbx1+rmvf71aLXueN71t6+rq6t79B0S3TTQNM6pAJAJmF+bDKDpwbxE0AhhYHPhhn/NYICCE2obVrTeooTNL05TElYIhk6W5uXI2n8tlMEFM1zCj1DKAkRAjC+uSADG12O3niiW3uUE1A5Bgmq4QEgpholGmK8wU0SQQEBiISSzFEJWY8KCvEqmAC84Z0jSFAJDEFLCSGDCgtGn7vu/1ukkYaZQBQQpLwiOlYaERojMCkojNBF+UCODY0JluOLEfyijR80XQKV+ZIxQnkdfdWNWEr9lGJGSQyBCbKduod1tSSkTASDsACiwTIWk5KcNOxX4IRJeRIpICM26cv5orG41mGHGIJPgclmv1jh9aRElMBr0oYAwSA2CkMAKyZ2Yq8Lquy7Mp64WXXr3/6H4Aq98XjpWVSTxUHVKYrK7UpIjdXihA5bPEd93VTmcwrJqamqo1Gp12GwFhuoYxNhjttrwohMB3U46VJBgRvG37jk6nMzQ01Ol0KuUhKaWp6Qvzc0EQTIwXh4aGms1mt9vL2Fa/7+qaYZpmsViUAgapDJZpdvpurlDgnHuex3SNMTYA2Rllt0/Md9b3wTq9s73bbPL+P4r7m13/HSIYhJBSBG5RLUChQZHHgDDGQimskASlQGAAJREAJLesgAkhtJRKt5tNJTnTnLTOLA167bWFyzVdwr/9jZ86+cqzGcMeHp/sdrxMeezkiy8W0vlSvhj6kWnYDFEQGLDea3ulStr3FcMMKWybpop53GqnLfs//OqH/vdnv9JYbRo5LZ0tTc7suDw7Oz2cS5fByBTmV9ay+dzOvXsShb7wd1/ZaMLOndY/+qV/Vn/ye41ac2Vx5cTLZ7fNjOu6Xh4ZIpGaGpu4b89EWp9PJOut8v5SM4rBNHoEgaSdZhu2bKv+9Kc+lUplPve5z2mEYoyz2Wyrtm5p7B2P3T0/ezNFh92g1/Ta3E0cK5VK5XBON5xUvdtUHEmBOMciYkxQwmyKLc/bIISIhIdxxEyjUqlEPGm1WrEYhFdgiglIJSXHGDONks3DF1KABp7qUkkFIBMOGCNCBqoEMngKASZEJlhhTEARpYiSSEk58O1UEpQABUhJpPCAZxlzSSllGA8yFSUXUsqYi4Ht54DkDj8QrP5m3R8MbQmRlFKl0C0wcECngURuBv8SDAPrRzX4eEkVxbGS0nf7aUvvtNqVYqrf72Mlo9DnqIqJsmyUtvjYRL4ykQXR67c7Kd0GQVVMEwScAmUIa4BojPWSkgQ4RlKBIDrWGFMKUHdpOZNJJ9dvvPL88fNnr23UQ0hMOz3qqcYgZhAzDYCCUABUQWIauNXshSPFlGmBkFEYhJ7IpGweC6kgjBMhQUhp26brYc4TqTiACmvro6PDCkGhVBweHj574TzFaG5hbmrnbtPUEQFMSd91yyNDQOhm66RpBNlSapRizdChrbrtXqqQURpCUcQKWaFUo1UfG6qWhyr9vlsoFyJdQymn5wd1z7UiQQkhYAiBLMPqcsW5pBgo0YIkkjzSqEV1DaiRAJYSh0onDBHNYJqpqKYITfyeREQK6Ccc85hwDgIhoFhCFCu30bRt206nAUAAUgiCJAn7fr5cwpQAowYlGgxWP1YIDCPtur7y25KLxA9AKjCZ1m8szt/UKHLdbnm4auZyXsKR5thmjhDERYyx0nQGCLjkFCBKYieTIaYZe7HseaEXpbABHf+1lzb2HHzgPY9/8Ed/7Jf2Ht66UmvVu13Ntsx0uue2BwNKkBghjIEgIAD4wrW5rROFSjVfr7c+9qMf9zu1visLuVKzuc6TMF9ECIlKpVJvtjSMpFRTU1NRFDFGWh3/2vXlhx/SGo1GoVCIoohqbJDGl8uZQ0MGAMSB7yoghCAgPJE8kaCwaZqGYWACqbTt9vpCCLfTtjTmI9Wq1Uqjk5lMLoyjtJNqtjqO43R7fUQoGnCBhZQJFxhjTBGAAtCZdmddxghjtGnpMfgRoB/wjUH4/6Nzv2NOducDQt9k1yi0WcEVAoQQVooroQYBbGqzmxuQODa9pFAQOBhSjqGDCNzeUK68ZWo8HkmdPXETKDjZTCZlFkYmmxtrp05dq7ly266xyOdJIPNpSyS82/Zty3KMTOzzyE8oioBQBroQqNfsFvLltzy47/67dn/sZ/+d68VOXrx64ngUutev3fjQO+4+/vrxdz+6Gyi5fvNaLOCTn/r45//uSzJJAOH777v/m3//jUN79tVKawASUMK452BEw8bjbzn8yH2HbsytPnjQe+XVU8Oj4ydPLWaLNJUv7z1w91ve+d61evvk2XMvvHBqbDhDQC3cnL3rwK5HH7z/mae+o0McdtaGs7qODZInXt9vrFyXRPkh0R2DA8RCQoJBIKwsLAXmkqOEaVQoKsMAIWRZhqYMN/CDIECIEEIIJiCV4AIjRCkdmO7LO3xdBhU0iqIBcwbfYsYMblgcRiClRqihM4NpFCPOOZJCgsIKGCYDTHwA8eBbzhUKITLQKGGpuJSgiFJIgQCB73R/VgByIL9ASknJQYJCCgghiZCDhFUkMEJoYKIgxB27glCD0BGRiIGF6eAUYllWoVCI/R7FJA6DfiAty0g5hpMKiJaA7AJ4mHAv8DG3iGGAaVCGBcJChpiHGjIi4DxKiEAmYVg3MKGgkQz3N+bmvvm1J57+7vnYB4LzsTSwcBRrA0EYEYSpkiDVAI3Aum56nicFptTgIuAJJAlQpHEu0unMYG30er0gCDKZTKVSGp+ouoH3yiuvPPjQ/esbG6MTo0Q3q9Vqt9d2+11Ayk45SilkmCPjwxPTW2FzESpJCICmBHCCCSY4jhVXjpXiWHX7vWLP5JJnizkhBDGMuBmnUmlL18GypJTIMvt9L5NyAAADBoWQREkYU1MHhFQcxDLGhmASIYUQYKRwbKQYJoAUMAMTRhFVhEHoEd1SvicglMB1RhCA4kIknMeemTdIOsUDv+f1gVDNNtO5lJ52lFISAaYaZoxiDFKCEMC1uNOKhCzkshYR3fk5nPg2kaK2aObTceTnDQ3yOd72CTUV1RERhmEQITXbBsmprgPGQiEZRSAUj0UQSYYYpLNQXw078MwLL/uCdBWcu3ijGwDSoZAzFlbWbYcN0EQiEZEghcISI0W2TOQbzaZBkJTw7e98b8/2qdHRrZKHGxt9jPi1q3OFYrZcznOZIIQAKwOPvn7ieBRFmgbpFExNb+FSxBGPEj+naQghikkcBbpG4zhGIEvlShSGN27eNAyje/36ULm8vr5eLOWVkPl8nmHUaDQ21utD5ZKt09iHTCbjOE5rsRVE4erqhmbqrXbkZPR8Pj+gshiGEfEEcf5DwIu6Q7J0W556JxY/WO//d93qLUok2rSLh8EaRggRpABAIrxZvTEo2HSRAgCklPxBbQ0lm2cHDEAhDA2k0hoT3E+SsJBNzWyfVrHrGOovP/PX73n7W5cX5sea3tDh+//j737rYz92DDju9TzGdB4hHgPBGhJE120uPEYtjVlKIc3JgWAi6qNs6dXvfGnP0ft/8qP3f/ovX1paXh+bnoib8fBIcXrXrrGqc+3sa6ZF09lMoVJttGv3PXhfXqOf+vC/+4NPfyoJwoWbNz74z37p+ne+Ob9wbayYarRrPgoioYJYDaetR+6+d2a0UCiM/Mo/nNRTuWdeen1hvfXVL33h6Rde6/b9StFMkghjOHbkgEEF4kFzdVlwKOST4VIq9KNqoer36NUbG0ijq62eybBCknKQjDAwmEowSMlDzBBCSGPEMAwpZbfb5Qo456ZpCqEIwpQQJZQYmDGJN/VEt//cg0IzIKjcHqDfvutIKgCClFRcxFEksUJKEECcc4wUoxgpIgESucmwuu1aI27xZzbly2qTVCNvNxFq87NFEIJNPzIhlJQCAOFBvIdSSkqhMALAA/L9D3lfYIylTII4sg1z4M0yWi2Zus4DRClGSmciq5QXc5EkQcz7UdJhWBANacxUyCJGGkyLYxGKPpLS0LR25PNQohhbRAdKIRHQ6/jdJvDw9PHjr754vrEBQ5W0ZY502iQIMbCB8ApLGAipEABGQKRIJAddN0FhzoVBTYx6cSwlQDabGYi8fd/3PK9QTGOMt27dOr885wbdJEl6vd6ouRWSZOeuXe12M5/PQhyCaaGEg+Tbd+4EykDXQHCgGDNMJYkimQjBI55VQBBhuhnF/Z7bt/qmADU6Nib8mHCOMAYpIJ2ScWyknazJ+kte1k5BojSiAY80oqk4gXQWkpBITBRgASqWnCfAMNW1yDC4kkJyjDAyEEOEaTqKAywSsH0ZhpgLhjBIxaM4ieMqNbAC5ftSSaZpHAM1dSubAUSE4FJKEJwgAMoAY0AYPGkzo9WuLdcaVCRRpw5BB2xWoCpTyBIRQehCLDSqI6K3+kHFwpZlYs5Ny449T0ungGAASBLuub6BDAJEpzokqLfeNCiA0D77hefvP7r9yo2FjImcQoHoBPc6QcKxUghASqEkIUJJqTBArdYaGS6tLtUzFgRhzDl+8tmXDQYf+dA7MI5PnnptiOmWk8rLxPW6jJGnXniFYPahD31obW3j7778/W9+8+l77zlcHR56+umnXdeVUjKKez3fd/04Bseh7bUNjLEC7KQyUiRBHC8vrKytriAE9RakdXjssbvE+Fir1fTc/uTE6OzCQiqVaTabjZYrFUgUpVK0VC6blhPzhBBiWVbY7XDOB/KlzUV3a+IFd0gU31zjt5iR/z/XnXYFPzCcU4N3VurWvjA4FBCEFZIAgNSgErzZ+KtbhsM4l7JkHPXbLZUkpWK2XMo167Unn/xOKp1+8JFHz1++bKWz3SBZPH3x3e87Giq93/MQIplUlnMRhpFjZxGi7VZPcgCJlIDAj6Qfx27QaXag5yZRb3X+6uPvfcc9R4cQgk6vmwgeCfmZz312aW3VSNmnz57N5NJPPPXMyZMnLNu4dOHib/z6u0+dOL5lbAxL9d//6a+ePfnGgd07u43a8uy16alhTUbN1Tkmg8bKvIm4piIrbfzxp3/nX/3W337pC09+/e+/12n2MVKZTCrwwxur4e/+6R8vzc/98R989l/82i9Wi8bhA6MpJ5q9thz5iwcPjr3vPfd84P337d2rEyIJBkyBMqEbnq75CLelbA2YjpzzgeFyu93u9ToIIdM0B46PtxEudctD5jawfht2H8x/Nkk1d4xcMMa6rlNCFBe+6/U6Xa/fj+MYIQWCI4Q0QrVbLyHwZiiXukPDdpsKeZulI6UE8aZOCmNMbwW4DBzv1C3j/zuPgbcRw9vFHW7x6Ac8TsOw2u2OaZq+7wuZSCkNXSuXRgjRe71e3+1KySlDCAvOY6wZmOqAGBBNKZRIgTXMsk690Wr3ehEXhBAgBIJgfWnl+uVLn/3MZ779jef7XRgeBgCytt7q9kIpNTFQZqnBPyk3Z8gkjhOMQdcMpYDzQaoZC4N4IC/o9vsDbQHnnIu4Vqv1+33DMO6//37XddPpNCRJnMSO44ShPzIywqMIEOKc992+Xim3ux3gnEuhAEDXiO2Ylk01DRgBZiileBwHQRDHsZAcIcRyOc2xgTHHcZIoAkOvNRoSY6Lpvu+DRCAEJhpIpRGGFAZNA4UJIhQzAkQkMom44ooSIokeA4sUjiRCxGC2Y2Tzer7ITJs5GT2TZ7k8OGkwbWra1EwR23G9Xrvd1hw7MzmRKxaCJK43GwKkBJUI7keh73nK9yFOABAkSneyzfX6N778xLf//umV2VnpB3Gva2IEKcdQym93wHN1plHDiUIR+O5ABweUep4HAJAkSZIYhiEFDMLkojDhq6uXL17p9yERqlplV29cd9Jp07ETwecWloZGR5JERRw4H7jRKSE2OQVOii2v1svllEJoy5ato6OTP/qRD+7ZtztfrFaqo0tLvheEnudZtoExOCnrbW97m2ma8/PzSysr1SqJY9B1/amnnpqYmOCc19Y3MMYjI5XJyfFCwc6m041WZ2VtAwDPzq5EYbKwsOI4Ri6X5TFMjOgA8MzTJ44fP711asvWLZOXLy4PVkQ2m5USUik9CDaXgK7rcRyrgWJLSiXkYEX/EHXi9jr6v7fnd3Ai/3+uO1/y5uYhbrfnb1InNiuJenNLuJ3KDQC0ITLparG7MZ9xtBQQaLaozf7hh39EQXL27OlKKpU1UAr7jHeId8OQWksiQljYDdLpLLVYm3tcZBKrFOpGvdnQlJbIJKNMQQWMlp85//rNm4u7j9wHkDx4aNsL31/DWsftQlfvAlBU2KGr5OB9Q88/+Y3WCuwdzS+/dqb5ymp1uGQCqq93947stCCrZ4zra9219sbozPSZxeudqD26b2s5P9ZqesXh6khh2+KlhVdPLmMDzndhx57dbijqzdbNlWhqdLtBV3/m//kX+97yoa99+Uu//Om/8TxceHY+k7YeunenrvGVhTNTU9UtW0bGCwdfevm11Rq0OtDpgkKQqLDT9yqVMbk6peVThmWv9hc91UqVDUwDBG4U9zKpfK8e69QOoziTydQ6q0ojKDEZY4zRJEmiIBiEoGu6FiXJrVsxiD8FpaRSSkMegAQqNqs2xgJRJTHRnUF5tShNETJIyw28wHB0gE2GJGye5gbufEphJYUQg74eI4wBYxRRAwZQvhigAlgiFauIKwQalVIF/bCUzlIB7Uanks5K3xUKUUJtHSsVBUHAqKyWTcnjOAq2b5uiRIt4bLCipTG/7y6R46ZDQQk9NWwa26PesEW5qXpRo6unQzA8iBHToGAxIEi2WttRH0iu32ga48PLJ5Zte/TV1+Iz5zZOnamtrUM6BSP5nAipYYKpQdBv4bpmpgixVYQ7MSBMbBTrcUS12MilsYFdtzcb82itA1Yu3+9yH6ylumcZOStvBbW43e5HoXfvPQd1QruehyjtNDayxQIwFHa9dCYzfe+uM2fOHdh7AJDnh+10oRKtL5RKKbApHVgnYgIxZ90YBwkhFILXxuxee6UrnWErPRVAPltMAUrAVKDCxuLc8MhB4AkWtsUmXTep2G+gaAmwLlUYqYCW0kg5ceRrjhWLyHP7Uc+zYsNhGigNpE4MO23bxGJ+6HU8V4LUNE3TSYIZlcRQdtx13WbTJCyTyWAhXAFkPNPvdFbdcNjJIWIRGRqI9tfqlq7ZtgkMy9CPvR4ghTFmdQaBX5Xq6M4tMSX54WGcSzckL+zZARq5VONbpyfBNEHGYv3aKJWRBEQ03cpBpqpxp9EOi6PllOioft9qN2zLgWanudCsprZcWUo6EnL2tlp/AwdepeCsNZeZBimTlEG8451v//6rr12Z6zp5ixN9qdex7LzhMKJ4IMHOQxirctUdH+/1NtY/8vjuk6+9ZFB7KA05s+joQ9964jsPPfawxGhIZ/fv3ooQLCzdGNbg45944Knvvfi2e3e+/PplbEGqyGbryzP79tU73hJCK/MtAtNcdbHoZ4esq+vtSjHvi1RzPcmmyrXW4uRUrtFsb9+e7frrhJn3HTvy8o03iik76vW2bc8sLHQPHxq9dGk58eu1sL1j595nn3+tXCkXMpkgTIqZAhDszl3WUxBj7ErJNTNW4PGEIksqRRVFCgvFuZIcE2AIU6IlfbjNmVESyYFlCFIAg/4NIaIGQciAYeAxdXtjuN3aAwRBMGjykFIEK4bxwGC843VvbxK026lTaRXyztR4cf+W6ng5tbE8+/xzTx09dvcHP/D4pUsXCBK1ZiMJ+6lc/vrl6+mR0dZG7dDBw51Ob/fuvadOnhkZGXUc5+z5c3fdddcbp96Ynp569ulnDh05eOr0ya0zM5iS108c3ytQu936zV9/59effPaBR/Y8/fzJ4eFs6PX2H9z/7BNf3za1Lfb6V+aWDu3bO/UhuNBc3b7zrlZvdmxmy59941mkwY//1ONH9+6aXbq6sdKoDG2VkP+TP/vm1YvRT/3ke7596X+fPL+k6fjFF7/9J5/76r/9gz/fNrMdEr+acwwVTlezb7z0wivffYEC7L1vOJ+fSprzuVw2ZdNyuei52vzsYm29dt9991HiDBXRp37mI6vr3as3VhYWNrxQvXhmdowUwqCLzFQhp5nYccOWF0aUgKPTWAIGDSHGeRjE0SbVJKEIoUH8qWEY/JZJ28CoCH5wZgIAWG3COHd+Hfz+bcakuhWvSikFhP4P4O6OwyBGSN0B8w10qlLKgUGMUIAUGvhIktu2kZt0WgRAKdVNO455xEWciDASUSziRCE8SHvBg7BvBQkXkgspVTRUGVZJFPSakR97XhAEiWYqjEjCJeMSSwUKg8JKEVBIKLV4c25i3E5t3Qmd8MaNGy+88LUXXjwhEXc9zzTBcXCSJJIDpZZUSkCiadpmzrBMhCJISYoQxjgMQ5Jjgx1RN0CEt1ILdBpGcb5QCt3m2NhIs7ak65bruvrIcJWpoNPWTCObzfabbcAINIaxTGVzQCkA4YkIez0gVCpFkgQQKCVRFAEXCiPMKCiAgIeJkoQxw2apjJ7KaZYNwusttYXbbDbambW6rZcyqSwABRkPqKuAMdZ1TQgxODmBigLXymQMXatvrEdBUMznaIJEvy/ykCgpGeVRpKJASZmEkUAq56RvXr0ylCtmh8dShMSdPgjRa7V0A8LQR5GwLEP6ieCxwyyazYLOoFGPWj0lpFTcNE1EmQi8uLYec4ENY3LHDuLY1LbA1BQjUK4EG2vbdu210pbyXZTOE99LvL4QiWEyjDEQZNuWBAkiwkgIKdKZFHTbQGh1fBI6NHADIWDu+oU9u3a1O8jzmuVyutdrtTqSso1mo0SUqOSxwDJKooxjcRmFrkinrOoQTWLpe3Dt6txEtTBcrD7zzHNexx0ZHn/nu9728uvHn33x5P7DW7I5e6NRz5hGGHZ0nW2drlJKjr/2cj7HNtZXKYZ8Lh9w1Oo3N5bXE2CIY4YgFlAoVZTSrs6u3nNo9OaVZSyScna402lSiscmp9qd9u79B0+/cdFiBcsovP3t7+Scv/ryKxhjKeHc2eVMFo4ePbq8uv78s695AjBStq6V8gWmE98LjRT1It4XUjIEDANlSEIcxybTsUAUE4xJooSfhGEYAUbAMEJIAWBQCgY+n4NlSDZX7K2GHQYCFPzmGOzOKjHQrAxA2kFtGURj5ou52zRrOlRNp002nNWR6ve6ckMQ363N3uiuLn9vz64t23dMR1H47HPf9brtmW1TVjHT7IW58tjSeqvX6/W900KIK1dv5nIZwdXVq1dt0/rWt771oQ994Oq1y6PDI1iqB9/6GJey1lw/fHjPyXOXf/Yf/NjJMxcfODJt26mlG1cny/m3PPa2X/3F//EzP3VXxrFDUJe4yFWqL62u0krls889f+zxt95z370ra0s1LxmeOlyV8rVXTzY3arv3vLNY7H35708tzK2OjkOkyD/45M+2QlW0iPTaDx7c0dpYWr25ICx4x91Te3ZOJ1GUSaWee+65ak584B1v8bwAAPLFXYV8+bXjJxprUacuFpeDKPj67r373vvWh93AP3/x0tSIXl/q1FrtlXYtcoFliGWbps6SUBJh8kgjiGGkC96NogQRnMgQczYo34wxTdMIIQMk5Lblr/rBfFQsOPwgRn+7lN+Gz26/hFIaS7itg9hs20EqBAPyDIKBxcWm+QxCiA/0EVIqIUAqhBUgjDFSEuTmmBYAFEJYI8i2TUrsUAZBGPixjEJIIsyFVCB1nSEAIUQiQ4mEUkHEQdGktt5MW7ptprMpmyjaqnd8mmiMazpwgTVJQRFQCBSRAkmAbK6QCInX1j//uS8+//yNs6fXVzuQs4EL2D7kZDOW1+srgRmBRERCRpZhICYS2BxTY9jUWHHOTTNNKQWFdJ35YeL7PkVpHvsUK6S4rrFKuRQHLaU41Sl0mmxstHv10uraWq5cMW2L5bJRt09MXMiXAFPAGqU0iMJsoYIMM4kipDMphRIcC8SYBkBknOAYQqUpzdGsDEnlzFQGNA38iGlOP2joRqrnhqwX6qMZSKSMhKFpiYhpQhBlxNAHxR2BQgiBpmFKnL7l9vpRECClOOd6EDIAklCkOCMECBFSCi6Wr14dTueunT1vXby6+6GHta539dy57fsPAE+wJyBOZBS4vdiyTIRQb31B16jvu5ZlISSbtbrkQtO0fr9PXM4BpQqF4bFRyOcVKEEpTdmA2XrXnTqwGzy33++nqQ4WeK7HI245ephwI/SAMqlC3w01LN1eO5tK9TcaKVqEIL5y7vrGaoth2LtzXIoOUT0F3CD21N7pUrX85FMvP//MWV9AdZjUO2EYQ2m4HMaKMj3mst/tdetuKQPnzoe1xZf+9T//8be+7V1Uoeefff7CpfOUgqbDxz/50dOnT5w+9ep73vpOx1S2zWyjhAjWDeSkM4urG/ce23fx2myz4R7ed5Ca2VMXrizd7KWydL3rxcrDpDs9mVpb28hms4nLQKo4jvfv3z0yUqVa+LWvP+f1odatUQCkgW2D58Ejjxzct8/5+tderDXhyqXLUcwPHdhmOenF5ZX1tY1yqbBRq62tNXZsH3fbTSol1/ReEEXCp5pOAMtYBr4HXOi6RhjWibAsQ7eMpNsDUAghAhjhgd8jUqDwoGlDMDCBAgClOABW6M3K/kPSmUE+n2EYjuMMVF2u6wbd/pude6u52AgVGWF5jadGp/funJjZdv9bHpr75reeOn/+xJ4DhzOpPNbMykQuAortfBAl9x44durEG71AXb1x2dL1oWo1C1TXzdr6hu97jmlZpj5crUZRRChabzWOHj3691//+igP1xavvfbS2R/72Lu6G/PPf+fmxz9xfzGXWl+v/fKvf7jebH3ley+NjY194Bc/XltrpLB9+cLNr75wo9m48fCpi1cvrk5Ps6FKkSDMI5Gyy88+93Kz7r//fT/ihnNnL15Np7JvnLviS7xlZCgO3ZMvvjGShscOZTUR/OTj902MVl54/rmH7j1i842JcTI9ol27tprJjraa7Ytnbv7p/3i6x2HbpJG2rfp6l+3Dl869XijYNFn71CfecvbkCaDTp6/efOXM2lJDmMLN5CrdiOtGLokVIxpwpBBOkoRoTMBm+OHA8neAsAPAYIO9PdS+/RRCg6RyBAgQRgPeolQIFAgJUiFABAA2HRkVUoA5f9MPWgEeFHoFCDEsQEkJm6QopRBHCEFMOBICDcY7CBBgqZCSSEiu5ObMHQAwRqamZ5xUFKkwklEISYKlYKBASiGljJEkWAZRGCWYUqFUkiDODGwmOgUtCfx61Lwmoqif3TpVHZuYbDSWlGIAGmAMmCggQiGhZLZajV3SbvfeOHXu1Vd6KQfGilbME01L0qkio6CURwiJRegHERDGqA4YBMZIIgxq88/IBSbENE1CiBACEZQk4HqJbXKMIZ/Lhl5ndKREiJqYHF1emk2nHddzHZVVCEKRMF1jjgWAACPAmpPOgETAiOWk4kSgXBYYDdotpjGMEeeKEMSYDkQmCdeNDCiOzBwYKWCmIgZSGAQy7DxmtepQzotEu9mtDBOIpUUN0zR93+Vx4jgOHmRsxogopDEmuz2slO2kiIR+r8PDOJPLhd0uCgLQGKWE6hpoDJQAyYHqma0zdznZE99+4vyX/37vw49uP3T3qSeeOHTgmEGzRj4fb2zU1+q0AIahNRfWDcNIeBzrwcrKyokTFzGGAwe3VqvVOGszTEkuyx2LGjpHGHQdHLvVaXMrBZrltvvSTPmJsExH6j5lgHUjDlzh9izT5okvpdBtGgV9MHSRcMDq7Mkzz33nDc+FtG3VmouYQKWU7bvdtZUupf6DDx5eXiz3g2hupZsp2G7YM200Oly4dn2+3qwbqcm0U/V7axgpQnzTgY1ar7ay8NhDD27fueP3/tuTP/6xA5/65+996envrLfW73/wQLu5IHlHgURI1dbrQ8PjV67Pj09sXViqDZVGEPF5oJrNxmRli99VtUazPDQWRY1ub31ouHxlvj9ejEScuDFUSvlup+V5qYWlJc3Ci2tyessQgVQk1trtvqGD70UH9x2+/96253m7du368899+8FyOXA7G0vrCMPls1eEgg+995HZWk90Az8MgGCJGUFAiY4SkXIsJoUIA6aEEkkcRSICSBiXbBD7JxFguRmtgxSAwgA/wIFHCN12GFM/qItUt0I/0K1gpgHQTyklQmiMWZZlGAbduX1kfX7Z0pJq0ZgeKxbTFMJ2t770+Lsfefal15ZrtS3bdlmZwp69+1ut1otf/7onnIM+bgVwfXYVCfX68fAXf2E4lXL6vVYYxjyO9+zc8cKzz+VyWcsy8pVKwxdrrY0jRw+LJHrbo0ef+NbzO0cLqfsO3nsgqYxMffOJZ5fWW2sND+upQmVLI2G//Ft/e+XS2q4t1dX59XLW+emffvTvv/iND7z3UORuXL+6MjaEZ6a3jYxUf/Ij78LIXF9rOOM/FuBvfff5F6hmbBuqNhu1QzunJ1OzfsP7B+97GEVd5i4vnrvmLl8y9aNvf8vdtcWXmkvnUCR1XD352omb813DgKnRiUazlc/nDhyYGa0Mfe3rn9m+rWJo/NTL3ygVYdeBI/sOD+3cO//dF85evhFrQLNmBgtTylgBDsNQo8SXPgFEiY7oZhT67Rn6nfvt7eJ+5w4MPzgfH0xdBnyP2xjOm5NSdGfPfuskpyCOYzHYA0ANPiiDqOOIKIIQA4wpIXJzUiqkIowIBVgpjBFIxSUHUEyjURzxBBQQTBhSgAALHgqhpFSEKs/zUxbRHQYYIyE1g1rYAsGTWCgdEUSlQEkseSwYNSg1gOpAMCClEBn8bzvNrkZzpZ27P/6Jn7hx/X+4fUMkWrfnT0wOgWJhEFCiaVT3+qGQoWPrIAGQxIAoJgJAKSSEUElCEFFKcS7jONYQ4XKT3J9xjLSjh2GiMWVblGmpnmvrFnMqxWBjDRia2jZjToy5a+v1xsrUzp0SBxgxHsYUC2raVAfACKTkSmJQQBBClBANmAYqTijSUwWmKaRnlW4JRBVmQDEQvdP34wQNVUphvdWod/KtLss7aTsDiY08P/D6RIGdcjBhlm4AT0CIJAiREBqjBBDikvModj3Z9WJKECWUMeJYYBgghQzDTLZQ++5ztm7cte/Q+uz84vMv5pz0aKF8+bnj2Wy2OlxJ/LC1sNFcquVyGZ7wl158yU7bIyNDGmGTI2UpJeas3/RH7z2oGxa1LGRawjCJYQLTYkJ85E7s2selipiZKxSa6+uWlTGL2CQuOI7qeUkSJQwhCDWCCCNZx5BRaGk66M6NS7Nz15NSWmdKswyfEFhf6UgFDz44mslle52abpDpHbs3Wq/0uj3bgG279uzZf0TTtPn5hY5n+W4AUo95gglwAcdPnR0vF+bmFxeXl/7im//lr3/vt5/51le9oFsdKly7diGFjWq1GgShkGCaxsrKytpaf++BwvdfOL1z/+HRoeL8UuPMuavVkUlbS1Xy+veXFgt5lstlm836sUNDYTfxeEwlOnb4AKbhxXMn5lf6R++b2WhcW693jh49tLHse31/YmJibWV9dnZe04yl+YWb166/5diOLdNTZ86cKRf0w4cPt1qthbnZy2dep8N7kli1uy6KqJPNMl3jcZLEYa8RMRA2xbpGEFIhFUHCeZCAYSiMFCCEsQTAAGpgGT6wBB8E6QHcTsu7Xc7vrA+Due7AzUYI0ev1pJRJknAuHNOhiCKBVKLoyvyyDpB1yORQLpeiFkmk30mbrFrK33vs7m6MsGYDC2dXm5lsbqOnGv1+wxOvn7lWW1U5G+59oLB9595zp16fnhybvXZ1545tnUYzcv2FVuv973/c9/1spfTGuTN3H9xnOs7G8sIv/Mz7n37iK+99/EMStFMXb6ZN7dy5vl1GhuO8ePZmaWjEFanpkdz60pryaavnfuCt7+Trc9M5e2Tnzn/0kQedguk11gM/qs091em6+/Yd+N9PrPz15789MporFZxOo5azyGjB3lXZtqVkmUnHpHG/vbFzx8xw/q7O/OVsechCcaPdwcLeWFk9fWputQkCyHrDM+3S/NKqk9L63ZWDe3c7ZmjQUESdom3gaNlE9v13bUHAuq3jfS8QAVWgEYSFCOLYzVVSUduNImFaFiGbB6hBfR/IUH9oFI5u5eEppRIpBoQnCUohULfcQYVQGG869iulhBRcSaEkYQPs/s7KjgBADKKWbhl3DD4NAlQiIoSJQgRhMnALBglKSUo1pKRSShKkQIiEiySWkkvFgQBjBCRNlFRyQI9WSoGUsg88kzaLhRQncRJxrOnKT+IgQDLJpgqVSsU0UKvVuX49mto6QjQdCAMEMLBPVZJLiSjreoEl1F1veezeJ8995csvJlGkMTOTLoaeKxU3DRMjkCqmhrJTJOlKkEphqZQAIEiBUkpxIeUg0zIlEQglKQXDZgoRjYjQ7eQL6V63sXPnRJR4O3fNWCmr21yLBXeyGQhCkIoDQowCwpiZgkeIUBklmGigU9HtcwxM0wYgF2EaUAoIOAJgTJoppGOqZ6Wuc4wVAtAYGKYExEwbsvlsAiv1pebaeomlCdYBYwORMFaR8EwgWNMGpzGIuW7YkMSi58okyuiOSKJ+rVnAhuJCAAecQCLBVAAKx8nS5TPZdMatd24sX+ZBpBPqN11T1/2uv3hz8cp5rTxUJUjrdXvtRldhFUfCW62vrdaK5eLMzh1TUxNGPg+mIQsaNgwwTKA6MAM0I1bgJVzLFDVruO9taKk8diyl9yXSsQWAAcRm9GMc9aUINUIhFrqhx/UeJDqA7Hd9nYKpOY31njQAI9i5O2sYhq5rjDHG9EOHDoVcDY9UO/2w2fNXV1d73ivXb8zXmlFxaOvSylLGQDmiNTvg90DHy489dL/b6XS6/Sc+85n3f/DDL77y7Gf+Zvl3fn/v0tJcbbV/17Gpl15+pdX0Hnn0LRcu3bjr7vGLl25MTW8XkhJiOqkcJfrlG/MKgAAZHdqdRA0Re4Wsdv3S2r0Htg7NjAfd5PqlM6YtCzln+66Rr3/73I7d48Xy9hMnzoetZdtmx47ce+PmNR5xjdDaen99rS8lZBzz/mN3LS3O11bmNMre8vA9s7Ozc532xHDJtEit0+Fez2vHIKGQSqEwshjDUvgdXwBoFqQ0mgCPmX5n0waDxQGQJBFGm6rBwXN30mbQreiP27aAUspBtz7ACaSUhBBN00BBGIb9fp9zQR0dDuwcnirbYzkD89BgacBqeHxieWExV55wiPM3X/32lbn60gZkc9DuwtGH7u8FeG6VlzLAGLzr8Q9YtmNZjq7rY6PDUeCZurHY6d9731E7k+202rU43Llv10Z9w0ZyuJjdWLxxcPd01F67eG3hyD/59d+a/ul/959/+j/84V+tLG8URrdcW1ibSudB9B/cs8uEBPzGV/7n73/yx9/JeLNTv96fXXW0cRu5UX9lWzXLy05t4bVme5pScGxrfX11uFyQUf/pb772N3/+yxnGz7z8XSPNsmkLGYRy2u75WY0ixZYX1iKVzpQLu/ZtM9aiZh81OlE+m81SiQyrH/SPjO5orF7gPNqzc3sl14MoaHXqmSpL6ZxwHnudbtPNZZBtaKHwJPRHRkZ83gtbfYItKftwB2tV3aKi3957B/d10M4LIfDAHQKUhIHl86azGEZIDOKVbtOhQCGCEaZvwjJo4CIEEgFFZFPARkApxZVUChGlQERCKQ4SCwBASsLAY04IKZS4pZZWSgkEQImKpQcICKVSCpIoTBQjlBIt4ZGSKgziOAGmOQhDFCWKmNVyoddp9zt+p91YwmE2pW2ZKI9Pjmk6A10DigAJrjjnIIhSUjjpHOdJd2Ulk84cOnLkc599gSBVLVUoZkGoNJ3pjHl+W4hINxiHEOO0BCW5kJIrpNRAoocQQsj3fa6kphlIcaZhiiy3n5iYAiSGhkGBkGEmazMTCyQWlxZndu8wU47LE6/VDJN4fHIqDH1DT0UissxU1O3oFIGhd5Zr2LYy2aLLk5gnGqEEVMi5AkkMI4qo1Cg1dIGAJ2GceJQhkCKVSukyAdPS8sRka/1W3UkXVLefyiUaxxaQsB+4QdOxbEwpSAGJBAQQcwgTFHElleAxDgSXsZQyEpwryYzQtDlhNJFqbN+RhVePU0pHh8ZPvvZGp9WulMpBEGzJTwWRqNVqIV8bHh3SrUy7ttbut9teODYxns6mRidGtx08AKYGvR4Qih2HJxwSSU0NdDNMlMelwtTK5FzuJ8CyqbTndu10Pkg4CKxj4JGvlDJMJhOX4IhRwr0ehEJxEB5326t+PzY1CNyQJ1Ca0s+ejaxMf2KyIBEtD03ML6/cnF2YXaxFHJCm9fy4tdSkelPTtUyace5WctmhioNVp12DgwdyOsR/9udf0Am8/31v/aM/+p4bRg8/+uCla7NPPvHMhz/ywT/771+4eHXhxEnPsqHZE+2+SCF0+cbyth37vVBx5c/NL0hQxYyjG9b8Rs1triDsHtgz8oH3PPi7/+EzE0MZ5AfPv/JqPmX8ws/9Qi+s/8Xn/vrtj229Otu4dO5sv+0NF9Ou6165fPnq1autllupZHI5M2Wb27Ztff2149evXIzDGAGIBJqri5xDsbxlatvUWtO6cM2NlGqLOIygoKNiqZpPZ+IwWlxa6HQjpJCU0guAsUFlGHh+DQzUQCkJhIKSEisikURKSYXRgOG46Ul1u6wPvnLON2Wot7DfAQnSUFgIQZNECEHLaTxeLTPhxa7LDQArBd1WFPijo1uuLtRixr/89fr0DIyNZZbXuh/84LuGZg5+86tfVQgM26mWss8+9/zOLaO7t063a8vlcjkJvMDrSg6FbA6CuL5ef+Hi+U/+xEcpT5avXyKRk2GsWiqBxIeOHXG/+8S/+9fvtLKZa6ticmtlZaO+dccOuHYCK0hxvGfrxJbq9owuu3MnbZaMVjL9ei+ZW2KWns8Pg5CLN6/Xm+0kLGdTkHX04s6t1y9fnxxKvePDe69ePD9ZtnWdMc3QdLy2Wm/2+7nK0KsnTreuXZjYstMT+jMvvQFm9S3vec9qK/qff/k52SUYRKY0UXTyly5fHymkAzf60heO79sKO/ePU50Jr++2N0wG26eH4hFnfqFmWTZK+ogElbJea7JmE2tgubx9p4fMbcgljuM7m/fb90kj9NZpawAsoE3d8qa3+6Ye4TasJm4JkQdGE5uWEgonIhlYw0l0yzxggPAQPGi6uRqMbRDChGDkh74CoIzAwLESA6Fg6FoiOqAoIA2whrCilFsGxUzrdiKhgHOQgiJsY6SkCqWw+17dtrRcqkog5pHX63uAy/ZQBYI2EAkIg+QCEolACilB1pre0NAMyBxIcteRfYwASM4IYJAEYcswKBahHwgpTEyjoJfCmQQhwZNEJBypzfwejBljXIYYY90wZORhjCWhfuAPpdO6qSMQ5UqhVlvfNbyj1am7iZsuZM1CnkdRaXg4jpP5q1erY+M0wVIqLiRYNur2gdCBtXoqbWPDAC/mPME6Q1KoRIBUOtUDrDDBwJDiSRQnBCsdJTgMFHApOUQRaNTQWBQGMui6XpiSNmBiShp6iR/F1OKWZQz6taDVRIIbhqkiUd+oKSlyudzK4oZSKuZJLBXTdScbaoYJGNWvvmRZ1tLiOlZ42469ly5cPHXm8vj4+GunT23ZtlXLZs5dvnZlZaFUKQdJ2HO7ew7ue+ChB61cJoy8SCbL12eDINizZw84TlBvxJHIOzlQ2AvCUCA7m7Zo9urs5ZHhMoZUv7taHa4GrZpSGAAlScIYs1Km9EOONdA01On1Wr2cMxIqtba07vcjJaHvRZlMfmG1NjaFKyNbdCdfKFUiZfzt350ACkwDqmuBKxJOqCYNw9ZMq7FUc3L1yO9YxuSW8fGFa2vNVvvYoRle9rdMTa2s1qWCr33txo986ue3b99z/vKF//mnXxgZn37+5WsrdXj/A4duLLRffH2p7y89+tjd3VA89d3jQMFK6cSgtYb78OG9n/jpj/3HP/hfGGLeW//G5z8jOHTW5u879Ej6nQ+Evv/a95++vnB+tGTMXr5RLo1MjU6Usq7fXu3Hcn1pJePYXs/1en3dYBsbraXF4xPj9nvf+fZTb7xmmRpGam15aWJ8VGfpYgrV51at2Nu3e6vC5MrlaxTCtdnF/M7pseqQY1tBHBPH7EfR8vpa208ANonpgxg1JZECoVE2GKFJJLBScDsqj9HbWO6dpeOHvpVShmEIAEIzKKW6mWKM0XzK6dZq6UJqz/bdhvSg66uY6JmqSMj2HYd+4Vd+TwLwGEwj/RMff+/GxsanP/3Hgd8v5jOaxs6cWb57bzH0c4yghbmbb3/skW6z9vrx+VRKz2ZzGxu169dv6Dqb3Lnzy3/xZ285dqS7uoiVAsBgWBAmjm0fPDLz+uVlAFAyLuSc9dWF+4dh367CWCVVysaaWOm3eqEUa51OKXfPwkJnz9FjEEaij6/enD19tjG5ZWz3zHinvpRKkfXVtZmpcm2ldv+990ivASihhmOk07XGxkvHTxu5zDaziFLFF18DPUvbYTy188ieux86cfnml5982szrzag5MVy1cvaLLzzNu/GDd40yrj71M5+cO/6E9ExAOG1lt02xsaHa9Mzec+cXd+4oExb3fL5Wh+8+9VqxbGfMlI4dbhh3QmO3rztR9TtPWxF/01VucMsGNX6Qv04oGdg6DsC1RAo1QOXQALABvhmgKhAimGCFEVZoYNUfRhHnwiilRMKlkFKCIohiJgAJKRVXVtoOA1/G3ON8JJtrrLYJUUwTvh+mM7lavSEEKxULS8sNmRCNYs6RbjrNRqfTCoulYrzRp9lcIJZMy2o3NmTiU+Aj1fzIxFDUqUsVGRrzPN8pp3gUNFvtobHhMOHFQmX2+s0tex4Apa2tX922LXftStuxmMFIt+WnbeqkrQ5lSoS6wZJEKk9GIgAkDY3FiEWxwFIamsaE1u+7oDDn0jKsxdVu1jENw6rVNvL5LCIwPjUccBcT0g/8seExhRHoGpZ8fmFufHLL1m3becKprq3WGsVsrre2SoTULBO6PcvUbdMIu80wijTHMTUWR7HgkhHGRUx1zTAtz+9n8mWv39GBxF5IEx77/XS51J69KWOeTVmnz1yKPNd2Mi++enN0dHRq37728rVzp09tn95SKZcNjc1euxqHAcUkY1si4c1WPQkj0zQJcrrdbhAnhFI3Cnr9vuGkKsNDhNFotaHpxsmTJzOZzL333OMn6PrNm1nHboQu2FoX4P67DqzVNt7+gQ8kInZyqT5TEiXOUBEomSqnMWPgOLznWqZjMx0Ax7FkzMA6w5LUmrVKvmwQHUBWR0Zlv80AqK4l/RBjHIe+9BLMEPE59PsEqIkt0RdYGOdOX91Yg7ydToKo3evKFDR6cvX161ECQgIQ0GyMiC4B9XyOiC4RipMgjgMtVul0qliALhFLizePHqz+wv/zQGNt8fDhvfPXZ3O53Osvn9ix3bx+MwCSyubG7rm71HW7xBia4unZpdMHjrz1v/zO72u2c/ehnU5+9OTLrxAbCMUdN7rvwSPy4vm9B7aPjBf2jueYZhHUMRgcfbzCPSnDTjGlX1tbyFIrcoVti4O7RoFmL1y8ziMt9Lr333N4Ymrqi1/8cj7nHD58+PkXvj8yXPTdfuB6J0+ebNY3gr748Icesyj0Ou19O4aWV66WtaCjQbR+48w1eM87d4+NTYFiT3/v+SfP3Xzfe992Y3kl8KKlWs2Pha3r7W5HcGXYDsE0TjgAUF3zgxBhRTFmCBBBhGCMMAAkcQIAA/1jHMdBEGCMTdMUQgxElHEcD0xNBgHfvkxEEApXcM7pttGxoN/BQs3PLmR1LLy4UCh01tqZ8vjffObvVtfgXY9OXL6x2G+0w15P+FGz2RkdKiFIlpcbM1vShw7sxdy9eOHsA/ffs762NDYyNDU11el0FheWp3fsvHAp2PeBfZ2VDYroxcs3q45pptOgpdZmFyrDE5ev3/jsV//63/z+f/5v/+YTv/Bbn80U2nv2HTxY7mssVri/tLJcyGSHyqWgF5ZL463E3vPuTy5duPrEU69xQLv374OsuF6PNzbObJ+ubt+x53vfe9qx7Jmp/XNzc2kdbfgtIoKvfeeVdh+IDQ8f2rX/nof/4q8+mxsue1Cubhmm6ezZa3Nf++5TCxudLTPDUX2j5dW//8rzB3duf+jIwWe+/jVNin//7//yX33qvb7s5YrO9597+cyNzq69+zbq6xQlG63FyrBZLsrVGrz7HeXXj9dKmZF2K0TGD0uN75xu/58XwnST9XhrfgK3uTES5GbYHgbAhBICECXh4D3lwGlis+nHMIDvxSbCTSizCFVKdcKAAGKIUI1RxBTgAVlSYwZBlAxc74SM4gApwCDdfkIw8MS1LQCMdV2OjqYlZ4DZ0tKaodvttn/+3JVHHnlkx467lpeXJyYqbr/rhf1KIWsbJBbh2sYqZUKiuGznMcig7+oOyzpOEgSWpdfqncnJyaC+QaQ/PT2EkDdcxYFfsw01Ui3YJms3am6nn8oZKdvq9RNNp3GMY6mk5AohmaAkimSSWDgBAQMZqgRFCCBMMZGDjMOU7bQ6HTtneIHvpFOmZSUgQWN+O0ikQAgVK5UoilYXF51CKYjCKAwNTMD3IfSJkkgKDVOdEjaINWMYEQQShV4gosA2LQyi39hIUeg316r5cuj1NIxnz50fLldeff2NifFpr92sL68WCqWiUTzz8hudlYbv9beObqkt1aJuGPleNpNqdRq9dsc0tJRlcS46rf5Sf7XpquHhYaZrtUZHIsgVhjlSV2/MC6Wa7db09HRxZEwpdfLi5ZW11eHpLcur89Mj+WP33nP/e99avO8YzM2CbdRXF0tjw0oIYAgsHTSGRSziiCd9GXJFBAiEJKOmbhumAC0SImVYhq4RoiAJACJsaphI8F3OuZlLEelL4WEVKy6Em3gtP3GRhdWrz524cbWuMeh7vsSaZmkuMxTiQiZKSo6UAgJKA0kA0YT7IgHLMou5VBQFSilK6fJc8/3v2zk2XMpnje3bJjPmgdMnT3/5y6d/8Z+MffJnfq7X8+cXlk4881KnE//t3z73X3/3F//kr76eyeQeeOShf/Gv/+vdR++7cOVKP8CrF25cm1uvDBcty5i7vLxeW56YrH7rya9Uz5brNxcyOThyuHzw4JFTx09sn9rl6PrSRuPhhx74/ktPqQSW5mFoOJ4arV46db1kVbZN7t66der4yTeCEIjrnj9/dmbrdCabjiNvfWW522srpTIZ0tio6YzObJsW3bUcE2bOdAyFTFvHq5OVbDFjvfDiaxTE4V0TrVZrbmHRFdKVKuQiq4UWJaGMGZKdXrc6NBzFvOv2gWAMCDAopBRCAgYzuE20/TZ1fYDlJkky+JwP5qiDCjPQn9NsCkmMBEYEUR2hTKFw75H9nbWF1YWb/U6vsnN/saz/+9/69MkLML4VHn/8ffjbT6TT2d1bxszdM3/9rReWF+t7tlcmisOTlXQS+zbhUdhbXpxVSTS+c2b3vn3tVieME8Fl14MPPf7B9dW1sdEtC1evZ7dkImXIDj95cT46Pfuhn/qZ93B27tSJr3zxKx979/T7PvKxWqt15XvzhWJucmb/2tqKUNBSqWurc7t3VFlq6tVnzp04df7GbPvjP/njHop27dh58cpFvHBxtDp67dLJV1+p3XNP/u4jB1997eVjh/ZfuXDF6zb9GN76rkOZcrkbi1dPnLlwZW5X6b6EFVc7/OVnn3j9/A2lQ7bE1uurCGDL9Gh3ba3WXP/bz39e9pIje2be9Y6D589c3nFwSrczI2NTPl5rNNpPfHvp53/+E+sbQ/1grlh1Hnw4/dW/v/Qjjz/6xS+c12GI38Jhfqhz33SA+cHOfdC9A0KbLv0DzH3AaqeD1PPBcFVuDlcHYD1GWAGSZODEJBUagOxCKCGEkBIA3XaG81xuMmAaI4SAIkqAUkgCxngznUNnDEGchKGmg67RjAW6bgZhnHEMJ50rFKtj41t1zXn9+Jkw6Bq64zj2xkbj7NnzoyMT6XSuVptzHCebz2CGLccpZMtCoTNnz5cqWc2k6YLt+55uamnb6bhdyzZ1TcdMj9t9GfNcKddux2EP7j1WXV2qp4yi4goEz2dTqZSlkiTxo4yGKcJIwea5Bg0kWTIRCZIQJbGGkZIKU5AIgFAhpBeETja9Ua9NZieCOErlMobjWBQDwXHCq9UqMg1QEHoekspynNj3DMMwEYE4lCLRKJJRgM2UgZXkkfCxUkjTLAAI44RKAAAb8MrKUtrJuKvrLhe9Zjf2IoNo3Ub3kcfeUVtYeejovZ///Bfifj89kg770Xe/+d3HHnvM6/gpI7W+vKEkt3SLURMjv1Zvt3AvlbLtTM7J5gs4s7Cw4Pr1QqmUzWYUhnw+t/fwYT8Mv/fM07PLi9lsdmh0JJfLVSfH9u/ff3PpYjabBRO7oVdcuQlpBhRKW0Y5D6lNgRGhIhEGiUzCMAyisMSyiBAFahC6TjSdKBpFMTUpoRS4F/XaDGKc0kAEQb/RbtTM7CSWMnBdamAqIYmUDElGL0YuO/n69ZUlGCmbzV4AGHSdSWASiESEI8GVHIijASFNY5bp+L4f+56WMi2G4iRiWH3k/WO5DLly7kUp1Ozl1Mz09NLc8m//509855tP/++z39izZ/tPffJTFy9fGhmdIDo8+d1nx8a31BrNS6fOM915/Y2zbde1s5XXz1w8cnD3/NJN3aQ/94m3r9eWnn/+kh/B+lq/kMD737J3976JQtGqLxe3bdv61S8+0+upbz3x+sz2dL4ER2dGcoX8U996GgJYqy1KHGzYtFVb3Trl2E56eXWdabhWX8vlMkBwFCYa0YaHS7VajVGCERp2WNQL282mlkk7GXv7tsnV5YXjx99oNKJaHaZ3pq9cv9bpubHGQDM0XSdBW0ooZnOxVMCj2sZ6JptDCCFEACmElAIklICBgQyo2wFPA2z2NkNm4Dl82xFhkEwXRVE88LhSIABRIvn64upFDbKmnskW8/n8+sLaMy+8Or8GD71leMvMrtkbVxnwoawueutZZ+g3fu0f/7t/+0ft2sbEzjGKRdokMxOTJ19/gZLijoOHoNeJYq4QDI1Pfu2rX2cGgGTnT10YKpVT2SGsFdxY63W7IUnnR4sn3zjX7ff+7I+e/5GP7Xvl+LmUrJVH7fNq69JG0vj+8vLaItM0IVbPX1wevtBf3/jmfD3eM11IjQ4nObvRatp66kb7+iOHd504eebshf6eXbC42Ari6NBd97Ta9WyhipXcvXu42WivNBozu/cGIn70waPf+fub66+8pqdsYmrF4aykkMjYso1Wrd/cWKuv9EgO/u2v/eqVk6fvPXT4C3/zuXfuPaJbtu/2gyg88cb6jr07/+k/+YmnvvNKvqifPb+0/zC88x2Pb5nY8uf/87mMke42QzB+oILfLu4/VNnffPB/9PiDS9d/IDB30KIOcBisBv5ZCgAGlV2AIoQBCCGlusVMF0oiwYUATkEpxSUgnigBCiGFkZCKqxgpiTVMKU4CUcxQyzJFzBQhfk/YFZpPW8WcNbO1QpmRzdw1NlZ45ZVTge8OVfKdbv/m7PVjR+9vBElG0x2N+r2uG8YFmvODpN7sSCyJRg4MHVAIuT0/rec0pAk3Np283+lmspnWRg9496EHSs9+r85wf2TI5nHo9wNb18vFbBgGjU4Hb6ZBCSk5EEUGWi1KiVQylghBknBdI4mMCEEDmlAYCaqg7wWxiqKEY02nugEYsbQDYZBIkR8fh75fW1nzvGBqcosvpWEYmmEIt++2WwbFGiNuv+3kbA1UwhMec6mIjjWgusUooSkIJdIM5AUihrKV8jfqBtLXltc1al69dH3blm0yThq1uoON+SvLvGlqOm23g8XFlWazPjQ0FEYiisO5144Xi0VNowmQruv3oggAfN+/uZyMjmaHR0eUUnPLi5iQadtEFB18yyMHHzwGji2ata7b13VNKJkul0v7RsDzwGCC8n7YTaVLfrdupCxqUIVEo74+vzTv+X6pWtmydUthehTWPNANUDRJBqlAQgiV8NBEGqgIZAgQcu5rfQmxx6OO4CEEbuh2eeADMVQgIUIG2BTSFy/drK2D5BAnRBEilMQqShKciIEHLQLAoNAg68vttx3b0nAShbEMAkMnaUcrZO2CRUcqznve+g/+5m//6qF7j+hMQ4J32jXX6/7H3/7n33/h+Gf/5jPpbGZlffXXfv1n5+dnjfSokNHTz7YUgAD46Ec/+Ld/99Vf/cV/1O12z5y9mMsmEyPDIPxP/Nj9q2vzjNGF7823Nxb8rik4HR8frTWbL5xqjVT0BEM7iLduG0OMZtOZ7dPlRi3safG+/TOrq+u+H9dXY8ZcOwOWZUxMTZ4/f7ZaKSVBIHhkWE6rvpa2raXlVZ/7Q2MjpZEJPZtZqjUShbw4zuYLMe8t1dwgDJMkIQybphkAHp+aMhvq8lyH4XaC8FAxP7vWsm1bxIlmEgAkAW1aAoIkA0thvMm/GBT3TWcbtVn0B+Xetm3TNKMoAoDeLUG7UooWUroKrcDrT08OYwWaYb184tR3nl2f3sGmt+8YGRs5ffLk4f1bJ4cKDLjoLbRrWiUHu2fGt4yVcxbOZyyGhYg8CgnEYbvd1O10KpODYvmNM0uZPEStLhWklB8KfXjm+TeuX1/yPJiaLjTPzp28BBzgEx8oVTLknn3FHbtKN9448e0nzjkZJ1aRIlxRaPVCgSDukmxl27YiD2QgefQLv/kXjgF798E//SfvvWds70Pvfcdv/LPfzFfGVjc63/jOE4kviYR7Dk4JQBpjnU5f0+lwzuKAqhnDe++OC5cuLq+sLG+sJQoEhjiGme1Vo6BqC72Du6t5g167ePpd73747z//mfvv36MDBj0GjY9Pjx040mu14cDeB0VY/fuvfmasyh68Z88f/t43/s1/+Lmf/+THfvs/fAPbrP+Dwbh3Fu47v95+igO5TXkazFQHDBlIxACKB4wRUlKIwSnsVnLq5iT91u6AKaWYEEKZEGIAsUsBSimqAyFIKBnHMeIAEiOCAZGBeOK2TEJySKVSGGTsMYs5GRtPDE8Mj1dMkyHl9buNcqW0bftD1eHck99+4fr1lU4HytVqFLujo9N+4CKhCLX6bnj58pxj0kq5GvpBfcMF6uim3V26mXaQpedDr+cKt1gsAlIaFQDub/zGz49WvvjcU1d3bh8PXCVjQFiphMdRpCE9k80k3UQIAQMzNBiYTkmlgFJKYBNtTCKOMOVSSEUwYZphxIlkthFy4aSyiUiCKNEBSb5pqBm5rud5FFEw9G67PVQogJLtRr29vjpcLlIjRQQHz5WCE00jVJdCQhKDQCThgFmyUmOloh6o/sbG+L6DrdmzY6NbLOJo1F5bam4f33v5/PWxoarw1yzMltZqtm0OjY68duL01m1bXj5+ctfuHctrGwop6HsJjxrtNkKQy6WSJKm1kq07Ri5cWJlf7Rw7tmt8cnxheaHdqWvGjlPPP7Vtx7ZUdoJYKG84UC2BkuB73sqK67q5fJYxFQQuacmbczckCMxosVzM5DO7ZrYCSMKojL3O7NVsegJ0CkinRHIQMgoSiSSSCAnJQ4y5ntLB98J+k8d9QuVwuQgiTgKfIQCuwn4ofYJCcn1+8clvvpD4oDNod1wz7cQ8kUjKJAIJBCFGESH4liGKshjTaVysFEaqeQJR6HaGqsUDB/fbVs9JWRsLs81l+eQ3n/tnv/KzJtP6/aRUyv3Rf/+9VpufuQG/8LMPvO+D7/zes9/72teuPvro1P6Dh37+Z99y/PiZfQfvOXP2bDFn/Ol//xOM4e6D29rtxtri4s1LF27cbG/doufymS88+bt/+Xv/PvK6biiHJ3c8+/ylBKAT4gAh7JROX1kaqmBd12PBd+/c+cqLb7Tqywj4lgl724wVKxJLpBvW/PxstpA3LafX6Uoee37U86JCvpTLMyTEekI67V46pv0I8sVSfeNGt9XIpEtDQzybL7iSLLc3DFN4nksw2jJcadc6fQ/sPE7ZxvaJIT+R7STSTGMgQJSgMEilQCFFAAaoy6A+DI7jA/rjrWP/wHZ888IY00HMJ8ZKKVrfWBqpVjBB/X7v4qXLq7X2ygbsOmgdvOueZreXj12NJV5n9dLahdFipr66eHrOPrR37Mi+HeW8SZPe6y89V1sR27cAJXDj8oXprdtjoLVGszu/OjZZmN42sza3/NpLr/7JH7/ghaBb4GTADwHVgiiAj35k764d42+89rSji/c8ehjac735k5qpBZEb8Kg8VgaNxlqQyha5YBeuLxVyGZBBKQcP3pVOot5kGe55+6Mw3wobtb4HotlYWQswhrvuPrA2Nzs7O79v+0Qh49x7+K0aVUHgBUmweO3alaVivb/ObGw6ZimVLRRKi/MLYStEPJmsZsdLlZW5ixTGrl16aWLc6bk3y+VJZ3yo0Vq7Njf3Ix/7+Px1+u1vvbIy78owxzLyD37n9E99Kt1YXmjX0NVL60MFJq0fsPy9TWz/ocr+5uNNZ4kf5rQO/N9vezcOUB0ppZCJUkohQBiBAoSQRIAUiqII0Kbf5CCdAJRQShmMYIWVUEIIJDBCiiisFMIYIwwYFOcRASkEOKYRBF7OHGUIW1ba1DK2ZqXTmqWDbRud3rJlqoffcmT37u1//ddfefnFC4J3nn3m2/uPTjJCh8slJHgiCVY8jHjoI4w0kdCkHbFiioKlAoQMh8oYIYLSmfr1q6WhKgR9Ws5+8qd/lMEXXnr+eto0M3aBSxKEkYao7qSllH6SDIYESkDMeRQokShNMqYzBiCEkAiSRBBCRQIYY2Y6qXQaM8A6YKpruhlKxaUChbBpOo4D7baUcqhc0ZkWNpqJSoAxCAPXdSVPNIxAY2Y6Fbea3SjQ7VQ6VyKIguclQa/f6eX13I0z14bLzdr88tLsfIE4N09fcTeietN9+dVTBw8c+dIXvn700JHzpy5rGHdqiUvdnudhRt0YumHc8eXZq9eDKPECqFQi3TITjRqmZg8NpVKp8tbI3WhPbss0Gt0rNy4/9NADv/zjvwT5dLyxOjk1lMioc/NiGAemY2ZYCEq5Xs9Jp0XoJl4fCOAkIhxvGR6SSFKNBHHQXVtFBFLZlKGnARBRSoiIhAqYUpgJpZIklIgyHQciwDLSqSAkEijwoo4IezpDVrqatBth4KdSJgiFBcWStdvx5bM3b1yBfJ4ibNVbPStLEOVhHCFQFAMAZpSC2vQnx0g4lh667R2Tkw/de7jXWZu7fnl4SJ8Z0Z7//kXLNpiJP/LBo2fPnn75uWefee5GvQ53312d2T71+vHrf/Lpn/j2U09+5gsvHjyiHbufIFVfXThdrI4++tCB3/uDb378Y480G2sH9hzqdvvra6vXV72N+WemJtiPvufooQN7r1y59Oe/9S+JCffdd99zx1+JFb00v9wCyKXLArzzs2v/8Gc/fPr1p2YXVh48ev+rz71x5NChRrRULefX11dKlVK94zYazUN33Xt9bn4oPVRvNZudoFpKuVHUageO1cpms2eXe7lClhrF1Zp77vKyaS75fRip6Gs3NwwGy6ura82+BEinrF7oz167vG9X5Ufe+8j1+SVFjdOXr4/P7Lw+v5xOp2O5qS4fLFvAEpACjEQUD3J4Bn3MbdbcAJABACFEEAQDiCYMQ6zptwsJvevwvkzaWV1dFYrvPbDPO3XaU72H3/qYmc5HCwtR7FkWFklnZryw856D8VWrNzYpeNiur0hPlVKa5GJ9GQ7sxJN7dkAQgmFceP3Mucuz9Y7/4CNvy+TyMpE//zM//+yLr33jqeMdF3yBD95799atWwX3aqs3Wu32ww/e26/fzE0d8C6dOHRsx+9PPfRXn/3MqUuLnV6NOZAvVjteb3GhuWViV9bO6Co5dfa1+/YUpyqln/zQO9eePjE0MXr95rWRcfvyDc9K42pljGr6wcOHWOwe3D7ukHjlxmUC0fjYUDpjJkX7fcfe/pu/+dudNpRLhu96/abf6/S3TowHodw+ti3qtlIafvWlV4/+4w+uhP7M1iFnbPLaiefyY5nhyer/+JM/efq77nrNHM3s63Z7nVbtH/+z+w7dndMMXZvID5eg36lLw4QfvG7Xd/SDts63a/qdFMnbe8DtoD51h9SYECJkspkjoTbZlggwgEo43yTbYLQZlwsAAIwxxRUIhQimmBFEQGGBQEiBCVJSJSHXKBACjmNFUQAk3XX7Toos3Fzpd2sjUxkuUuNTw7mcvr5xs9Ntju++66d/+iMzMzsuXLjxzNNnrl1fKBeL1eIQUti09HzG7rVqnsd1HVfsws0by1Wv4Ni5yE8MllDqmCYD1wXJASsZ91pLc8Wtuz/xD36ss/Gn66ueknHKziPgSSKFlP1eJ46pBIExYAyKw+BAqlGNEIER3A71ZkRXAjPGuOBCQaFQrHdqhmkHceLk0sykYRQaDFuOw2Nu6kxyhQyjvbqBixnACmSScqySozNDA7cPBtMoCRs93w9NzWRGSgSh1/H67R5Kkhvnr26YetjrrS2tvuS96Lrx8nyzOrIVC3bj6pLfk6++dHKsWtUwnpmaeHlh2TBYqxMMjxb7UbjnyN7ZhdnJLeNUI3v27t2+a3sq41BdM0ydC9Hv98uFKsQhKAUEQRzGvVa8WCcETl++aJp6Kmunc2k/aK9cuGmnrGKxCP2uCH1EaSplm5YRun27lA97XYgTXQrL0gzbBo2oXrfnumHk57ZX/NAHzk0nR5mexAIQ0nXdD3qMyFiGEPVl3CeakJy7oZ8xMm6vJeMIlKYCQYBEMbp6/sbstaV0Cii2gZrMCL0wQEx6MVCSDHwuEFIDnSVSgIG7HddikHdABDWvMVdweIp6Z1998uLp+vhk+u6jB89fOPPAPfdevXbtN3/9Jy5evvHq62ceOHpsbmlxeeXmfQ8c2n+kf+Xaxcnpic7S/PCQTTVeb/R+4efuef6FFydHh8eq+W5j4/qq9+9/6Se/+PnPWlS7//Ddr7360ksvnf5X//Bt2/Ztn1+5+bVvXHnwXc7uQ8dOXPp+w0sUsTCDz33lWxYJizbcnF8olUr1el0ryH63zhgQqjy/HwUqigLGiJDAhXIyRrlaDfp9ppNao93u9nx9am5uI1aJxJykzdxQSWu1NNuG/kYiEfeDKILJkSzHUMymm73O6uLc3l07Z7ZM3FhaMyjpNOqh5+tOOvRDoQb0ZYE3MVeFFMIIDcKV4ji+7cINAK7rDn6ulBoQZjaflW8qJamuYcaI41iabk7d/8DC+sb8aq8f+FfmFyYnJ5Ogr2ScdYzxkeLG8Zf+6NNzK0OnDh3YO1bNF9Oaw5KPffSDzUfnR4eKCxfOThy+q3FzsdPplMvl4pA5PT39vWe/nxLw9ne+hyeq14VteyaYnbNSxSeffXF0pHDX/h1ea9b3+X3Hjiy+/Fw5Q0H63e5ly+7+6I/sXW21Xzm57LrrUahtnZ4UPl9aW9y1Zeqj73j8+Pe/obswvf9B6K+dff27//E/v/hPfvWd0zu9b3z7BYSxlLLZbL7jgaPPf/vLOydKk0OZkWoRqLp5+vXpQwdu8H4ioVwFUzMWbnSGypXhUqpT65RzGVu3XnrlxIc/sGf7lozXq2/bNtLv1k48+aX9R/cmLHr5pZNf+4Y0NZgo7WjVecasvuMdR+5/2z31le/FSfT8MyeUhELOrkl+u6Df+eC2JPWHrsFAdSBa3XzJoCiDNvgFoSTn4vYGMMAwb387aNsBQNM0uGU/cFvoAwAIiUG6GSFEwxoBJqWUSsRRzDAFKZIEgAJlYNt27HsgTZEEppGKo0a93iSa1+0rTEPd1Gb27J2fXTn14tO5wtS+/TN3Hz320Y9+9NN//OdryyuLK+ujlQozzF7X99x4Znp8bXXBMlOLc8tRFO0/vLffbfJmz6lUQt+NfK80OuJuLFuanrK1ZGWe2UP/+F/+2t/+4edOn7lhW3lGiOsGQgIATpJEEokpJkRRAMYYw2aKOSjsggIhJQCWUmE60BZobb/BDGbZKXdlQdd13/eHxsvUIBvNtTD0s4UC1TRQsLa0mM8WwshH3JZhqJIkm80S24TmRnttxUnbbGar3qh3Az+JQ2amCcIEYUZwZ7Xd2mj2pHB0zWZsfWlt5679Fy7N19YaI9WxldXW7h1762vroRvly8X15aXtO3aYtpVKpTr9zuSWqemZ6b7nVoerw1PjSnE/DMI4YLbJ8jkWRV4ShytLKytLrXYzlUqNDJVMU1cibvU6e3fv6nmdIHJ1naayeaBJGIbrawvj2RERhSrBYOlYY0kYgGMbvgeMgG6DYwIh0Gl263WFoZBKU0N3g66UYBFMNI0Cj6VCFCGKDFNXPA78kIBMp52QxH7QHrQbjBGQyuu7OGadZnTixM2lWagU0xv1kGjINOx20E4bVCEADgoDQgpUPIgpkgqkAuAwNZ3dMlbxu+tBv3bv0f35nP31rz45NpJ57KFHL145++gDDweRt3fv3l63m06n9+/fu1Fb+9mf++nX3jixurq01lxeq3WdrKbC7tPfOz8xpe3bd+zV1y8e3LfTtkt+wO+9++7R6uKXPv+FSrF095EDv/grf/SJDx155P7DCwsLhaGcYVuPv3/v9bVW3Uu8GMCigR8PDeUXFxoPH6tkGHc9f7w00a7NFnLpM+dujI5WMSUgxfBwptvtjoyN2lamWCwqIS2NNTc2KkMjfq/banZhshR3fUVVEPY1hPuRShAjRurofTOR65u6sbSymioUvvfiG5Wx3JbJiZULC88/94yTKR0/u7znyM6z1+a44P1WizBjkFqslAQECiFAWAFommYYxqB6JEkyOM0jhJIkoZQyxgZVAt1yogXFbhcHermJ88LQ6PT2fXed+OaLsxdbx7bv3mqzmK+JWr1QKfE07H34fb/9h5955dXGobt2ztQvD0XN/cWJjdrS5PatKEoMZhl2IVOE3/k3f3XXPSOPvv3hqzfnqkMjG40r73j73ouz0ZlW5+9OnHMruZpeins+GKs7K8n2zML9TmJYLkKINPV87kBTpNxF9t3v13PDj+GUfPqbX8MaFEwdQpWJezxoaFL+wsdnEN7YNV09f3b9L37vf85sO3rm+VOf+uARsdiPVpb3ZqyRFLWNZGrX5KXzr2zZOWVmDM+kNcBZ2zy91jCbzaZ//q6dxuWLoa0FOILW0sa2iS2PvOdDT3zrKyvzqz/1k+/LZeJsCXeCxaTHh4ZyTz2RzLz/nX/9xSf/9C/l8GjRD8L1zukd22AiDZ/4wDb3wnOlPUf+4r/9ry2H3xoNu1drfZUaBpnIxGNEalhFro8FyWVKQY8rqSFFJcKAQKFBO61M1UeA8CAAG286B0hQjCIhlRBSSCFAgQKEMAKkD9p/zgEJiQnGGDBSmARROGDOSAQAINWmjQzmioDCILGKEnA5QhKoQKQXhJpAWKqsDjKCQhpw1EoTrugZi7G+20fKxMFwnxRGclNpNIx49/QLN4keWRby+xfLpeHSMAGJ7np034vPd24sX49lMloc1YlpWGOLK5xAcW09CkPkL8xbaVUespgmQVNqVRZGh6EreEhDQqyhoSiJG36jWDE//M8/YH/9me987SXlQz5VdLtRHPSRNQU88tstwcOMRUBGwGvZdF+qxOuBVzdS1ZlWcIUYUkBfZy7CpOt1O+36vYcPQBLmWZ6C6LTqhVIulDxG0u35+dKoTlNmcSrX4P2lZVwt1aM2zeppDcDXMaeM23B1vVwZl1GvbaHl1sJWp2wHfipRLSM9f7O3dWv56lItnU2nq9WXLl0aHZuYW1zIFwvZCZivn5UpZVaHO0aQmLpdkVHSXu/OT01N6UNIpaND9x2AIFyaOwtJODY2aksPWnXvxkngfOnypZFCtWQYk6MZTFHsrnrtgMtEA1WfW8/ksjoh3aUl20lXhiZBiu7aWi9axybChLTC9X7Hj5PEv+lnC/kwinSkq1YbIWTqhlXIxEEoQFG2rtNOEMqg03JSJRPphiAqQGaYMJUCzyW+JMxOWs3ElRPpbVCbJf0glxlubyTp9K5+Qn/+1367XLZYKX/FFz5lpmmt19Zmdu568Y1LO6YLMpCdbrtUTHdbPcdRtgary3DsLti5rZoEfUZWnCJL20Uu3NdeP/O+H3/P8eMXFdQzKYWkD9yrrTckYErZzNCEaWdX5ub/7PdPWDokEt7z+GHSpp/48Y/9yj/+NBT0Snq8tvrSgcOPIjO9tN549tXXVlbXfV9dvLDxn/70J0/NXf2rb7zxi7/0IxV97ebijbGto/ffcyh7Y63eNua3rXDBFt0N3NzYWYaprHB0OTOWW7p2OWvymq/ruUK941eGctWhSr3WyjAJiNy8fvqxRx47d+4cy+Vmr/cm7s2mCtmNlW5ZzU9us5qN9qrf0xRVLZ97cb3vdddqQqF0OvP2d7yLc3nu/PXmQrtYgImjM81+f6nZL2yp5IdG1OWredvodn2vH1sEhoeHmGbUag3JpWnYnucpg7ZbLiLYMAxmGnGS+GFCCAHDjjEBRRildNDVCSkl0gwyGKgKKenk5KTkqrne+q3f/JetWufjP/4+EO7c/M1cLucl3bmbc0hP/a+/+ItycWTrlrjXae0aSk9sneAqttN2lPiN5ka5ku+0W9mx0e07bAS42/EZNQXHy0sbr716cvfhh8+ffr21EcUkQsNJbW358Myhqk5yticQWWt0oiTePXPk6qn53/7Db5Yn4CP/8Hf/43/5tzFySyW950a1jajgpM7drO0fRn/4P34t7C+urTWPHXng5e9/6XL/zOULcx986777Hn30s3/+l7VGY/uOHdls/sLFixcvnc/lUo88dL/bbw+NTD779BN3HTmQz1eimOpKmxyZ1GQ98NR73rZ1aW499FonXv/u5ERO1+OUQ7vdjcmJ0cA3LMM4c+rqv/zX/+l3fv9P/u7r1xgF3w9jLyinyfbtY594z71kfLjzynWntlpvNO4q5DMp0/GSBLGO2+VJkDL1BKskUUhJ3wvlZu65BIwU4oAFBq6QIkAGff1tqvsAoRl4R9xq7+8IcIE3Mxs3KTESSZCUUqkUASw2WTSbpgUIS6QkBoRueVIO3jBl65gSoqTGAKvQslg6lRGxB6qrJCglQEmEJZe802svLCdevO4Gy6kc3bZzYnRsTEvlQKk4iN7zjrd+88tfWV+FPdss1+u2vNZIpYoEJypZ26hns7hQLEdRsrHeyOUtK82LY1Nht9V1O0bGsiw7DCKJoDg63l1vZCZ2vvM97+Y+fu3F06vzjdADS8drK8uZrE0oHDywb272uqkzlYgkTJDEUkGr2fGCCBDmMsEY9X3PypV5HHLOc7lcxF3GWOR5gEAIMRhJUEqBkCRJIPCyuWy7txBs1AybNVrtTLmCDcO2bej1wNR7NTc1Wop0NlwauvLiG3y+ofWjC1f7pglKqaFKUSjp9d3JyclGqzk0NKSbRrFcPXbvPQPS4cjIyI4du0MQxtgoWA6YBqyuNpeW1q7dmLtxc7hSmdw6Ba6rEn7mxOvbt2zxuv1CNvfG8eP9fldhlErZmVyqOlItlPIIS55AvV5HlDDNaDab6+vrVipdKBT6ic8TThG20qlMoRwlsRsGrXbfSaeJpm2KpQkFrnTTYblc1PMZtcFQSaK8nqcbIDjy3cA2TNAIuEmnXUuZmmZqlmBer20nMm3ZwotCN9CQd/H0fNqChVmfEJ9SsJw0BcEjfvaNSwe2l2/erI2Vs9VyaXauvnPGSVlEZ/xHP3zXYz/6ePP86//1P33xIz9yBDT6vS9/YbhSPvbwI9fPnzu4/+FXXnnxrrsP1uorr7z6+tFjOxcW5++9/77nnnv2hZeDX/nnH/nNX3/sD/7bM1unrYP77wsjceHspR378ivrrVdPnFxakS+99Mq+w0cljz/4+HufePLJqampL37h+7/6y780NTb+c5/alXHsV597+fEPviuXsuqdZkpnX3jyW8CdSzdv2ggNT1X37K7s2JZfX7p++doc5sbVmy3s+7quryz3LCfbaXZKpdLy8rJhGA898ODLL79040b47ncOve/d+5YXFtfWO5YNfq/jdbsLS+7/S9l/hkl2ldfi+Lv3yedUztU5h5menEdhNMoJISMkcjJZ+Nr4YsDXgE1wwDY2xsYGDNhEEQRIgFCWRpqcY0/nXN1dXTmcnPb+fejRwPX/hv89Tz3d1V376f6w66x693rXu9a73/0gL0jf/OaP5ACHGKZSaYajIV3XT5486VMUDAbD4Ui90bAsq1wu27YL0FhZKbzz3e86cuQIQDHG8ppm2I4jiLISCtbrddtzI/GY5zvoNWMZz/Mcx1kfe1yv31+7nQHI+nQ7rHPx19QyL7/0glrXjx0uP/Lglr07d+Ryi5EgOzY2PTzSThEVBIERxV3b+w1btkwmEEqi6hleYdaqq5GQXFVrq4XVzt72YnGtWKnefdfreFEen569OjbV3tG9kqv+9PHGX4802mJSSxjahoaqmrV5uMcy1flCrn93r+45Lf0bcytrlbLFhFu5OJQd7jfP/GI6r/V2hNZWVEmSAyI06+ofvfeO9739oUsnX21NBK0mft97Hr/rjmg+X7vtjp2xuKPX8h1dqeOn8vtujOmGLQjClq3bL1y4EAglTdP5/vee2LhhILdUX1sz9u0bvnRxqTCTE1kpk4mpzcaNewZSqdTY6OiF87P33r01oIBtUMv0Z6bWauXw3v33v/3NHx2dhHgLRDPdPggFd9EyzK6Odlnhq6PnW9tSgP3/8fdf+P13faZog2sj6nkiFRiRYxGxbUMUApIg+R7jr6csYgrIBexi7AFyEfYZ8tuJVrhOwWN0TUp2jav57cAxRq+l9wEihKx79hLALM/ha8ZglFBArynrXXfdIpgARvhag4sBxEgc7xGfQwzDgEssluflgKLVLJsSQL5HbHCBB8S57ErRzjcsH6rZ9kAik0xk0nw8Sm3ftmwxoPCI++M/+NCX/v7rP/zp2K6NaHhws2ppmUTCtXWPmLrtLuYKxbIzMNAWjWSAEcFym3VVNY1ANAxyAGsNy7Fk0wwFI/bKMsvJD739LZs37vzOv//g1PEiAQJAwiGpWlNX8yuSJEmCAByU1RIQhBGslQzdcBDLuZ4hypxeh1SLYgPBmJVlRSAIY+zaDiMi13aAZ4nnMRiARZZlWJWKGE8HRblWKseDrWqlpjJ8WFBYltOtumfplsIxum57XCwYUySZSyQyWcUhDduxBIG3Xc9QjUxL9uYDtwBG0eEhfTFHgAZ7e0EJQrEAjgOxSGNs4uKJ047j9A70G4a5uLjY2dm5b8u20lp+bWyqUlitF0vtLSmwHBGgqRn3vuXN0GgAIrreXFrJUd9FQAChRDLGhULAcq6quj6Rg2GQZUAQYyRimY7viYIEiiwzWPZcl/hNVWcYhQ0EQJLAto26aRlmnJEtEYWCQY7B9YbquA7LCJ7nmXpN4gGaBdeoMWDzDAaMOYYS7NVXypGWbsanyCZrlaXTR4+ODKQict0nYiqZnZ1fcDV31+bu5eUlsButCRB5bJvqwZuHZicnejp63vzw/fnl6UvPPlstr3zqU28sFUsri7Nbtu8IJxPLC/OyEgAUthy2qflz88tKkFdCyq69W8WINLypT/cmLNfYtGljb/+xepOcOnWpp3vo8eef6+1tFULxqdmlWBwBILVZD4VinqFl4pGTR17t72SW5wpHThe+888f/co//tPHHtk1dvnyDYm9IiY8+P0dmSNHVwfTwcGhkfMXTzyzlN+98+HZ2elwqnN5obzn4K0nrxxVbT0YxG3ZFllSNE1r1NzMYBqo39PdGYs0X375Un9vMNuS7e3rciz76MXxaFS5/64dMs+u5VcGe1NNwwbMOY6Dgei6PjY25niQSmcSyWSjqS0tLbkuEAKKwhu2c+TIkVAoMr+wHArJgixphtE0TYxYx3Ut18M8K7CIYZHvE0I8nxKfuL7vEkIEIYjQemrztaQdgHX8IAAUI0qB4peeX5ycLN98YyqdTuXXlmu1ylphdc/eHcFgkMFcIpoYHtyQTabmZyenJ64y1OeDnOmZuqc72NMdnRFZy3Obqh6MxhZzq5evTAEVrlzKf+Kvjzdqzm+O/MuWgY6Fq+e1IpQXp3aO9E1dvejb5o4dOzxgqqZfdVgNBy/naudmCmUPFmrexdFTLRHsWjxxI/MrRiSY+cLn//TO2/f8/PFvg6Mfffk4tgLvesPI+eO1rRv7q8UZzahoRqnWLHzlnz+Uz+cqleItt93a2t4xvHHz5aszqo6kQCoW71pa1h5+04cuj+ae+tEr5XldAXr/bTduGcrcfftIVxtqb/Ffd197KgXjY6ddz56eXt65425NCz36of9YmIPeTlniYufOz1+9PCGx/Ibh9s6OjGWrsaFeFBSJo4Fv3n7b9kYNZAG7dY33qIw433S1uuHYvkuQalgEsQQDwZQyLjAOYgzM6Zgzrn/8/u4QGvyvxJTXSXyEEH5trhUhRH4nmIn8jrU/AACD3fVQbAKU/DbgkWGY9cx4z/Mcz7UccDxCALsUgGcpxyAW+axPOOphp6ZXlvOLkUR0ZNuW4c0jcihIHFs1VNUxKIuB2jtGBj/03od3b4LLV+no2CUfeYVG2UYUCYJDgWA2GEoRwhfzTb1gGDUjHIjHQgm9Yfg1nZdCsqg0a81msynIMiOwvmv1bx765Kc/8a733UpZEGVQgnhkY+/MbCUSDTSbzXqjyQmK72GOlzUdLMdHmLd9ghjGR0AI4VghGAw2m02O4xzH4Xl+naN0XMtxbIQQYEwpLVeKQL1ELO6bJra9AMMXcitgmIamsTxHEUp3dTMICwxbyC13ZNsjoTCKJXiWO3KovLSw0pJKPfR7D77+w49GI2EOweKJU/PTU1NjV6++9PLs889dOn7sN08+8e2/+stnf/EE67gDbe21peXzR46XFnK5scmXf/XU+aPHzh05WltZc5pNCZjpy6N6pd7b2bN84fzywhyxLSUUSsVjiVg8EgkFZElVm8TUfUM1LB1zGAISOOba3Izd0G3L9z2kNu1Goa6WVcfDHB8OR1KsHAYuAIwMlNdMUtOcetPlUQg8wfdYFgssZhjqM9QXOcIQQyst2Xo5EuaBJW5pWa8WBQSRSAtYUJjPl5fWTr964sqZplGtiMRnHD0sst0tya3D3duGuu8+uA/b9l0374qGAph4pdVV14H8cu7HP/phJByuVquDg4OnT59BwPT0Djz/wnHItiDM+whbvt7S0Xb4+LEjJ1Ze/6E/CoSyV67mLp+fcTzpllvue/bZVy5cHL319luTmZjja8BYQ1u3XJhY2bh1NxZCD7/pLYuLy2dOHOfB12ulsMDed9sBiYEDN2x+/c3tM5NTugaSIN96623Use1mvS0RPnlo1VNhQ0f285/6OLFh+9bEU08/S1nFIMLhsyt8rJMSZGje9q07FCUQCgRKhUIiyrEIjh0+WsyvDg/2trcy4XDQNLS1/AovsHfdsos6ulErFJZmZQ72793VmopLHDPY30ep73keMNh2naam1puq7XuqCoLAKgrv+zSRCJ25PFeuVkzH8RF0dfe0drb7CBiRz3a0JTJpzHOmabq2sx66tK6P4Hl+/S197Za/7iJ1zZOKYgQYAYMRG4/B1q1tI4Mbw8GIpdfCSsrQa2tra/tv3FFrVhme69287R8+9/exZOdQT1d7Ji5ybS72lWjQpr7jWKFYfGF5pdnUWzqEjs6Wmbmcqjp33Xlw06ay7dJPvPe/fea/HXz/Ox9R9cdUEsjPT9xxy/7Jq5d+MT322T99n95YffXsGS4QT3T1H3/5yPgabNu5RbBmF1fU1ozMEvT+N735Xe+67+c/+dIvZ472ZqOh3o5GqaHlnUAg+AcfuPfClSMH79ir6Su1WmloqP/8pbP7b9w3Ojbz2I9/Mtg/cunK2N5dew8dPhUNR+oquTq+vGuP/pOfHorycPDWG2ynIfjm3bfssN368yd/GYmHCoXG9u09DPYSiXa14X/3B88ceXU5kYB0Oub5DEXc7s2bG2qdx+aWkUFBQNnWlL0yDZ5FWTF/4dxb/9sf/PiXv1/X/LQiNpsNx/ZFmU9FYw6hpuEQzLgYAQCDCMI+xi5ibIT9dfrlug0/Qa8FpVPieR69DvGvQTZCiMEcAKWYYsCAESIIIaAIXMdHDCUIiE894q8jO4MAMyymlIIL1/zlqU/BR9SnGAAcjwgIIwyO55uOz/EClhXiI59BmGc4FoAjDCU8wr0D3T09XWJE0NQKj0EJhZFpN9R6xMW+7d9+YN/WLVse+/ETP/rpuZWXzm/ZnB3ZtAGz2NRMnhUxF1iYK+SXSjfu362Eg5CMCY3qwuqCly+18G28EuZ423I8EARwkWrVJRZCg52PvOON7d2t3/3mz1fXVnbvupNQm0W8ZVmG6mdTbXrdEwUZwPAoyzIcAewjJChYNyxFFhU5mMutyEoXph4vB4nb8MH1fIQoMCwCRAMBpV6ugqECULBds1bvyWRHL16AuFWtVttSqamFOT4T56OKEku4TQMs0JuaV2wA8TcOw5YtG/sG+hrVSvnZZ89dOF9vNlOpdCKVxCw/PztnWVY0HouEY7H+sFGunHz5JUpRV1dXSzhmGMb86FilXAUCyaiyqOvD/d0XTpwMStL0WiEiSaGgomqa2myEBSbe1gIyD57dLFSC0VC1WgaWiyXiWJL00lpT0zDLFksVUZQlRWFFHrEs4lhArOsSTg5SAN9wWYdSikUlhrlAMBbjOME0LM9zOJ4ReAaoy1A7ICLkacgzeEzBs92mqtVrGJBHEMvG5s9cOHvmSkBOqqVGbxv4Lg2KQkDkp69e1Q0Y3pgJSa27du/v64wvLCw0qyVL8wRWbcvIatPgW1nP8+ZnFzaPDHR19Vy8fOX2u27r6W3Pnb1IAHG8vFwbzTdXHnnvI7W1ysLZ8XKpKYvDAh/SNde2uWaDuzQ6ncpmBMXpHgqozpQUTu+/6eaJ6YWRkU2/+MUT99xx6y9/+fLizNTU1JRhuC1tmXAwxGLmwIGDX/ir7+3cmfU9fOiFQzv3bGAoCaTjD9+fBch87YcX/u5zf/rFL3z06tT54W3Do1PTtQbZvHv7mavzgiAbhs1xYrlYmZmZadadvr7WUqkYDAiGrnquvXHDkKLI+Xx+crIUCEgz567ccmAnwwm1RiM3NxVLpg/csO/oydOMqHiOyzBYUBTXA9v1i+WqYdnBIMswHM/zM8uNbdmWN2zbefzkSTkgr+SLvCzbrqPblkOoA8S2beKD6HvrEjgEgBmWYzmGYdx1ER285ij7O8IN4jrXn7M339gfjyZOnjh6474bYrGwa2kbNg7Pzl0dHZvo6uk0LefpH/5k9LJ18wEvFY94tuYLXFNtSIJYq5aJ6/R0dy3OzQfkwOpauVzRDdMTBCUUCuqGz4sBjDiOhZXFuYDMnj/TuOG2bpc4d991h8j5F0fHwyG+Y3BzoqV7rmiZICSz8Vypbi+p996zd2Ks1mxYVy5d+aM/eFpkVh59/90Rxl1dmGF81zNpoqUNbPvB191d01YGBgamp2bOnB3dsWvvN771wz17d915192vHDrZ3TvQ0J3XPfDQz3/2RKGsRhPZqdnlTHvHO193D8P6heLSxOUz0ciWiakLkRCKRdhMtmv06oVkesDx0ejU8i9fXd7S0+YTtlYqyYFQudFgeAURV22WoiFp+8H9ky//ZG3u4oHbDkAgmeRh4tDh97z9oS/9889ZrgFW0/RBFkg0nS3WGiXVDMfTlu1RwIDWXR99vI60GIj325g98prB2zW7uOuiyetPKAUMBK1nLyFEMb1m0s6Yvo4ppgj7lHie51PEAcYI8bwI1EM+As8mPiGEepR41GcEmZd417Ewy0gBbLmkoRqpeNjyyx7xKcIMiwm1fM8JBPlEMOW7puPaIlZYzNmWK7GiLMuu69WWlqMtbeBbiXjwD//og609zz32+BMLhXzT1bZv2hIKhHRDrVR0ActA0dJ8uYMLBngLEB8Nxhzs1Up1xuAC4ZAUkCv5VYGTI5mUr7lafikQid7y1je4pv/FLz42t3B13/7dLzx7KBQNIerohkWA8SjL8KztEmAZhpdszxIDAdN2g4GAaVr1Wt1QjWCMB4x5lvWoDwgJIocpA44VjUccw3Qdi1TrnmFWc/lQS0uIEQAxnuM4noc4dmZmZnj3TgCOi6aWXz2ul8t2qdloMLcc2NdoNFYWF85fuOQ4ZNfeHbF48siRI9T3ovHEQFdXKpNGCC3ML01OTe4aHL7hHe8QU6mZC5dyudxAd8+mgYFKpXL18iWZ51Ti5hcXgwE5HlQkXp6ZnOJDokdJo15pNqup1rQAIeCZeEsGZCmRTgLDABCwHIZnEqk4JymmZhECHiWYUklRIBwEhIntTM1MK4GQHAiEQ1EcCSdExVJ1lmWp7zqWTXxb5CWMKXEtcHQMnqk2gpIMDO9WanpDi4aTgJlavpA7evLihcncMnS0NW2DZuKJatWMRjJnzs329qcLhQKH4eCN+xzP6m5v+dbXfymE2HiM5VjwXMfU4Y7bbs8tTNVqNdf1MSPs2LX32OHjDC9Fk+krVy7JsrykzbzufR868Yvn6hUSUdqHBvZPXMm98srlUrEcigYO3Pa65eKMqJBYEs8sHitXvUhwayqd4Hl+cmw8rChqtXrz3uFXXrn66KMPzczOnzp3oa7Rmw7e8fkvfu8Djz48tGG4NnnkwtXFREvM9ZsvPP+1m284qGvi177wns/91X/Gouy9D939qb/8R18AjwYIpNLp5NaNW69cuXT50ujg4KBr2TwDsiBmUslgMOg4DqJeIb/s+F57e/vQcCrbkm5PBi+dO8sJXP/QSFsmOTEzm1ta6R3efGlsyvc8hpcsyyKUCgJvuS5FDEK+5/oUeQEebrvjztGxMYbjLcOKJSOGZSKWaeto9ynUm03EsYlU1F4tIpYBjCilGBDGjAeAfZ/4PkFoXcS1Pt4CFDC95vO6TufiQy9MT4xdufvOW6MRxbK13v6eYrkQicbb2rtD4aTr0suXpvbtTgocb2gNS2saNvaQXFXttWKjVNN0y7ccGk9kkplsuVoxLYuAb9lmvphX1UY8FT1/ZUxznExLdu++zNz8TDwWsSzzwqVLsVTKsD0pFHv20JE/+vQPTp9bSKVS1PM72uC5Z05yrB8JcZMTZ1vSkXhEXpye9h3nlhv2jF0pSLy7MHeRAbNSWG1LZ8OJlqnpxV179j733MlQUGYYORCK7dm333FpU9VCsfjkTBXznEvoT3/2q/sfeF1Agkox194WS8UD9WqpUa/09fU5ru8TZnhkR9P0/+Grvzp29moswveM7FlrEl6UBUmWZalSXGHAHuptJW6zMTteLuYP3HYrCBI45NK5yyKrbNuwIxMW9Frz5l09t+3qErDZrOY8u+k5hmFo6wBNKFBgKGUIoYSA712r3K/zLfCaAeT/kpOh11SO63/qNWnNawa/BBBdZ+Tpa4J6jCgCuq6WxMx6qDrDXPOX50WBUEQA84Lc1Lx8qYxYkVLke5RSn2UAiO17RjggDg10E9ctrqz5dVVkBN+mtmZjwKIgRxMRdTUHvuUazaXczENv/r2vfuOr/SNdc8vqkTMnC7VaOJkS5Fgs1iYJ0VOnrizOLTfyZXBQSIkpvGLqTq1cr1fr1bUix7CSIpparWE0AukQJAJWNXfH629981u3NY1SsbrS1OsI+eFY2HY8zHKW7QLmNNP1CeVl2bAdhhMYLCDAudwKxzCapslSgDSaGDPUJwgIJ4iE+n6twgXlaDRMEXUdm7peYWmJLOVCvASARUUqN2oj+/ZkWls4WQHLtWfml2cXK8XK7Oxse0s2Egys5pb0ZqOrs3VosFtgGa1eeegND/Z2deZzueOHD186d06t1aLBQHdLy8TYleeeeSp3+XJrOrll4wZM3OnxsXxuoTWdaslmbj14MJGMhULBer3e0dnZ0pYVRbG9vTUWizmu1WjWirnF4uI8EM8o5sE2QW+uLS7ML82btulTojaqgsBxIoMZYlh6vV62KmWrVmk0a+VqyfFszDGYwyByEAoKsuAS19ZViYdwSOQZF3wDUwtcw2xWsecRywLLwy4jIQVw2CzYZw5fefnFyVIRfB8WFq3lnH/xYjm3pE9Oz2Uyyv79+1s7WkdH1/7zP7/9xb/9u/Hxq7fc0jMyNPjg/fdMLXjlghcKwLe//UOOE/74j/8kt7zWs3lbqVy/cHkas7zpeu3dfU3D7OwbhEhMtWgs2TY+tXjx8szOfbcAI5eq+tkL0y8cevUXTx47dfo0QaR/sO/9H3h9Ohaurq2q1fLeHdu2bxpSq6W5qYlUDL7y5Z9LklKu0taO1q987aeJltDjv3npE5/9+69959DeW+55+fiFasN448MPxCLhX/38Gb26+qYHd3RlQuA0b715KB0NWIa+urxy6JVXTdNqa+tUVb1WriWTaZ7FsiQFlYCpa2urK/VqjeMYBlCxWPR9X9f16tpaQGR2b9++ND89evEKz+CF+bKhNYEQhkEAYDsOMAwAUIKyrS0Mx7MCz7J8PBkBjJ9+/hgF0EyLULpSKOSLpYahlWrlerNhuHZdVzmO4XmWZxmGQZgBhChClBDP8xzfdyn1EaYYA3PNoYrwPCsInCBwosjjm/anuztaz545aZhqQOYqlWJXT2c8mci0dbz40pEfP364pbXdtH2BF13HEngcibZ1dm4QhATDhTEbAiQGo/GWts4jx46VK5WW1hQvcR6YsbgSjHC208z2D58bm+aC0e179nV0dIyNXXVdNx6PLS8vl2t1lmVFUdy1kd2+KVVZXeR903dgy8YMkDoha9u3Zm+7ZVt7S+bS2cnc3CI70POed2/bMJIKRdzhjR08z5dL6pWzE54vAgSi8ejuPTfnV8u/eer5k6fO+ZReGr3yzDO/+bt/+Pjs3MT88syuvRsMu3559JgcoiznswKjqiqhfKVih8OdBMLfe+zQl//1go3A48Phli4hmeLisc6etnxhafeuTdu2DK0tV1uz4Rt2bxUFfMPdd1ZK5dLCyvz4bDzW0nXwnr/687+u5u2uDHzuz97/t3/10W0bM9hzoxEmm5R5xsPr7vyAKWEoYakvEg+I91uTmevg/l9g/XdHnBBCCBig+L+YhXnER6+Np1LErK8EjDDGluO5PiH+tRkojucFQRBF0fM8hLDn+a5HKGLqOhTKNdunIhfkWUERZEUURB5LLKSjwcGujt62DrVYW5xadFQ3xIcUPoBcrFYawOBgMAhAOB4xDJ6eHuNF5stf/fJHPvqW8SnviV9fqFSbhWJlYmqeEKG7c8jUXUQ48LHWNI2mxQCncAEOsbFE2nEcwzAkSZRkzrN1IIYYUYBx3v9nf7z/pp0LuWklJOTWmogBXuIpgy3HJkBN2/YocKJkOB6hwAoiQszqypoiB13bC8rBZl0FQJ7jUM8HBvmOXa/XgMWyIiJMRVHkGdwsV+fHp3hCwPMDwWBVawLxAoEA6Aa4ZPbqRDaejgRCGLPnzp45euQwxzLRSDibTIYUefTiBY7Fr770Iotg68hwLBScn5mem57iGBjs7/m9t71p69bNpqWev3B29OolXdd4nhFFARDNrSy9/MpLmOcK1aIUCeTWllfLxUA4EAyHGQ7zopBqaYklEh4ljmnI4UC5sLq0nON5NpVJY4axPUcKKI6r81El2NuZ6MpKMqfp1XIlX6mudfd0tLWnZYXV9BrUSuDqSGaliGw7FUFBTFQEjoBvAPiYeI6mKUrQbjqk7jBsTGDTRs48cWjs178oFKsArORRKFZADkmUhWRryrBpqa5//ZtPTM2utHUq41MrmgmHjhx/9dgcxzEdnW1vf+MuSuDd737TyMjA8WOnnvrNM23tXZXltZn5JV7kdduVAmHDcUe27lic51838tkjR6ZWi9r50dn/fOxnq6WrDz6yP5b16hTGpxeybYjllWYDYZI68upcbuoK6xojvR1mrUgM9f67buvt7Ni1c1MyDXXNSLfFj55fYYPSfFGtWMyaTms+HDo79Uef+uJK1VRN16Nk184ugfFu3ru5mp878sIvL56YIKamlukH3vP2m3bv/PkvTmRbOro6e59/aVLTNEppLBIdG52URDEaCSkBSVVVzLHRaDSZSo2Nj5fLlbbW1sXFRd/1eno621pbu7tjZ86cTSaT6z4wHMeJomjYlu067Z0dLS1toUhUVoKFUv0r//KNttZ4uVaXFYmXJFEUeJ43TVPXdTkYiMVituNgjDnMrI+pr9/CDMIIoXUfDvjdGNV1zp3Q9QemgE58fJ/tOizLygEpm80athUIBhcWliu1xre/de7AgYRPECGwffv2xYVcb2+vJ0VnpyePHD61bWtXR2tqeLD354//aMfWEcvUK5UypfSmm26em1/0fXr/Q288ceQI5snsfG5qdlUJpDghZFsuy+FaeSWgcCMb+vfs3/fDH/3sR7/IxdPgUpxp7epKp/oGuy+Nnj15avrtbzvQ09ZSXV7ifZN1mvX8zF237VsrLLOc1NoxSFGgqXua44UjkXK1sbxSqDW0WkObnVtYXfNrdfjoH92/lJt7/evu++lPHjt5fOVtb9u9deuWKOQt2+Y4zrCtYqlCGW50YjrZ0nVxdPbqjFZtghAUg9FWy+cWl0uRaDIqmlqz/vWv/+vf/NVfnDsze8MueetQ9t7bdmCvHuvp+PuPfev2O7dsu+n3vviFb7xwLN/bkfmLT94gh4LlptazcfMTzx76zBcPxTPAKVHMxxcXi5ISTsQitWqB+GokIhLf9kzmdyeSrpXnQBmGcT1vPauP4t/G8hHKrKudWJalmPHWE/AwpggRQJTS19I8rnVZHQAeIxYRhrrI9wghgBmCeMPxo7Fko9GgnpeKKPVCWWHhjoO7uhKe59rUd8C3qGcy1I2FlUw6fvDgLUo0ZOjawvJCa2dHuK9XzefK5XLChWAmC+EwUKz7ULUczSWIlds6uo2G/r1vfedXP3pluCt0w7btMsvHQmFKm7F4JNuWzXRnfWpfnrg4sn2kWCvH0nHEALAcw/IsywFmEWIAIa/cYFOZ5x77GQuC2iBf/adfmiokI0EEcr3SBOJu3NjT2h62nTIv2hQcIIpjaS3J6A17t6lqsbsnm2iJsGFGs9WyXu8aGiC+p6tGMJSwKnVLNYOmuTA/r1erCEg2m020Zi3f4UIKEwzUqpVoSwfUrb/9H1/buTHVlmwJiFI5r+bz+ba2NsMw2jo7AoFQrVabmJo0dHP37t2XRq8sLORDIclxHIyx67qDw/2+77e1taeTqcXFXLVSR5QSQsLhMAbqOFa5UnJdu6OzLZGIaZpqGZosyy3tLQyHF5cXCQOZljQrcYjDUlBhJZkApYAZQQJZAo4HtQwcB8TzPOIQz/SJoCiBaFTTdTkQbDSb0WgcENJUPRCPu5pGjTwvSeA7QHzfNBhFmjxzLhVNR3s3kKUyBsnXWaPpHX3l7JNPXIgEASHJMCxKkCBIlGDTtAExiqJgjC3XouCzLKLgWo4NCDgOsMcuLHp33jmkaep999/14ovPcyx64cVcPAGWAX/4hwd27NzSaFYnJsYc22QY9Nf/NOZ7EIkCIdDRARs3tPX0ZA6+KJynEAABAABJREFU/p4Tzz0niIHHfvCyIKDhDbsvnJ+2TBoKJ7d3EYyx53m6rp+/UNi0NdPR3VOuadFMx9CWnWsN6w8+/sVoS5LygUrTcDyyIcRRt/hXn/tIfvGMBPr2/mEpnNUX1xYXFzds2/Cr557I12sOGz57udbdv2fr9oP/8a0vxuMR29RbMmkW08LaSndXezabMUyNZXGlWq816ohlbrzpwHe//+tYjDm4dWRuYV6Ug4wgyoEwwcLE7Dzl5Mm5JVYO1nXH8UEMhFXTdj2SzrYERag26o1GwyeAMXZ9z/ZczyeIZQAhAsglvuf7FCOeFzmOS7jreauYIKAIfEo8QgghqqqxLCPyPM9yDMKYwrXeHDGvhwWxjWpREITeviEP/EazHI4nREV+9sWXnzkGn/7ogUKhEgnHw4FgU9Vuvf2O48eP/uTJX/sEbtg/kIgnf+8ND/3Tl/7GJ/Drp0cbNfjc5++Px6MrKyv3vOG+53/zm+PHXlxYWlgzfIS4mu56yLQrWl9v79TEaDFv9vbwLIP+8e++vHPXtq98cd+Tv37xHe/44MLSys033f/O339kfhXe9e6+kNJUhLgj8b7qZVPtleWZQIQdSmV9wk7PzYWjw4YtxJIt3/veDxLJ1NXxCcOi84vQ24Mohde/fjiZivb33Th65eyxoyuxKHR0xGNRbmFianho44lT50yD9PWNNHUvFO523JBuyI2mFowEmw4NilK92uRDYtWuYU/dtXv7iROHFuZnh/tQvWTUEquJ1D1u3QUf/dFHX8+LqbnLY+dO5VtD8NFHHw0GTh4/efjuh96oq4sHb9j4+2+ZfenIkm3VivlaOtLKcLLR0FkQKIO0po0QJ3H4d4r066X6tfbpupqV4mt0DSFEEiWGYShFiGUQQp7v+5RijHXTRgwCjDnErJtUeMSnlLo+BYIo8iglyPfXm7UUMxhj27Y9AixmPAKIA4/A0kqxLZykhCWuI/KsLAVcU/Us09aM4spaK+Z5VkyEs+OXpkP58oZNGyt+IxiLUg+QjwBgdXW1pJtCIMzKlGeRJzB/8tlPfehd7/7GV/7lP3/wyp/98SPBUHhlbtnzPEmWDceQw2JvZx+4iCFIwLxDXM+yPeR4vCCIEuIRMBzbmtKWFke2bZgYnU63x//gvz/8nW8+rghCaa2GWChpXjQedRyrXmu0dkSVQIj6YqXkzs4sdHdkFBFlOroK+ek4F/WIm82kwHMww4gi7xkawyDNbEZicaUoWTXM+DQaCOrNZoPYLX0d4HlKIAQ+Wh6b2NAtd2faEcUXz13saO/u7mlfWyvG4/GZqYlYMjGyfVehkK+WK0cOv5pKpW49sK9WqzUajWw2KwjCufHzGzdunF2YMR2rvaN10437Zs5f4jnOMAzANCxGQsnw3OLcxOJMVIumUqloIhmMBAOZLISkoUwCfAcYcKnreC5iOMAYKLiea2oqaTY937eM0uLiYkd3V+tAP0s4AQhF1LebIoccs84xxHc1y7Ko61GV2Loe4BxgMTBA62q9UomjdCaaCcdal45f7hjaCRXnzPGLZ0+PzU4WGQDPFYEP+lggQDASfPAN6gMF8MF3bNf1CPJYH1NKXA8AAUsgHpBD0eaJMxMrNbh45T8++tG37b79wM69z//NX/1MlOD46bMEwdBw345de3LLiy+++KLvtTLIqtWqw8NRUVZ5hQTjbi1/5syl091d0Uf/230/fuzFF1849cC9b/7Jj5993zs/Mnr4047tdXR1TV6de+tbbjpz4crUzML2vTfXTK9QN1cqaqojZfis7ZC6YQXDcQewYTM/f/qlnRsTsbCYr1ZDdWN2bGZwYGBhdiydCNf0ytNP1yIpSIWl2bGLjg8Dg8OpZPzMqWM93R2WqXued/HixY0jw5FIhBekXH4tlclcuDTa1hHDDHP60ngkEuGVcK1p5CurhOGahqtaJcAMIIbjOOAwz/MipdjzWYyahmGYtmW7jucRQjxCMYtZlsUsSwFjBBixAgB6zVeK2CZCiFxz+UMIAYMAGIQZYBBQSnzfA4wpBUSBAmAGU4QIAowRRo69aXgwHgv4vplMRVStduzUicVV2LMFxmeWMR+JJtrPj05dGZu+ODr2+M/PUR/e9PDdIxs22Yb95C+eJL5/28Fbs1n46lffo2nawsIC5tjL589QBM+9cLy7t0sIJ8qq2dnfb3uuKPHnzpxJRMM339i3ffPGl188cfcd+8Myv3247xMf+f3i3ChWi0/89EeJoPiOh9s2DKZto3DuzKHDhw6BT46+evS97/99QWI95C0VckvFwpe++rNcofmLJ54an6jwgpLOtvf39ToArku3bWvfuW3rYH9XqbS8e9emWBRUFbZu7gspWHPV5dJKpq0lEA6tlauWDS0tA7Fwx9jVomWBpMQ8HxVKlYZexyKNJBUfue1dWd2oGSpIHHAUFqfNmdFRLhCCpmZb/oc+8M33feKn2SS86+1v2NDXEkpJA4MZ4KxKeW518coffegtg12IqJCJsCGOqMW8XqtFghGOkXSdKEr8ujXYdRLmmlTR865bSaz7vV0T0gAGwD5ca8ASQgkhru+vAzpCDGIwwzDXHGYIIhQRoPQaQQ+UAhAAQhFCumlTShFmDcdlWJ4yMLOQ0w3AWEaY9z3KchzHM57neK5byJd5NqDV7WbdLRW0q5emS2sNz0WLq+XF1bLe0JdWC+MT065lR8JhU21eung2Eg6ApQd6Oz/2D393/wMj//nDn14YvSjLsmma1Wp1NbdcLVRCkYRe10JyEAuyyIo84jAFRCh4Hngu2BawyPTd1s0bEq2JaCq8+8ZtYgDml8qG7fACbY2xMzMTrutu2bIlEUmeOTFhWo6hm62t7ZMT0xjj8XPnbMNmGbZWqQpKwLZM6vucIBLicQFFlITC8lKmqz0cCjAU5qdnlGjU8ly9UbM8h49GgOVmroyFGGltcVmt1nlWWMotnj5zsdGora2tqmrD1NRfPv7j3Qdv3rFziyQJhUL+5IkTc7Mz4VBQlkSOZfbftBcw3bVn+8zc5NLK0gu/fCLbkuIEdmjzxqGRDbF0XI4Gduzf9XtvenjD1s0VtXb8wtlTFy6cOHF07uJFU9eBYTwKmOOVWJwirKm65diiHAxEogjjer05Mz2Zz69EIiGQBK1RAc9mGYqpzyKiNyoSQ6mt2s0yj11iNZGrg4SrC3PVhVnwfB4JTs0kFkNV6Nh2EJzAj77/1Pf+85XLF4oIlGymp1SyVBcbhLERb1LGpIyLGA+zLkIuYnyGIZh1EeNhnjA8ZTiCxbmlZs9AZ09/+6aB4MjmrqENW4BTevuG//UbHzNdmJjSm4ZVrquabgmi/KHP/sUb3/hIPJWVlMDsQtXx8Nlzq46LfvWrZ9/z7gcdmxSLpbe99c2dbbGJyStdnS3PPPNEOh7RNTMUUjZt6ampuhyO2ZRZqdQff+q5f/y3b3zt2/+5nC+WymXHsUUOJ6OBYrnGcNLFS6OcKLV3dISjkWAswgp8JBbp6O7s7Gp7xzvetm07EB98z3n26WcbOkzMzsRT6T37bojF4gSobhqSJGHELq/kV1YLPT39W7ftzReruuUbNjBShA+nCw17qVC9NLF24lxuKV9ZLapKOCpICi9KLMt6nmM7lmXo1VpxeXW1Wq+7vs/zvKQo0WgkmUy3tLS1t3W2ZLLJeCIaCCmixCHsmpZWb1yX0l3Ty9FrPK0gCCzLYvifcANjjBCz/gDA7GBfdywkq2oDg4cZcvzU8cnZZjwNI5v3X7gwnW4Z1l2mZ3BTbnHm6998IdsCQSmyYaD75UMvPPzGBz//F1+6846RQmHtwI17Tp48uWnzxqamDQ9v+OLf/qOqQTIjPvfCcV0MmLq1aXikr6PLampgNu+85Qa1WQkE+I5WubO97dzpM6+89OxA7wazmj954uzlWXjozfsefPjgf3z3nxRFapZr89MQweezyRBIIiaywOLDJ8+HE9nuDW2aj0RZ6ugK2p47MrKBF6VsWzYWi8zNzQSC0pXLF7s7WkytuW1EbNSs0kouEglv3LL1xLFToWBiZa3S2R6TxODTzxxSwpl9e7clMp1Nz7cvXtI8NxgQS7ViFMf6u7qujo7v27mlt1usFKy2BLA+AEHFxdV8Pjc8vPHTn7ldEhOyks6v1GenTgQySz1DfX690NGVXphb4UPs5r7slTOrAcVDxAhLyPZZ7Ps8zwcDYQIMi/E6iK+DNb7W+ka+79PXdKyIMgih9WWO7zm+d60Ni7DjuYQQihhKqUcAg0+JDwA+uSaAxZgFTBACRFhMCaUEAFEGAQXbtgVJBowM05A5lmVQuW6vFOqDA108j/WGxho6jyjmWIoZ0/KAVxaWpmaXVuKZlNWonDxzOZlO+KYdjcd8JJYrhXpdG9q8tSWduXTp0o033ASOYRm26DoQCn/s05946xveWWwU+jIxxkFqsxmKBB3TAdPBFMnJLOgaIS5Qn8GYpQgRSiyHUqrpeiSVAJEd2TZCPODY8B//6YdPvHLhxKsXRsfsHcNxU20S3716+aocYHbv3LxcqGDMhsJRR/MrperU5PKd995MPR8RChizmLEMXVIQL3DgO4oiLa9oUoNt27fv6Lf+Y3jTSD630DbUO5VfzrS1iaIARRW5JBWMLM4sOZrT1toqhmVCiK6ZsiwXCoW2zvb2rs6v/cM3Mxm5tbW1o6ODulQUxeXl5YmrowcOHHADZG1tNbe8tGfPrlqlnkolFhfnS6XKxSuXtmzZlG7JKpEAE4+AIglWU3Ostr5ehmEq9WpZbzZdSwnKHvUCoUAkHgnGooFUGkxTbTY9l/Ci0NHRVcpPbxjaqLR2QLnWqNcDoRCxHdtzRVG01DoTDnq2jW1LiITB9xQO+5WaxAtSNAkgoNKaT7lorA346Ngzp6YmcqdPzCAMSiDQbLq6VUasXNe0dXk1WT/6MxgzDGUwBQqYWfeRASAMvuZdmmoTT5xbfOCBG1s6eiYnx//2H77yugfunZkaH9rQ+4W/fM9HP/6fP/v5qU9/ZoiX5JXCys8+9Rkb3YvE+sbenkZjJZcrUx8cI54Ib2Npx/bNdy0u5IuF6sxMdbFWfebHf//ccy9cPpPrH2jzMG9SfGVsxmelo2cKlVdyXV2hpXydMhCJhmQlaNqugMCqLjO+05ZOSQI1tQbLZbHPCIIsBJXRqYmzF0+KYW6T6/T0p5HkTs7OffDDH8zrhaPHDh85fiwgCs8+fykRhK42aXCo3/X9Rl2bns+H46HltdriUoMy0NaWLer+yszKyko1GBKoyJm6Gw6GJY4niHN94hHfdV3Hsz3XAUJNQ+dFmQcQBEGWZZbnPM9bL+PmZ2fXb/B1xxiEMQsYALMIU7zuWAIEAVmfV6dUESVCCPUJRohFeJ2IxxS8147/FIDt7O6cmx6XQ0osHRmfnRyfbAbiSJCzMwsrwVgmEMm2dvYszE/PLRcRD44PiKqP/+Q7jzzyhsOHnn7H2w+OXr5w5123FoorkUg0oIQRw//DP/xzpQLBMBaE6K6dXQXHCCqBuYmxTYPDrzx39K7btu7YuuG5p3+9NL/a2d765C9+tmF4ZN+evaZmhRRxYgx27IxRs8m6xKq71VVD4vHuXUxIkN77vrfrtRLCwvTsamfvwExObR/YWK4be/ZtufHWvdlM69mz5//t60/cdFPvm9/yhg984ClZZjtbM8l44hv/9pXWdDweMkOycv7kaSnDBwLx/GoZKN66dfOFcxOXL5Ye/W83JdJdQih64vzVy1eXWlsl4LmILEcV5e3veO/n/+LTR18abY/D3k1t9xzcU16dNhoGjwWe54vFtbahYXBoaXm+Xi9sGN4k9gw5lXI+vyJJioyZi888cecNOzb1bvrrLz3HK43uTEfdgLVaQYhEI9FgLr+ajXLXpe7kt7p2yjCMT8i6cgYh+G3oNsYYY0oA4WuaJ59eE0IRQlzfI4RQwOsvUbzuKrauiPVfS/iA621bhmEQxrbriqzIixJge2J+OdXe0pIJGZageUZQBJETLc/XHW9ybHpptbqwUuKjcSEQn1+eNwgJyhFfdVGxWdMsTpARYUr5tfmJiRt37Zqfnizk1wSG7Whrj/cOpFqlC2NLCcTEUwmGZwRBcCxbbzRDsRB44NR1H3sUAWUR9XzMsQzHYoyxKHLRqK81mKjM2D4g2PPI/Zs3jvzBo49+9cvf+OkPjoVlCAdlFOQ9x9QbBsvygiRfuHDh9ffcNjN5sb0jIXB8tVzOpjPgeUwwZK4uAYAUCFXzRYkX0u2tgkvtuZkb77335EvPb7/jQLlRibdkCIuBZSrzC7FAaLh9MKXEJ+fnDVWfmJ+6//77dV2/cOFCMBicm5traWl505vurFSqkiRNjl19/vm1jg7Ytq1XCUgrq7nW4fZtWzZfunC5Xi4Tn8iCXC6Xd2zf2lRV3/enpyawwKSNNC9LqXT6wQ99CCpN33NzucV6oxYKBQgi1DUIxpISAIrAMH3f41gBI+pYjqrqne3dyXQKqs38yloqnQYl2lyc84iPAoTxKTgeNS3WJ0AI2A4AII+ROAU0YpQr2JelSBvYwoXnz2g198Thy/UqBIIiw8qsYOmm3dPfd2F6kuM4FrEEPEIJRR4B4gN1iYuu+RcBADAMgxFDfOpzIATg6sTs3Fw+HhXG87Zq/qK3p/PSpfH3/vFHfvbTlo9/7K8+8cnvfvKTd4+MbFjMLT5//NzmHR033nDDvjvv/rs/+Vh7W+sLT1/wXdPRIobe6O7umBybeOihLfFU5PLYM9Pzr3gAVxfzCRs1TF8lTN/A5o/ePfj5v/lqw/Y8gFQ8Ypm6QHBprd6S4hoNV0FsMz8f7+TnJi7uGknzBFHBb+ls//sv/fjj/+PNkwsTC4VyIJXd3NamNkK/euEVrFidXV2KLC7MTAVkeODBA6tLi889e7mlhekbGNy1O3v4+PnVcjPbKjCsWKkZhYbJMEzdgaAUEXiOd8suEkzDRqbreq+5+GIUDgUESQQAIZa1LMt3XIQQ8YmmGtVa2dSd9aA2hsEMBh4xLMMSxPiIYTFF6xIZBBQopeuoQASB8zyyntSGEFoXzFBK1/UU66Jq1mvUFYFHiFiGJstiZzejRNs9HLNXncnpPOZnS1Xz6aefXF3VRjYormcqkh+OIENfC8i0XFr8vd+7m2Ewx7a0tbUvLOb+/HNPjGzi7rv/rnPnLwlCoqlSn9Yp48UDbF9rYs/mRFRCRnWtsLrQ19/f2ddTrtYbml4oFUcvjNq6/dj3/+Sb3/02cdQrZ0fBlBvFRveW9nQi3JaNaUYJY9Yjguun+oe6lJSlU0ZJM6q58MKh09FovK934A/+8L7FhdzU1HgkDMePjO54dPjsyVPRQJihuLuzj/EYs2k2qTXYP2Rq9KZ9N9u6evrkyxuHoL8n/otfPr55x7692wf7U9DW2TIxvxwKhldnl376+K8P3HznxeNH4yKqFBsrS8WRgSEgDcdsDO/c2cgvrs5d8Vy3o7NHlkKaPmGuBIlnJxMtclDWq7VsLCzxNNaTfdN9A79+bmpxaimcCQsCMvUqBokV8fVj1zprck3nTgnP8663zqhf66isUzeuT4lPfUoQxRQBJQiAUgQImPWN9z1KwFtHdgyI+OBj4iGCCUGEwPohARGMWYwpAYwpRsD4gACxkszNF61Mbi0Y6xZjcbNhENanPNc0PNawXj5+Wg4mhEBsamE1lo0zSihXrMXCgldSV6tqMhkbHNjEs4KlGSNDG4Ky9PgPv+953vCGIbVZaVern/zMn/zxH3+hVC2zIhOOBF3b0gytXq1JklBcuZrp6QREAHzXdx3H81yXXR/Gi8W1pgrUFZEPvg+eAfVaQ1cz6chHP/GHLzxzLB5gc7nFTCIeCYeq1QoTkHzfYxhO1/VgMLguHbUsKy4m7Xpd4CKEENe1JQZjDKLIS4pg5yu6rns11bZthmMDIdkQOGAZEMV6pe5bjlFvxpOpjKbrjnPv/fccevXlG2+88cDBm3Eo2sjlLl686Mx4+Xxlx45NB17/wL59pcnJSYxZ13VPn76oLF3eOLRx0/BQPl9Q6+rcYo5huFPHjkaiUVGRNctkBCYQUEzHrNZI0rX4aIaRxPbe3lbicSJPPMu0dACwfd+xLAQMy7KiHADAfr1uNVQOWAbJ9XJNEsNcLOMXKkbDyLZmm41aSAhQ3XQ0g2dZUHUwTaCAQ1G1WPNsiASSiAteOTw6Pjp/8sik2oRGDQaGUvWGNj5d7OiMPnDvAw9/8IOvv/0OhmFZjiBEiO8S4lCKHButt7sBgHoepYgBBJhQSkGUCGIMlwQi8krJ2DvSMjwyPDM1tjCfP3DrLX0H933lq5/5t69++c//4tkPfiBXrdQsT2+o5eXlxUuHDo1PzKgN6+L5QjgI9cqRSFh+2598fPDy6See+nEghL71g4vJFKwuwF//3YevTM5CzZybmP3eEy+Umi8EInzT9nmZkyWhUawjtp6V4A237ggH5eXJxqXL5wLY9jRgPZNheJe4sY62v/y7j16dHYu0djaLhbn56omzL5+6YrTFW2qzqwK3uGlD274b9r/tLa2/euLnZ88Wt25QVld1ea3YP7QJEHR3hYOROGX4qelZmw2kUikx5jUMTa/VCcHEcHXdDIUDjudyHMOyLEGgKFIwGLRtu65rzWbT0PR1IsWzHc8lANCSTr82rQgY0LqxCCLAcAxCiABQdC1ReX2N7/vE933fx4DWMyHIuqUMy71GwFLW0rV0Jtk06pVmta29YxfFhQaZWzbWyjXV9F559US9aabi8tCGtBLmbjl4f2Pq2UqlUSzObtw4pGmaJODp6enu7t5Tp04deuVUJAS+z7380rHh4S35QsVW3HSbsLo4l4rElqau7t2+YWl+YW1pZu/O7ZgXHMcBjMKRWHtnz+ULY+VK7RdP/kpTa33dXYvTy/MTjVtu3bdhpNPQFznBEyV08tRFhknny/Sv/vEbsY6Yw1HNMw4MsO/74LspRc89+1Jfz8CmzUNP/eYXc3OwfbM0evnyYG/vyIZNs5PjPW29rzx/eNfuHUwq0qhVPYOIqfRL3/tOvQLt7czPfvLNW2+/N5wIh2J8NikcPz6bTjPbhjbOCLlXD59691vfnEy0MUa9XsmLjCjxgVxuYWCorZJbcImuBNlwNAphkG2z2VgRud2BTFhbW9EqjeWFhaGBIfCZQnHltpt2LeaK1ZN112qEw3FbdwzTCYWDxLCuU2brAarrQ0z0tayP9Wr9ekPV8ajruj4l6zJ2QihZZ1owgwEzgIEjzDWzd4QQfu0JouveMteGlBHDMBhTz/MQx/GSjDB1fI/hOCz6V2fnQzF2Q38CyaJDdFngqAuqY1s+S2yXD0VUtVFVzUg6WilonEM5jm+abpqTunv6MfI8Rxy4bxg864Pvfe/lq5dVrTE03Fet1bpv3P3jl37w5F989dSpU5FICCGfUL/RUAnxmnojGo0KAQkCEocE1rEs1wGfEt9fK9UEkeEYogREpAi0aRiaTsAYvXhCoAHbhKLhdW+P8TxfrzYUSVEJIa6/adOmK1dGd28fyi1NTE8q3cNtxLV1RzOpI4kiw7LgupF4HDy/XCtHReHs+XNZOajpNtPb01yaFOIBhuXA9xBCHMKF5VVZVINSIJ4JXLp04cCBA4cPH9Y0bXBwkBCyafNmQ9f37o2eOXNm7cknbtp/4+Dg4PT0dEtLZtOmjS5rIkINrdk7snHq9Lm7HnwQbLe2VlxaznW2tum2sVJcq5bLgiJGklE+nQHCEc9hAkFG4IA42OcUgWs26+ViubO9g0mlQDPKK3nTNCPhWFff4MLYVeACAutIsTBYXj5XiMVjSAgYzdVsZ4dZKxHL5aMKqKZrmRjAdsSgkoRYGAw8c3H6m1971rMgEpJwEImc57hAEQ5FgBHQ1YmLo//9w4RQjD0GM5RSoDYGAhSAAMtRjFlCqU89BAwGhAH5hNRUvatvYHZ2Vm86LdloR1dfbjnPcNKu3RvnFhZ6c+0vvfzKxz/z6XvPn/rzv3ginYR4+/DzL4y//MLsYF/gz/7szwSWOdr/8re+/+I/ffl/fP+73/z6Zz6palXD1G47ePMnP5b5xref/eK/fGphefUr33wmmBInFqzO/hZXMQVJqZQKsaBkGWpIgqgIIgdRrCd4dMM9BzpilkvztlvNL80EQ1FLppKNTR9nOnotxkeaLUSZsj7X2dleq1E5CC3phO04h48dPXLIMlRj03BAUeRdO9sr9fqhQ6826qBgxwMtlsoKUqDq8hXNEUWxpruW5cfiEZ7jQ7GEaerIIyzPYwaIZXq2Y2KtVqvldGqblu/7giDIkiAIgixJDMMU8msci3mW4xmWYRgWMyLLYZ4D4l5TNiPACDPrpMt1S8HXKj+MMZDricrXAt3YQEu2vDQnhMV4LNZU6+FwmA8Fnnj6iel5YFmOYaVMOuB7ZltH1003br8yer5dQn19mb7ejkppNZPJBIJS/0Bvvab97GenCkW47/7BclVPpjtcH/f2bazXGh0ZIS4JyPHMhhqSxe721se+d0iOQqUJsQx87LOfHzt/+elnnpucmsnnnEuX6sODEI+GMun208dn+3tGquXlTDaUSLKU8c6fH52cGB3LQzKpzC9Vw63yH378D/d22pKknDl9DmF3rbi6Y9uueqP2trfvkFjet51oOLK6tNiSzj7+45/v2bnDs2lpuUyoFw7HoFLNLeV7urEsC+mU7Nr1/IpRKNdu2LvjxNXjD9xzHzCB5549FEu0/vLJZwTP2tiRIZRNp1oFQdo4PCIo3sLk+OCGTs0ol4s1vkKCspRpCRZNDypN23ZZoEM33Zw/ez7b1nfq+JFosu+Bu2/PduaePny2bunhSIiYtmFrQWCvgzihv01xcl13/WyFMaYAhJB1eg6xym/F7xhTTDEFxGCPAMYY4Wvb778moGcww2KWRT5LKYMI9T2EGIIZyjCIIZ7nrY8agGc7rsciiKXSC0v52cWl7p4IYrDrAxY4gXK+jfuGhq9OzCtCoLWzs1AtOITyktzQzfbWVkOrLywtpxJx8C3HVuOxCBCXDQe333MXuBbUatF4xFleZHluz5493/72yWRyqbe3OxINe45bq1lt7S0Xz51Pt2U6ezpRNIpkRnJYSgliGMBMJtu1vDhuKxzr+iu5xY5sp9Ewq7XSzXu3fOc7n7v7wb9oXVka7hvwPC8STJtWkxc4AFQsqppqhMPho0cvtPdnMMtylKuranu80/d9rdEIpNL66hpgdOXKaKFkFGrGO37/blhbc30vE4tRhPxyBQNqzbaxqruymI9k04okxVNJzdS27tjqO77jOJlMZnpqVpKktcLqrfffP37u3KHDr7S3tImiyDBMoVCwoRkKhDpaO0rTMwNDw+cPvSIIYjwej4TCVy5eWlhZbOlo2zq4s6E1lhYWEUJeONmsNyRZCAYVSv1gSGZlUbClnp07oV6vzMzapiWKcjKRdhxndXGxJdUKkTjT1AE4qumSoMitnerCrGXYIMl+3qMeBV4C3cIEIUQR4UCKzJ6/+vxTr+gNChSymUi9YmiaowSjzabGCCzGUK5WGQFGx6scC9T3EGUREAYRwsA1BoD4sG5d51NKPB85FIHv+y5Gs/MLHqHtXS2peGwpt1KrFgUOlpfU8fGrdz78gKqqzz/1zO233fCVryiz01NzxYGAmLx08dz0jPazn/+0WS8M9nbedSB14tTzmLVa21q2bD1YKpX+6cs/+cM/fOtXvvSpf/7hC8++cFrzoJa3YhllqVARlGBhdS0RCbW1ZUKMv2dTd18y6DbyrKdppeUymk2FpXxJtw24cmlm247hVFpxCFAGpW68yV9devi9/646oASBYWlVNQc7Ahcmyr1Z9Ldf+Mtjh18OiByP8bEjRzdt6dzTetNPf/7rrv7k5atT8UxEEETb9uPZlkKhwIpKJJ6i1AfqrxbW4rEIcS3bdTiOQRg7jsOw2PPdarnJBCKiLHEMKwgCyzCI+AiAw0wmlWYZxCJMfeJ5HqIUA2GA8X4n0gcjBASAAbw+yr4+ocowLMuymKHrp/zfIV3ZnHpRbo+Xmm4i0nP21csPvvXdf/35r1y4ADEFWAYCirtjRx/L2qGgOTv+m45kmFsIh5KhIBPoHMkuFBevro7xUuznTz9XdSDbLjma0iYH2UZZQqpkX9nVlVqzpLXF5S1bbj49N/bYk6O7du65961vfeXo055Vv/OBg8CpP3r8Z2NXobcrcO8jb9Wa/iZhISmHf/P0D7Z2gGg8PdTbki/nI3yfZdhvePPtPhN96fCVybmaN+ckhA59SRSh9W/+4dOhuP3oR9/oQ4WVFj74zh0Xz65kE7uBpBtVuVCtxVOQ2tjyy0sn3ryxn5/IhbP92cENpyebV/WObHzDuROn46LLv3L84x9+QzwA/Xva9CXp9p2ZT3z+3+88uOWpMS+ZCrN6c7W8dGB7rLOnUlk+2Zkeqs7jnthujnosn6/aOduQNgy8ff5MrTtwHEAOYNYlbHV8Krvlhk//ydff+u4HZ5cqs/PLN9x59/mZlcKV5f5UKmT7xVpFC8Svzyitl+cAHiUEY2b905kQuj6twADDsAwgkxfAB+QTx/Xx+vSp51MxELAcx3Ec1/MACMYYYYoQUiooGo/YjkqA+sRHCELhgGFYPAD4vuvZ4Ok+9QUREAZVg2AksGWkMxyU5mfMlkRLOhZAxAeihcJ8vVZIxnnXr2nlZojlsWbHURAJGTWnRqKJ9mRmNVev1ddaWhOaTQRBoDZlKgZGjEmCjuOJoozlaPz+7l+v3vbZ//7fnzt/5t4bb6RFpyWRAN2VsFyv2kzIDiAU3bCttrBi+yQgR9v5HKgoTDaItMfR64oURQHStE+VG8cAt7cNd7zr9waefHKqZ5hjUnKBKfEZz8gXV2fMTS3y2NGrOAw3P3JgmbCmBZl0V8LSgciMqQVisZpWFbuTiRnxsZ//OJTG3VuTgFkgCGFuzXVCcjToozAJlSuLfEIJ7m9DvsdKapIL8zxHKSzkl0prFd8inS2dxbXS9MQstVFnSwfj4YXFuXQiGQoF87lcbBu/opbsmh6IxCDJdm8f8l3QNcul0NLbtWn3Ns83w1HZd6uJ7pSsEGjhFFubmxlvv+FmsCiYNkicEBSgkqO+VVi9OtA37DqWq9mhSCYUTkCSuM1FvkMERy2Uc+GoDFbep43unoyxMmf5rmHYIRAsJuRzRJIUie/86d99dWl+bXIMBAxBGUjdJbrDEEDgsBLTcIgrxXWXWVsCT8kKQFxgGg0rGZPNRrFac8JRjDnJRTieallaWAwq0ZZkrLi8wFEzrChN0RYwdjW3ryNQWV3Ua2oqhBkBig4wAsxefXH7/t756fFv/sc/fPBP/vuV8y9feuI0H4A/ePubnzt8YePWOxKJlg984k/ecfCmX//itFWzOXPl3KvnPY75s89/6rEnfi1fzXd0xbZvjiMPV/Ilu6HfdedIW1K6fOGMLFQ3j1giC4iuJrmOvNHIpvvOzuQKGwtF26ngDZcnczKvcOGhmsO2tovxZAJW0KtP5QMGGw8K0SQ7t7o8MgTlBdjXB6RC/+nRT23vE2++62Dfhu69LeTY+AWPMQ88OPDKyatchucjYc8PhoNd+WZu3cMNrs0oQiIqA3WAEpEXfJ+CTwQ+SDywXRqJxD3fYniGYSgCm7jXKFmEkMiyQAAAEADHvtYYA/+1wRWgHgUAROn6iwzDUMxcG22xLXKtfkcUcYQSn/o+Aba9vatWVXu6uotVbf/unTOXzj3zzKWWEBAMiah0x20HfKr1dKbHx891ZNPUt3fuawcWu662MNsYuenWWqn2yU99bWAwns5Wbty7vby6VtXUbCza0zUyO3FVCvYvL1xob+s9efKk7/K33X7j6upa0/QikVDfQJbFymf+5O/DIfFDH7rBUPG58ye2bNqTbe9AmHQN9I5PzErB5MJKOZZO1Zq2ahstnYNzucbl0Qkfgh/5yEc+95f/NPuVL3+vpt1//+Btd26r1lVRBsuxeF7csmXk37/2ZHdn/513vK5QIYEA1zDpzq2x1aVKtxjmlagNrGZZHZ29iytrlNJms7ljIBWLxVy9FI2nP/ToRz788S+1daQCkahtLrCBIAJbEpEsi4VCiUPc8spaS3ZjpVFnbeISr3dgo6Myp59/YdvI/eAljJoqB4Nra+WphbXbenf5CDZs31c3zj32+E+PnrxaquqhsLC6VtZUMxKJmpRe8/65RrdRsl6tv3Zd19K8VrDj9W2/Nq9K19WvOJcrcCwSZEEQBJbF65QMQgjpbFOt6k4zGpJ4nq3VHderEwIca3suDQaDyVQCId/1rHQm2tfXs7SqcgzCvu05RrlcZj0zEZYkniWEOJblEcKLIuL4dTUOwzI+cSRJ4DjWMDQfOQBQqdTOnb2we89OXuQ916vXy6ZjB5SQKEkgcLwSWZmf+Ow3/vPlf//65Jmzv3fHHbnZacQym7dvX62VHMchnqXOTkVTWQC2XCwJMRb7IMoKiBwvRhPBrG/OLucK0XimWq2H2PD7P/S+51/4RLValiO8LAqOqWFgBIFjEeY4UEJMMBhkwwFFkSj1eZ4nmoZDEviuKIqe58Bqtb0z2ruhd/bKpcLqajokJrOJvK61xXtAIj5xbdsUsaIoil6tLM7Ph7KdDCNpml4sFucWKg1VH+zzAoFQa2urYVhLyzni+bIsNzSVl4T+ocEqWt6xfQ8fiFnlxvLsQiSYiEaiiRRbXi1EIhHb0cvlKs+zsbYuYKhXr1z8zW+6u/u2bN8O0Sg0VHBsp1yuVIrhmJJbno+Ewo1GLSCGg9lMdX41FIr4HGYxgE+0eqNWqfiG0SqJkXQWCJE9Ci6TaMsCYontIcxSH1ZOngUPDfUOsX5ueVGvlUFSdIqAZaFa1YNxOSCx4HqO72WTMcv2moVqT+eAbzWL+SXPcnkGKCXRWHgulweuCgCaoVeqgFme+lZDU3WPAi80a7C8vEYtM52IhMKSbtcHelmfsVOphGOLmJr3vv+dy68eikSDb33bTYv5SrVaev7UpOkzB2+98w/e/JBZzT/yxvtX566MXZliBDg36f/xR//qTe++JxBLNKr5ffv2IQ+PXbhKbUcJRffdsj8U4Vy76Hj1pZXynXfcKkvxkr58fnZtvmpuT3QcOXp44nIR7GCjUT126tRmo2XX3gfGx8dnnzv69NMnWxKBqlrnCPfwA91CwCFmerCjO0iYw795NiIpTU0HXlpYXoslW149cvL8rGO4wLDc5OSko/Hg8xCD/6frd8u468iO/ucAzv/l+v/ltQ4Uv7sMA0GIIgwYEDt67kq2pR08t5xfwaxxeWxRwbChL9je2SMI/MaBzNTkJYHqnKdnIy2U8ppxaXD7jaWcFgt2Pv/Tl59/5ST40Nu7kcDlmrWMFSPbFh/oHDRrXlFnVxtCSGk//Mqp7r4ezddqjVw8KU9Mz+/dt1tRlNX82vwMtLRYdIRfW1vOtkQNOz++4CBMU5390dZM1WyeOj3/kY/d7LpObWW1pnovvHz09Hl4/wd2nr1wNpWNr6xWbt0THN4+0DrYm1+8whJBkuRsWBm/NP3pz7xzenK1qU9JsuoRFgBikfYTZy4xbfEiqVE5ePLs7PhiM5Xp/NM//dOf/sdXrlxavbjp/A27NwOg8xcurxZAzRdVKsqYb1ZX44Kj643uro2GaW3asKm8WKUIJVtTDWs+1tKSX5iWhNTu171u9DfnU0Ez1dlXLzfWqmR4841jl+fe8MgDSwul5146mVsFqamyAo8ZzrI9hhUNmyCB/S199tqGwbUSHnyKKODfvkiBwQgAU0QJBaB4PaMPAPV2dai61tAatm3zIsdy2PM8x/EGUl2UCoLqSjLDclgOoGQyybK8Y3s9Pf2yLNuGyQsMx6FavTw9OZbIDGCgnu0auu0YOuuZAo7wkaDAc0ARpYAQwoA8SgABxtjyDCUgUXCbqsWJbDAYQohUK2qxUE1nU6Ko8JzlUyTLMjAIDKPK8cmuPk/Vb33X+zBBP/rlr15/1x3VSlHVVZ7nQ5FgIBoeHRsblngmEKJGjcu0ARa5gAyODtgHWcZESqS6clPjhm4DqsZ23zE8EpieX+kfTAeiQcv1OMxgxJqmiTHE49FYPCIkY0JQwuAzDKNW1WA8QGyTl3mHuJ5phkKRZDI5ZruOY4HnKaEAcbTltdl0g8ZiEb69vUGNlbW8RP3WbHZNVQVBiMQiN99y04GDnK4aqyuF5fxqSzpjGrZtWZQSlhPW1lYr1WpLNuvE9WlvUeJLPd0D4SAjioFSoSzxUjweR4kEUykqcqhQqHDV+tTUxOxcefPeVp7lgOUWDh/heDHT3sqLfDoZz60u+a4XCYVsy0Xgg2uJAmIxcWxHCAaBEOp4EsuDD0alIYuSazpcukUmOrjIyJVXVouxWMLGztljFwJ8+JYb77j1BmFmKjcxPttsak1Dd4i1tFbiGK/RMAgGnkA6EqtUVSJzZrNs6XVTdfv7EhjD/HK5UMj3D/bXmiYwbK1Wa2pqayrhm2yjXicez4lBoHajaio8E40kWNarNxxOhM9/91sff8s73/We+1jkWlOjbRt6db3s08CJJ49gaXxHL795U89zzzy+c+vmsrGqa75P6m9/x0HPcx6WxNVa84nHn2maIIfBNuBzf/6xUr4cC0bT6cQvn3u1vz+zulCU5Nh8vVzwQnrBkzu2mrVZJ8b/x4+fmxxt6DXo74gzvh8IKx7yG43q7PToaq6qsM6OkRElJHOyYZKVzmzCciJ3PnjX3JGTe3dtR5afbu8+duysj2RWVnJrzuw8JFogFIzWTNshTiwYqlL7d9H2fwPR/xMcr0P59WudMb+mOvr/G9zpa3TN9dn19a8My1xfw+YWVjcMb2tWG/2dnUdPnFfL+Q++aziZagmFIprWXJu7EMBWJTcx0BYPIi+eiPKOsDJxprV37/zc2g++ezLdzgUUDjHS0MiW5dXJzZuG56dn1s6fnR1f2bZxrx8IX3rpsKlDo97s7E7li1OVSqW1vTO/lutsH1qcr4aD4JhcfrUqK8K2nRuLpVWFTyyvLEVCsStnx0WJed2bH5qYLszOz4mBQLfMLa1U774ru7qWf/HQRCYbfv/737J/CAh1p6bHMPZDfNgydM9oUE+V43TL9uS585cHN3RNTC8gYDxP5piAwae6B/b8+qWzTx+aEEOy5XOrueVyoSBKUCgUsCABy12dnLrploFD56dzq6WE3Ecck4Ha9q1pisxUsnV6bBE8LtEbaRQX+CC3srQST7RqdXfquedGRvZcvlJTTDmy/4C3/AvDD88sLx09eWl64VeFMgRjEI1lXBfVmwYwbCAULKyVsIBfcxy4Xpuz69tPAGO83l/F1981r327Nq+GYD2Cg5ZLJYZlQ4EAYhiEKcMghmMYhpmfXsikJY+algsbB/ve8ODrH37kITGVvfjyq88998LLL7+MAbW0ZkxTtywjk0nUGnWWAQY8BgGloBvq2pqlNaq9PR28JPIAnk9t28YMxyBMfcIJHiDbtEzP8yQiKYoiigLCXH61CoiPx6MMFiWJZxgOfB/A54WMSlTbcFqC8VseerOpGxNLuT07txTqlXg6HkhGgAOB9bXKSpjxkyFBMxiGo1KM92zTMg2Zer7HDW/YaTeseDKrllQozn3gw2/9+7//91gsxgCPgWMRIOIYms9hSCaTwWBACEk+g3ieAdcl2ANDp9gnxGMxsJGopmlziwupVCKVSgHHeJYRCEuJaELPzYm2GerqCEUlTy36epMXlXTQFqJRX9VzudVisVxYKVGKOjo6T50909nRzXEcorizu6tvoF/XVYRQxz17G+MTU1Mz4C3JcojDXiAQkAJhcH1rJT965VKpVBofL4gitLYGH3nofjFCBUkEH9R6o7svwTC4sJSrNSuOaw4M9lDqSxxraM215ZWOoRHwqMgyYFnNaq3ZqEfkkMKLnuMauk584FoUr16Zn8v1D47IjI5dplSquE1/rbLy2MxPNdVtNB1JDmbb2rtS6VBM7mmWdFu7dHUCs7BWBqsyz9gQDyQstdKaiSeCDAPO2lqTUgiFgufOTREW9uzdFY3FZicnitWKyEAkFq4bjMCHwrLDMQzyHU2zdK2i2z7w5l9/8EN79g6N3H5w9vCL4qbhY9/+9707d3znqRfe8/v3f+M7TxFwEKm1tUhzc2fvvGl3fu5qV0eIxVp7Z3o2t7Jz0+Bdd9/2+b/5u4vTJBqCf/3aN4Jy5I0P7U3E4wb1D505093XpTM+34YaYtvXv/fDV07VEMBb3/DA6vwqG4kh21U9Rq+UMKc19QbQNUWgllZ64O59roXbO9K9/elnX/pJRgBbQgunni+tlvfs2Xbl3PhSvnRlZmVFrWscbVgQToILUGsaPrCiyHnE/b9g+f8KrK/d3YQQQq7z6f+H9f87cIfXPirgtUAIAFhXAaxfbDzahkGinscpgbZsYiW3GA/SVIzml0c9z1PLxV07thua2tXR1qzX4rJgepFsOlZaXc2tFAeHIN2ZvTK1ZFkWh8S+vhta2rp+9vMjUxM0JMG2fbRC8zu23SjJWLMLupWnyMi2BrOtkc6OfrUOzbrbqMLQUMdavsRw7t/+/bclGf79q18JLGROHD+MAnEf0z//y58PDUlbtm8jWDAd9PAjb7kyOvXcS+ckHiJBtiUdePLZ/3jzI28yVS0SjCihhFayq5W1DbtG6itjkY62mjrbwsZb2jMkb7kQ4fiuXxwa/befja9VoW+oYyXfoATxHEd8n8OQSaVXFnOZzq5tu/d/+JOPdW1uKze96tJKLOJKov3mN98+deF4uu3G733zqdc/cC9Qp1Bb6YglbIuKTEy1q66m1nLTfZtvpYh56lu/OH7qwqvHX822w2oBkhkxmmItD2YXi7FEGvOyZbvYo5wSAOr4FF3rcF/bTALAIIZjKPUpIEQwpT69tp0EEABQQBQQUIoQRgAYAYcZQqnvepj6mKGm69oNx3Ggv0cYGurLpJO9fV2bNg0PDfZzvJefOLN1R2+judJo5vLLeaA6h13giKXVMI2CRxEmksAhRnQtp1qtVn1H4HF7e2s4HDZMm7ieIEiAkaGbUlhyHcN1PUqRYdBCoaTIAV4UKDENY7lYqIQjATkoYgyCyENIqYMnYCmb7q0XFyOp1D0ffvSpf/2numW2dnfyEgNAzGqpp7uj2WiAXodIxNAYjhCJeKzCKALWVN1p6vFwZKh3C3Z006xRfWVk31AqJVDi5ZfXwkkGUcpijjBmLCqnUgmMgQLxfFeRwp6hCQKvVktKImwbJhcJAENtx8strewa7hdEEVikqo1gaxePkcexHMeA74BO1mcCwfMaRjPMMgww7Z3trW0dM6GF+dmFYrnKihIn8I7jNBoNVuAzmYyoBGzbfvob30sm05lMu+f60UhMUEIgCE6xMjc3d+XKlflZ7eDBTR/8wC08z1+9cmV2cql9MJIfnxEk0Wg2FUFwNK2QXzUtNZFKiKJkak3HdirFomEYbmWNUspEY5btNEoV27KivMKJCoc86juUIH8yd/7s5aujE92Z4bNHzk9N5xcXQaivM3lqICAQKnjUr4xOVxo1xEI4BowALIKOtggL9Y6O2H333Xf+svnEz39WWDU4BJEo39+XEoORo2en7rl//yvHzszlFn3f1x1fkXkPwHBsz1UckzJY5DB2TKuYr+im2drOSSLzvve978KVE/nz5w1d0y9cuOHgrcAxg0NDFy+ee+MbDnz5X1+VBHvi6syjH7xXZvxv/Grhe998E0bUNk0WHIkjyNZu27/rzMSp7/34+5Zuf/c7j/3RJ//RdiHdApYDiekcFvnJ2fp3n5ks1SDZkXFd4ceHL9ebZXAAAYqGESMLlVrZ1EBg8n/+ybe/+sKh227ZsTC5UFybEbvFO3Zv0YySClqAFWlMuDJ6buvuWz77l/94bkqTE2hZpYEWMZKQi5V6vaEFxaDECoalU+6/YO7/K9r/X0D8//XyXeu34G45gqqScCx78tCr/f29Q/0dly5NlAszDIMiwdBQd6olIaOYxLIAkoBcdzUvdHTHXz3+TLI12z0kTc4vdfUllEBweVUjfvqHPzg2N0uVIOy9sXWlOUmV8Ob0vSdPvdraFSoU8qtF8977NuuGX6nUXn350vjVtXvuvjsSiSytTllO+a67hgiYM8u5mtqkvPjKq8cWFwAIfPotv/+rX/3q0UcfvXp1fHpy5tmnz2EMHVl48P6Dy/NXymWf5/xYNi4gpri4mMrGAgFYuHKutT1WXBifnbei6UI8vfkn//Z4rQGGCUUbklmx4VoNk6YzbQqPn/3NU7YOw4NiKBS6eOXyVik0snNPPPPY+NSyz8u3bt+fWz62f3cHQ6tDQ10Xz14sVqCrb4Np1gnjEfA7OwZqJS0oxJN7h5745rf779s8OT3z1W+82tMfibbBShWimWDNcmQlQKhrEFNeH/oQBNN1Ecf6xEIAGCggIICv7/BrtDv4FAgldJ19Wc/puPYOQggBUGAAAKhq2YlUXFb4QrlYLFvBIBy8Zd8NN9yQCOnFtUK5XApFmERCRoyFsZFKKcCaB95wx+aRzq/969cPvXy0o6Otu6NjObcKPPYdG3yfExhRkAhHHQaIa+WWViRJkiSF4ziW5VledDyPUuq4qu24GHGiGKCIsy2H+KZCuWaj6VMvElU4TojEYoIgAULg++V6uTfSMV+eCwECwwRNu/9Nj4xfPOMymAAoLMOIPBON1RYX65VqOplKdG/Bou/adY4hiKUM8ljMgUVlKdxolJMxBQ2m9bNjHGOX15YxWje6AVmQQXJjsVgwGLQdE/m8z3jAUp84DKINQwvQMPF8REHNl0RRcrAjCEKjUQ3HJIwYAK9YWQthwoiCsZxfUctCPNgSj7GOixg8PjlRKlXSyczw0Mjg8LCkBCvF6uTE9PmLl6tVCgC1WkPVtXQ6HYvFh9iRRCIRGhoCwwCElq9cqVary8vLpUIhk265+UBbIBCYmphQm5rruplMi2/5hqo3m005oDRqFYpQNpmIxPswxlbDZBnesg3Xsgd6euZmJ6KhcIAVeIZtS2WIRzGhoDpW06yXGplU6/LSajbSxg8HWaQsTebHL0MoCNEIBMPBSlVnOUW3KIcFTpaCDBh2zSHgNCAeg3q5rlZB7vK7b9j979/4LLjQ2R1uqo16zQnH4MAtN8ytrd18y4Gx2YWrE6ssCxIHnCxyQNVGHRHZdV1m/RhKgRAicLBx46aqtmob9siGTc8+9ct4RNq0Z5+9tKBrzYsXL2qWu3XnzrvvTBx++eyH3n/LxsHWf/+3b+7dDTjMVWam44Mb1NOn5yfGt+6NT1+5cPC2LRBNEqtiUc4CSHUopYYeS8XmK/Vy3XAohOQwijBXl+qUkZLxFpYJZdrSEsMxmAqY9XUQRFhdAQZZtx/YBYzW1ZsIsHoxNx2NiUS3WjoUQ6tmki2ezT536OW5vBZJB3MNjQsFPTZEgcEC5X0HMAsMCBLvgvP/BL7XKfL/Qqf8n9f/71Zer/2v/57/XVrGcCTTUwRfWCs1pcBaV1d7rbZiaHo2HWnNphPRBKIW8QEAgQ+F1SJWur7x3d9QDtg4NXza2Z8hOFKtG6aOjo1fOnX6UiwOvRsyW7aOrBUuK0E6Pn7RspsLi5V77rs/X5znWSGYDr3wwvHx8Tov8LffceDEiRNNtTY9s/Sx173r1OnDFy6f+8lPDv3Zn32gUC5dHp/aMYJmZ5Zuv+2e1VxheXH5O986s30rmDbs3rmhMy1Tk+88OKDXaqziAsZrqzOpSD/E5Z8+PvfBDyup9p57Hoh0bL5tfLR0eQ4cD1ra2iVGrdm0vS/pEnZxMXfjjpGkEmSN3Ic/+P6xyycww3KSsri0+rFPfvLRT/7tlk3b/vt7P/RP/3w1HkGvvvrMu9/57s9+4zueDwwn8tFoY6buQtRRba1Jo+2Zl3782E37tszh0I9/dSiUlkfn6i1tmWSQWV0ri4HAUqGSbW1LtQV839dVLZFI6NUqAwhhbx3KATEAGADWA5jQNT0TAABFmBICAIQijPFrBA5QSl+LWKVd7dncylJ+Bbbt7PuLP3/zPa+7q7U16/v+7NQLKyuRSine19eXSQd9T7csIrDM3MQsz7Ftnd0f+uBbJJ5evHClsLJIXE+SsIUoBp9jGIFlEBIFBjCVquVSqVhhGT6RSAiS7DiOT6kiy5q3BggwwzIswgzPsTwCzvew6wBF2DJ9Q3cAsCgpQB29WEz0tpTVnMRh7HlqtRSUeEgkhm+6qTA3YamGL7KhdAZ8V46EK4Xi2Mxsh1hKDWdpQ7OoKkoMdc2wFPSbDkNQOBYDVYXinNnI7ds1+PLzk4lkm0dt3ycUkOd6juOYls7YSiyQ8YgGnsMwSDc0SRDBJzwvENsvFiuujxDLlstVVuLDhIRC4bpjp+LttakL6vKy4OFkMsnHAsT3SoUCE4+3dXR29wz4PlnKrRCCQ8Hw4HB2x+13q4tLzabKMHjdAESWZY5nerq6Vqcnp3/9G9s2PeKraiMcDg8M9aczyWQyKfFSvdpIpVKtra2peAqiUTBXMq1t4LsQj4BWd32PkyKEECzKoEOjXlOkII/KQiwuLi8GAyIPDPIIUgIM+LVc3lQtrabPzy4eb5xdXNDvuvOGTLTj9KEzns1kY35/f3p2opAKBJ2KaTlesaaxFuFEwQOQgzGMLeIaosxrdWfPjtTQwCDMreSXK4hApdRgORgYSHT19W7YMMQK/Gc++ze6C+GEnEqlaqXiWqHWkgxKiuhYwDE+JoQSV+CQIvOmYUsC/+jbHr3/wT//zvffG49lzpy8+sAftp/6yVP7du/KtLRXapW5mel4WPnDj+xB4L743JM37utzDHV1elyrq/PPv9DT09s6tPX80dM7N28/rsVffOrlz33h7xDGQoSfX9WjyeBcvop4VomGsE+LNYtXopu3b6g09OXc2kAwKrIc8p3V5bn2FB8LwyMP7kxHyEvPPXX/XXcuT15oy3QgsBRFLBdrwVDUrOYTPRvHzk6vVZgzl+aFSHCx4kbbBoqG1VBdh1qEIEQRsWyCPIHnr6Xb/RaL/y/gvh58v47s/5VR+T9e/wXcr7dSr6dBrH8VePb6wDuLlZalgjk6tdA1uOX0qZc2O93d/b2O2aC+k21NE49SF6manuxsN2rLswv5GatIowlV09r6b2QK1QuXxvfv233y1JUTxy84Dtx601Aqo4RDJC5L4a7B06df6VXSShDbHp2anO/s7iCEPPnk0xtHtl06f2r7vuGzFw41tOrIpgGGdebnlotrWpqr3XXnyL985d8//IF33H7g4OFXDs/PzNfLtaOHj9ar8K43DaSTMVnhXMeo5CY2dLVZOo6wokj9AA+btw7ZjYJgBHu6AZgQDO3X5o+/8tLo177zGxxEQTGbq9vhbKjeqIgya2h6KhnlMPHM5n133YrAu3jx/MNveWs0lX3o3Z+HkMSw3J9/9gvMYrFUyD/+Y9i8CYA6LAscB4wSNNVCNBFuNBoRpfXb3/rNux65dfu2Xc167q+//2+aRZqqmWjNTizleUEIhiO26yvxmOZYjmUzDHKp61K7oVYTiYRvE4wxhXXyDF0H99ecCIAQQl77CV6bRkUUAxCMAK07gVGytry0Y8vQ3ffdde/r7urZNAgMVFeXVldXk3HSvnsYUywoQWrZTdUSOYKw17Nrg7ucA9FVJBqQIBkNylK0VKjIImaABR/xDKbEcxzTd2wGaCKRUtXG2tqaIEiAGcd2112tXYelBPseNU2T5ViBkyjBumYnkynbtQyjsbiwLMhcOKLwAtJ1vbo0Ew+GJQa5elNgkO9YnqoLEpfevGX87Mni0uquVCsgnNl9Y3Bq5uTxEy89/dRbEq9jORMjE2zf1jRF4GprxZiIsOSeP/nq1PjsfffeeteB/c8+MbnUnO7YNkAN33Qdte5ivpyq1wU3gqMhXrWIY7Mcp6tGSzpDXSQGZMO2XQ8adQPLfhG8zoFuQAgFFeLbAFo+vxpx7WRLV0OrnT9/nqUkI4UCcZYTuHA07hluYa0GFEKhmBQIT5w+YxlmPB6PhCO2aTqOvVYsLC8v67ra2dMdj0djib5arSLKA8srucXlRQxoYmqiWffAh9sO7k0H0oCJu5bXnWokm7bNpqDh5YX5dFsLJJK4UjMrqpTKLl+e3rxjK/WXSLXZ2d4FYRnYmL64ZK5UmjU1t7gsYoUBtl7UeC5QKeqmRj0ZH3rpZDbbapvl+blC78augcEROVFAXGS10LB8rJtGXa2ultdCQQYwOEQqV53e/h2VSu0D7/miHIJEVPR8h2WZcCRUrlaAY0Y2bVoqHxcQX6mr1VqDUMqLSFLEalFFLGZZBNT2HZtHhMF8ow4ruUWRF14c+96TX/sKzwf27dpWePksJsHDhy4ODg6//MpLiXgUoZDZqFNkJePh8fGZUJDdtWP3an4809IdCWdGT1wYHtq6uJj78pd+E4v9hsFsuealM3K8NTyzWEqlg7ph+cjzCQpIcqVSKmGWUrRpoLUbMYsLsyEJhrqjnWn+7Mm8XssPbNvZkwngaCBlxQhynnnx6Ns/8E7My5ISCnBebW6uVq/lVv1cpT61ChBMrOTKSFF8lgfMUuQgSoAhGGPE/D9zKf+/uon/c/F+na7531Xu/+Uo4Ln2umeJ7/t4Mle7MJl75vBp0+c27dxfUTWCcSKTzra1YllipUC1qUUTrbPjs9/8zssnziwKLYmdt90eaRuZzaGJKayprcePLp44cjEa4ndtT23cEIgFm0O9cbVUqi01M3Lfy6+eaeuI7du/S+BC0xNr9QqwKFIqNuIJmJ2/PLd4ETFqPBHgOOH82fGtmw50t6WKK/MtKeZLf/P9ZqU43NtNHev5p452tcTf/+7bbtm3yzOqnK9Ts7JjY4/XXC1M55JtXWqhCLbh1vOW2QSAN77zIYqT2oUiKwyePFdYWgMbRXwxZCDW8UmppsuSGFJ4rbqWX5rauWV404Z+TWtyopBsbfvJz5/QDKg3zXQ6OzEx9ZMf/6C4Co88HP6917fPj489cP+Ng4MdoEgA0NnZeXVsYmlx5cabhtOZ9mjv8H9+Z6ZQbRoEuGC4ohlCQPEZpm6aLhAP+Q51EQ8UE05mVbMZS4YIckRJ4YV1F1/q+77jeY7juK6rqup6JK7v+wyCgCzxPG8YhqJItm16vsVgCEg8Q91mrRaSmQ+85y37do7s3bEhHuYA2/XchKkXWjJyuictYMe3G8vTVxF1wgERYQJgQz3PBREY5enJi8XVxVhYKawsCyxHXZtDPsdQIA4DoEhyKBQKBAKBQEAU5UZDnZ+f15pqPB4PSHJhNb8ePwYAsiz7PnVdFyFkWbbjuI7jcRzveWR6evb4sZOHDx996cVX82OXA77lVkvI1JVwiEF+pVamDAaWG9yyDQT52LkLRAgAcHw4cdub3t7dEnv8B9+auXoOArxvNZ1mrVkqCJhi3wWO1aqVG3b3llZyPIv+9cf/qrDYsYlHqOv48aSyViCReKRn6yYwNFHiCfWo69m6AQ4gRiSap5cNx0W1uuYTLAfC1UodCAEKIs8B4HQqkU6lAOPDR45xgrL3poMU8KWLY45NgXLnL4426obvoRMnT18+fyGTaens7mk/cFCSFAJw5szZy5cvT0/PDg0PZLNphkXNZr1QKqb7+yKxOC9Kp84t6YaXSCrbdw1JkmBa6sLCdLG0vLy4dPXs2bHRK7npybbeHi6ZJMsraqUh9W6cPzchMCFgQr0bduJgollVSblZH59RNu2ol+q5ueVsvG1qbF4WIhhJ+/besn/voCLH/vmfH9+2fX9376bBwS3t7b1sWHnu6CuXZiYuTY6t1StiKJDt7KScwMpK0/Rtn1MNxvbhX/7tmedevmg40NvX5gPSTRKNJwY2bOgf3vDVr33zyMmThuOajisFQ4hlBEkURaFaLfM8I0nEp6rAO5mWUL3pP/rh37/3vpHDh/Of++xnoa7eduvdv/rFKddkaxX37MnxjuzQb55+fteuPYoUEFkmrMjpWCK3sLh508gdd7zexQHdEwLJnpqBLapwQuz5F0/IMcljgxYSxZDYMKy6YcQTsm25iVgyHgyLCCTiberKRlmDtwtQmzFWZrOSJ3llhVT2b+/62EdG3vyGe229mchmy9PTBHyC6YG797mWd2kyd/7KQi1fDUeSnT2Dx86tlXUQ48Ga7YrRBKdEWD6AkYCAQwzPMAzByCH+9SGV68Lla8D6P7c6r1uMcBy3XnT/F8/X6wvgtabreoH/X6R06HcujPG6yxjHcSzLrv/HdcMSjDHHcez4Uqmvu20xb377sac++L77733TO4zinK6WbUsvF6qNulGrmmcvLwlcZMf+TQP9G/756DOji+W92+4+/NKVYk6dm1yQBOzY9MHX7dq+rdU0lnOL1QvHZzZv3E5Un7fFvkFYXZvef+NNVy8vHzk8enX0+B137+zqbInHw9GkVCivdbR3Ly0tcRy3a+fO6cncWv4Ez8PoWbjnzvT+XVvOnjrHI+fAvu5NIxslkc3NTbWlYrIAZlV3G5XWRJRp8ObUfMvQhsbipXBLNCxxtWIDeI6R2gMt2xeunHv1+KztKXwwVGs0RIVvVJf3bO7Rait2rZkQIREIbd3Ya+ulT378B5kWePfv/813nvr6xfkvHDu/YlVrP/vxTwJLOcuHYCC6ZWRkfmJh864t5bz9k6995XUP3VQu1e556OHnHn/eJ+LFscn92Rt9DFjgCKWEEoIQy3OIIgLUBx+v61yoj4Di9XIcUwAwGt71jUQMgzHGDIcQCoelpmYwCBKxqKZpK7lVxEA6nW40q5LIKbJYr1SbZUcWYLgve+Dm/cRT5QDf15UMZ4JQXbK0fCgkC4IHzSIOR+SAnJuZ+/WJE5lMGqjLCaQlE02mogAAvmHbarPWYCgTkoKW5xJEgFLmWgQIIIQR0EajKUkypdBoNJeWcrKsRCKRoBKq10osI0piECOOUs9xHIyEcDhUq1WD4YAoyZVqs2mY2ZZkMBD03FxxanJZljdu2NgoFOz8ihAOCYKAeN7VNC4Y7dmwsVgsV1U9YFOPYM729z58T9cZfmz2VKUy09HVnghlqEkcx3LB5cLS9k1blxYnuzoHgeFzp0/GY2GbYTlBtFTdM3VeAk4QwDJrnh5KBYhHXd0K8AFAAlCBGhbYaH5hZWXVRaLmpxOswq03BgCQrtYUSS6VlkWvfv/9r0Op2KEnfzV7qfCOR99+4cKlyxenBweHWcQsLS53dw10DwxW8wXP81aPHn/xxRcZBg309cTj8VQqef7yqWKlYFp2NJ7Y/bZ35Y+f+M73X1EU2LytJx6Nbh4e1rWma+q2bTquSVis63pbe0s81SHGAyBxY8cOIyQN3/WgNZEjnjD49vfPP/b97r426mrTU0s77rvj9DO/2Kp76UR2Zb40MTq9d89Nr758TBLDL71w3DA9zEXue+BOzbBtzXru0Ol4IiwCu1bXXA8IeI2GO7uSVwIh13WTqSTHp4uFlcmZqizizr6u/4+zv46SJLuuxeFzgymZM4uZurqrmXtmepg1JBhZLNmWxgLLkmzZli0w6NmyyBZYZNHMaJgZerp7mrmLmZKZIgPv/f1Ro1ZLz2O/7zsrVq3MWDej1qqK3HfHPufs09HW6XF6nn/pob6+iIUowvK+cGxibv746amqBUTgbKAAAAMBYiPAFAKawpIDMnHDQlBK5UNuyBeSf3TvPX397a8ePHD/9/7zPX/+mV3bh3/ynyev3hd//3v+JJNKv/e9711ZXchn0h6P6HM5l5YX6xVzZMueeDK3kkx7YwMvHjx/xZ5rBqODH/jwl7AJhuzDQBEwbQooghkK0UBRBBw8TyPi8jiBWGBWQK2ICLwijtAOROtqDW7dP7RjfbPIWqBVLVUtJdOGhWmee+nV15uaepoHQj9/6H6Khm/+/T4DyW8cPVo2oIrBFgQkczXTpIACIAhsGhEaKAQ0xrZNbIqi4ffj/7/U6BrvhssElrW3DMP8t+vXmN//HEyyUJ5enI8EFI9fKNfMXDJnaYalE5aVCKEsYksuJ1Wi3IEWxRlIFCq79t310guv/fRXD7nE0NT8VHtLUzGTuOO2vRsGuwSk5vKVgOKVCIMMjRiaW3KM7NorS/4HHngAYc/RI5mvffU+Qtmnzr25aWvXcnzq4uhkKBSgaMLz/MT4zInj50WAL//9nRv7Lw70Dz9y/y82btwUDXkjkYhaKVCYz6SWvV1tDEJhvx8sk5e41qF1xeVp0bQNi6qWdZuiTdoT7N565s25iy8/+chTB5cSxWCstVyvVcv55rameNKO6/P9be6FVdi+tePD77mTgYbbp4xshIlZoHmYvTixshynKAgEg4uzM55iPhaF3r714AvzfBJA27Vz+OyFsbNnzoRbXbV00elyqQhaOzrHzoym8kAFKduyDNtEiEYsRyOKWJZt2QAYABAQIJisWapjTBFADAcAeG3kNQYbY4TWknJFRVEolq1XK6ZhBHxOQRBYluFEpVqrFPMlQ4WujsCGof6Q39PeFuJZIijskQPP5h5P7b9hb2yoD8w6gAEMXZkYXZpL/PpXDx0+pN9zT/fQup4t24YKpQQKiPWqSmHLKYnFVFEWQhwjGkYVEUKArJXPI6AQ/l0vFcMwhJB8JrvMC3R7p8fjKVeLiuxAiLVtEAXJtmhMLIEXbcwAwjzP8TzfqNZZhm9uaicYJVZmFy5ODLb3uES50WiAjURBBkHSKkXWwfg8TQRRjWqdo2iOYSrlsiO+FO5pDUXZ1cyyqdtLC8tqWXNQQlARWSIpfRuXD50YGIiC4H32+cfThaLk9TGAVE3lTGjvdAUiIRB4njEQQpws2xU9EIhB3YaaWlEbnCTVa5ZpAMEsywgcK4BuQbmi0azPFzk9dsijmuFY19LS6szJk2pd/8hf37cysRKLdCwvLE+Oziwvr0bC0c62/hMHjzEMMzjQt7i4sHnz5oGNI88+/CDGdi6XpWm047ZbIV9KZQqnHn3yBz98853v2rR9206HSxm/eKFhorn55XIha+jVjcOD0b4e66jh8bgEhwAsLF8429/TC7TSGJ99/fXTLU19z//1vximVqtoHje76fq7azOTLsUTX0mFQzGecwg8deTNkwuLuH9AbKi4Z3DjV3700iM/+Ltz58f+9vuPDIaZTLVancWEAEMBUJiXeIpieR5cLsfE+Gxrm1cUZMOFvZ5Q1aBeP3oxGIjwLnYunqlX7YVkfXLpZ3XDqluAaUA0h+23ZsgQIAgwi4CjiK5poSCKej2ldOHm/XvPnD4qsNipCIiYxULuX//icyMjW95xuxX2hP/pH//l6iuuogo1lga/z1Wr5hVJXje0Pp0rv/racU+4dWT79ZrFXlyojy4XFqZPTNVhe5ds5xnABBCNiQkI0zTNAoUQquYzlma4RNbrEAE1JAEQBrtoASkGw3RTt+Oqnb2OsFRdWcKUEgvFatVqNNoMDASiYR1sQNT2fT0/enCac3emMpXXjuULGlQJmKZVM3CpXvV4PBQQjgYGCEJACFgECKGY38rll1ed/w/xv8ovfwDu/y9y/H97HQBgEMtxkiw6nBNTCZ46GA3eMLC+PzFxTtcaarWKge/oHGhu48cmlwzM6jZz+MDMudOLWg0CnlxzC1WrLF5zXd+WTc3IaqQzRdJQCLC97a3Lq1NuNy+KRrVai0Q6VbW+OJe7+57NgsDNL81ns9mZadpG+qaNQ7YNPC8gpI9PXNi8ecNte70HXn5x1649pUKqu6O1XilFI37b1jge8Tzt8bhXVlaikWBXe1c+l15ZSTbHkKcpUs8WRWe0rOvB5s6JC7Pf+a9/PXK8aAFQDO8WWaOc6m6J9jYr49NL7725Y7C3p5hO37yN3b1lBPRsQ6uVTXXLtmHCXWjuHvjKP3zbsIECmJ2Y6+jq8onB1lbB6WwyU6VwqOnoa8+MDO3cvmfjd7/9vSvc2xcaKxs2bXjoN0/v3Xet0xNr4BcsQ7exjfCapbJlr/mwY4IoGqE1vRwhQLDWOAxA8xIiv3siI2uu7oDXxBCMcaNWIhiLimKbjXQ2U0cgi9DU5Av5fEM9XQ6JP3fq+CvPPrl5c2es2X/tDftiMebAi4+5zjg2bdkQaW2CSuXkGwcU2behb3CgHV911VWsiB2STGEncFy1vKLWy26nK81pAis1aiaFLIwxWiuhfQvZEcbgdLgrlYplWV6XV1XV5eVV2yYDAwMO2S+KUrVat0zb45MBmEq5phuqx+sqFIscjxwOh2FrpkmcDt+mjeGArLz++usLY7PtPV00woVE1hnygIURzapaURB4WeBoXVd4mrJJtZrPr0xFoZkPeJp9AaAoI1ecHZtYWFiAUNDhc4LLU9eUxZWGw1U5fi5NABDGxDBrDdPHQXNLCy+KYBuSxwUsBhOX81WvHALL0KpmLlMErkGA53igWQkhlqZZsImpW4iwgMSNGzbkDo6fPnZ8qVzaes1VVt149qe/WLf5Gp8v4BkOK4prcX5e1/V4PL28GA8EAu/7o/+87+PDikP+0be+FY4E4yurTU1NwyMjrz/yaLHcqKp2d/e6H//in8CiCoXSI4+8trw0H/QpqfiCLAAFsHGEWh4dtbEpDfRbixOM39/U0oTCoed+/qha5+68/cMP/+b5ZLxwxb49ulqezaUkSfZ4AwFvaWUl/sRjB97/vqs0Nbl951Am95Iv2NzQ7LOjk9dsaf6Lv/myRWD/ts7T5+a8Pr6q6W43AovWG7rMswLDVKv53KrZ3e4wjDrQrNMlOd0uVaPq6WquqoqiWKpWGAYYFi0mDcwArwiWDSZiCBDAAIggsGkgLCIcRWUq2ObIcq0QkOHmd7zjzZdfeOPg6729PX/1hS/81Ze+vHvPjv1XX/Ffcz959LHXtgy32LZB05rb4w76nByjI2IBL/sC4b/9h8MJfKan48nz81hkwOVA+SLpjQnxqkawg1CACEGAGYrQFGEpRNsUhSmRR26RR4ZqaWbIB0E/Xa/ZTAFcor1hIFovLsis89TRNwYHNnnd0VqlobgVbJlerzuRrRZKhf3XXHv+4oqqu6dW0g0AyoGcUqgKvMBin4KwqdOE0JggRCgCNqEQhQgBjLXfdYdS1FraDCF0Kc/6/0jjL/cguTzebjOg6T98YlgLjC8D95VkMhpUVlYTPjfcddddA31toNZLhepAX28pX6IYWdfI5Ozcl7/23A039X/ivk997lv3SSIdDNuGDk0RvP3m7l1bNps1vDKbCXnDJWDiiWVJrjOC6G/y1upZp9J68tj5N95ojKxnh9d3P/HU/WOTqXe951q1UWI5j1PxHD54mAAnia6m5gAnWPVyxSU5ZU7wt/nPnD3b0z8wNT2NMW5tbc1mUv5IaGYizwgSpvl4uuz3eU3eWEzME1Zu79t46NUjT333P86ME8kJFQ0ECfw+Giycz+qourBt88a7r1jPibnB3nDJT/skOShZ8aXlhlYPxkKyLDncroaBW9uCB45kKg3YsqGP4eT86pw6nXrtwJn9u1oDrUGEVdPICrq4e+vIug3b/v3fv336/LkPfOyPiSVoddqkABsmTVM0zWCCLMvGmCCaYWl2rZWUXvufYxsBhQkCTDTAiGCKohCiGArRFEUBQQjJIl8q5g3DkASBEKJWSqIo9nW1RvvDsijyNBVfWDx76k2Wsllib9vUeu01O90ekQF1qK9l/fVbchNnJ6ZORbr8QMT50TGE5KmJ9M4d2xmMPJILdJNFAIAtTcum0qamWxq2ACyDyArCmP7tnfq7XlmO49buGJ7nCSH1ai0ZTxAbt4+M0LLEszSxNUIQIRYBkxBkmg0bN0yTJoTBGFfK1XQq53A4GMZNgWN8YkkQPRY2V1LxnW1taqXGiFSpkCdOQRZ4oAxK08AmolVRWrzJzKoLE09zJwDLNfkH/OFwKFDLZlKpPL1Sdfj6T55Pq3o6WYKB4ZCFqLqumwRYkXZ43cVaRStYXm8YKBbXqplE1hvzAQhGpZ6czybz+WLBMnRoqGa5VNMlBiiG5Xmnw020MmKYSqW2acs2JZF69pkXnKKjMxQ7eeyiJEmjo6Pnz1vYhh3bHTMz1UoFnMpSZxsUi2VFliRBXjc49OKLr67fsK5aqw+u23TixAVQ9fml7Ml/+69cvjI7k5RlpqU5jMAqV8HtdISDcnTD5rHXXxzcuHHy5Rd4CbV3hNPpJMnkr776Wi4yfOrpEzOTyfm53MrCkzfefNXiUsbn8508cfbqfTsqZe1DH+wvFauK7F1cTGXz+MyFcV50zi3FM0WwAKJtvrGFRd7D2DxHGbqh0RQmPMWJNIPMOmebfgV4q5rLAqF1E2qr8bzTG5LdUq5cRmotEonVa2XVMqKdoWyhuJKpeSN+2wILMI3W+qQRA8Ai4BAWGDAagAiUTXjztYPDwxsWF2Zisci3vv2vrc3ejSNDZ04cGp+YMgzYsLFX4WVvl+/0iWPzU7UdWzchsPRSaeSam64+s3h2NrdasmQPzUnOhmn4mmiNo+KpAiNbDEGIwgQwTWEWYZbCFKEty3IKkiwIjXKFBhjqa7vqys1uF2clDBMXo02saWWokGP98IA32IRVigG+XlTlsJDPxH2ekCRQ8zMr99zxju//4oXj58ZTKixXiRiql4xytWH4PF6OAdY2aRsjTBBiKMQCxSKGIZZ2qVn0EkzDZRSe+n1wtvF/D9b/LeUnhLydLPP/YlfADPa3VItZ0UFvGO7JpTNvZleGupv7u/obpZpaVjmRE2Tntn37P7RaTGUrP/zhjySwJAR+BwRbQRbh6r0b4gvTYFCGXtE4MjM/2dXd7fY7nN6oZlWqejl1bqGQL95+e8yycKWeOH0u1dtP9/V3Nbf3vPDsc6eOz6TiDQxqcwt/481XnDp1sjnSw9B8tVpDDLPvjjsmTxwTZUF2OhZWF3VVb+/oMizSsMiLrx1dnIt/4P3vGku90d62PhgZ/Pjn/ungKMgM8G6ZV4T1A556Na5V1d524Zrt0cTMkkNL3XntPcdPPZSaPtUcDiGtYqBKV0/k+KE3iwKybbO5tUX0xHRK8fszkIPu1tZ4Mls1tUJRn5xKvOv2/VCeGxnp552Snku3RGPQwF2dHb4WBdqDn7r9b9UK3T+ydWXyDA0UQzEmAWJjIEABQ9O8ZWN4a0TWmvU1RhhhjIGmCaJtAEQwsTHYmAKCCK5VShQiDEVZhkZTEAz4OlpbWlpasnY6l13V67VyNssCdjqltlh4z85N7S0BzSjLnGXUM7Uz066AY91Aq5VbxEuqXq653U6ZRj1tXR7RyUlKo7xsQYOzFI5mkolEPqsZhiUwtEP00IxGCPmtcTRaK9TBGFdqVY7jEEK1Wg1jrChKtVodG5sjjnB7O+/1ehlGU9WGZRkUBbxAlcpZxelgWapSKWMMpmlPT8+rqurgfbwcqqnW+GRCUvhKwwJ3wE5WDM1AtinQPIBON4patSxQtGzXGzKLWdrhDoIQLCzHWR472oLe9UNe3Tr+6PMXTs4FPZ2r+cz0/ELVBo1mda1hq3WJBU4URIcCFKI5FjgWbEIpTr/HDxqpLqeOHz2/ksrlKnW1JpkW6Bou5CtVBwuGbRmWbZoURSFMlYoV3au7XO6rr7kh4gsdfPal1eVGo9GoVKyhfp5lWYfi5qjqHbcN9PZ2t7c1j46d8/nc+6+88tlnn77rjltoGuW0hlWv3Xzvh77y+S8fP7msOKFSB1HgEcXNzxXVWp2hwFCruUx199yizx8GbPYN9YNMzb15qHP39uLsyspq4vyTp6684t1T089GAmFBEH7wg2c/8Ymb+3oGH3vslSt27hzoX59MZNaPbHv26RePn5pcWgW/WV1JV3sGAyIqlOr2ai6veN2IoeOpfFBy1Gs1hWV9Hg9t6abeaPFxzU0Bw27celOfP9I0vZJ59NkD+Vq6rWu4jg2KCeequqYRwKgWz2qWTQtsVTWB4TABGiiKIgwgmsI0AE3A52lJJ1aikXCjkHr0kad27finWKz5wsVzyXi9WKun8z/6zCc/+uEP3/zME8/E4xPX7L/W0clspdYlFxcZ2pxfmHG4IwGb5Mr1c1MaKBTrCpUsbJoGpTcYrHtCvFnFLCIUhTFghsI0ZQNGxEaEkFpdM6p1jrKbIoo/FJYdiuISaoU8S3OFclKSNDO+5A0HSE2rV5C/ucOspvRyqbM1SrFKMbMa9QenpzMXZkorOQh2teWyOcbhZnVN5jW3RzSrZZaYyLYBAGNCKIYgivzW0vUPYPdyr5j/X9ua/qAq5u209beVa6jfbQZMKrkcDXlvuf5mjmivv/rMxv6OiEvIqLWWpmaBk0ul6quvHTtycqlhgmEDpuDG63zEtm6/5QYKG9Gwb3VhmjJJrZbPF+eAylNipn1go+IKp1KlhRV1dcXQsvmhdb3VRnHzlvVTM+Pf/d69jzz6/KOPPbR10xUHXz+VyZVohiqUbYez0NCLzW3Ow4eP3fL+PwK1fuTNw4888fjI5k00x/oC/vGZqf6+wWy5nK/UM8lMuVhp2DC7mKZj1PGp05NPHTk8ChG/3xPsb5imqmdGJ2evubKzJYgCorWhvZMZaV+cWDr86x/vfv8OALRy9nxTV4+WTi+NLrmcwsE3jgle5aqb7jIo+fj5+T//9Ce/9a2f/PLJFzc0R1o62hnbZnixUjE5SxNkFmophBVfpPOv/vy7d39k98bb9uVHz9oUTC/aKytTrIMiNrIJRkCxiEIUDUATCxAGgmigKEQwIQjsNa9URDj2t+NNwSY2sS0KCGBblmW3Q0bErlXLTlnq7Oz0ely1arlq5ZYXZ20DAi4uFggpLFIERhHZqfHzV+7fbpjlfD4R64hAd0v97FHTtJYm5rAORrXeFI4EPQFd1fkKJbKCZtWhodmmtbKYqddAEoII0QzDY8skhBCC7LVhrTbWDcOysG3bDMWapqnVGwgwszb0Xoex0RnbQkNDsiBypllBCAsij4lBwKQZUq9XGw3V4fLaNllZjhuGlWdowwSWYerx/PoNAyGPE4DhOKGkZgSJppEFqsqaNYRVaOi4XKYCLbTIpwt1N9IkZ4zlLVLMl/MrDl5cTOYXE7VCqVpriLkqjUVIVxqIxaxlukQBKBrRlKwoLl8A1r4hulXMV1bnFzPzuTcPzElu1kRUraZyPMdygmnatmHbFtZUrVYsBn1hAPD5fAzDOQQh3NdrZvInTybqNdizZ6eqqonEajKZ279v/5V7r3Q4ZENXC4WiLIiHDrxx7yc/jp57+tyZ0/uvuy6XSoUi0bMHj+kGI4ggCO6+geFzZ8c41pXJLEsCeDx0c0ugKSbHE5loxK/Xa4Vy2hNQLo4vIY7q6FnnaWq+/1dH21pW//7v/u7Pv/Dlq3fuLYVKP/3JM0899UwkKjz33AtLi3mGhj17jZve9d75le9s2tZ94vQoJZmZQtFGVCDmUW2rUK2U6ri9KyxWecrmFIbGmtUolhw88NhIzMevv2nTtut2A81G2mJLyeSjL0zVtbzsZHWbT2SWIpGg3+dZWllkWFqWlenFZZ8/sFaVuzbjjcGIAoIAaKRUiyRu51iTbOjtBdFpavorLy2/78MbA1FfQ6ufu3B8ZGh4x/ahzRtGGpXi2eMXu9vbu3ub6oUqAiPQ2owr5aa2Ts/UKY33zSTznKLIimLqVYdTrmtVDlksomgKY0QomtAEY2ITC/y+oFEzDLXKcKJlw8kz50uV+PrhLlTQvQEqHHLwPGUbBmvbiOIdPi/UdL2uFrOJ5r5YNpNfWVrdum3ggV88ms47adFfqCPgnYWaaiKbYVChmHJSQBGTRgSAtYBgQmyL2MjiqN/qMGuOMQBvuQtcAvXfB3cC/z3Yv12z0tuB+9ulbS37d6DPDPZ3V0uFuZlJ0Gs8yzlkZWp84oZr9gPGTzz6VCJd7+ju9fuEvftvQIzsCwQDLXEG8W8eOL5uYFOtYEi0j2HFk8dO1hqwdadz296eUjW3mqocODBJM+ELF9L71rcBYbu6uvKFlCCho8cOpNKFttaOZ555YWW5xglStawODkQ++Zn3za2cFyTXSPe248+/2Nnb89QzZxZWYHL+OEHg9kN/f0swHPnef/x0dRk62+g//dh9xMJLi4urlbSJnI89V2lq4oGOjE+lHF63w+3s6O0IRz3bNkdELZddnPQhpSfqTy2lST45PTHpc7mhkDxz7KjD5aZl5y23XAGSZzERL2nofe97XyZTz2frHW4WAU5k015RmZnNvvrKoXfcuxFqRTVXlCLtL/z6sWQCejp73njogX03X/Ppz733jz/0K5H3GpAwLcu0TUQziOEZijFtbNnGWg0MECCIBkwwxsSmMAZVVddKZRiKYmmW4TgWEQqIJHDJZBIRu7ena6i/z+VUDF3TGVrB8l13v+Ndd9zhHxiAhZmH7//V5IWT+WwyGHQuLsxwIok0+wDZEJ8vFbIxR8yhKIpIN+rausENfpdvOblSLJmtXX5BFEldLRWLy8sgS+B3O2oVXCnXBNG0MSYEEYJsQiwL64ZpWZhl+VKpZJomz7CEQLlcJjbx+7nJRFbgxVAoFIkGWJYVBJHj6UwuyfN8tVpOp7MCr4RluV7Ty+VqMBiq1pjFlRWXUxI4FIg0swKx8yUAimAsMCxoul3N05QFTglytXouCZ0Rh8uZSjcKldWW9l7BKdhWxR0MfP+b36nnULi5c/JiQbe4qoYd3oDoctVqGYFlRIHXjYaqqgghQCiVSoabYnOTE08//Xx2FGIy1CrgC0q1UrVWNXhB4Diepm2W5WlRZFkG26BpmmCYczNztaw6tH9/fnHxpedeHBzyux0bAoHA1NRUZ0fPymLuyJFjwaA/nUoMrx/0eeSx8dGWlpapN49s3rixta2pVi6Iokwh7pvferJQgliTG9He5w8e3L5uVyK5KomecFBcWVru6aJuv+ud+cR0rVZweEWapjHGt7/nBqxq5XxJFKS//dIX7/vYP1YKdMgVOnr8DAL1zruunZk/PTubnx3XCIHPfHo/zYhQU/v7B6dnlwrlCmE4TJDD611MpINNQYVxUbJeVetGwZJ5QeJZrZgTWWrbpkGZ1V99ZbqQXp0/e3wpm92+/+Z733vXbPx7iUKxXDMpsdkTCFdr9Wpd5XlJNfVcoRgORRqWRdbSRwjRCBAiCANgyKbKne3dMksyy3PBQOTZB35z7uypjg6IRsO6rb755pGduzYePXbQ73ICMl0+R1eotVouCEAHmsIBP1IL+bPTkx/44IcPTeaPTSWbOjqqhpXJJII+qa43LN30gsgiTFEYEMKIAMJgIduGRCLlFJ2K7OY5I5lJzS9CRze17a673/zhfxVLakdPcyGX9AeCqdl0wOGgLTO+HJccdigYTC7MOjz+9ubY8sy4z+XQbNbpC8yl43I0kC03JI/kcnDF9Ipl2ywGmgAgQoCYhFi2ZRLCi38Ism+hM/7vwR39jwnXS8h+6cX/mqH9g7Ct320GTBc/ExwMLcxPCVKsd+DaeKqeSDY27Ws7efyVg6P19713g62X7urp5GDWKTr00kSdaZ2bHt29eXO5lNVJw+ViXnjx9aY21DfYRxDHcAHbtr79nadsDBtHBofXtw3RJ2NOaXL8UPfm/pOpJUuWRm5YnylSi+OLeQGGe1s4om9a33b+6KvD/cHnn3ljynPB6/X1x5Rdt44c/uZZThQyDWFuAnrEjU8+IZyJbw4oOJOpLPzT/ddv7b3z3bdVDxxqaend23JU1/Rs4uJt/eHVxIyPojoD7j6JRtkGxVHhaMgpelPxwobbr55aqZ+bpXdtb17MZXi/w6Yb626+qjC9aItsdyAyvljkHNwj//WgKYDG0ppWl+Ua76gWa+YjLx95xx+9t5imJH4AiMArp0URUouj/eG+wnSle2BoeD1MzS0Ygf6l5QXFpYRCwXg8Xq+X/L5wo9Jwi04ag1ouBD0OtZz2KKhUUykEq3wLT7MSQyii88iUKIsjGjFUu042tAWbW1v8oSjiuKX46koyY2NociTOLZ7v8dSude6FVufdHx184+mFiamTgY49/ta+XKGqQVCW3Y1aqmRI7c6mudl5mvb39bWFIsH5xTHRwQoiMrUiGwiiisURxVIhGA1WS1apWAsG/UZlTdFEloUJohDFUYQntlW3kIVcJoU1C2FEEcFjY6hiTBz2mbnVY+NLf/NXH+dYpVzOd7TFakyRQZRpYb/TbdooE09zvOzzBimaN82JWAuLWG1mYfH0TOgd995dTSzgRj4c8dZmLgLR+aYYqJBcTZpEcHXudlVg/Nw5tW5EYy3q2bGCaVk2WVpZVheqiuLOpqdDfsfKSrq4tBwKdbgcHdrqrDMkBmPOdKZYFdIgerV0MSQ6oIKf+cVLE5PAi/KZmqA72aUVWhKjeyMTisemjKSk8KagFGtFV9EbJQ4wFKhZq5p5+sTc4I6dkMzesXNHuVCcWRTWjWw7dugkx+o+VwBhz7E3p1mWXVk9uWFk3V3vvO+fv/7V/VdHH33s0NBw/AOf+rOD9xsPPfEgpls1tLKQL4WjrMsB07Nv+kSuLRTUKimPDTv6m2bPvxxpEgvlWcbY5gI/T5zp00mPP8ghql61loqnb7ix99VXpzg2/YlPv/PC+YkLYycmJ0t9fX7FRD0Dsd7uznRpNFl8fP8tgY5lfvXHpFbXGQ3ohuhE4XoSS26xVChKMviCVa0BDcpfAZ5ytrx2UQ25KC6AMgVVWprYt3fz/MXn65b4w29+6afffeClV08sWWmMgLAUJlCzDZMQTGNTK7OEyDQtA+2yQKYoFsuUbRKTcD4cLy47Jb7CkudOHPrql744tTpvqZXl2VI+vTLUMuRG/rn4vE/xmwTZtu0QFJY2BY4tzS9jG+Wrdn/7unJyltQSURdU60sKRUvuhkKrIgLNBE5vB9NEUMd0FWzVpgjPiDLn1An2OUI8WMjM9/V3XDw736zAxYd/5IZEyOundMsvthVXzFBwO6K8q8vLTYM9EzOvdzmdEg/l6rJe4zuGr8EvpOtOR0krcE7QqvEAy5K60ajbLPZZiC5TBAMmhCDAFEUxNIgUMVXz8tpz+G3rqYl/a+BFoUtT7xFCtPU2iVD7LWfvt5bR1FqFtI31/3Y9vA3ZVzjh0gKqpkG1YdmIdrl9NkGz8wvLK/EXX3xZcTp8QchkMs1NrW632+VyCYLQNDw8N3NCEHVPs980VITh8Bsntm3eePUVdwpUMOht12rwpb95iqWgo81LM5W+voAUdlexIblDy6uV5ug6jvhYWznz5tlKFm8cbopFpRtu2BeKRSfn4l/9P8+pluh2umPBKFj2tVddeev13uUZLT5fUhhy/tgbF04eLGeXRMbS1XylkkXIBFvr7O5eXFjet6+1vd21a2/vjTfe6HSKzc3Nbq+nqallYX7p7NmLrQNDpUotHIomVhPE1tvbmmggLEtv2rtvw8atZDUFFMvQwhOPP3Pi+JnHH3v62WdHEYAgiZFoFGOuVCLhiLOhA4Qll59lJXtx9BzHSlfsdYyOrnhcLd7W3rlTJ/7hH+9rbYFSdtEhgFUrzk2M8zQV8vodosRxXDy+Qiji8LgNbBdqjZpuUxLwDnCIrFNmFIkWecq2dMvQRFFobo5t2NDb19/ldErZbHx6aiwVX7SNqiygdQODn/3kn7mdrp9853sXHn8KKHrvnj3vvuue5MpyPp0K+70SxwFFKoUChXF6daVQKFMUo+mqadUDQSfDkkqtxHq8oFq2xv7sZ0/7fbC0lEllMzRHCsVkXdV0w7IwEJoGhrIpyjDtekNHFMNwguxwik6FYuhypTa/uHJhIp4tFCwMpgkPPfKYpDgpmp2Zm2c5Ye02pam3WjYsyzIt3dQ1h+RojkTfeefdN15z3czEZGJiyuH2zoxPZicmFIejXCqVp6aho8ulyMmVZackQbT5pRdfW5hffvWVQ6++fjibKR158/iF8xNOh9s2bafTKUqsptXbO2LD63qq9ZzH7fC5PbraiEad0WjUsixBlBAQqFbCfm+jDtVSHRsNS6+5FB5hva5BrWYYFuZ5lmGpulquVApgNqz4CjiVnTt3DA6GHn740SNvHltZTszMzO669apjrz3T2RXVzfLKava2264ZGOxcXlF37NxqmGqlXPj0pz/JMPTdd1+1bcu22ZNnvvGjryi8Xs4vNUeczVFfvZS75cZ973nnzVfu2TE3u0qBFfABSzNdvcP5XK1U0CvVLO9ggWiKi5+dGxsfP1OppttaAyMjvVu3BT0+WLe+671/8Sfv/8i712/ynxnNTc5lu/oGZpaSNoiR5oFTZ2YDoa5//PYXNA0ME+YXl6rVqmHaDM2xLA1AF5PAI7mSLzc3+VmukcnMzS3PxLPE4RP23Xyjhfho+9Crhy986N7PHD41VTJYACAYvdXPbtmI2BRgmmAEGAhG2LYBYaAQzdAMj1iuUqtIimjaRmt7SJSFn//8Z52d7el08cCBIxQNmqaWyvm+/i6XU15cnAOwl+aXDZMsL6zKissbbupo7xZ4+c0jJzIZPZvRtYbJsSJN8/U6NHQQRECUDcgCZAPYgGxEYQBMwA5FgguLM7ZtxuOr5XJx+3ZntV5xOBySLEgOCSwDGMDYQBQBovt8XgC7tbWt0dBd/pgseZ1KoLac7+sZtMkluKQuB1CMLYIxwZhgC2NMsI0xJpZJ/X6g3447ZhiGpum1BiX4bSvT/1ycfqnf5dJm8D94zly++PIglwUVaWkONnU1tffToiNTquZKZcPGBw4eQgy7YUNftVozTXN1dTWRWB2fHCsuzg2s83Z2Os4fepoims/p3bF5f2f/PtD9LrHz1WfPfP0rj7XHYN+elt07+yWhiNBiHholsBaypa6+nZk4ohq+qZOLpAI37mmntPTGoejZMwf+9u9/TYkR1ukb2PJeW8NgkoXp+YkzZ997153/+tX3DbXTblbzclrUQWIuVEnPSGyjq81TKq5APW2YpKWtfWlldcvW7b29vflC4bbbbmtvb49Gmian59rbu70e3+P3/0YSHdlckWVEl4MxGiWETKdDtitV4GVMOCCcKHpa2rqnJuPPPHdIcYI/ElyJF5O5HLJjiATSmcqOPc1Qmo9nR3UotG3qD4Vjx49XO1s3M8jfSJQ5jjONwl998VoJN0oZbagjqiCQEbA2Hh+fElk2FPZn8qnFxKJJY1cwoBKmrCOL97llIlIaCw2BMXnGJljDxGA5qlorVqvFcilXyiX1atYhQH9HdOfGvpAvmE2k3LJreGDdycPHDzz4KGIll8cT9npnJ8Ykh4R4KnnxPIut9du2jJ0+E1/OSLyjp6tTVphUZg5RWjQWBNEBruaZ2cLEOMhytFYHA9vAmqpdwAxrAFJ1s1xXK3W9YVqEZmlRshGlGlamWF5NZVfTuUKlbmCgGdAsm2Z4VoQz46nRySnJ6bYJGDYGxNKMwPM8zwlr/bdgY4yxwgmnjp6cujB67XXXXX/FledPnZw9c6atuUVi+Qd+8UtNbbhcjvknHz976tTIuoH5yXEoNPKF2omT4wwt05R0/ux0X+9IU6y9WtFMw87lMlPT47VaTnFSFi6XK8sel0sU5WKx5FRciiQ3qlVbU7VyCQxt97bNnS2glqBWVFnQgl5eZA0DAyuB5OCBBYJsigEbdLWcZxw8IBtjq729PZdVF5Yqlk3t+sCf/Nc3/6azx7cav5BOr/b3Cw8/+lPLLn3zmx9vqLmmaOALX/jGE48//NgjL2zbu+/NQ4f/8i8fu2FT7N9//Y+xAGC11OST8gnC2I1aPuV3izddu5FncH9fqK9v6MTBEwuz2S27bk9V0jPLU+ARkvmlhdXJvoHmTGaWZVRJ0KNh+brrt2EoP/C9/7OSmPr833yypQNoGT37yuGx6eTiauNXD7wKqMnRvec9d3w9VwBOdCKa5UVZ07R4PGlpmEJ8m78tv1xnCcomZ+bnF66+sf3G29o++bnte67bXShWTk+ufuwzD1RwMFGj0oYDu1stoDAAxsS2bYRtGmMOCEcjkaVZ+i2PFJMQg1AaUAYwqWxddkgNQyuU8hcnKpV66bYP/dGufesHh5qAtirVfLmSpWi7uSXU3tHU0CqtG7Y6nP5QuMUGNp+t0KGWv/7ST0bHZ9wuSZFZIJzWsInNibxE01S1CogyEGUQMAAZgCxAJiCTgDE7NxEKe03c4CWmUqtIDjnW0lyuVjwBv+R22Vi3rQbQVr1eKJYyHA+NRl3y+bSGlVvNi7xXcURTibre4AiiCKIwUASA4LemKaw5oGFsEWIDWZs1byPbIthag+/Lufka8jIMs4bvlwzc/1dwh982rF6+JfwPK/9gO3nLF35tUvZaRXW+Ti9n6vm6ffzs2LHT5ylO8IfCmEIH3njD5fYCxWTyeURTTS3NfX09LpfDoeiREOd1M53tTQ7F5Zb8tcXqhVNL//5vvzbqotsBH7j3dp9LLuQXW1p4w1g03Y6sTYJtgxfG0wuz5cMvnfXS/uGW5vzCwofedVs2Obu0vDiyxZNv0CB1P/Tc+OkjSyIryiy/rrf3zJsHf/iNX3z8fXf+5of/srUnkJsfa/HiLQOhQlI7fbI4NpbIZBaCkRbNBECsx+9TtQYn8KqmUgydSmUIppOJTP/AhnxOT6Zy/mB0YXGFIXWXgw4HPA6vu1SsWHXDshhvoO2Vl98MB9vrNWio4PVI2VxecUmK2+109ZTKNC/7T5xbOXP6UPOe9ZxMzGq+q3+oWARJCj7//MFCru6Qndl0vLU98psff6XNAdXVlbBEQaXKmtbW3l6iN2rVvNcnR5p8Fa2Sq1dsXhZ9LQ3kkOkGaeTNeo7CGs8DILuuVrP5jOyUCSKY6IrCeN2iSOtYzZrVlFFt0IQyatqWkS3vuOm2lbnFg08+DZbV094aciugVqFaAl31+j1QV0+9Od2omTRF2dhgOLuzrynQHTGJUV9NA5affOp4R3tzMmWaNsfwQr6a1UixZth1ExoE6cAYhFYtqBhWpWFky5VErrCYTC8lCul8rWFZvEPxhDyi4rAQYgTJ66IfevTJQrkeaeqoqzpBDMVyLC8JgsTzPM9xNE2zNEouJ/bv2Tc3MXX0pVeG91811Nl18NVXluZm52ZniUXABr2uhf2+ejFXSCU7W6Kgk8lxwISZnUtm06qqwqE3TiEiGTpyOQPlcjWXUds7oi4XnUpPtbV7JFG2TcvQDF1tNCoqskk1X9AqZbOYj/W233LtnqYgiDS4JWzVkiKjBmJcS1dbMBakWCCs7fQKkkLXGwW1mIJqYXllMZcvdna1GiYcPHgS4rmt27sopnjjzdtuvW1kz76hlhYnIUUbSqdPT2ha4eN/et1gf09XR+DTH/m7s2cL69dBrRA/9MA//eD+rwsIkgsrB177gVktEK1kafmR9V2KCJpaFn2BctGqV/jsfJ2WHa5QCOuNrnVDV+7fJytca2uoUk499uiLmlaIx+cee+IBjBoun0KJ9PU372wgKlPVBHesbnkWE9RPf3Hi63/x7boGDRMswkmKIit8NBKiCERCMafoqqfV4c7uetG4ct/gAw9++sqre4PNdKjFUdFUFQvJCo8leOn4MnG2r9RRQqNtDJZNbIyBYAoBxyCJox085RBYmWdYhgIKWQRUG9ctVLWR6IRiraRZEI4FN23zf/xTfwoKTzMYMbY/4GrviJqWOjp29tTpo5pW9obc1dV0XbUswgmy37dua2pmddPW7jNnUsWSytCiIroJZi2TZTk3w3k1AwjTAKoBVIOAgShCIwBkEtAjUR/F4nwh2T/Q4w/5G4YOFO0Ph1leNgyzYRqFck5xcTUtpxsVTJk2NsC2OVYeG52lkVPggrouHjo0hoFam5CDAS6VjK/hOyJAIaCB0BRmgDBg02tVZZflNi+ZEMDvuwj8r22rl1xiLl3nf94MyNsFhS4dFOH98byWLGnLmfJysqBjlCuVeEFSVS0QCLa0tNkWCYfDNMvwklitVxwOOZvNNre3xVdXwelJJXNnz4w+/dSLiuiLhdramzuS8VRPZxdFdI62sFVNG5Cu2zXCLSVy2WyZY0Sf4hWBXd87IBJ+fmKxVIBUtnZ+cnklXw92Dt11x+4zJ04KDG3Uq2a18J471g20eF985MeSlf3qZ+/piwphF/zFJ/fefUfY64OzF89Uasb07JI3GAJEB0Mhv98rCIIkKqurCafD09HZrzXsTZs3xVczS4sJyeFenD3b3uIDytLKZV8o2miQi6OLmkpt3bo/l60SDKGgo64amaxtYHxhfL5StzSbNTE3srl34013PPvLB2ino6Y1NEv72RP/9IW//UmjoT7+yKMCK7Q1dYydGaPV5Qd/9Gctbihl8LrW5mIqn5idlmg75BZrlXQulzFx1Rd0s6JEKNHCEjSKtF1jwaCxYZuaYYCNAbFcTdNXk4lEIkEjiPrdIa/iVZigg3FKMk9xxUw+MR+XWGnT8MaI1x8fGxMpGL5it55NQLUQ2b4ZAD/2g+8TFTiGUhQJE13Tq5bdqGZSpUpd7tt44rmjr742wwhNK4lGvmxVG3qpbhZrVr7WqOq2jhjMCDpFlxv6ajo/u5RcTOaylZpBECNxjCLajFBpGJliheKEYq2haqYnFEkU4OXXDtYaFs0pFqFsmyaIQhTDMBzDUCxD04hqijQlluJOUeYAkoePNPf1fuiDH5iZmDx78qzT4S6Wq7VaTdq50+N2Xjx3EkTm1z/7eb4Iibi1sBCXJG9bS3+jQc3NJBpVa3k5bmhGJCLEoj4EaqNRCPg5mqJUtSHxvKY21Eo56PXZjYZDYOv5NBSym9f3bd0QbIuBQ8DFTGm4L7xxx+ZIe7PidbpDHrdXpliMQecFClEW+NzBYPDYsSmb0Bs2DvQNjIyemeztDU5NHZdEy8Z5zcxcuX/junWtMzOn77vvhuF1na+++mI6tfLhP/7wt77z+cF+yTJgywjsub7v5OPfv+GqyN989o/mz53WysXk8rzAWrJo/+XffDoS9p09fERVqXwBnnzyREGlH3nykE27S0WDFzzE5k4ePWdr9vvefQMLDLKgKdrc3tadzhXuf+ChE+dGebcjXa199z+f/OFPnyUQXUnAcy/HI7Hmjo5OTTN0XS3mUxyLDU1HpjE3laxXM8XM7Jf/+l1+Nz508HFARZvUZucXZ5fSTZuuefXQ1P2PHTY572pV40KBhF4xMLLJWk8bxVFEopHMIpmjeGSzFKEQwQAGQjowKqFUwlAsXdcNSeFkt5MXuedeePaFX/zY63cnksmW1rDbowAyN40MKg5+aXkWOFCcXiXcXKpqEIhOHD6pGqR/aGO+Ao0GqFUNbCQLLgr4ctk0DNbji1C0CUgnoCNkA6z1fNuYmJLEF0tZTmTHJsbnFtLDIyNVVV9azWg2nclXdNuuaXU+5EUsll0czViSzBFdl0SnzxvVGgCg1Ctobt7ABBGgMQAQaq2sgBACiFA0YmmKoxBPUxyFWBpYRNjft4TEl8Waw8zlrl6XzCDfDtz/74+vXeG/jUvLLv18azOg0KWDsRiPSaOl5RXB6bOhVtMb2WSxr8tZKNXHJ6Z4uuFzcU0dPY1iThB5wespZWYkIQyR7vzJV8786pfFvA5Y3LxtvS8Qsm27s7tXkKnpqYWmaGexkm1t7s4ykaeOPL0yO7l5oDlfTvW1dSgOvrl5U1NL7Ec//9nJixrvgTox73nfO378q4cXEqO4077zrttWFxb0On3jdVc0dN0tozdfvOCNwC1/dBuuJ3w+7+47b8ufOXbq2OGJ0YnRxDOJVejrib786mvxeDG+qsYiSlOL7533vCuemDQN0HQjnSqEIs3TUwubRrb4ZCdHm6Zaqjd0hnc0DFpSwmfPzOSqxqPPHV9NgDes+v0hRrZXM9mW9tiFqbPbtw4tzhydmU6k4p/JLVv7tjOe1s6lizOt7W033xo8P3rKE+S/8fX/+NRnP9rdtDW5vNDav+lnP/q373/nV7955Ex/0G0iejWTpyRw8BD0QU0DCuqmjhmK1TQTU5rC0SzPWxau1SzdBKdX9oZivZ3t+Wy8mk9jjGvVcrWYBUtnrAbTzDXUcktbAGySWE12tXdxbuXsoQOxWDNgw9DKfKQNzIY6P9eoatfsazv3eq1QTG/d1csKZHZurrt/KOZvuvDSm795+GWguNm5tKQES/lFxrQVJ52v2LykNAgplWqq1jAsbBPQDUu1ATABClEMQzMcQpRl2yZBBiYcojQbI4xKVTUWdR4+uRAOn9yxdbNlNmybULZNIwohRCMKEcC2Va3UNU3TdNWhCF2dzYAxiNK7PvaxC2++Pjt1gbCsw+eF1RWapb0+58r4uRtuuv7mW27/1S8fPX1y8o2DR/2+aEd7VzaXzheqM/OZjk65u7OjUi7Xa2VRgHw+zukOXas5nJTIcgwgVhRRxqR53u3lKvEFpxIKefiyH6pVEGi49+5rCKNmcwnSqLsDDm+IV/WCic2AP6LVLHVpHjFodBwMdX7DwMC6jRvHLoz5M9XWlojkVzgWy7KUTS9PTU3fcNP+XCZbKFSuvXrH6MWJsTPHvYHge959z1NPPXXTPVFw6q++uHj3u3e2NIV//osnWmOxK95zz6EDzx8/ceCJx/PVOgxs3BQgstuWLk7MvHFsWeabDx6Z55G9c/Mwcks33fvx6tz88UMXX38lv5IGfziHBKjpMLsEbg+kMtDd5WpuD2sqOXtuFYHzpmv3nTt/JhiUdX25KeqzLA3ZJZ8CA53NPoV79/buSIu/eXOnfWz23NiY189ff807HnrwhZGRbYmx7Juj2V8+8OTffvUfPvaFz/qQIAcpXEUUohAQhqI5ymZpYBFmAQxDx4imEAcIEcTaNGUjyiZQqth9PbFKKXfo8KTMwAsHEl//3JV7rt6fWJ0ulIs06H6/t2/dIBCzUilqhVypIoTb20WHq7yaJiw3Mbt4cSq+Y1tL9/pdT7xydGo57Q7wPC9XS8UawgG/D5kphC0CFhBYGzK5RmPnF+aaAjFkW06/DHahXDPCwejs3Gh3sMWwdJmlBcUCGigGI8ZQ9Yoii6ZlEkKGNm9PzGQ4BAuLSQbBWm8HEMoGRBEKEFAEMF4bhkfW7FtpAggwDQQAbGDgdynN3+U2sY0pigIa0JpiAwgBwoS8Xcfq5S5j8PsFM2+3GVzO4n+38rLrU+cnVmRv7MxoqlDTCEXbCBwuJCniFVfu8Hh8Ai87XV5QHAYmi8sruVTS7RlWVffF546OTy4vxAsd/e3eqKwEeFq0aYnKFrPlemM1Wdq07xZV5Z577ugbLx0/8Jo+tM47sL71M3/54UCzDLJ9+OSpf//PB6+8+o8URfa6myXe+ctf/MAllfftjrV2NBNkB8KehlFhOTI/N37q6Gvf+vq7elrkx/75S+u6Wnfv2Pbij3/y4ssH6waNRKc/FOkZCF59/U2hSGRyUgUER6ZqgO2WPXtaom3f/dYrlgkU4nheikRiC0uLkcEuTqBYnnV5vIiRCSW3d68/e2H6gQeOmw3oaRcpoIv5QqGYUxtY1dXewaY3ThwMhJv7B1qw3fSxP37/3/7dj7BBVbTSxNGnP/DpO/dc0aaqeiEDP/zOA5xvfcjFlOZGL7zxfHJmQgIY6elg9HLUCbUK3Hv7xn/6mz/e0u9pZGuUmo24WJk0GACGosEG3bAxAZZHGMRCxRyfXalpiOGduoV0A0uC7HX7nJKcTCb8wYBDcRk27ujpZ2hheWJiZONGrV4ojJ+VZAa0UuqN11ZWl665as/w8Pr1GzvL1dTU1ISmk6amQS46fP7s8ifu+/Fyohhr6yzUq7LXpbg9FmGAU2wCDQsqDTNTrqfyWqZk1HSLcLzgkFlJRgyvW6SmGTXDtBHDyrLi8pkERFGSZEe2WBIUF8PAm8fPTM0uIlokQJs22DZBiKZpFgDbtskKAi+LPp+vWCqsLM+DXoNqBSxzeN8Vt9x9T/fQeswJpF73hfy+gDsY8i2tzjI8fOIz9330jz/icrkcivvc2bFKSUdElHiIhVskXjI0TZEEt1MydbVRq9EIsGG0NzcFfV6oVYlpgKkDBcjWC5k4Nit+LzfQ69+5o4WLyZhDzogv0Bp1+J2MxLASwwk0omzR75UUZXBg3b4rlb7+rmSmfPz06NRs/NiRsW9+Y7KayDY3t7IM09nRIorAMaizI/rsc9MUMt/zd19IZZbq1RxDWSKP7GJ88bXnP/mpbZ3rhr/x9W+3xDrecfs9uVyBFZjedd2JIgSaqFcOH/rbbz7zy0eenlosHDmePnw8+cbhpZ/87NhPfvyClaIzF/MTF7O9XTvCAYZH4JTF8TGolqGj3a/rEAhBvlCu1coYgyi4i6p27PDpXLoQX5q3dXNkXdsdt+yJeKhr9gzddfOeL/3FH2+9s1t0pJJTrxG7+MGPfGTL8N7PffIHLz+7OD+V/8kP7t+7bt0/f/Nfmps9w8NN07NzNFMAigaKpmn2LddByyKmgQ0NLBtsixAbKGQjMAFpgDSCFIeMgc3ndE2Hrh7/hk5ob29fXVx0u93lcjngD4ZCofji4sristPlFQSJ5Tlcr49NTX7oTx5UvN6HHz/78U/92ac+fV8o6PN7FIHGxGgwQCRJQjRfrukIEUL9DtcQIIRpwMjr8bE8l06nb7z5lp27rnjhpUM1jVI8TZkcVdfEUg3JzmBhNUkopBp1Ta819BoABoSBoViOI2AXCgWKAkzWQPZ3Ro9roEkhQhFMIcIAUIjQQBAQipC309wv/+zlXPvtmPvlOvvlfB+/TVyC9T/4RZZtXzrQZ++59SMf/uC973ynxyEhS3fLvFtAFK7v3r6Bwapaz7a3BK7Yvd221cW5OV5gSyV3tVZWXOKx44eamsMUBT5foFxpTE8tbtu+NxHPur0+h8Px2oFXDx/O33xLW0k1AJmbNg/pRiWbTvb1rndIkddfOfvaqxfCwe54Ij2ybT0w1fMTp295x/rWjtDO5sD0zJRbdvhcznKpEF+ODw6um51fWlpKOnyRPVde96WvfJ1ihb//P9/67re+43K5pmePfvhDH33+uVfe+64Pffvf/oNhOI6mKMratWtEU4uzUxejkWB7e8fC3OLY+alPf/oz5cRj3o5+Ld8o1VB4eOf4sdFKDf/oJ88IApiEquiYdTjKFozs3NO3YfOnPv+V7q4QzwpaWXWygt8h9rb4VhdP3XHr1u5OxeXAHrdMIenRh18o5ail+fLw8I4bb2CkQPtf/MlP7r7zBooJnD43EY6FTUrlHXbdKjR3NBFgllZKDz5wsF4BjzdYwTXTsuu6ZdiIE2VGEDXTUquV7q62od5Or8xWs6t6NU+bKpgNlsLbrrwinVrt6WqWJMq2qz6vwNGGz+88d/ZUR2dbuKNtfnwsXywLgtDT11urqT5/29SZ8888d0yQ5GtuuPvIyckHHjq2efvG5XiOd7iT2RzNMIQimVya5ahqXavUgOMohmERQzM0RzG0Ydq6brK8YGHbsDB+yznjt3l5xNi27VSkdCqOTVg32DE2Nt/f4fnExz5m6nVsaAwFAscyNEVs0zRNXnDmMkkKmSyDr7v+qkhPy9SFM80dLVLAA8gGmYVqbuH8ccqqR70Kg6zFLGnvWRefyfjc7X/5+X+YHF/t61lHLFs3VKebD4Xd6dSyZeu8QKdSWUniWJ3zuEVDz37oA7d09voaxUWtnvP4/dnlFafDV6uaY+MziBKbmttsQBRNY1+4q68dBL2SnaFZVfaIYOr1kga2KPt7izPF73/r4ViwffzCQqUMoaDnEx8aEkUxkUj09PevrizyPB8YGEiPT2iaVqupnCAuL6/uv/amk8ePHT40dtNNe3q6MtnVyth0RVL6Uzl685arzpw7d/HCscF1UV+ApxlbVLx//7XXgQVRkSs1CnhOZNlKPuWWKKOM20LgkemAx/XBD3xA6Oz+/If+tG6A4guOz2UC0eBP73/wzIn//OsvPhiLMqU8EMvh80ZLhbzXI5pWoVYr33nH1i2bB77/3f/aONLe0dYZ8AbaB+ZTi4lwx7qVudxTz5x433v/VNeEH/3wgdNnUhrAu/7oHWLIW0HWBz93357r98+sVPxUkEI2B5hDNkMMDusUIRQGjgFEM0ALNsUZwDRMSrOwaWGPg7Et3WpUOptDllpQ89re7dG+jnBve0QWKWI1ypVc/7rBcjaNEfYEAsC6k8vLwVDshz/4aVfvcHffiOKOfOAj/5irA6uA4gtZiC/WNMTwNC/VG2qEq5u2YWMdkE0xiKZpsGmwGdsAhZfLhbzfrVhGMRJx7tq+4cLFUzu7tzs9IMqVjZuaJyZPtLW02hqRecW2baebRzROJuKRYC9A5Gc/fPalVxYuhP0Yg23bGAEC+hJMMxRQiFAIM4RQYFGEUIAJIURw/YFasgaytm1fnhpd01gwxhLLvx1zvxymL+0Tlq39t+svKTx/QPCNyzpUqZOnzr3jjnsohpZkYfPGdesGu86MFsNBn67WJVFcPzxSq+qTs4us4lNNMrecyNegqjNj08ulurlu87ZUsbqczmWrjc6BDU3t/bmq8cKrh372q4fSucrwRgFT9IYu3/bh5pawlEkuvn44sfm2WxfyxacPnW0w/MTKcudQL6KMUnb2rz552/7NrbK+zHp4XmF8Mc+ZyXMXJsc37t05v7wwMzfd2dUxMrz+P3/wo4YKn//Lr/3NX/7T2HS+oMrveMe7ZmaXdM0eGxsTRO7aq6/I5RLVSq6Yy9ZKxc0bNymK4/jRY9s2bxleP5BIrHhDIajXdYuE+4bOHj41tZhaTZe379xQrUM44EcWdLfFejtaBA5NjJ/zeymnS3bKEsZgWqRaMw4eOXXl1TcVK9rBN4/7ItFCqQhgd7a193Z1d7V3jZ0bJYg6f+TIfR+/dtvtN6TjM8sz526/83qruFJcmtzSFRPU3IYW3537Rj7/4RvtKkSYMiG82x2pVu2m5i6alTDwuVwlGG5NJAoXL86Mjs5W65auo0isbcfOfeWKcezkkXQ2+eDDz37n359eWFqkOZ4WBKm9befVVwSi/smLZ0ywOvt61l21v9awFJcf7Gzvhl6PTzl2ov4f//H46IXS+g1bl1ZKhVptNb1oUVWNlPKVTEOzylVK4MOcyHKCLEgKL0gYUK3eqGu6hQlBQDGcKMqSJPGcuOYfDYBsbLIcpWkNURQlmV1diXucTDxRfPXAoeaWjkKxUqmpTU0ta/drvV5v2LaJCGEoh9d5YezcwuS4ahmC240RbdGsVtcIzbVv2dra10uJHHIowagnnZwPxDzX3/SnqUzcsmB07OL41GS1Wve4/cVcORiManUjn6m4HW6WEnmaxFezLgdXLmezy8uiy4ktGxAJRKOZTGZiatwGvGXnZkdAmV2Z6ehvbxvsBZkDiih+Py8rpXyhWm3I4ZjsDJSXkh5v1OPzjE4uAC1gBDQn/+zHhxbnSpFQ79zkqs/bhG0WbHTo0CHbtgfXD8qKEE+kQKajMX9bu6wbFWD8xTrX0r6xtWvjnitu+esv/+vPfvV8olB9/ciYOxBJFsuRzs5PfO66kgEly6gSk5W8S8m8N9QsOoKigyK0VK7Z6Vz12MlzgGH7ju2ZHPACe+01Ozs7muuFVD418e1/eedfffajtG21hCWJ1kTGQHbZ60ROEdTSUiE50R6Fzpi0dUOzRBdtPR6MKrZWbW7tjIZbPvzB7/uDzX/1f/456AWvBHfcsnH/7g6jsvC1z//Ze2+91chCvV5f8+v/LVS9hR2VGpiWbRNcrdcYltWNhsfnpjnaKXvBoh2ixzaBpVjLgmikqa21S9MsUXQUC9Wuzt5cPAMU5/FFM/FcemWeYVEytXLTrTe1d7fOzk99+Sv/eO213Tu3ejwSEC3nlGyGNBwKVyllHQ65oRuE0Cwjc4yDIgI2OGyzQFggTEO3Jdml20CxciZXf/jxg6Pj6q9+8/oDv3nt4cdOffd7j584HXd7vaENGwzbUhv1SqVcLGRoGkCmLauyZ9/G9cPOeq2GANumpYgSYFwsFiVJYijgWY6lKQZRFKzZpSKKoliGMnXDMkxs2RQglmZ4lmNphkaUwPEcwzIUDZjYpnVpweWsfA3Qbdu2LGvtC7X2dm0bWPubM28Tl+8K/3cN5VuxJehjaeJx8vHFZCwARhWuuaI74nfzCAf8HrVWLeZT6zcM+kJuh1N84onHxsbVlpbonr3bv/i3D3z8z3YwDNNoEIF3ff8/npVEWEzAlvWuK67YTlCtUss4nPy+LrFh4sVkfnjb3kwNTNr94mtnf/GrQ0ODHaVcvrs5vHEwRtSVLcMxp2wY9Vydl8PhcCFftG1UKpS3bNzy4x/+vKO5xecNC5Inmaq9fPBUucFmKraGBY8/0uKL77/qqlKhLAvihuH1P/r+9yrl0vYt6zKpVV2rXr1/H8fQU1MTrc1tuVzO4/Gs3yBXchVnqPPo6TnW0TQ+ubK6ki1kCyPrhnKZDM/zbf29R8+N9m7e9r2f/Urx+Q1TXJhbam9q9jkctl6x9cKebf2yUDcaCadov+ued4i+oJ4o8rTnJz+6f3kh1dwN7733HkEOZJYKQX9zvarNzk6PXjze3hnevGXdsy8+tXnzVsug24e32UXt5nd/a5VHHl+A5YR8uer1BTBF0zSdSidKhYLXIcgMHu7vDLmlai4R9DkDHvfmK7sX5+ZNS0vEFxjKvvXWq1sG2qCazWRXgtHA0tJS68AgOHyvPvhEJlu66853sVyinNT++ovPJRIQDLXnyrRFMRat21zNpCqE0m2CGnWk1lhiOjnW5QiYmqbVG6qmGbZtUzTLMAyiGVVrIESjta83hdZqnwkhFtFpRNm2bRkmQkjgOBaBZRgUMd9/77vXD/U3qqVyIet2ydVSyeN2np1fGhrsqRWTpl6OhN3+kLd/ZLhiWMG2FloUMTEZ0uCRahdX65llFmsNIlom7XLE7rjlr9UqsAAUoRiG6+3qDAW9hXwKkFnIpZwuBWPcqKtBJ7Ktxvbt/T2d/tZmJ++mcSltmXomnY81tT35zKHewZ7+/ddkpqY5gZccCtfSBzILtVSxuCKLmHMIYNi4ZOAGxyhtU0env/fdp2kAgoWGaql1q02Cv/6bP61UCoHOpoWxs4ZZ4yUaUViWeX9fN5TLmqrOLy6FQ9FisRgIhAQecd62yfMrh44tBEIDL718MJNPu5yU1498PvpDH/ujueV4rop/+NPnRZfftPlCqhYKeKqFnE/ha/m8iGDXlq6p8dmAh/mrv/rCajL1/EsvtfX0jk/NMoLQ2tG5fzv3/Auv0+DVdbGQN8+dnY5EwtjW/uRP3v3KK4/v2T2kVbM9nU00sVhFWhgdY6Irhby5ftMNQMLpFeP4kQsj60Z0vexyMogzdGLWMSv52l4/OfN3//ZMW2sg08A0EBpsDjBDTIZYFLYIBpGj27s6xyZmdJsEm5pWU9l8SW/vbKHrIAqsItJaOa1Vyhv6Q1fv3Xzh9KHbbrqKWA2tUc7l0/uu2f+bX/5869at4XAYsfrickIUXQamGd5pWPRTz7yIEJ/KlWcXDG9IHJ9ruMOumaVy7/qhxdWkFyyapmn6LfGEEAKEooCWeFHXNGJZNIUx1vRG3cbA0uBHEZopGXajfwA+8qE9He3RQiqjltWm9rb0ylQo5gViJpNlh9SsRDc8/pNHPvf0Is2x9XrD4/MioEuVssvlwpbNsBRgm8IYERuBxQBQQBBF6jZ/uSBzuUS+dnItz/mWtkNRLEVfqpy5nHRfztwvnQEAmvnfNffL4/eYu1cRPYrQqOQ8MpgqfPj9ez993wd3bVm/eWR9czjq9/gRLSUz5TMXZhDvGhzZsWFjdyjmmp4b/9BHRwDRmkEzjPuVV89Wa+B2NbdHlZXl8szcFMMZQ+uj0Rit1Wd4puxxcA7JMzOReNd7vvPwQ4d27x2KtjiHN4aCUbWtAw0PBXwyUgiSMcezjKIoqm4YNsKM8OV//vmG7dtYyekNRuKJlCAIV+zbf2aqVm9YDO8sVPVspvKrXz6+uLB07S23JONLz75ZuvWmKxWJFTlq68b10aCfocmWkWFE9GDAsX7PFtApmnfXdGpg0675ZGF0blUHpm9oUNfVzrbI7TdfmVycaA27v/ZPvwh4JA4sFpSWSHNLc6RaS7K8RrONw0dPO12eq668HUHw5NHF2nKdF721avH9H7j9ne++AgNcHJ0CClnQKJVXZKe9MHemv6d5fX/fwZderWe05kiLTxaXTx2hKfX5l77Y0d5VqVRsy0K2WcynZ6YnCqkVpFU39La3hr1q2agVc03hgCzLuWzB4XRrtRJD47amyLr+vva2Nqfi0nKFo0ePmtgGhiqWStPnL5JMqbNz8MYb31komQDIFYhYAIpbsMGjNvh82W5YVLWhllW9WIeqSnQL2xjZFqs3mFQqlclkSoWqpuqACRDb1A21VmUAUUCY3x4shTkKcRRiwUK2CZZBAWZpxNIMTdMMw9br8ObRE1PTswRRNgYENE3ThmFQPFuuVggFkiT4/d5yuYgxVtxuTAuEV2xG1gmPEUexEs1yNgZBVDCh+PZOoABjEBVaM7CiCLGmUKGYrqslU6/TFJi6Xi+XfR63oTe8Xr6/v12SadtuGKU8JQq1eqOprb2im06/0n/FFUDRU/EVPujTBTZdKwCxwOlkZUetgc2yCRZH0W6G9YLOnjgxijHoBozNaNfecMsvTp4Ih71Hjpz712/85vQbxwPBWEOzAv5QrLn5xOlTyYnRfD6TTCe8XrdmaoihJ6YnUiVxdUn95UOvPPPiheNnL66mc/mq3Tc0Mjyy85nXGk8+faB/aDPNiMks5Mr5lVRcVEyLlIq1WiKX33nlhn03bjJ5+4Mff+ft773tez//7s9/85ORrZ1uj6Xpi5s3hVuiGBlqS8D96IPz506O3XX77p/++Gtf/vtPfOpTf3TixIHbbrshFPArEpfLxovFOGh5WcHNsRGGCS7NZCYvzvgD3j17N0tOjeUzgVaLwOL09AEaik193Q7WKwFA1eVURJ5jEQHLwjambGAsxGJAFC8tr6ZUncRaYsVCTpHZzjafU0Q+l1stlnOJpMzzLAK3y2HqWq1aQYBVteb1eiuVCtAsxkDR/PjEjMALieUl2zIpirJtm2ArFglu2tD/sfe/c+uwU803WgJQyZZjYbGcTzMIw1r5OaYJZglmCGYQYQFohGjdMOpaHSikuNzeQMgX9LkDPl72m8Bv3t6+ffc62eXOZDLeWFNT3wAwrMPhqpbL6VSK4xHN2UCqkRanKPASxzGATVWlEOEZ2jJMigbABP3OUYDCgDAggtElGk4IMU3TNE2M8f+N1Jd+Xl7zvkaP1mrbL01QWmPr1GXTmv7bQG8T1GUHE3CKR87NhAXYtMGp1SoCVX/jpSc7W9sYJJw8ey6eSJ+9mEYc6BjOjE1ef9P1jXphNZ7PZPVSGW68ecMNN9z9lS9/89jRnN/Fra6kW5qj+/ZuvOHGzYa1DChTrtWiLa1AFMXjevaJF4+fT91zwzqdotu6mxKJ8XVDYbOWcAglGUDkBAmcVsnq6OyemZiyLTpXLp04Md7U7l9Yze7YtAVZmOf5er0aaWrqjALnCNKyN5EtLi+R9cP+z3z2c4dfeWn03MkP3R7yuuVd+7fnZmfjKwuZxIrDKTEM7u5u5kLB6sq0wxe27IbkiOY07tFnX8+VIBaUJZG++cpdF08cOvT6ioNjPRHnJ9+78cFnzwguxFCRUjqHmnwCR6qV3EBfk8KhakU7e3rqpRcXdm0hHHJs37FB06tKgB3Y3nX03Mmnnj0vSsrQru2l2WnTNHsHos2R1qNHjl19zW2PP/L4Uw++sGvPTtvGizNjsabIu99111e/9k+VYurvvvQln8d94sSx5555Kls256YWmr3AYEgtZcvdiVjAVaDMfC5Z19K93d0Kx/hjTR3rBomaf+nFxytqdsfuzeVMbnh4mPLHoEGHI06hd+PSUy8eeOXZ3btvV3UoVbBu5CghKEuKzVWrVc0EsBBQCDgELMsSzBGLoQmWOJYSGJplGIZBCFkmNmyLEIIQDb8t6sVAMNgECEUTGyyKxohmWZZjGArbgBCJxoKpZObhhx+77abrhvq7V5fmAj5PtVoJBoPLi/PdbQGXJHmdDr/PkUmlB7f31imWomSbomzcsIFlaVHinQCkTmREscA4CwUI+YCjeRurwZCnWstpWkmWqGqlYNmmRxIYxHo9csUGr1dQZErk+VotS1OGj/fQPE9Y/sjJ45t27AGX9/yRY1I4JkZbQOAcikMr5pGlKd4AKA67VrNVIDrLOJtTF5ePHVkoF6B/sJ1iCofePPzE3t3v2jVcrdV27e43TFPpbLPnLnz/R0+8466NA0O9Xr+Xd7mK42VfIBSPJwExp8/MH/rh/D/8w2e27b1+KfPsqQtjTodCGsaBN040NNi2Tvnpr6eH1i2//uqRb3/zL779gx+vG26NL87KInXP7r3FbHYhOU8sQ2TB5ODV119r72xyljPhZke9Wrrt1h21elpg5IkzyZ37r37jlcWlOOhGHBjXL3/+q4OHspIId7/nzkd+/ZOWmFdkzZWl6Rtv3iMq7NxUNRZaZxhMLBajY/7M7DlCyrnMjOSKiA6+q6812tL+o29898CRXNTfu5irR72IEGwRAhRCDIdoRCzbAtOihHw+S7FgWkY8pUkCRKN4biof4t0sTRwSG3DL5RSkVxbyXvrqK3f98z8+Va/BFVfCnj3brGr5pltudoZC08/MLo5PhbzBjr6BsfMTtUbdF4g4ZUlkqOzqwvX7dmTjL15/+y0/+NXTqUrDHfNnixkHzwN6K+GJbQCgCSBEw2pyNRz0uT3+Wq26kojXdJA5cLkUl8QP9g/fdNtIU4teLkyrxYzP7aMlbzWRdjjcICo4Y1Vqajw+4S9ZmDRoYjlEidhKvdbQAWgAIDYFNHlrZv1b44sJIQAII6AI0IAoQAQTYtkYYxoQTTMEr00xA4oAwYQigACoy5B9DegvySlr37VLFP7ShgHwv09cujyYy8xrmHxi8bpNsZtu2L00d8YlBYheiEXafE5hZnLJbGjHjqXLKggusGg4ca46sDF/3RXX3fvRn8VCEGmCns6m1eXRfXtHyoUDDimsCJ59e3f5vFyjUliJT4QjVFPQ36jajz/+JqEZmwTCXs8V1+w7dvq4aKY9TKXZHVYpEGkdGcQyFeAFxRPJTC2TBlqcX8lX9Z7eQUl2JeLxfLGqV6vBcKBSqj/37CMsBRxnVNR0Z1cL7au3NLc+/tCjv7n/5a9++T2Urbod4uzpY5VCbuOunen5GUOrR0Ixgsz0xGlJFsAWLcJqRPri3//DSg5CEUW1zDPnJrNLk5//+B/VCimaY5964cDwrqs2DS3la8bC0up11+ycnx9bXSxdeWVfa1PowpmTmXixXqgFA1w8ntyycQho9OqrL191xTZTL2/evHdkQ311daErE3SHODDN7r5mrQ4791w9OZUp1YTXX0+GWivb9mx55bUnGa981zuuf+apB6YnF88deymXSpRLOSdSt+2Jvvvuu3PZ5Csvvfja0fKhly/s2hUKBTyWpYZdkk8R1EK2jqE1FJidm8jFM/uv3w2inJ8apymuuHyxXmdb2zdA3kzHa0vLRmfK0kwoVI1yPeP1SyZG9XqOkngaVCCACLA0cKyIaNYyQHH7McamaemGYaoqADAM4+D4utYAghFCQCiCgCKEWvOb5m1MAWY5muYomsc2mPZaBwdtGFZDb5w4caq9raVcrcmKKIpiXTMEhq4VSm5Wxpra2zW4UijXyjXs8FGYRYiiGYsiACZNDKBMSrPEUOvgsYdesDHQDF+va8Eg7/M7kolFgSOKU87mTJcDenubdF3XG/r69TG3SygU4j2dMWzTsqhgbLOilM4VW7r6glt3Lo9NLRcrN9zxDnA7y8WCIlkWgxTOBcQsZYpGxfDwbpZz46x+5tQ0SyOWJ2PjCwzHKE5KlIWFlWlVrSkOfu/+Oy68/jzD47/4wt1jkxcHB4fq5TKvyE3NrU8+9VxnZ0//4PpQeDIYMZ99+fDxU6czBay46Cuu2oVNa2l2pr2p+cibb95705affP8BENhHH3wsEy8ZhlHJqfd96aMXL17MFgruQHhyfBob8OBTz336vj85/MYLVV2/OH4xnVi89123ajW+WMjMLmfnz47+8cf2Cw5xen5uacUaGG5RPHJHe//yUvL+3ySvv672sS/epz75C5Cdxfhia3Q3EwhW4olcLkUK8VxpadcVm2H4euPYG1ys1VwoHD0z+/1fTXi8znihZIHSqGVN08QYaIoliMWIsZBlAsrXGt5w1FCrc3PZqB9EAVrDbo8EyalSV297PrOyPFcY7HFctXdTtbC6vDT9w5/96YmDL+dy2d6+jrmFuWikCcC+5ubrSpPjjVpJTRV87qDbzWfzhdmJKaGv96nHLnR2wjf/+Qujs6tb1/ccvbiUTCVdsoPYBkZrY81ojAERIDQAgCSzJtFyxTomVlN7xOFwFPKlxcWMUZhu7uw/ce4ILQTXDbQaVefS3EJHr8/R1Ze7eNoflF2+cLW+rCiCokgXx0arJeAZpIiC3lAtoyEpTkAU2BgBEEAABCOggAJC2YCB/D+N4riE2pdo+1qsnV97cck54A9mXpO3Afe37Yq6TMWh7Jp5zd5tRi3jEaEpIHc2eXs7o4X0SnJlcdeOnR1t3I03DO7aPdg/FN25rw9xytxo+mf/9v7brm0d7nXEwnIkRO3b0z6y3nPdNX1dHaKpJXPJOata2TmypSvWU4pXXj6UGZuDWkO44YYbhvvCsxdeFPTFTe3KcMzpASvAyX7Z75S9FCc2sM14nEsTi5zFYxX5PU0Bf8vTTx/Zvn3v+OQsy7IIbEmkRs/Xw36oFLKGmvjYh+7aunnH+bOjHo/nvvturZQKWqOqNUqd7U0iT0O1GIqGg0H35Pi5THJJUZh6LT+zkPW1D3zjOz85M2Z6I85MsaYT20LgcFLBoOJzMWeOvt7XFVlZGP/Qe+5Wi9Xh9d6eLmdrU6CjxTdxceX8qWUGgsl4bdu2LZ6A86bbrkykpo+98WJLU+zgG0dDgY71w5s3XnWN4pDqakE38rML5xgJMENVG9RCQj1+LqnRcHG+tFzQr/7k5148dnLfnn1TY4t7trXF585cOL7Y5MJf/OSd//il+1xU/sqtnf/wnb//wdeuX9cD81PpC2cml+ZmUwsL6bmZnqamLTt3025/Ryi2d+uOcHPb1OuHbdXgEesQnD0dA6ISOvXcwddfOhYObZqbrVTrQGjEy4zNNOp63iA6RbMMwzIUEAK2Rdm2aWPVskqVQl6rVcGyKELWTGFswzA1lSWERcAi4Ggi0CCxlMzRCs+INAgsSDySOIZFmGCMCOYYllg2xqS1vf3i2NLMzExvT79p2ABI5gW/2zM/OelTnH6Hs1EqB91emiBsgG3RHC07BB9NKUbNrBVUq2a6nF3g6/nB9x+IhERNJY0GbmlpMi3N5WIrtWqllurtlXft7nd7KH+Aa233bVjf3RTz57MJ3ai6vQ7W7WyYpm4DIymDV18LmlXS8dZ9VzPhpky5XrBISa3ZCAjD6KqpG1Qg0MoGOqw6dfjg2Yd/czCeID5vgKEp07aWVoo1teoNiB/86D2FSuPfvvPrpja/NySrRpkXAJCFaACHUlONppb2puZOQfYPr9+6sFRJpfPhaDTaIhZKdq6wJEmgNxrTY9M8CIV4Q81jpHOZlUzMLyeX1FDA+S///J0f//jVN4+ljxydRowD8cIrR6tf/LtvAOMd3rDn9OlFbEA5V1mZmwu6XFs27ZufjddrquSVV5OzNS2z7aot19163eDIplxJbwDUdDE9mdy2/xZdAyLIDC3UFpcVifX7pHBY2bVnI2ADxmfHJrIvP3RUcAw++txZhwcon78h2IZkaLWKZei2bdsETAwNizQspNmIMFK2UGUEURSBY2Gwr/3ee269eu8Wr4N2y4xAWxwD11+z+5qrdtC0PjOdXZo6v264Z8fOERCpzq42QttzUxf1etkd66Js6vihk8nldDaV52jB5/YR07rzlj41D41cdnV2pr+9IxYKVUuWz+kFZBGwyJplNtgEbACbgOl0iQ2tmMmVEGX0D3Xv2bdraH2/Nyh4gsLE/LmXD5xciE/V9RLndwRCIfD4oNpAICTjhUKm2tTcFWtuF0Slo6PD66SqxTo2DJnnOJoSeZZlaNs2L5PCKYJoAhQmCF9WMYkQulxRgd9XTi5vYvoDjZ5cNlbbsizTNK3L4v9l87g8KPK7g3n3XVfo9cKF0wc+8Sf3uGScjs/PTpyXRF+lVCgXi+FQJBJrmV1dqdb0cId3OZ6FrGTW0q2hrv4N/onRo5t3DM3Mnty0yeWUrUx81e/xDw2OLM5MnD50Jh6f5Vh7PNM8tGG3x4Wmpsd0PamwxVCEqsXPrWvrYmkRSwptSaplKP7AcmK1lk8GHaELJy62dA0okdafPvRYa0ssnsjGmpu9Phcy6hOjF7u74Oobd//r9w93rfNIovbqK693dLQl46meruDxN1/v64q1Nw9Pjp5vbWk2dHX89IW5+eVrr90pOrjFpWnTMnKNJvXU2JMvrzR1iIZNr2ZA5K3+bt8XPvPBAy8+0tcUbG8JeMIxJqOePXH09pv3vXzyDU7oyKWXi1nN62rLJW2KaLfcfM+Fs893dinl2kKsVaxkM2FfzO3YnE7otfg8w2ntHS2+nhDoWbxqYBpTvLCaK//gZ685nU5aoaPdmyzB95Nvf+8/HyraJmzaqAx0h6e0ZJMfPnrvje1N4UZ8tMXP5hbOCCmxPSr9/Rc/wPDC6MRkMpXhG6l6Pnf26Jul4ksAsG3n1uaBPuBoopu5fKla0Tu7N7zxyhsvvnguk8ZOp//06eTyypl4EhieCA6gRYtlQJYdNbVC0Ry2wTJMgjGidAqwjW3ANlA0y1GyKKzJoGvioGGZa1ZKf3h30kBhAogAWIYFtoERzYmiSBHgeR5jTAicPn1268YN9RpfrJSbWzryjapTFEDTRYpRS5WAJ0QpHpqWbcJQmGUoBJgy6iZlAeNwARc+/OtnpyeygYAPiB4KukRFLpVWfR5GcYDPz29Y393SHJ0YGw/4/cFgiIKyz+VsNERNr0vhCCmXMCEszwElGvliXoNwW2dwcJAQTDtcLc4OGhqF7GKmUHRxfKitG0S/dmHuiYefe/mZ88QGp4PJ5cu1Bl4/0ldRq2qj1tEdOHv+8Mc+cdOLLz3rCUhel+/kGy+NjIzkC2nTwPzy6vTsXDTSTtHir39+/+pK+rN/8WeHjxycHD3vcFNuL0yMT67MTaXmSdAlbFq37fXDh3Zu3fXRT3309nvfx8pwz63bVlfU1MrF5rDHsIjkcNoYLa8s779y1/L8+Le+98auDfKdN13vk7FR05DJyoyD97S0t5kzM5MaVLv7O6JtkXIl/8sHno+EhttbRoaHw75g5z/9y3/94z//iUkYd6gJLINGhm0arCzU1BLFMvFk/v77TwUDDn+oT1DWl1S3LdAnZuZ5t2TTBmMCQQhRDEbItIlJbBtTBNMhT2B2asztEtvaInOTSYEhsaB3cdqqV2yRw7fetF9T8z63ODtz0e3g3vGO4emZC6HQDk9zKL006/MHLdtgOVRVS+pSsrdzwCRLZ89PHTqW/fuvfOSOW+98+tHf3H3rjVuH13/rX386uHmoDtTS7PK6vtaVXJGiLABCgCKAAdMEMAEECBdLeYeTj8QkmmXGJs+eOXcSAev0OgZaOvKFCbdHt+zq5MyFkMvj5gKQTJ4/dmH9li1A6oXcClBSfHXJ6aSuueOdZ+pTDz38mFqrSorDNE1s2QS/hcEIIQBqbbwwRgQRipC1eapkjX2zLHu5tv4HIH6plOUP6Dz8tnTy8vOXKDzN/Pcukm/L3C+b9ERNj1+cGrtw1ZW7S8Wspas8S4UCXqcibt28+eLF8wzDVav1Sk2laLZUrqfSOaNK79l6NTJpYlqtzcFUYrKn1+fz2k5Ho15bfe7ZZ77+1a9+458fKWZKQz0ju7deu27kZoaP0ZxLVasbR9p9bpsyyyNDLS6OklhZ4f3FlJrPqiA7M6X860dOioiv5CvlQnX0wvjObbs8Hr8kKV6Pv1arxZqi585muzr4bdvWCyysH+r+7rf+WdfNkycn9+3bV61WFxerCwtzkiQGQwEaQTGfbWmOuZ0sw0Ihl1Icst/vLteND332J0P9SrVh8LLj/R+8+Zrr9r/7Pe9aXpn3uGSBp8Mhn6nXGWQ7HVIhkwmH4PzZN6anyhwtueSYxIRLeVytGICIPygLstHVE7ZwXVEckuA9cWy8Odoc8odi7e3F+RmwteaWSLlWsAiMTc5jChjRv1wq+WPdC6nCf/3m4o4rqe9854+/8nd/uXF9394dI0EvdGwZIloBNwr5xKzEmopEmfV8JR/PppfB0jau779iz+6r9u4N+4OVYkkRpFD/AAhi6fyYQ1ZkUTLUBs8K5Xy1vaVt/5VX5TLFdLqRzdmxqOxwC4S2DFvV9Eq1WjYxxsBSSETAImBphmI54Hji97o5hqpXy/lsupjP6o06sW2EEI2otSki2DItQze0hqbWNbXOIqARALGxZdqGbtkGgyie5zXNkCVHfDUZjbrPjsdPnTnNMIyu66auMQh2bN46OTa+vDAf8gcoigbd4iUnR3PEBrABdAImVgQFwrFitvZnn/gblpMWF/KcIHd19RBCLMtcXs6s39C5a/cWSWZr9aLi4Ht622jGymVTikPo7GynKACBzxdzPM8rwbAnFEpk8pGu7kAkOj85U1Q1VnJUsJHNL9Ybaqi5WYi0LExMPfTN73zjX7/zxJPngYDb5TQNoshOp0NaWl5dWYlLiuTwSCZRH33s2ff+2Ycz2fjE6SNDQ32m2aBppKpqMp3auWPX3Nyir3cwmcqtrMI3v/nd1dVlioJsDm8YiXzpS5/4xMf/OBxELsWh1819m6+87uqbvv+dH8QC8o4t/QLDnj87XauDpqLBgc0Uci2tlPzB9ldeP1mpkt6uMMO4N2/c0xTpaOtZ73b6wWZ43tG5brPX41ccciDkVzW1XC29fqA2vxSv1I1QtJ2XfPkivPbGcYcvhFhheWpUDHuBaOASMtl4PLHafcW1zc2evv6dd//Z1/7t279eWKmtpMvNnWEi2LakSSIviyLPswzNYoJsTGGCCMVmckW316vrutfrHex39/Z0A7FGhvu8XuB51Noa8bglTHRJZDaMDA2OrAsFffMLU6BWgiEfwwLGlsfr5nlGb1iFXNGlePftvSqRh0NvHGrUGm6n6zf3P6DX1Pe95/pMPP7Ki8eikcDiwjKLGAACa87xgAnYgDCABWC5PUpD07OFoqbXLMsolBvFagUAnzx9LBILtLaFlxNpn9+FsZFOJ8uF4vr1G0A3wbAVxQWI8rh9Pm+guLL63ve+JxIO6A2gANu2rTXqhmFc0kzWMHMNXe3ft1//A+b+32c7KeqSNdilKvhL4gwAMAzDcRzLsmsjUsnbtKf+D3F5IpcJsMUbbto/NXOab2qfWprq7OuxaNdrr583Lc+hyYTkCEcV+/z0vDcMbCWPadPnr+sav3mLCFwNGmg+odYralPz7lwOa0b8wNHlcAh27g22b2nFpJhGyQCVFXy8IHBKqLOWNRDu9oUYUNrAbsTj8Vhbd24h7fK0pqdrb76wevX+ew9lzuC2bjHUE+QcqwsTO6Jsk2Nhfv705p07zh9/sSPmuO6Kj40er7YF3E/84kQoBh/+YGDyojZ56qnhnisqfZbfHxw9DazLfTF1sWc4UGoU2vavH03qqWnBLLmWpvNVcX5TALxGfVOMIcby1TK7bsvgzLmHHW7ZKXPxXKJ9YGT83FTZonfs3Xf/X3zreL3ZKfHOLm4psWAY5wAX2obE1dWXgh7U29TllpjiirZ1/V5PU+Tn3//+VVfupUFGlgGl6tShybZWVyAStkBBiosNBuMArBMoW/769772wXuv/Npnd0eDYhO3snL+SIvPVzXn7r4+XLp4KB6Pu91OTdMkr8PAuo41WaQFGnwOHAjy02fnMpmUJHA33b5LU6vV2SOOYEChsVUlA5HeRCpLcpUmBzXS3fz0M6/9+Z9sHb3QOGbly5ZWLtkNmgYkxVoHRifGvU4HbyIOYQdF0wgozGALWRZdKZkUxQqitJbBNy3LsIFhaNsGghDN0AxCBMGldH+mYl66TRkeHDwATelGrVwv6LZgMahiEUpATx88e5unxRcbrucXPB7PYmrJ1do1li01UZZdXgp0OiD5cimRcjm9oPjyq5nHnnh265adq8fOfvWvv+iTfA6e8/qoLZ0xNTdv17Prmt17924/f/EoKqH2nua6XtT1ii9mTh49NdK7hXO7yvFaXaPcmOcCUS7oAMGqaPG2zWENT1RKVDTUIXBCo0zbGhVw7q6lE6B1rR469g9/9XA5VQu7PKRY94b89YIaljzplVx7eyyTy8o0f83AjoF1vdl07WMfvLo2Ny6gokyKInYDchLDBXognuXmEsxjh4zvPvmvjCPakM0pozJbMkWkGNVaa9H3iU/8RzTg1nRB8DqOzp+KRr0rT59r1PKf/MjVllYU2Hrjne2/+vkkRwdbvFumLzx48/6mHbuaHvrNfKNs1PJQBM+xsfOxFtBoju3vtrxRujpRX074A4wsx+qqJPtbPv/n/1jT4bWDSx//s+FwlPn5f35/oAtaXCaVzzgRWqb8eoVGlA90VjBZr88FKzPvvm1vtkAgdTaxcr5WKG0b3Dg2l0INR8ARWLTnBIFBhEYYcTQvM4xXcebTiXop29cUImZ15sjYn370iu2bel559gGng7/nyqaWliCqzaBawslKlI0bdSOTWB3evOs3v7p/4IobULmcXloKtbfXs9lEIiGEvcBKXkfn5z/3Da8Dkll1tZDXJcbd15+Vw6+cmvjpgSKWZNlwlP1GkW24NRdFUYgCjDFGJiGEAYohlFkHhvGwFNMog2nqCrCAQcubvA2Tx2eDO3ppzRRzHXo5IUPV5a9bxQXG77GqVc7tB5qxWa1Cclghsdyhz+4I/CyVzat1wgJx8IlspbU50KgXWWIhDBiDRWidEm1GsoF1IfW3KGwR/BYc0xRYloWARmutRmtVNQQBoQqmKopipVLx+XwURZWLlbWJlSzDMQxtYmzpJk3THMexDNNoNCzz93n5b/k6Bnz5mUuPBZe711Cqhqem52NNnRdHZy2bf+ONMxPj8709Q9imgsEgYHtyYiwclK/au7dWMVsiMZ/bI3u9AFSlXKZpJuQLUkAvLixkkplEIrVzu+emG7f19w8MrN9kWaRcUiWB9wfcDEWWl2Yr1XxXd0tHZ6ter1o28fqC9WrDwCiTzY1NjhmWPjpxYc+u3e2tbeNjFyxbs3EDY7y4sDo0vOncqQvhSNMNN97oi4UnZ6ZPjJZqKvQPdHiCXTfcervs9Nz/4K940aaZWiG3QBOtORienViSGS8FChD+8Ilzv3nqjfHF8Tvecd1//vQ7wZBry45N9336/YjlZscmQk1tOmYKNSNX0pPpWr5kDgxumV9IlyvgkgWaAl2t+rxOnqYkkbFNg+eY1uaY1+XkedbpcnA8A8SORkO8ICwtznzjX/5tdW4uEg5PTizT3qDD5zMaDZ9b4RCUCqu0rTYqtfOnjm8cGnIIQqlU4nl+enq6s7Ozvb09mUx2dXVJktI5MERRDOcPRts7RVGu1Wqqqs6PjVm2HY02VavVleXVSEeXwxfILCxpmoaAohEyDGNlZcnvcZ84dqS/r00ShJtuvKaQB4Jtr4cJBD26Vrtw8UxnW+tb3IfYBGwMNiCMEAYKGJ5jeG6NgFAUhei3Wi2s3zoTWfj3HJFYlkUIrWmFlz9aOhwO27Y1Ted5XlGUbDZ77vz5hcXFleVMvWZ0dPSUipVSsVgq5gJhH9SLb7724uLCFCsL4JIdsvKrn73+iY/9w1999md963rm8vlSNb9uZKBSKyKarF8/iIl18MCBUNDf2d4xOznV3dXjkRxqpdoeazaJAYT4Av5gLAKyjBnWBrah205vCCiOpsVAMCa4/GBRCCOn4oCKoXQPjT7/2p99/LMLszWnIlaKpdbmYEOrG5qqKKzbw5TKacXBRmJeQaEvnjm577prMMZKOORyeWSHBwSHZVIEaN3A//4fD7/6+gFAtKrp50dX4vGUV3GKFBNwuRw8LEyNel1gqCVFInoj43CiUMjJ8+T6a/ds3bnTISvdHX33/fF7P/DuHcni5OE3nuAoraetuS0W+eyn7nVIoIgo4Ja/828PuSSPQIumavAsDwAMLzT1dDMMk0zFp8bHr9y36Z13bt+1s+Pb//Z/HnrwfsCwf/82gmkQ5bHzo0NDI5lsaWxi1kiXaFY88ubxi0ePz07PtGza9NgjD9/77jv7uoMnRs8oEulqDlhmvqs5aqvV9b0dMkfcCp3PLuaS826Fvmrbpv6elljQG/TCIw8eMBuqx+mwdS0ciXn9vvGJKYKgVCrNzc2Vy9VIJGI1GuvW9YNhWLWa3+/PLi0RQiRJqpYrCJNvf/NbmQyoOtz1znt1m5gEUYL4ne/96JkXDjfFAqIoxpMJyzBsbMFvPbYulZRcKi+5lKu8pH5gjHkeeIGZnVvO5Stz8ysNzS6W1MJSQtMsqOu6ZoNugWWzLK9IDpfTY6fjTU3hD37wCpcDsAWNWt3jlIrFMhAKyJqdDJDf6pOA8JpEfqmu8RI9/797TeEtd0mMCKYRmLqh1uqmqfMsE/QHKOq3ggzgt+R2237bgsffvyb5fR+xS0G1dXefvTBX02heCL/2+sLScnV0LBmPl0ulmqHr5WLOJfPRoD+XylAWDPeub25uBocDLBtbmKFYRBhTt7ABiFBD/UObRzYP9Q899eQB4J2ZbKW5qdMyGgtz07PzY6ZdkRRC8WbDqlUaNVXXDZuenF2p1K10vjS3tOAJeizaWFpYRti++ZZrTbO8uDx14vSZcKzZMJie3o3JTKVQrZ49c/KRJw/0tvFf+vJHhjfsnl2yFhLa1NLq5GL+9MUDheKEbSStWp5qkJDcqhWEyYvp9o4NG7dt2rS3dfPVI5nUzNe/9vne3maGhwcf/U2guXk1X5lZzdP/H11vHSXXdaV973MZirmqq5lJLbUYLcnMbMdxHKY3mTiTTL53Jm8mmeBMJsxsSuw4ZmbLlsXUakEzU3UxV12+93x/lKwo833vXbV6VXe1uqu1zt1nn2f/9rPtYdpRH2pcyzjqZ5fKC8uVx59407TAUqvlXAI0yVKrhKUpFUPkSLdLqI+GeY7CliYIDMmQoFTqG+o0XZGU7A3X73zm6XewRfT29CTGZsuraY/L2dPeSJpQzmoBJ967o9PBoEom47c5aZpWFKWhocHv9/M873a7ZVnWdb2ayyFE6tm8WqpMTk6rqilJGsMIfn8wEo7uvOzyrq4erVhOLK6oqq6pOkKoVCohbKly1eN2igIfDnp5hlheHPnbKz9rbnbNxAy7QFIEdtnFUjFHIABkmdg0LE23NB1Uk9QxqV8s7GiGrpsGxtgCqHnTmdiqRXYTWya2gECIJCiaAIBLgzuBLyw4iqIwBk3TKJpWNXN8fPzMmbMIi6uxPMfaOU5w2h3nzg7Fl6eN+LzLQWlyITU3WRoZYbz+gS7vpr7oVTtaz0+cjgZpl99G8sjuFQ0sZ4upXL4wuLZvsL9fLhY9NpuUynY2Ni+MTnKYIhgCI53wuYSAHyjGokWCdwLrjKUq4AobmFtZzoAM2AC5pJCMHRjfb//lm1/6/NeVMnS3hWlgFBlTJE4l5ebmYDwRD4QcJhjFSnVgXWu+tBiO+KV8RtHk3/7o+XJZ87b3ZFdzVQWXqoaJaM0ClrfPLCymclIgwHkCHlTWOAsTiswi4Cmo89Jrunw97a6GMLNja9e/f+Ofv/LFz+zavvFvDz1oY8VPf/Zxnqj0d7ha3WAq09s3NgSdJNKqPpH69U///card5w8tdLghwd/9YiT9SAdS7lMNZbQLEuvStlsOpNMGKrksrGnjx87fXzu+TeXt2/eVBd2rls32NbV89rzrzjcgdNnxj/35eddrlAiXVpaTHb3rgv46+x2Z3F6cvT80MzU+bV9jVEbpLPx+PI4S6ZWJheafPzQsZP5dKaaWGjxCSJZafQzycWR9nrPlz//sY4mR1cL0dLWfPWunSwiEunU4vLysZOFGz/60UQy2dvba7fbs4W8oig9W7cp8biiyCTLkgCqJGWSyaDXUyoWR0fND3/0yjVrmxULZSuaRYunR6fPTUGqAqqJTQsEgbPbeV2VL0UJL5YoLcvCBMIYG4ZhWCYAXPxUM2ndZOIpubGlNxhpdfvqWM6lGrQt1AQ2j2jzAMnqsqFKWrlQLuSKJpIdLnbL1nXX33BZZ0eYoUlRENxON4EpwCQGAvD7lSewAPD7cdj8n5TLJZH9Ukt3O8+TGEgMNAIbxzoE3tT1SqlAEySFgCQRSZKIAAubiACaof5vkf3icfl/NKb+gyxDCw6SE6oyVShRC0vgD1IYVWQ5oWoWz/N2uzLQ1wnIGBs/e9WOnU7a7nczYFm6agisSGCUTeVMzEeiwZdfOgzgvOuO+15/49XBtT1zw6OKjN/bf4Ks0MWS5PYQjWs7IlEny2Ndt1jgSiXt1dfeicXh8iu2RvyuVFHu7e/bfNddoy++oFXzLzz/15dey3/5s5093c2hiHdhblq0sfvem+jtZwY3XXH51Wto0c0LvqMnjo8vL9u5mFJYbeomViYt1Vg0DWzjPAwhgkZStLe7tX1qKvXIE0OeIKxZA+lUvL+/3mYjGluibr8tli8ih88RbVIZIVMuywZNqeb4XHEhefTomeyGNa1KWcOS7hHtmUQ2JPBAQFtTNOzjbSItVfKyXPR6BZIkipWi02OPx+NuuyPgrS/motWKOjO1cMWttxVSxfnxcdbT8ODvP/2Nb/7BK2Ips3D1tZep+XxFZ3wNDQzDAMDs7GwqlWpqanI4XARBnTw5tHv35bqmsaJNkY2Get/yUjwcEhYXVoqlvNvpJBFubIi4vD5dkculQiAQyBcLFEWRupHPJq/au3NuYdHp4BmSNDMzd99+dahl5onXhtwOR17SEVgWNjHGlmWYWCMACISBMC2wlIpeWzQ1HbGWwlsXwGKwAAPGBCYQQhdkRWxiy8Bg1hZcbXnpulEoFH0+L8dpuXzB6XS6XA5ZVubm5ujV6saNAwzlFAVXQ5ONZMo8S1Ii1bu+r7CS4Gm2nK/qS6s+wZ1KlmemVxQCQh66oTlAsZpcyKczxU3rmikrV98QOX3ymKoUb7jp6sXF2cZ1fV7BGXD5VBujgs4xFJgYgESCG7kiPGFFfEQpowAW6ls6gPGYWd1G2wHTv/zqD/788EuRAN/d3ro8O02aZtjnyCbTTVEqFkvWRdl0JsfysH1Ty4OPHiJJiIbMjXt3VleLPX0Oe7S5uLBss4XSWe302QlfXX9VgUNHh2mHM2ijE4UsKYo2QCGPp5JdbvIxl23uRWalq7NJ09XhM2eu2bv2ucd+YxPEdHzVZbOZmnndHmHyzLs9rdGdmz1OW93DTx//5If/2R3hR04dERG6+5ZdImH+/oEjXt569HePfegLHzvw8tO7dq8BSTt+fEi3aGwhnkEungw4mZ1belwOp9flaG5sWliMjY+ccTh84YbOfU+cJACar75FHTneUBcBGp86etjrC0+Pj7nt/K9+d4ChQLTDf3/9LkzTy/HE64/ti9goMQDf//5/njhx4ne/e37X9qYPfeCud956ZXVuuNzmvOnqy4Ie2+O/+cXkRObWmzfNrmTWDq4PBH0vPPywP+CemZvt6+08fOSA2Vhn62gvlUp+j0cpFJwORzab1TVtZWE+EOy88vL6Gz/9ufF/+85n7v+vf//2J2YSq++dyvjqQZK5TLECgs1mF2WQbDwFMtQUjlo5kkAIsGVhQAjV0teLsc5EYFmWZvCliolMcLrrBVuonFukaBcv4PhcDBEmzbJ2N2kQlMCKnM0BBEnJmaDbUdRK111z+VJeKWqgmoykaoBJwARghAHX8HcAE/3/9Zde2sR08aW/6yqablkWjZClabquW5qhWrU7ySJQzcyGupAkEYAQAfo/yO5/L6O+H8prNpAXg7ul/x2woaYXFwc37wTEPf/yob6+tnMjMy4XFQ47l1fG2lobfF5bLr3U3dWm19e1RRsWZxdgXQtIVbAMClGKImETCIIs5PIBnz+ZkJ968m8P/fX41XsChw4dc3sZm90f9bsEkQ5EHJwNNLNMAm8SRDybf+7Zs9097ZdfuzWdKZKccOe9980vTT33258eeOVcPAZ79jAvP/8ZMLVEPD49vaTI1P7Dx7ft2tHe3R9LxW0+x9xi+sQf/rKymmbcwsb17Q6REKlM76CycUdXOVNy2OyO9o2FqUKuBM++/vr+U9Obd4fWb++JZ5dtJeW66y47eWrob08/PbB+bUlRPf5ohXSXyuaJ86tHjp8rFiFZAheXjgTCnV3brNWzOc7Q5XLADhypbd3RvranhSFklsKlUgZbKiCDFnitKIkOvjpfTiwPcQNr84WC190UCLSZJWt+dlX0BpZGh5p7ej9897rRkXOfvu8DT//1z5/85CeVTCIfW3bXN86fP+/z+QAgFos3trRNjU2uHRgslyr2QBAYhueFUrFaF2kgEI0Jcv3gZgLhc8OnBd5RyKdTidW+vl7D0FxOD+CCJEnJRLyxo91u42jCUEE6dvTt+s71X/jCJ987eS5RlpBJcAwlVQ0LrNrp0USYIExEYgNZFHthcJKhGwQiiFprhVkbTQOolhMhjC6Ed9BU3bIsEhE0TdMMiYDQdV3TNYJAhmEggrAsIAiCYRhZlk1sLSdz3NgsxaO1axv6+9eksxNTk1ObQoPVVLJSKNn9HpFl97/+1upSzFAYFqC5jV7b11Et5WYXZu666ZpzbNXj41uiG2emRw8cSO/cxgFFCQxdnV90i3YwEeu1lQoVjsAKJmhWpAgB0y5EUZqhKzoVaG4DEOWFFB/tgqzyh299//nHXm0JBX0u++LkgqXqAk9LxZLXxZSKmt0GDK22d3J3feB2/46NBekr1arR2dUETnZlaOWyPXtXJxdF0VGqAMsH5xeH//L08zYHVC12JlYM1jmbW9vHpqZ6BK+ANVlVm1r8rXWeSLg+k1oO+9z85s7pyVO59OJMrpJahTtv2jR06sTlV+yRtSnd0HduCnrddR/75A1vv/giSWl7brl6bviUu53bu2Ogu7HjX77xcCa28sE7Uts3DoBhAcMKNoeiWi2tLefOToTCDZ/56D2SrOVyOa9NiKxfPzR04o23l+6//zodcV29axzvjKdOnAn4nMOnDq4uz1x/z92p6dlwpCWVLt3/EWSQ1BMvTnqF8oZtWzSzZem9Q9PThWuu6ertjPQ2XDl67JWQXf+P//2D665t2Li9t5pfXpqfmbLMnVu3NIeXwh7/Uqrygx8+cOMNm669/vqpyZEjhw5F6gKDg4OVUq40NsZSNKJpvVxWJJkiyGikbmJkMpc1P/qFL/72m//50runL796y+HhiVffPkMQoMpgWSRrs+sEkc/nTVpy+XhLviQdBnypDA3vQ94YQc1o3UKASYeJdcNQ3zt8ppBJ0kZ2bU8DRaBIuFlWioLXBTxPSrKBSV1WVN1wkTKEQoWxFVFwk6AqpaLT3zg9uejzeWtDry3AFtTuBYsAqCU0FxUS0zTRJVT7Rdnk4js0JBkh4BlG01RVtQgEIkP7fL5EMmXVvEdIGhGEZVkYmwCIQP9Ay1wM7sb7Eij+RzsZdAldQwWiUU8wsu+dY/kSJNIWxQYMoJZWCqmMFImWB9auGT5+OOy3IcU9PjS0ds1aqZQRMEeSSNPlslQJeH26xZ4cOud0NvT21E9Mzn/igxsam8KqXsjlY91dPR1NbSDnwIbByq0kY1kJU7RTNiBU72XFcKShTycS+UJ6/+Gjf3703bIE1w2K93/+CtFmvfr6EzSBGhu68kVzbGxp284bOZs4Obf4h0deXVgBTgC3O1jftGbdhpa//OXJXdvFq27d0t3uWZ2daOrq5Dw9j/3kof3vrmgmlADu/uDeq+7Y9uLbf65r8RFjmdjyrKzKPQPdFmtbiZc3XrXzZ79+6ODRecHOYtMJAt3fWC+VFElSn3j6le4+lrWk1eXK5kG3Vs1fs3sbT+umUmIoLSspLgdHEBYIDCZMm01weZxKpbi4MrOcqGzb2rwwt/TegXPtPV3LiZVg2P3Wa081Nzd+9qO3FtNL3S3NB19+beett6mZEatUikQirNPpdntnZmbmpmY5TmBZ/pFHnv/QvbfYvP66SOP09PSGDZsmJiZ4znbg0BHL0GIrpYGBgUBHH8vy84srhqa0d3U6nVi3TJ7nJ88ONzU1LS3NMRzfUO/P5xPG1Jih61IZ3L5ArlgFIEgSMCCMCCBMEwGAqYMZ9HgIgtB1vSpJGOMa3aWbRm0Z1VYtEAgjwIABY1NTgUA0TTEMQ5GUiS9ofx6Pp1AoECRlt4sERUqyKiu6x+NmDPvscnx8blTFe/deu71p697Ei6snDwxvvOry1cWjY6OzxZT83DMvj01AWz0aXNNTjOQrhaUN6/oJIxoO2ZtuuqIx4vvaV3539R7fxk20CbpcyMuq4o8Ek6urNMPQQgCpFPC0rlCcM4gUK69SDAjxZLq9axCAqi7FRc4PsfyTDz3+8G9eXNPYZep6YnEVTKW7rVEpZwtZdW1f5/T0+Q9+6Na3973W0BwR7cS55x5vbo2Uy0XTUsb2vdEQrYOO7gjvxJLxzjsnJqaOrSaqigFemyuTLTU3+KuWGU8mOro7+KUVsypHvXRvWzSXXNy+89qFydMBn+Bz255++mR9A+IF4q67N5EYN7bU5Yvp3t3r4mfP9vcEsInnh9/Ty7kN2zbFzpxs6aoDOUlisTHS8Jvv3v/IX3775ft//7Pf3Z7KVAKNzb0D6/bv2x8JBM7owz476xZIjmRmx2PdnW1vvvW2YZkd3TbB7uPd0daO0H0fv1pWlTNnpy1EuDwBLZ112VylQiGzukzbbPd85KM7dwycOn+K0ppOnzr6ra/80y9+8TM1s/T23/5EM4i19KPvxn74/ZsoBPlMNp5cLWfTPMskY7GgN3Dm9LneLVu8AW8yvvzQIw9Zpup0irFYrKkx2jAwMPLe/lDAV0inXR7v8swsz/NKVbJxLGKdTz3wsGJwey/fefTMuQpUKxZ4fdzCnOK0g8tlz6RTFE94PM5svigAS5IkTZIAYBm6aVmAMVmTQQhEIpJAtXz6gpdLsWqEAh5R4EYmFkvZ1YGusIGpfLkyMzsmVQtd3W2eoN8wseh0IUSTCCyzrCyNZzJ5hRCDHtvsstTLlW08T1ikhUiMCYyMC41FyEAANawF/pGcgfddGy8VSWqxN+Lz5osFgWN53iU67IDIlZWV1dgyzXCGaRiGiRlMUCTGpm6ZgAkW/8N8j4u7xMVfdOHU8v7Pv3QeCNHR2z69tHDs5HhdY93MQtblblA1Zm5pVXCwiloWeFi3rl1gTTtHWHK5o7tb1iqVSoFgSJqmy8USSZJ+rwdbejYdW12d6+trZRnweO1nzgwDQD5fhJIcj6VyK6vlShUjghedgt2HaEdFpZfj8nMvH/jJT//0q9/95Y19BzAJV17j2r1j+8H9+0bOn0SkZCKlJJU3X3HDHXd/2uFu/sFP//jjX75aUiBUD5oJNGcfGNiSXR7pbITrr9lTqlaWU9nGng1c++DPf/zAs2+vBBuaAnXNPE3WhUPp+AJP6AIpe92eV155t7GptW/t5khLd04mbrznG0fOL+o8i4UQ5QovZ6WJuZVUoQgU7fC48/G4WS121ENfe317g48CRaCxjSccAsMx4PO7wdLBMjRdIhhU31RHCmSuUhrY3Lfv0KlkEXsincPn56qK5fV6Ozsa1g20Hnj31cMH3o2GQwLvKI4vOYNhWZZZr3d1bi6bzUbC0WKx3LB+/R//+PzYKFQqEtCsu6cv4A+nkunlpZWGhgZRtG3ftquru356djE9u8CydlUDjOhctoBIhqbZQCCgSFUEhmFqjY2Nb75+sKer6/CBg2OzIHBkpVShEG0agC0SAwmIxIjGCBlAGBhYlmVYlriExMIITNM04cICBeJCqaomzVuWRSGCISmmVno1LQCgEEFRlKabLMuSNFUpS4ZhAIl0y1xRkpTdZtLs0y/te+Txl0Cs61uz5613zj3+y8cf+NOzDzzw1AOPvJzJgcsOLjfrcNEe3rxy52B/W3Sgp36gv72p3nv40FsUDZg2N2xdjxmCtLE6haC7y99QR0fDQGMscBbLqogCm4tgPWWVJrhge9dmS6EriaoY7gAQfvqdn/zih4/3twWKyTSLcU97S9jnziVjDGm0tzgZ0tiyecDUpeuvvYKiraXFOd1QNU25/vrrdLPc0BBhOBrmlrFk/eUvz2zespeiHAPrN3u8ZL5YphjONE2Hw+F2u1dWVmy8Eg0Kmzf0DPR3qNVKYmp257ZduWwlEGz8py/cduQEnpix/GFfW3drWS86g7bS+Ew2ucoE7Kqcbr5sC5hWKV88O3wqtzyZSE5wfk7X5bqe/k996lONTfCt/3jGG2ooZYpnzo0lUplUOtHV1mLnGV0q8aRp56nU6rLP67njgx++8+77hkemvvyVb/zwp99/9PE3ZpdmSIaUVWnDxkFJkmZmp86dHvrwh+5tDgVXpkZZSz5/bG7u/LHZ82fSS9NbBrpAk86fPDR05OA3/s8nbByYSsHpoHWtRBJWe0fzXXfdnc0VHU5vY1NHPB6naXJ8auG2225TVbjuuutEURwbG6ssL0dCIbCwUlWKqTTP87qqp5PpAweyXZ09rW1dsUT23Phs2SArmCFdYk7Fgo8nBWe+XLUAOe0OlqZ09cJ4UpplaZqurUyMMZCEhXHtpdrSteDCp5qFNBOTLO/wuqqq6fD48mVJMczeNQOt7W3NnR3OaJ3TZeNsLEkYgFWC1uPJBZoxfB6+p7Op2Q2FbDzo8wIQgCkMlIVpAAoACIwR/E+e/eKT/zE69SIraec5gaKcNtHvcTdGog2RMEOTmmw5HTaGoi1smpaB8QUSBhH/VxSSpmmapmtjWi+qQJZlXdoARaTzibnFaURDrlRtbOmMpYsrqZw3EFF1LVcsnTt/gmWtqYnTPKX2tEWXzhyzSKtQzQNNkC6XrCq5XIa2C53tTZGIx+WkadpQlNzIyKlonb+lucHtsRuaFY42eSJNxZJWrmJ/qMUA+ytvHNt/KPHmOydffvXQ8mpJVmB5ybTb4eqrrg35PFdesauhPnDVFZe1djRv2Hv5+PDY7//02Cc+/b3JWaAEMBAMbmrfsacfSGpqdq7eXr12R0fUb29p7apr2XBmtvrt7/7pmXfKpJtayBUNGr74pc+2N4WO7Hv11qv2GrmsyxW+886746nqnx555rNf+OOLb06HW8M5hTQY10pekoGm7Q7MINbGSmrB4WQdHPjtcPetl/d3Ng72tc9NnkOGzJAmw2CaQnY7r+kSKFVJli1suQKB9p6O7/8mefDYyJ0f/jTvjjz2zBvOYHM8V/zq15/u7u6MJ1Y4nt69e1cuX1p/5Q2Zgvrmiy9ijLVcjmX5YCjEsmwoFDLiiXQK7r67mWGY1NwcJBLBYDCVSg0ODi4uLnIcp1tmKpkmKbYq66upvNPp7xjYkMwUa70I+WKpsblF083Ozs4//PGV9Rv6Kd758qtn+ltpmuYQsFLVAJOwTBIwjYBBiLYwY2HaxJSmKZquaLqiarJuqKal13jI2nRgjM0aY2NZRu3rBAKSQCRFAACYBsYYkEWSZKVSIUnCbrfLkpopSTTHi6K9XK6G6iKzuUWDozDHP/jo81++94s/+vkTk9Pyg385eua8GkvA2XHwBomufkdju1/04HtuuHKwvZ7WS72t9WCUh08dnhif/cFPP4wYIGz0zqv2MG1NgZYGaWmWiIYxwjpBWQyrAVXRMQBvkiIgp8DX6yq3MJe1hTpAob/9la8/+ej+qJ/RK6qDB1XKZhNLWjXrtJEih8qF4sLCRGtTuFjIlCt5hqLtdieyKF02T544w3F0MrWaSqVOHDsxPjHb1tqbTpcrkmGZ6OMf/3hvbzfPUrJSLhVy1UqpMRIplS2HG7w+FoOWzWZ//stXqTXb9+07+9/ff3hiKv7t7923YWskK5UlLPkaXN4Gx7Fjo51dg0o8XSxXIZvbe8U1gs3Vu6Z/YmY01OAHpMhaOTU77m9v+tJXP/zRT9adHZv6+a8f//FPh7p7+niejwQDoyNny6U847L/6BdnNFlx2J2vvvQKJqif/PrYUgxaO+suv7otnlyINgWamuqXVuYVpdrT020TRLlUEhhGr1RAkbdv8BmlwoduuUagkalVd+/csHP7+tlZUOXS3R+IIMIAsDZftjNXKlqIWowlTg0vPPHMq4pOJFOxru6Oz33uY+l08rbbrh0bG6mrC4+Px375y9c87e1er9/j8Rw7dpznbARBOZ3urVt87+4/+PTzL54emS9pJvAOkxE1iksUVWeoXrWIkqQGw5FKpTI1ma0LIXjfCBcullIv8WMBkrhQIsIYI0Ak4fQ4c8XcSmKVF8WSBGVZGp+e0CxTMfSKXLF0GbSqJJUsrWroVVOtYtqMNgW7u5q8Ub/HTn/g9suQYRazKYQtAGQBiVHNJ6YmyxiXpu0Xo/zFIid+vxfp4jckVuOmbjhEmyYrc7PTy4tLDtG2fdugx+kSeJYggMBAIEQQiCFJiiLx/+XieZ7jOJZlLw3xCKFLh3UQkpwfGV3RMbAClS6kHB5HQ0tTRZWBJg0LdKwB0gbX9QDI4ZCdZ/WSUhHcjkKpWM1l+jdvmZqdM6qVaH3I67aZZrlYWNG0nNfLNzWFLKy6nLbVZAp458LU0s9+cToQ6ibo8PR8ft87+kIKVJ0xLaa+sTmWhr7eyFf++ZOGbGhqWZVLDEtUq2WSpFbnFiuK9uz+2QqGzdta27tDOy9r+dfvfY9l2VQqfuDIuzvXOO/43B2Z2ByJhNPnkv/xg2dmM0KZhApp01goaVlMlR1284rtG5LT02f2p46dmHjr3ZNPPLWft0d4O4hOLlPSKzpV0ZGOiFQxT/EkQWOCUkURryanGoPsjk1r8snlci7htXPRoJtnELJUCiyOIaqlAsexpUK+qalJVdXUamwptvrrn1/W1NX2yz8+9Oxr7/jq2zJlraWz/3P371U0Y3pqRlHUYKR+3eYd772275G/vRaPl1dWVhnBxjBMYjXJMEwgECiXy/fff/ULL8wfPnw40N5qGoYkV+vr63mel2Wpt7f34MGDFVkpSzLJiIWiVJK0c6dHu3vXuXyRlXi2rrXb6fLqBszNLze3R6NN/d/61o+KFbAwo2mEw+kDTHKsiBAFFklTAk0K2KIA0yztUBTF1A2pUkUYfD4fwzCKLPM8X7MqRQjVWuAuLmKeZx0Om2WYqqbY7Xae51VVrZEMoigWSkWKorwuuyRJumHRDJdV0xYFFVOTgVxOV55/+ehzL544djIhKXRJgngaOrugo7+7uauOcxqeKMPrUtjJ9XS1AKiz54a27ty0Y2fv6MRwqDFMiow9EgBLFcIBJuAFjkJ+n4ooirdLOnj8UdOiGcYV8DUAMLpCtjR2QdV46rcPvvfm8ZAbeWyuar7MMIYqFw2tJLDAUKpUqRIE9PW22kQmm05g0+po7Sjlyg/86dTuy67NZeTJqZHWvk7DMBRF5VjbmrUbHnnkr5FIJJ/P2x3CtdfsnVgp+VwOS5dsNK1JVV8Imlv9FpKAwFdeff3993/wqe/8bH4JZhdg71V3Lycrbx5Y5VxuV9jX2NMUL65u2HJVLFlVTb6+uS+zmldM8qFHnx+fnt64dbOuS2BKopN1+xx6cbVUXG3sbR4+M3HqNPSthXXrN1WqSq5Y6OjoYBhqZnj40x+uV3TNxFZLWzvD2SyAQJiiGUNWcnUNfoLU3V6BFyhEmJaprl3XV8xlG+uiTpv91NETXt4pElw5UywUMpddtr1Uyrvcjh/+8J7Hn3yqtb3N7fMvxVZfev6lSLR5ZHLu2ND5uVU4cab6zMtvI4SnpydIZJEkisVWRJE/ceJEJCJ0dVHg8lSqcjpTuPqWO1555V3dgOaWDmcgqFmoobWTd/CIEWUTZYpSRTVFlydbKBuAWE4sFSsCx4UDKJvAiCRkVcnlcsVi0TAMiqEZhiFJUrdMiqFlWS6XyzzPMxxrmibHcaYlizZGkktVpbx2fbNmKFOz2ZXVxYpUIigkazIYKkVZpi4hMEWRRjTB8mwyEVMzK63tUbmYKpfAY+cNXVVVVTct3cAWEA6HQxAEqaRdKrjX7ova3qNpWu1ce/FV0zR1XWcYhmGYxGo8m83m8/lsNkvTtGVZ+XweIeSw2Xmeh/c7VGvV0Yv7BEVRLpcrHA7X1dVdenSunVFqIb72pPZPCK9HvPWWDSwNdVGPrBYqSh5InClkJM1QDKAZrrG5qSoVBZ4gCaVYiNF2p07S2bLM2FzDp86uG9x0eviMIHCGKYdDLorStm1bW8jFM+nl/sE1mlptWDPwxgsv/eK3B0kKdNN18uTizFzls/9085f/6Z6du/fG4qm56fm9m1u7Wlrji8vlbFHXSi6XoFQliuKqVYPlHKOTM1dua//YR27pW7v+5pvv3LPnyicffOjo0VOyVLznjpvsZGrkb79fP7hGU+jv/dejuapw9EyirrPPHg7G8vm777vW68NzU0P5+EouliqsQEkifvbXubvv+/hX/vW7gUhjMqeUJRMo1mZ3KqpalQosg202wLjodMGmDW09nU1KNdfaHMmlV2gKe112Q6u6XTaETY/bKYZCtMfHMKymaQAEz4mN0ZaevoGW1vaBDZuA46677faZleXjw+camjqOHD3l89etGdgEFP/sS689//oQ7RQGB7ucDrcuqXa7i2VZxIs1UsUwNZsN0ul8aXkRY1MUeV5gZKXS1dGGwchmK7IMLa3tBMkIdhcnegjaBt66VK7a0t43en787MjUyMRMJl8J1vc/9tQb58c1ggFJQ6pBSLLW2tGJEAkWNg1saKapWVgnwGRIzNEkQQC2LFPXNVWWdVXF2AJskQQiEYBlgmViyyQQ0BTJMnRtGQJYCINh6tjQwfq7+RFgwkIEvI8GYwIVlIroFx0Bt0mSsklWDaaqcTrm59I6xdo2blmz6/I90eZwtNm3aWf/DbdfFqkLgMirqVUjn8SWkl5dDEcD9S2NLT3t3oYIuESLo1SWVjlaZWiFQVWVyJcNTvQ5HCG5gkGjGELILqUEzgmy9fCPfvXrH//OLbAMIkdGU42RqGVVggG+pS1gd5IkZfm80NPt1NSKvz7sdAgMSY2Ojq+upO774NaF2dWtG3eHgv7J4dNN69bt2nGZJElKVdm0aX0qleB5ZOkVVcpu7uCDXkEkgTQ0r83GO4BkjYaWKMsznkAgnsq/9ub0fBK+8KVPQfeGJ559tbPPW1Z1rj6SLGY5t5ArWg3Ng+NT6Zn5Qkki/vsnD9pc7DVf+IKKsaTpQBKpwqpFS7JVtJBSziU2btrh9QNFInAHwu3dpbJ09tyoIDrypbLL46tvbFBUnaDI8YmJaAQampuamyNOl3B6aGhqerQq5UUb4w+4KtWCqiqh1qZEImFqZndbD02I9aHW1HI2GA6cHTkXrou09faeHR3btHnLqeGRfFldzZROnVteSRU7+gZJwUUw4A7Bhz/5uXIx09JYd2b4ZC6byudSNImuuvqqvr6+zZu2wsrKvn3vqroxPTp52Z6dDpdXUnSgBcrmfOHV82XFSBSKOiLdwZCJCB1j3cSGBQCAAAggKaBoEmrcIUZAEEStCGSapmbotUhnmqaBrZr1rmGZuq5ratHpEhxOVlZKNjtLUrgiwWoyE22MegM+w9CKhaymKaalW4aCkFkoVLLZjMfjSsQWjGL61usv39QraHLRYWPtTjvLcUCRqm5kM3lVkv1e8f8mm1xUSy6G4FqYrkGTiCRomiYJWpKkpaWlc2dHNE3TVMMwLNM0wbTAAgJqxr0XdB7LsnRdr+1etY3tUgrz74Q7YBNbtaov4bbb6qMBmoZ4cs6CiiAStIhonkEUKalQlrAgeEplmeZohsUYVUoGjM6sOHzRlUTZG2j0+huB4BDJBoI+nmekSn589DTG6sYN6wqJmI3nD7zxan1zy94reoACjm9MpJDX1/3kU28cPHri3PlhloW+/uhNN+5pDPtAUW0kg3GFpRHDcKvxfENjNwb63PlRzdKWY4tTM9PxRObE8eHv/NdrdgGwCQvzQ+V8oqer2ZKN3/zq4eUYuD0dVZkmaGYpNvfVr36IYYup5FgmNdvV1hoNNm5cJ2y+7PqffPsTJsF/+vNfqqqm3eGy252RYEiWKjRpOUTGaScFzsRmVVczCJd8PpvTySNLcdt5nkEel40kAEgSIcwzLJgmaJppYF3H2EIYk0tzC7WR0IVSLlTnf/TJPwfqgqlM+kc/+d2G9dsb6ztWVnKxWHZ2aTUvwZU33lgXqQeAalUGIMrlqpTLYYwBsCgKXd2krMD8wqyqVVmO5OycaakWVl0OYXB915q1baJoPz82rmPK4Q3Z3KHvf/2/Xnp9v2rRobo22aQ50YMJ3hFof/tgNicBa3coJkUwXLFcplmK5kiapmgKKIKkCJoiWIbkOcbG0gzCQCJEAJi6DpZFESSJiNpHAhBYuGZzypAUS9EkYMsyapykrmq6rtfut0trPhgITCCMCMDI4eFKlerCctJC0NjUYrM7C5WybOh7tm4bWLfWG/LSLKljqa7J193fyEVs+ZUFPb6QySYwtsLRoGqqwYY6R8Bjj0YItxMYUkagkkinSZ2mTJYJ1nU6PfXlsqHJYHOHGMwiyfTWNYFiferuex/61QMtYR8D4HM5t69rzGZSDEMoqizJRUk2TQNEG93X38mxSM6nmxobJsZHf/fHOTCgMdq8tn/D5Nisaep+v99Mp8fHx0VeqFRKb74xNDuT4DmLJuT6sDObkA+dWI54nUqhUFheqcqwsLSYyWVCdSGMIFsoPvjELxpDICk6JFIHz6of/9T/shC9NDHbfdkVkab2oopXs3K0aX2uRGaK2ic+86G7P/yB8uSohUlVJywMpUqOoBSMqojGiqwF/OE//fE/6hvaRg4fB9auGGg5mTs2dM7uC0RbWlfiaUnTn372OU3T7r//vlw6dW74nMhy2Qx43M6FxVnTUvOFtKyVEWEuT46LosiyXGNXL4XY/e8eJZHN1xDSLS2RTgBLu9z+oyeGG1u63z1wPJEqh+ojFikYiOUE9yc/98F7PvyR1VTm6it3a2rF53X43KJNYP0+78i5M/X19ZHGxrGz56+9/sah4XPNLe2agUbGZs6enzRoQSc42g52f5Bk+LIsVRXZvDAKVAfLQhhIILEFCBE0Abp1oYEOiAssoGFdmGSEEaIYmqZpqzYWg6YRSWAslwtJm0giAECmzc61tIBuwNmzZxOJRL5YqFarBEFZhlkqVgzVYDnRJrpoEulKtZhZDUfd1165nWegUsmoWlkzNSAJ3iYiRKqyVrMCvpizX1rq/B9q+EVgBpOUalrlqlysSrKq6KZlWGCapqYZtS3J1E18gU2D2s+/NPfXNE2SpEqlctH06aLsc2nZ9sLBWimVsap+8O5dIgdONxVLzszMjrm8HsHuUzRYjlUWl4ui6CcpBijL7bFZlMsVan370NnR6eTwuYXDx0dpzh1PZGlWNC3dtNT5hZLAUY5gQC5XFEkJNAacfvfDj41t2rzjrX3n/vzY2w899EImr54fmU0kk1dfvfbmG3c4eH11YVwtpAsrMV0v8iGPqhgOWzidrFYqxmrCrCql0+eGDx0a/ulPH3/2mRMD7fD4ow9//Wsf6u0NOj0BRSOyBWVypurxiARQO7ZsXJw+f9fNO/OJkanz7w701jvsXDJbcPgaW3q2agQNnDg6s3BoeGVxaaVaraqylIwtyaWM38mH3DyoFayUBBJIy1Iq6Vw2WRfyz8xM9vZ1MwzFsozIs5aiUBQLQJRWk+VUzjQxTTIkyeiKubF/7bmjx6fHztpE9MEP3fbmgeUrr9r13w/8fnCg21CBBJEhbbJiHjioX3vz+uXMqiQplYqEECoVi7lcbmFhgeC4WuPr1q2bIxGmKhUUtawbEjDACxQCw7L0urB/cHAdSdNVWT99duQb3/rDI48/s233lR/62OdeeGX/ybOTW/dc27lmk+AInxxbrVjAOmmV4GVMMDZBJ4zl+AIgHZEaQZoMjWmKoAmSBpK0CBIQsjBH0iLDkYigSUpkOZokKYKgCLL2qEV5hAEsTJIksjBNIIokaxnTpZCvhd6v79c4eQKVcopd5HweDmE9n49ncytOO9q9czAQYPZcvv7jH7/9zruv6+xuiNR5CdIsLc8tJJYXEyu0jccsITbUOUN+cNqBZWrapIkIoChEM4jmKI7nBYcskQ5nnd/bRCEbKCSSMS4qUNV++KWvLIxMhl18wOnkSUjFs0sLiyTCJM2UqqBrBsOCboFq6E3N0fWb1vEOYWzs3LZtW7uagCCIcDBk6cbiwoLP4yERAtOKBEOapkXC/sG13k0bgqV8rFhYCAeYL3x27207/VohawNoCvjdTlAViyJZmuMOHHz37LkTv/jBN3fsWju4oaeUXNzURx45cqSjozta1/rYT/90/vTM+u2bDUw98cwbf3vizZaWnqNDR1iRiCdjNCtQpKgp2GHnEVRYxiCx5bR7bYLzxWdfveLya212/8uPP61ZtC9c7w5HOYfvqZde+8mvXotnMl6//5XXX/H5vG3tzaePy4mlTFeLU5VUEhHZdEqSyjSNbFG/N+CJ9nfppikXSudHJ9/bn9U1OD101MAaQSHAaCWR+Nz9X6YZ++hoHgMPIPh89aFwQzJbODl0Np5KKoZualUwlfNnhghktTQ3zs9PO+2iIlVK2awg2lmbbei0UZJUE9FlWe/qWxsrVN48Miz6nauZLMHxBEVKUkXkeRIMwtJJbFCIQBgsA4NB1OgU/H5Yxxhb6H2FkCIxxiRJUgxtWZaJcW0Wnc9lyySKLAl2EWlqlWHo3t5uUQBF0Ww2u8vp41g7TXGmQaiqQZIMBp51B8vFSltzk8jg/Mr0xvWdHheQhAVIV3RJVhWSJEVRJElKldRLMceLF36/VbWmk1w6/NpECJMkUBRB0UDRJM3yvGhzOA0LYwwYY8AEWAiAIDBBAro4DvuiCw1+vx/1f2wql/7eC1SkWlIojvTYXGvWtDH2wOGTo3OL2bIkO212DJVczlpYKt9yxWBq6WxFShGUsZzS/vSH1x956Ns/+M/v3XD1lQKDhk8dbW4MRcMegXc0NTTbhFQmkzu5b//G666fOHSEcduBRRrAcy8fyhYBKCcjiID0SB3F0FWHS62WZyQkhL1Uc6je7/HmqkehnPf76qoyWSwYbz3/XEubo66pedeVu1eWk4cPHWVZNhz0fvebX19aXP7wR25Ol2MMyZYqBsVCxB1eWp2VOOLm3f2dAWJy6MwHb9m2Mnd+zUCfRfpSBVjImkuVieNDw25/iOegtb1lYNOWZ196Jex3VKtlJ4OQVsVqmSNNjoOgh29paiqXVyS5YmGDYShk1QqJJsOQhqZSdhuuSGAhluU0CxMWZZqIlFSrUh7saW/s7hHczntuDTz+2B9ojNf1dE2PzUyNjd1+2x3pfPGOu1s6ezon5+c1FWEMLMulUimGYVRVBa+bLBUMQ63vbFG1qmFoBGGpWoVRCZYjOJLWLRnAZFl6cma+rqGxVNUK78X61jVPzC4rJnnb3fcdPXpoYTHpcNgZu//pR9+jnHwVKLWimQxTtVRKIBS9ZIBBGAaNADBHYAabyNQtS7c0XtU0jSQImuMAIZIgEUmphg4AFCBMkkBeyFZMwwQAjiYssCiKAgyyohimRZKkaZlQ63gCEgBZtc4PggSMbRTnt/vLxUI6V7az0NZs72iKdLbbSavKsdlSEdk5W33EHehuKk6Pvv3m65vWDJrYDLS3plNxP2HZAl6gAAjGAIskEMlyIiBFM0wMFKYIkqFId2wxGw40E7YA5DSw+7PjZ777kU+NDY/3dYaRqY+enA34oLUxkE1lbDZBlmWvV2zpaDWkXLGw4vW4eJ4nA+7R40f23nhtOZW+54PrezbvGD0x9NwL733iU/eOjrzS09Ovadrk5AyB+COH3stkslu29D/1/Plo/cLyPN/ZFNSq8tDh9IaNzRQhbtpxxf59bzOkGJtfuPnuW1anp6dn56qamc2N807vd7/9v+PJRDaZX5kpqFUmsaS+/fp3p0b1RAy+dP/dot3W19+aSE93dDWBhWkTlLIVCfo0JcvzuJSv2pzh2allluZZRrBskMpWkpliIBA4MnRetDtuuPVODV5YScQ3b9n6mX/50qlDR0fOng25YWmmcM11mw++c/zWW3bncisen5siyeFD+9Zt2FlJrswtzng9IZvd/vFPDbQPDh458JLLa2vr6MmnEr/61cj+/SOaBd/99tey+fKf//LX3m73xPhMuVxuaWoeHx91Op29UZHnHSGfc2luet26dUG/t64uXCyWc9lsU0v72Oik0w0ud3Bu/syeK66em1twBKNVayhVqJYU7CAQz3GaVlWVCo0wASYJmILabAxsASACamyuaZrIwhhhAi5UL03DsAyDoSiEkKqqAEBRlKVpQZdNcwOJLMLEXocLYVTIFRhGaG3pKuUT586OW6be19fni0QwZi2DriomRcrYIsEmcqZiyBrFYaeTsSuaxrCKjKWSnC+YToHmGB7rqoWt/y/YXlNRaiM4ah5NtQBtWVZV1Xiedzgctc6PQr5YkSRCIQTBBhdIx5odDbz/8R82jwu3nmkCcWHO5YXqLrqwDRCIqv0ijDHBElzIG5wcO9dUH3Q6aIRUu52RJC2fVwFclukp5AgkhAnaVpaVbCHf1LH+1ruvffTx10km+KeHXn7tjeMORzSTqgqc2+3yNdS35NKFVFxZXY7pS4lopLFqFcdmzn/6czuTOfAGmiWFNkFwe71dfe17L18fDBCl0jSF8l47ysbnsVwJhOyZVDydzpHIkU5WJ6dKHMfZHOzs3Ni9H/rAZz/7uWJeGT8XmxxfbmxgKaowmxGbNt749CuHUhmw9DILhe468jN37rx8ILyz21tcnqJMDRD5s98//IEvPPTgi/uffeNAUSm/c2i6ocX5yc9+JBrxLcWKPGU5WMKUi1a1GHTYm6MRkSYpE+oDIdEuLCwvdnd3rqwsEwRRKpVyhQKItkwmBzQninaRE7BFFvKValU1dFxdjXc3RB2UmVgaT66OfuIjt954w66QTzSqkkDyXU1dImNfWYo5RNu+/W84nCwA0BRbrcimaTocTlEUAUBWqoVCDsCqb4gEgl5eoBAyK+U8BtW0ZAJMr8/NOkQAcLndiKADYTJXlGYX4vsPnmBET0ffIFB2wen/rx89u5gq855wSQcFEZTIF6oFoE3RTQMhI1KnKJ2hTYY2GaIGr1uaIquyhLDFUCSBLQQWgbClqWAZCJtEzWID1bqwLYRNkiTBqo0HQ4auG4Zxaeb+vvJ+AaBECAXtdYn5RC5VbgkLV+7u2bG5uakR2fjUtdd0XndDX9eGiN1H5FIL1vKik3fcfuOdTMhDeBwQcGMHrzEEctoly1DAMikSEwQgChCFDDCqqlZRoKqWy1Zd8zpNBnkxCXbfxCtv/tvnv7A8Nt4esi+NxcupjEeAYhoMTQqGAlWphAiH3RU2DEpSzFC4YdPWbfOLi6cPvuf1OfVSNpdN9fR15Jdm337nvZtu2QFYaaivJxHF0gxJgNtlTyWXWxqd5fLqhz/UZeMMj4OYHj/lEenPfGyHl+dp0+CQvyHYHvJGXHYHVNOnT73l8WihkPGTnz4U7HZrStLr5B2s/YHf/e3RBxd++J0josP87aFHV8owOTHD+z0uN+10YrARYCKKdhMmTTGUVs0h0OWCDEUsVxWPy5uIZz704V/84en58ZmlE2dHPv6/7u9dv+no8DkV0MJKcXJm+q0Xnn933xv/9r+/yIKLJRyVnMmRtlymHA1Hc/kMKzAtHc3YqNo8gs0taljzRwL5UrGaTnV2tRTyqUopVyjm7rg1oOtw/jwszsWmxmZV2dixddf87MLy3Mq2LZtMXc4kV4I+dzGX3rlts8DRLp+7PhqZmpg0TdPl9b333sGezVvXDNRNzMy5fIFMrlKVzXPTCzafN5YxWru6q5pSLpdFnlalKoEN0tQJy6AQkBZhGdgyEYK/YyF/X2MEqpUxMcYERdXqkxeCO0AulYoEA4asymUIeAMczc3PrrIkl89VPO7whvXbo9GOpYXU5NkZRUZsXbsvUC9VdbfDlRgdXV2cswUchexqS1OoUIBMIcWwpNfrxhjLkootZGrGpZLL/4i/+H3g/R/cHwlkACiGUVGUkiRJuoqBoGiWIGmCpAmCIoAkgES1/N36O2R50T3moohfi+C1JzX9Xdd13TI109AtU7dMopqXSQsFfH7A2vTUyMmhSiKp6SbOZmXAdkXlY/HqyUNnJMniBYdmGj//9aN/eOC1fe8NnR9dVnWqWLCuuuqWtrY1DqePpgRN0+fnpUoZfN7QuXOjNqcPU4o74EzmMnYHMbq4KNoCpkU5nO7pmbFkepakypEQy5Ll+rC9zmcX3A7TUliOnpqcswz2wHsn163tVDRZEKn2jqbvf/+7v/317xyCfdf2tSE/bbcRcjXhCG9879DU4aG4J8BJlfSVu/q+dv+9vLokr4701DkEU24OhY8cO7nzquv/6V/v0Gxu0QOYgXWbfQ8/+qfNWwbf3f+6VwCWsEhTpbHJAnLwXNDt9dqcDEEjEzie5TjOHwwQFGkhK5FISJIElqVpGiAkSXK1Kmuaoaq6aQCYYBfE3MqiXEgEnLTPRU2PH1fKyYG+dreNf+vloc2DW+YmZ2mg3t1/bueOzY3NoUKhRFFMJpPxevwXVkk8TlEEy9JGpVSTP0gKCSKrqFUAE1u6JFVoGgHGHV2dq6vxh/+8//h58+xobHDD1q3bd68mcx1dA0dPnP3e93+aLQBj96qYNkkaWMZAGDGYoA2CVCkOGA4oBijKoEiLoTBPEzxNUohAFqYJkiEpy7LAwiQiML5AP1qGgU0Tau7VJMXSTC1lQAQmMGiaYWgmxhd8NvClvYNAIIQAocRy3k46t/T27N62sbHOVR9hN2+M7t3Tun5LBJhsZuYoqOmIz0Fga2lmKZ8oaDyDXKJiKI5omPF5VMLCLGOSiKJpw8S6pJhVFTSTMQnGBDAIjzcaX1zmfA28K/ijz33pX/7pfsZCLaFgNVsOe8DJIZcd6qPE8lLl+HDC7XOLjqCu0+Pj87OzcYJk66JNw8NnZ2dnQ20tKysLjT2tw0NHK1J292VrQgEnEGpsJS4EAu+8804unWltbxtc2+9ycF2dTa1NwYX5VHJl2sbisM/REg4dOzCWXV2VC9AU7nz+yZdjiwu6UkMpDT4AAQAASURBVLzhtr2PPTox+Mkbbr/FXlkccjnQwtzkl+//4dgI3HR595vvPfWpz9xTOXHg1r3Bt98Y0vMZm4h99W4opeVcEVTEk7xZLFHIAIrkEZtfKQ+uXX/0yPEvfvFPXR3w4C8+898//tl3fvjzsemF3rUbH33i9KGjOU2Hz/7sZxzPrh3oO3H8iF6h6vwtlbzR3NBVyFcRorPZLGBTFNlDRw9qhhyKBFieau9qLUoFWmBkqdDZ3hwMeAu5rFSp/uDBX916ffOavnWlQmX0bOFHP/gBg8honX9leaGQyxh6deTcMAHm4vxMwO8GjoktLdEMaRhGPB7fsWvnc3959LI9V7751r6/PPqK2xdw+3zPvHx26Fy2BKBZVrFUqlbLNEnaOIRMwzI1wjIJABIhZAFCJEnSF4MmvG9pVwt2NE3XMuUa/44Qqn3FkE1DVhHGHAOx5RWWFlxOp6pgm+iamV48evj0zPRSpayXCupbbxz49ud/jgiOoXmCsxWLRUWqgFLV1dKmTWsaGlGpBOVqyeZ0sDyHMSaB1DTjYmT/H/JI7Y3V3tvFgipCiOZ507JK5XK+UKpKCiCSFwWHw1XjEvCF6R+1771QUL3482t/IMMwHMfV/tKLJsOX9i79/ZZLxBKP/eW5lcWloZPH2ztad1/m8nohnS7KqmFabLmkrSxlX3zpjXyh7PJ47XZ7VbYKChCkKNp8uk6Kdo/o8PGCPZctGQZkk/ltWzvAglKh3N7aEZ9bbutsVQ35mWfHy1VrXecGDNTguo0cx23bvomhsc/LNzb65+cXNLnocduhkFU1aXV15dprr//Zzx62OTyLyytXXnlle1ebbsgnT6Usy/J5/IZmdne2b9m8nmdxURd+9+DTFEdhAt1x+40fvvvG5enTDlKl9aIAarQ+cuzQCYfd09DaeXZirmDAjj3bEAP5cvaTn/rYLbfeuLQ4Fw4xulolsOWyCRSCXCqpVqSg399Y3+Rz+zRN6+hoK5fLLS0tlmUlM2mCIPRSyWF3AqBMOpfN5i0TBE6w2WwMzYGh5ZLJ+mBgcW7y6KF9a/o7lhYmnSLndbu+95N/mx6fevpvB84MnfvAXbtFG//OO2+m02mSJFVVd0SjqqqqqppKJ+xerz0QUBRJlqtVqWwYOsHSGHSSQqalsyxNC8LE+bMzMzOvvXm0WoHvfuOuUNj58J9fpxhuzdr13/nef7321qF3DhSj9aBbkMhkMUGqhl5WKg63kxOZqlJFBGAAbIKua7ohW6aOwSIQ5lj2IlZVK5ySJFmL75ZlmfqFAj2JEEvTPMvWUgqEAWNsGGAYFzTB/x8hEgCA4IHfsXnHxnUbMslELr1y/bU7b/70Xb3dISBLWn4+sToJhOJwCFjT1Yrs9oX9DXW++mhWKnMuB3B0rlrl7TbR6SZZzrIsTVYMTWdJmhdslN0DDpcsGeFI49FX3/x/Pvv50fMj9aGIUqlk40kGwMmzSgUrFdi7e9fXv/7Ze+/cUldXx7F2wHSlrEoKFAvVdDqzuFzuW9NfjMXCkVB2Zal/TbcgMDSDlpbnR84Nh8NhLVvIZUpX3njjkffec7rsmzavJ8A8+N57N9+8QaoWXQ4xsbIUW1m4585d/d1db752oLtjoK2l85kn35ZKWQDpm//Rk3/n2cH17YZRnJ4YDvs9Wzc3uDlw8B55MZvLLpuWsmP71rVrGx944I++1vrZ8ycXZicLuRzIOqLFUi4nMDTwrMvmKWQruWx2y6ZNLheMTkEikcxkC+/tP/Bv//6nw0eOPvfCzwwLIlHx6EMP6bparhRPHj/ZVN8hsG6b4F5cWG1ral9cWIpGo6qqmthsbG7I5VIEaaWyqYpcGdwwqJuaZaqRuuDQ0Mmg33fjjdfPHjp88803l8vl+fnF+jrqvf0L/f39+Vzm+//5jMcp3n7rzV63M+j3Nm3bnE1nFs4O1/f3yLIcCATq6uqWl2Lbd+6cnJ5yOt0jo/DrX/96cmJ6284WE0FXs295eZmiKFHkFami6RibgEzAloHwhbBIIYoimRoYc1EGqfUx1awZay/VqJLaKtV1PRIJZDJFmyCGAp5Tp2Z0Xe/s7E6l8nNzi4YObW1d7W1dDC0CUOFQY1+v//y5MWyRoGmdHZ0t7W2lTMIm8l2dbffee08wBPm8VK2WNU2zLIumaYbm/n48vSSsX6gHWNbFyUoXdXOCoBBFUywn2G12l5PnRdPEpUrZNC8q6f9w11zU1mslYo7jRFG02+01pJJl2dqTiz1NtaBfe4Ju7wcegYDBx0FTyB8KN0oWv1y03j41ORHLeHwev5N2osIHrhq8aWdPITH/Tt7+14dfsCQIO7x6IXvbjZ033LImu3RSqZRpwh8Ibnri8feWV/NrN68tqsnuNU1Njd0P/ukvb+/LdnTQoUhTXbTR63W/8OLTA2tb7Tayp6t+9NzJxmiwPhwKB0OryytGRS1J8OwrQwqyhxoHNu3Yu5KIvf76k/lM2esAvxsYAjatb7eLoVxO2bhhx+iRpWdfesYZgDvv3W5zIpGmfXZnejlWzmf6BroSpYJhDx0cq8TUxoeeHonnmc7wGVHwGCZbyOmyjO02wSaQyMpSOC2Smo2Ejjpo9dvbItHelk4SE396dqSpqd601Buuu3Js/Mzq6hzHQV3Uh7DR1tFUymZiseXGhqjg9+cXlzRNC4ZdQBDxxUXBZrcwEmxOoIWhM+MmwXeu2fKt7/1yKQHeoLeqoEJJ/fJX/nXQFqtUi6ViurHBF4/NaFohFHCG2xuq8Xg2m23YsBFK6uSZsUy62NM7oOsW3enLxZMRX4AnhC9+4o8OAT704ZvOTa6cPD8/ly7tvv6mrnUDX/jKNx1ecHnYYklVdf7SjR1hqPnJaYpqGIamKDabrbZ0Aj6/JElyuUBQJELvl6coyrBA0zRV02t3FCbIWgZRa6DQtZiqmRXJUnUAkkM0b2BK1Sxd1xHChq50dzStLs9VKyZHQX2D/epGoqm7YzoeEyPey264YuPl24vJeQap5cSiVsgh07DbXbTNrZKshljEcpTznKkhFmykwhAyywk+oEWoymCqkqUI0WAsn7JFQllVySlqo7fVH7NV3nr3z4/8dWY66fV4kElXyrLd7s7lcjxPczwNSGM5CIW9t9x8/QsvPmt4uNdfme7voeLLxo4NQRvHYE1ua2r0+32JxGqumNu8fWssmTh0/GhXT4/d6erctVPPZbBSOfDWaxv6+xyi7bHHXrvvYx9+4bX9m3ZdJxvUzEK8WJLnZuZ5nj9x7DTQcOONA6EAT2Jr88COQqKaTiz2bAxp8sjp86cE3ulxbX7myXGbvdsfqO/t7wd0olAoADai0QgBxn//4NEf/ehzb7/1RlNjtFot9/f2Em7P9IkTwWCQZ1iCIF565cgtN9/0wAO/j0Z87x1Y/dB9A80t9clEOpMr+gPRsfGFN9+eoWnQLeLmW+78y5+fCHUE9+zeVsrFIgFBKsa6W+tAqzoEm8Cw6VQ+EI4cOnzYF/B2bRo8f+p4fVMDD0Y+V3a6/DRpm5xaoFkunU6vXb+WYik25P/a/b/gRXDY4cV98Kef3a0qBlFZBEQyHKdohsjxLEOV81kw1XQisXnPHilXfuTJV3lfkHKEJcQtJdK/PzArijzDMLplAgDF0ARBGIahqxoJiKYoBpGAMTZMhIEhKRlrFCIogiQAkGUSGEhE0Ah0XceWiTFGJFHLZWtTBwiOd9g4S5UoUxroapk5P/7J+67naWtq5IwqV0SBqa+vP3HqzMbNGxwut2VZdseSS2wkNB+PPXaHMx0f9UfJ8+OH+3dffui9ia99bxgJjEQEZJrRaEsnVEErkQiTRA0wswhLB3yhHxURFJAUBkLHyMAkIimCILCu1Ibn1SJyLXCTJKkoysVaKLzPxmCMBVO7aCZ8AeqnKSAJTdOqkmSaJsnQBEGoumaaJkEQOu38e+Yey0G8CFkZ8jLkFVRUQDFJg2A43u7xeAmCkKtlliIdAo91vVrM6VJx82AXaDA6kV23tvWGO+8Agjh6dEF0ODP5AjgcpmnuvGzXU08dCIfDS0tLs9OjLg9/8y3NH7znjqaGiNfjPHjoQG9PVzQaNXVjdHTc6wnQBC9V9eX51fquNbFU7vGnhxBNbtlxWUNL+5v73vmPnz0gqxonwD337r3p5h29/ZG2jnaWZ5aXl8+NnltMLFok3P2BqwcHugWKtHNCNlUSxBBmA+dns7986Ohr7x57e//+3/zyT4SebvARYOirsaXZyUkaGT3tzRwF+fSKjSVXF7Wgl1o/ENi7a/PWrVuDgRAiqaqkuFyO3z+0j6ZJqqFu6PSpP/zh7O677uJ53uPxzE5NiaIYiUQMwwDTJAjC4/FgHVeLlVCknqQY0eHIlyupbHZ6dvbMuRG/L+hyuxQF1q1bl8llN2/bamJren7B7nC6vZ5YIsmK4ro9l3v8/qXxybmFhYatW2eOnvz+t59GJLV97973Dh0OtLapkszzvKHpxw8fXL+e+MIXbi4UcxMT47qpmaYZi8Xi8XhvT53P666WVYTBZrORJFmTwgVBsNlsGONSqUSSpMvlqqurC4VCDMOUSqVCqVgjiBEiL8mMLpwKBUHgeb6WKdQ4BFVVy+UyxkCSNMfRHMcghAzDUFXVMLSSXOrt67aL/JnRaUkyuzv9nV3BgTU9No/rsiv2/su/feWjn/joxs0bAJurK0vDJ0/wLOewi06byHM0zxA2jhZ5mqMI3uB4S7BTDsEd5nwBYDlVk5dLGcXGCpFgVap47E6qqtvLxgZv9/Lwyce/+MWHH34omUqGQi6Px12WyqlsqVAuSKrkD3gLhZzNzieS+Zdfmfk/X//5hk3rWZb93Ocuv//+L9x1x+bJyeR1d92NEMpk0osLc7qhejweQ1Mddvs1V13d3dnZ3NgwfuLYyNmhTCLREAmTgAlEbNvaC3Zh7dq1uir/+Me/euThZwCbw8Pj27Zuvu6aPSGf++zQ2NCJU1s2r3/mqceqUl6WZahaDBl47gn41jeK6aT8qU99ZiU2seOyrhde/c3LL75UzOfWrFlz+vTpn/zk0R/96RvvvvPO44/Pzs7Odra3JxIJMM327m6CIB577Ikf/ODxgYH+xx77c0tLy94rr+jroziO/8ufX3762eMbrr3x+MnTPn+4b02dYsBdd99z6PDRbA6cTme5WMrnc6VSKRKJcBxHEERVquSLBa/XG1tZaWlpcbk8ZqXS1NSk6zobDMaTCQAol8sMQ3V0dhIEYVlWtVp+57ln7rpjzRc+f9sHP3j7FVugqakBgzk1NQUA+XzeMAyCZipVuWXNun3vnkMkc/TdA1NzC8FI6MiJZM+atS2tHT29a+x2kWVZjLGqqrIsK4pycXDoRbn5oihxaUp7aQHTen/GdC1xudhhR5JkOp3N54urq3nTsDo6Ouobfa+9+RZNMYLNfuJEuaOr28TgctlbWtoKhcLs/GLXxoFQS10gFIjH4+eHhxHC77z9Wv81e0/sf3PHdVfdfmsvSVA0TafzCZuNtiwJI8ICAgNRO6taiLjo9n4hebf+AZ65qJJfel20G6sl+7XzR+37OY7jeZ4T+BoFJClyqVQqFovxRIGiKJvTAQCqrtWmJlAUdenRgarQPgNZqlItltR4PiXOFmWDSFctCTOIEcDQJEUi7ZQhl3PJVaWQF2i+nFoUadhzTcctN14pZRKJ+Hhbl9flC+uarOfzofrwa2++1tltl6WKw25LpBa6OhuDoaZDh05LEiST8VDQPdDfNzJ66vSp+fvu3SFX8j3d60xFs7vdD/7k9y/sM7p7YDFlthmEIHKpYrm3JWChSiELp4bPRIOC22FPZTMC5+3o7picmr7u+rtYj+xw0atLU2o5x/IOwhYiGX8pQf7xseezKkwrcYuGNT22uflZG6oQouV18AGnqCrKxNmj2DIao96oT/hf994nstLpI28kV2NRl0sQbKLNaahw7vywxw7zszPmytJtt9ysyI/8749+7b57t0bX9GQzCYyxs7FZii3nVhMer1+XZdTQmDt5MpkptqwdmBw+y7CCCeQ99300m1dffPX1D334Y+7god88+nZ/e+DQwSN9/WtZQ9t/9OhAfxeQ1MEjh0J1fps3KC0vPfNi3B8Zb1uz9m7O8c67p0KNnbuvvLpaKJa0osCwnMD4/V6ip4MgcbGY83gdRsUSZXNyavz0+GhRrhIUYWAIBF2pnEaSFMXRmqblcwUEIAiCz+dXJLlYLJXLkt/joiiKoVnLxBaYFyN7jU8ggEDIAgIpilJT0SmKoWkaEDJrLc4aMi3LNJFpgGFYmqVhRNMMZcf85MQoNpX6sEghzeHkW5qjfb3dH7v90xAJARh0ISWr0uz4GDbUbZs3yZkYwzIkRWKMwTIoEiPClE2Dg4ClyqbFEgSnUYzGMobNhmyszDOypbmD4eListPuFSnb+T8/8ZPvPrU+xGmqYZiQKxQKxaqiGR6fEI4EsmkCUaBjfXZhlWbgG9+6fTU2l84kQqFAfUNU05W+vp5CKjE1dKK3tzufTnrcTrtdpFkGADRZEpz20fPneFEItzQkqwWBRaGmhnRsORePl4vSG088ufvqW89PxnZsXfezR4YzqTTLwPjI+VAgeGY4f90VrVs3NoycOXPTTVfxyHX2xCm/x8byBgvwg+9cVSzyQkun20t+83v/z613rqHUte+8e7Czq21yfHRwMAJtLalUyjCgpaWFoqhQKAQs+7sf/GrHjsE777z16aefoyjC5rBt3bp5ZGR06/ZdPp+3syu9dnDwyd89dOp0bvfl3Ws27D315W+NTEw0trZNL8YG+te89NLTm9Z3b9q0Ib40MT09vWFN95mhob7uXpKm7Ha7aLcTFFmVK3aPu7SypGXSTU1Nx48f7+pcgxA6eexofUN0ZWWpu6c9Eg6oqmoX+anJubvuvOb82aG21q6J4+Zf/3r8P37/1RcfeLi729beu+bH3/nlju1dLY0Nr7z2pmhX7vj0F0z7q+8ePPH062OqBZTPUTP6IjBYtXGNhkEA+nsaW5PzCIIAhABhq+ZI+neo3MIXbBovcOUIAC4oOSRJNjY2aIrc0h+JL8088sgL+6aO/uQT9x45dry/s21gXSyZyG7dujUYrn/iyWd27dmNSGZ+9JhedTYGNrs8PleDneHLr/1cOXr2b1/7zytOvvv6jp3bXn57sZQvdDW3LmXnEKNYICKETIwBwEAECTWGBzAARgQAUau3EshC2EKIupQ1uFg/qJ2SL+qZtU9rZVhDU2iaZhgaAEzT1E0TIYRIoqnZbyFQVJWkKqqqmtjSDVM3rEtNJJE30iaSWLRkVquIYPAkaWFU1gFTnD8cYimT0TI9Efqy/mBXgBWgciClqhVobepvb+w01BJARrRJmp4uF4oiH06n4NWXj6eylUh94DM//MbIq08NnT3kC9QpEh4ZWdqyZVdsJVNf33j48MFQ0C3wTF93W30kbOlGKpZ89+13ZmbMxg2uhuYu2RTHppMFiUxm83PzSwP9fr8L+13QHHHs2LwxncwwtJ0ghH1vHzg9vrJ3R9dAh6c1auMpeujIZFn1Lhf4V46ez5pGhSgDZakyIBm29LtOHy24u9jpSTUYQM0N7aZieJ0OCilnhia2b3Zfedk6Xc51NtfzJH38wBEb73KIDp2vf+pvzwRDzoG1PVu3DL740nMT46sbBkNdnW3ZXDLg87A0Xa1WDU1ramrKZDLecPi5557fsWO72+vhRfuZs6MEw5GMvbd/w28feOzoqeVsCcJ1vpnFzGV79kbqGlZPPLq0bHzwnk2hkOvowX033XhlKORKJWM+n4cgiIceeq61Jby0nOjtWbNlz5Xp5RjrQ4ainTx4aG4iATpcd9VlvkDLd3/0UE4FCRh7oH4hnqUEwbB0w9Qsy0qUNVEUeYbVdb1cLuu6zrGsIAiiKFbLlXQ6Fwz63A5nNputiYMiR5MkiRHCGJMkTVGUiS1N1VVV1S0TY0TTNMfzFEVZFhiGgcyKppuaYekW6BZpIopgWIZjLaypSlWqyC1Nrg3rulgGGuqC9//Ll8ClQ7kEaiVTyrgCjomxszYWNXU2StOTAkMCYDANYDhwOIHiZE3jEY/LVZXlwO4tk5TGsSQvIMA0mNViot7phVgSVGrooSfefPz4pt7wkXicJKlyySiXgCVBFG3YIlRVr6+LTk5Ouzy0pusEgtvvuDyZWonHY9d94M66uujI2eG+y3a++MufI13t7exUpRJLUx6vW1YUXzCQKeQKpdL07EyoLrJmbe/poeN+p93B0Gq1Go3WE6JXqhj7j48cH174zBf++YGHH0cke/b0kk2Ar/37vzz58OH5xWN/fP3XsweemxqbNCXea490trV76nyGXKXs4YmRuZdfe/Ur3/zs86/9fNOOpvJSA0MSpqVHo5GFxdmR88O33nozWR9dOHwwl0n5fL6G9o5H//jHSCTS3t5ZyheAFJaXl7du3aooiiRJq6uJaENjIFj36GNP8Da3L9iQzBaXV7PJVGHztp3PPfcygcFph8Z6Zk1f8zV7N50/fcwh0nXBoMjblueX6nsHKomEzeOqVAucwGYLOQZr5VL1vf1joo264fqbKZKZmp0JR4IYNMPSDUMbm5hpb+sKBhr2vX3Q7fZUUqu5QrGrd6CusXluYXH49Nm21uZsKg1g9fWtOT58XvBGHKHWU2NzrCuYzJefPjx0AQNHyHxfsjZNkyRJhqQokkSGBRhTiKgVfhRTpS80WyAwDTAthIECjFBtaBiyLtDkiKQpkiQtiostrdIANhaifra9IdwYcoW8Tp9bHDt3BsA6NZSw28EXYL1ebyAUvvUOspRhkNSQWND8Lo/dJSvmzOPPHv3Y57aePJNz+i5/8NFTbxwZq4DuaxRVKChVF4FwbbgSBSYCC2FMwEWFnbCAMDG2MAKCQghZxoVGv5oyXpNcLgXhLx5TanuVVi7xPC8IAkVRhmVallWbsnDjjTeeHDo1NzfHcCxBEOl0ulStsCyLyb83zVI53aZaoBGMnWQRaIgGmiB5FhUqpUIuQ1lVH6+Qhq2YXE3pOOoVmj3OcE+TJ9hkSVK+mHe4aIphs0WT4Byv7Xvvzg98vvrsuxs2rbPZ2czQieXl5aW4kSstmjps3jpYKhVkTZ5fmidJsqOjS1MllyuQiOe/++0X+nvJ1sZ2jquYHpfgieYSpaPDIxUFHC53S1to3bo150+/tbF/wCmCrquqKsdXU+lMSZKLV1y77erda9MLpydGh5vCTfsPzAxPzmRNpsCFFZsoo2ImGat3w9W7nZ+89bp9nud++47cEoENg70+p3/4+MmRsbm9lzX86Sf/a//bL/h40iQ5GqzUanxkLOEQkp2dvb0dwa3b+mdmp+ujoSeffGJlJfOv//qxt954ZWZmplouRsORN954r6s9umXLlunpaY/HUyrLg+s3SbKOSsrR48PRhubHnzi4/xxctv7tXBn+/Wtf/PHP/3B2PBMI0ieOHQqG61vt9PZdYQvw4tLSuk0bIw0N8/OTHe1tgA1D0ywEvmCwZ2D9o4+9PD47H61rWLep49D+9ybOZTcN+LvaOgFRgoP92Kfu+u5Pnhxd1ZqJtInBVM18oURTVDZbdUTdpmnKmmqz2bxer6ZpyWRyeTmr4WzAWZNTOCAJVVUtyxJF0TTUWs0eY1RrYsYYm4AFu01VdVXTLIwNw4KaC4FlsogFrAKiGJoigFBM3bR0Q7doBnJ5+ZYbN7a0RFQpu3vnpj27tupScmH8bH1jlHM79IJMsc7urhajWlwdHXOzFFAckARYGGgKOA4YjqcpyNEmzXJOHzidFU3XwTAsbGGdw1q9sy49cY5JFoWMtHj09MaI4FVwWQZVMgCDaEM8b2NogSIY3jDmV+YsBLzICQS1siy/tW+frEBLq50kUSa92rdh7fKJI7Jc7W5rcbrEkqUUC/lIXbBQyhMEgGXGYzGXw+kQbXIpT1s44vNpUgUYhqDY1EqMYD1bt+/KVogf/OhnBlAYyI7uEIXg05//cU+4HmOYfvfQ00+//dF7P+Dmm/78wNM8E46nym2drVff8dXfffcLn7//n/713776z1/d8+wL70bo3MrKyr333nP2zOnNe3ZJ1eJrr74yMRH/ylc/bWiKz+dLzM9fddVVgbaOuTNnRifGPf7Q1dddnUymOV6UFDNa326aaGWlgEiXwx1diReefG74X7/28XNjEw/85WW3l/TxpsNBLy9rDDF5882Xb7hyrxpbXF1atvGSpCp6Po9IIptOMzylKIrAcVpVPnV67KprNgcbO5565HGW4W+687bRM6colvD5XQxNumy8oUoMS3jdYiaTDHv923bufvGVN9NljRfsFO+cj2W9Xv/c3NxGX0NDBz0yu2K50EtvD/MeJzACS9EAgGtmWwAGvqBRIAsTNFFjsQBjRF3o9rxUlQaMa0AJWWtlqu0N7/v9XjBdIRmOI9tbGkuZxMyC5HdW7v/8Z/a/9dqxk2eVSmlNf29HRd6/v4golSCrGza3vPrqU+t6BzhQaJacmh3TjPiOu7fs3D127uz53t6rFN0hVbIeB1fvDy3lZkwSMCJNAAJZgA0MBAGIQqYJJFgWQiQiKQohsCzLsCxDwxgzDFPbwC7KR7VAXOv+uzhZCQAuyFOIMoDQLNA0Q1VVVdNqIs/CcmwllkimsqLDLgiCiQmSYGiG1y9B1AhE2wzEKgZZ1nC2qiWypdVUOplOeNwOEsuEVQ66mOZGf2tTuKkx7GmMdta5XKSaGDtRSs56Q/ZcPjU6Oh4IRv39G1s6e3/6k5+xIje7ODM5OxFfWd66aXMwQukAPWvX5ErV8anZYqlSlZT+dYMVRVd0850DR/7lGy/QHIQizQ3NXc3t/d1rNlG8c/+Rk6oJdQ11VaXscPIjI0PdHW1+ryvo99AELuaSLc3hgYGOhgZfyO9IJZY5jqJo2t3bv3Zrr0KAYQu7GgcmkhWDcZMc9PR47rjxGj+HOyP2zia47srBppA95ITPfeSmj93ZK1q50sr47VftdFKmWsxbstzV3nHFFZsMDK++PvKHP/7m8it2NTVHeJ4JhX0bN7YdOrAfIVQsFm+44YaZ6Wmaho6OrsXF5a6164v5kqYZDMM1NbXkM9nBdeuDgcCX//mDP/jqtlIRbDz0bxx86A+/jnhBLulqRduyvr9UlPP5TC6XcrkdHMeOjo1MTk6qinLy5KliufKZz9wLJDE1M8ly4A95w/VBQ1Fvufuuf/vN/1m/YV0kGnK6xLPnTzvd9o9/6vaGEKiaRtOsoZvYIL3uUE9nR+2WMAxDURTV0FmWraur6+5pcgog2m2yrMfj8WKxCCQhCILD4bAsy8SWieH96r1lWNiyLElWFVXVNE3RdFlVZFWpMQCKgg2dAEwSBGlZlqqqmlLRDYlh0bXXDGzasgZBtauzoaHBm8rM53LLmDFMygBcJVmrUkgZhsTSlM/nQwQHwAAlAusAxgkgAMEC79A9QcsfAaffIkQKOC/jjhKeOuDDFrNw7Eh1ZjE+Mh6bmLxiz64rrtqzvJqoi4YsBCYCweHSDCuZzlgEamtvz+TMUJ3LHwqsWzegaNDd2/Hhj96wZmAAY/V3v33gkd/88sEHXhBE9siR4cXF+Vwxz/IM53B4PB5JktLp9PR0RtO0eGz1xNGj8dUEQRA8L9jsLmD4qmLpmJycXpQNYmwaNExOzqiIZPdecU13O9PVFx1LQ6FYvu2223/6478dPTa/fcdtumWTNXz89LF//sjmhx77PR9x965pSiTLN9+68diRud6ejh/89yP9/T0Lo+cH16/dunXzXXddDqrKsjTDMMePH19aWrIKhWKx6LC7bHbxr399lGVpXTdOD58fHZtu6VybSFWCkdZ80ZhfyagG/OcPH3x93xFXgP3qf3xzy+bB7o727k7ntdderpaL8YmJdDrdvGHdSnylsbExnkyIkUipVDLNC4ihw+Xcs2fL7OxsOZW64Ybr/AFvOrZ88uSoKle9dXWrK4s+j1OuFiu5dDGb3rC2vy7adObcuAEkQfFjs8uk4CkbdGPXunVbr4jlZIUUTo7MPPLkS966uqrJrCQrLoeTY1hk4RqnbWo6sjBDUhcRlBpQeFEq/IfgDhccgGvcyEVl4yIIr+u6aWJBsM3PLSaTktcDPWvWfeYzXy1V5JtuvuP4UOXk6fP9azfv2hP84L33egNRhnXU13kDwXpJLgGt6ljiBHby0PFQsK0u3JFO5FSljHGBISohn82qAqkBRsgCMDEygTSAsACZQGEgMEIXH3BhJh/UtCPikgu9f10kfGr/7bqua5qmqqoBSDcsSVYrslJVVFnVZFWrqtqrr7+ZTGdplq9KSiabB0QKot0yoSZT1R4UMiWMdWSpNGWJFMkihkEkTYJcXrXxRF3A3ljndIkkLxC8QAJolGKC3x7CYrVaBa3o9Tgt0sgW5NPvPhdPFJw+j8Pu62ztzKST8Xjc7XH0r7/szPDozEJqYiyxpr+fpoRsNjuzsHTF3j2//uWfYiuwfatdYG2CO7CQSNtsjp6G5i9+6ev5CrS2R7dt33V+5MzU2NhNV6+/YseacmbOwVICBZnkUldbs8AwImfaSLBUpbG9OcMQy1MLLx8cTRtA+zwnJyaijc0VebG7q0UuLP7hl0/cd2XnxPnUfXdcbRdti7Mz1fSqEBav2N4XX2CqqYW5yrKuSpwg5BIJAuiGhobYarosz5MMTE6NbNm84fDhAxvWDxSLhdWVpUq53N/bPTQ0vHHD5umJ54rFYnNj0/5XX21qaspl016vd2Z6siHakM/nC4ViqSyHog333rY90tBy8tUXvvbNZ5takaczMjoWe+GJ5zd2AU3o/b1t62+5EVYXcqvLYZ+DdbsElvG6XZlMZmLs/O133r3n5htLK6szM3M+d6SwHOPiq9l0yunzshZyepzB+rrXDp/BFCCSwgRjmBrGRDpVoClKY02SpBCGSkUqFsuiKIYDwWAw3NHWybLsyZMnM+m0ZQFFMZppFStVEwNYgNAF8Q9hqE1MVWTNAgyIQAgZloVNk8AIIWRphomBQEgzLE3TCAICAX+4PrBj5yaG1tta64q56Wo1qSrhgD9oEyiscZpRBJkMRFx6uaRWq5pu2N0+xSgZJE9RNuB5EyEZTAwsy/FVzk4CaQBlVGRK0W2ECBYmU2UoZY7/+cnLt22q87kzcoLgKAhFbvzpv335Sz8uy+By0gxrq1aLqmbFE5lsNt/Q5MEApoW379o5Pj0yNzd37XVXWladsKatbd+bQ8fT//S5q+VyKeC1L68sX7V379LS0sLMtNvrVWTVNHG5BIaBXS5X60DX/OxMrlDhKaZalTCt2j2hhURZ9NXNvDvcMxhwOHxApbJl+cTweX+kIdLquE71iW7no48+84NHnr1j192X77o6kZ5o7mAkYyUcDd/7qTtef+l53h7J5olIY+Pdd9F1dXUUCUIk1MiTU6MjVanc39+bSiXC4bBhaJ2dnV09fYvz81OTM3d/6lMnD7wdCgdLpRIAd9muvc8///rzz77q9kRm5xcrirYSz933sRsffPQlVYGrt60ZOnPm+t2X/fMXfyoI8KVv7507+lbQZxObwsWFhVgsFq1r9Pl8oCp2u51l2XK1xPNsuVxIJbMbN24o5Kv+uuDWbVuWFhdvvHFPMrVcSsT8Xk8qlenfsuPc4VMILE1RCuWqRdCc6JlejAejTelC9Z0jI7d9sG0uMfzbX/yNZABYKqdiQ62u5iVvMILAsEzTMkxEIIz+zhXiC8dHXMvcMcYYXRCjCQzYtLBlERgTJEnTNEORFEUpslVTPGqaRm3eryRJGCO3z0cYupOn/viXt7rrqaMnzqqq/rFPXvPIQ6873FMT08lc8cUrr7wytppua2rIpCqypgkc5Q/zDG1fXJpO5uS+tesIsMbHTt94w9bzk4k/PntqbVd9IpNfBQKBaQFgjAhAJkFiwCQiEBAWBt2wEFxgGRn6QitTrSJ9aXH4YiL//8WITUSYpgVmzUAGCIpBCAGB8vm8x+PhWBZLkq7rBgYCg2aYl5adKR9ZxLpCWwqLVQrrBFYxgAXgcxO9XQ2b13WGnQSjZWhGBxqDoQLFKfPTnC8s+u2F9DKmWV03D797tFRV7/7AfUePnDBNhElTVissQx8+fLTripuaO20/+O8Xurvssyv5aimmG+p111yx/8iRogx7rq4vFArbt23e9+Z7mzdt27Rp+8NP/U3gwLQg5HeIrGljjBuuHPTbSTmf8Iusi6NcPN0WDcmlzPT8Uld3j1cI5kvJ+dllm9czE0scHIdQe2RsZdUXrJPkeMRLWOWEic2e7qDT2XjjTZ1vz06NxWPr+/taBtrmxs5qGbK3o0Upc4cPHfX6nF19vYl0QalKEX/U4bDRLIRCXgKZi0vTwYAnm804bMK6dQPHjx3hWF4MCrFYrLenqSFaPzEx0dzcrOt6fcAnimI+sZqNr3R0dsYpyu8wZEXyO4Xpc0Oiw/udr149t7jq8gZYXP3kpz5Tzg71dHUmErHVg28SyHTZ7aoJaiLW1lQPpkpg/Zbrr2J4avX8cKS9LVgQNVl22ARDU/1+P+g6oqjGltaf/PxnB06VTAZEhzOZlWUVuz0BQzNJRNC0aVmWYZlAIJqgNU2bX1qcn5/nOK6nq5vjOJbjDNOUZRkhxDCMifH7A1ORiTHCFsbYwsjhciJEWhfc6UzdNGrjs0WaN7AFBDItHcByue29fZ3rN/QlUou33XZNR2s4kxzbc9mGSFt9dn6SYZ2gKoJAK3JRyVVKxXwgHAEVwECMM2hgzuSdpOgyAMuajBiaAkcS0nZgHUAzgDgdIFeBREw6e+rUwbd3NdX7TBMIHGzwVk0MdeL5E4eSSZ2mAWM+nipaBm5saicIYnJioq21gabRuXNzHe3Dd95x918ff3g1liBIWH70cDKW/vSnLnO7bEo5t3nv3r/9/o8Mx0cbGk+ePBmM1NMc4dWwBTOKakajLWWplMxUKlV9w+B6YJxVncqUtd8+coC2Q1v/ps07rvzhj35Kk0xXW2uovuWZp58anZh56tAT/+dj9x0Z0j5+9323feA+wMRbR1+OrmnZumVdtKHuoYdemhwr6wZ4A666+g1uZ8rtFNev6185e9rptMtKlaKIQqFAEKhSqbhcLrvd/vqrr15z9XXhUN3f/vDHsenqt//8nT/++7diywbGcPcH7j1w4NQzzx2OF2D9+hZAlD8Yuf2OqxKZtAlodGoCls7eeXsfgRRwOXRdLVeMTHKlcfOW2YcOVaUjd9//uemDh9s6OxBNZvOZQCgwOTodDIbL5bIsq5VsdnJy0uv1EgTRMzAwdu40wlZ9ff3YiROhUCQYiFYrqg5cW1fH0pHj6WLJ12IvalVX2P7Qky8dOnQKOOBdrsVEgbY5eZt3c8+midn5aimvqipGwDIcQZGKrl3wfazB3RfsVrB1QXPBJEGAaV2audeAXYZhdE29+BWSJGtHT9EmppMplqZIwKlcvj7CIZpOZssvvnLm29/47A03b+N5VrB7zp4586OfPvvRj141P6V4PWR7e125lE5k50nCdtkHPlOcWhE4Wyw+qalF3k39769+fHp6enwypmkCEbAu7kZQe5MEUeuiMiwTYQNjjMCqgecMw6ja32ecXsRaAIDjuIvwzEXZnSAICzGXTp+/qOQEwxFJkpRyhWEYjmY0TdNUtWZ18HdZJkikHVqswSaJRkXEqk8ArwBX7Wz98J1XXLd3rVc0OEqhKN0AnXY7JcvUckXO4wWlAtW8y+tIp5P10abLdl7hdoV++Yvf19VHm5rrSAoLIjc5OV2p6okMHplMFSRYTUojYyvTC7n7PvLJprb2mYXFWBauv/XGwU3r51cX1u/Y2NLb/tBfHzp+8JwpQ0NIvOuWK/PJGb2y2tHgtZEalvJtTVHa1HKJ1YDbmYgtCiwiSdPMSiISAGyvvnviD08dAzck5IpJaxRZdDF5VomJhuQi4bab7nF5Ovcfi40PT7gFts7nUEspB4tdNpRPL5GgXnfN7qHjxVwmb7PZ7Ha7XC329XdH6/12h5DJJn0eDyDz3Pkz+XyeQGjH1m2WZSWTyaDPX5XKL7zwQu+ObeVSYXlpIZtKCA6bS+QL6TgYeiG12tgc5QnDyaD2qH91dpTD0i1Xbq+m5++8blfYjnlCKediNgZzoBcSMb2SL2UScj5D6hqAKdCIsLTU/EQk6tezcaedsQyNIAmGJu3hEFC0haiR6dlTZ0sOL1gktZrOahaiWU5SNPP9C78/BQaRBEmSDMMwPGdZ1rmR86lMGmOsKApJURRNa7rOiyJJ0xZAzTFV1QxApCAIFMMBQSiaWq5KhmXWELqyVC2VSjabjaZJVZNDYf+mTYONTZFKNf+5z39izUCnqpfa2usj9X4op1kGV8sZGjSpmKWxRliy28Fr1RImEIgOi3OT7npwNWp0yKLrWbHdoIKrmikAVZHyWCtxLA08V373HVhaPvrEE102G5FPg1IBDsqmZLnoWCmeoGSKpi3M5Aqy2xnWNFSqaNWKSpD0/MJyPl/8j2/8ayqVGho6vbpsvvzyqz5voL+7Y/OG7vb2NofHxbJsbnlp05ZNp8+djSWT6zdvrSh6tlAdm5qzuyCbk0Mt3bPLSUwJFZUYm42dn1o6dnbC19j52S99LNjam61aoi+iArdh+253IDI5v9Tbv85k4K+/+f3eG64PNcNUvPrkq3/buLufcMLdH7u5ubf+qRefeezlskWyJYk5cqrw1X/9xc9/9tbw6ZNiwBsJ+wHrbpe9oT7Kc6zP65Wl6qsvv+L2etra22VVkRQl2lB/zTWd5uys1+v9+Mdvy+fhu9997LO//W0waPc64Ny5uUeeeKKrq+ull94UBCGTyTQ1NTU1RFma7upsX377zUg45PP5eBsPydXGFlizthss0xcM5HI5XZajzc35bLZardI0jTEwDMcwjCyrTR0dsiyfOHyUY4VAKKyoOssLqm5YGGXz+UxRHptbPD81T4quZ1975+W3jxcN+qlXTiFRBF4sKpbgdFskW1G0ydlZDARD0XbRZuMFBGBoOqpNiwbg2AsIgKIotSlLGOPamqxF/4twpK7riqIUi0VNu+CuXhM0CIKw2WzFYlEQBCAQzbCi3alZEEuUs0WINjlXM4WVZDaRKegG7Np9xYaNjceOD7FE88j5WKlSFpxEtMlT39Dw63//aWwJMkmmubF327YNHo/xxot/vHzHOqxZQT6KMGYoSpVlAixRFBFB1ZQiCxAQJBAUSZIESddYz3L5QgNU7W3XPN9rzVb/N/93WVN1ywSSIBmaZGiCphBFIoqUJKkm8tTg45pghfGlahAm6EKpzQlaQg7z0BmB3mbm8x/de/OVG3jIW1KcwiVNSitywcSGqugGyTJ1LVjWweHEyMpmEm63e2pieujU+aW5Za/Xw9CULJcB6elcFhHMzGzulVcPHTs+tmlj28ySaXe4u7paSZJct2P7Jz790fp6+OVvf2P3igRtrt80cG50+L3j00iFbRtaP/Oxe15+6i+WlL5sU19fW5i15KBLzK8sizTrbeuYGp+iadrn85XLxexy1ucMz80l/vzEaqoKYpiuGHIo4hjoDdx709artrTefc2Gn//X18HgHv3bu4+9OBRwUS114Uxy1eviu7qaUqkV0cYWyoXl5eXmNtB009vcmkqlSqUCSZmD63p8fheBzEIxk89ngz6vJFVisVg+n68LR4LBYKlU8nt9DQ1RNb7q9XpcLjuB9WJ82eu0NddHVmbGu9qazxza7xQYo5LHSmH7xh6kFnhWz8bmSCMHatohoFJ6uZKLe/wOlrBi8zN+p1OtVixNBUniBIEGy+ewYSlPUyZPmjaft1zMAcflVlaLhQqQrMMVlDWoqKBbNCZ4RLFAUBZgExsWmCZGhgUmRthC2EIWRthCgAmMSIKgCIICgkTvP6/1LmEARBCIIGor1QRsWAAESmXS+XyR5lhEkalMVtWNlubWptamZCqWTCa7utp37toaDHm8PseOnZsr5RxFGYGIr7W1DmyMZcgAqsDRHAk8wgwyGRLTNGJYChCh6qZK8xJhKxhcWiXSBpKApcHjYKI+MB2S5GAEiK8uPf+sVchK42cDTt4uoGDUD24eTIXiybKhcG6bJxqmKJtpkl0d/dl8SRDs01MLxUqVYZhMBm/duvXc+TPlcvm1l4fb2x0f//jHq5WKyya4nbaTRw7m4qtuj6sGgDqcHpq36RYpG8RKPOePtO7YfW3vwJaXnn/r7XdmLMS5A1GLFBDnOjux9PBfX/g/335oZjGdLCo/+uXvcxV5Ymb+9bffnZ6dP3ZyOFeEo0NT/YMbr7ppA+uBMpYefeGXV9868NDjD7la2kRHcG0XTE+riYxGACBEsjQMnRwFS1tenLM77PX1dYVCTlVlTVPCTU1TU7mPfOQpWZbT6XQul3PYXSRJ/vd/P7x967Zjx4794s/f/+THd+bfe/v6665KlaChXvzlD/7rlZeed9ipQwcPZ1PJc0PDmzas9zgcLE3WRUK5XCabzfA8X61Urr/xWqfbAdksx3HecJikKaVcBoDG+obF+YVyseT3+1VV72jvOnPiVKSj2+50kzQn2JyFilSWjGhj29jUXFtn/8Ti6tDIZHvfhvMzy+enyzrFreYlX70/XdZykl6UFUkzay7tDEkyNIksXCNeSEAEQgQgEtBFaYVhGIZja+M4aknr30cFvB8ELzquXMTJL063ME2TpmmKIjDGkqpUJBkQ7Q24Wzv8fes2pnPF2cWVWCKTyBSm5haAoNs7e1aXFJ71J9MZgrIMQnF6vCTl+o/v/PFfv/LfP/3Jb91OgWOqg2vqeFprC4QVuapKJUOtUsjElqFrSq2DyayN5wZUo+Dh/XkGtQv9f65Lxff/cV2AGhDUTgO1v44kyRpsw5BUzXm79vF/PKg9/ai7uxss0+1xUgSyDNUnQmJh1G1nsKE4eV6uKrquUYxT1k1OcBoFA0iRwmhkctztC4p256H33q2r725v7YlE/TQFgA2W5TRNC4TqMBaPxcoLC8VUotjT7rPzXLVc+K///MlXcamzM/Kxj14xPTVezMXrooG/PPrAieM5rwfuuWY3w9GplZmAh6+LuHlKXZ2f2LNzE4uN+OKig2GPPf/a7JxWh8uNHf3xdDLgqctm5cPHzuza43/5ePqD997y4J+fpa0KUU2VYhmruvrmwWqnP3Lm1PLJoSmfr7UhpNeFQpGga3ribCToXDO4rpzPlaqKLGk9A2vtLi+YqFDIKaZMshY2K163S1cVTdN0RbV7POVSCZmW22GXZdnrcitqpbGxPpNO7d//Tld3h8sh0BSRzaZ5hvV7Ayqnnj1z2tR0G0fTAJIK/mioWsyCVmoI8g7OpAQozCfCwdD09LSNJZu7u47v25dJJKNNDUqlolkmYxMJBYHdpmRTnNNBkFY5FbNHomAYFUlpaOvHCjpy8l0dgSojGdEWySGSxQY2QcdgEvD3EV8mXDCJxgSCWip0SW/I+86pqGboSBAEkFTtX1oWmGCUMmUgKYogJUkiSEq02wiCyOZz5UQuFPbWN0abWpvC9YFAyNPe0di/rr1ayZIUBksVeBqwjsGUK5VKIRcKBsDSsKECVoGigKEsAnREWgSLGIECJ0ORBmACDAQWBbqQyQje0PlH/4LKClEsrSwutIX9jIfhWwIAajm5jFx2W0OPWZbGzk797sGDlSLl9/vnFhYVSe7v7W5pajw7fGrNms7L94RMXXrjnfdCAVsqDQLP2ML+6lRWrfy/fP13kGRXfTaOn3PzvZ1znJzjzuzO5pwkrXJCEkkgDJiXYMxrG4yNA7ZfTLKNMcmAJZJACCSUtdqgzTlMzrlzzjeH8/ujV4uw/fue6prq6rlVUz3Vfc5zn88TxK7eHrFUIkny+PGTDpe7v39wfmFl08bB2cm5hsbWuZVMMZO7eePs7ALYsd359//wJy+99FK2UEUQm5lf4RVw8ng03GVbimZgRiBIE0Wb4omkyWSqlctNYX80jauq5aH3/FXPAPjIJ0fe/4W/P/30T3/z/G/uuGN4dXyFIYJOs0a3MwMDAz194V89/58NXrB7V9/05Qs9PT1CragoisXE8tWyqqq+UOiRR/Y2t44NbN06dfUGy5jC4bCzJUwSnCAIDeGglIotLk6/9Oq5trbQ9//lk509g5/7whdPTxY/9dRd6/HEa8cmgn4hHY/tPXwon1xIxGO6oZrNVlUTGZYjrXY1nk6mUzTFslarJEnlcpEkyWql2t7eWa1IYzfHe3o2MAze3tk7eflG3+DA1OzkyrVxmuE2bdy2FElJBkFw1rH5dR1gthrM1GTGSSUrki8QqsoyzloBqjMGmA7q7lEFAt3QdQBhvQIBYRABYBgIM27NResEC4HhAADV0N/hHG5dX1eaGIahIQMhhEEAIcQxDIDf99tBgsIwHAGkKpqhqBhLM2aL22H/5fMnDu/f0NbVk04k5uajHAvNZvPc0iqb1TdsdktGxR/ulWSVZtjduw9eOPszRVPFGg8sTDhoX16cs3HusJvDBS6BpwkcmM2sZiCkqzjEDENXFIPE37EyQcxAAHtnoArfZcuqn0bgnahe8L8tZLwruwaDt2RBACCtHrx664j7/VEH3kXLHNm7pafJe/eBHUGnhSX0juaQLtUsNLSQGC7zJhyRQCcAZClWUXGImwlb49RqGtBm2mxbiUSi0XgoELZx1s6mNhNJp6JRValWa2VBFNPZssMd2r975FMff4jCgJk2MokYRygtQfLiqdfdPa27tgzaTfiV8zebQz6oSe1NwOfCMEPFkHbj6gWWMFx22sygoM+uScLk+FSgfzhXqBqQY01gZOeh8YU1CdAVjfiX7z0dz2hOp/vBe/ocJBxub8JrRVoRlFLpyL59JACrSyvLy6sEQQwMbBgeGBQq1VKpZHc6WKuZoJnFSKxrcGNVAbJO8DI48cYbvCTabeZge7it1e9yuQzDqJaL9VhRv9/vcDiQbsRisXK5aGg6zVAOp0UQeYhUhiUNDDcQNDA8Vy7miwVFVd0+L8AxiqNMZlYu5QJ+N19M79q1qVRMFNZnCRxyVhNNkpl0DlitEODpdBbgtKpDVUVAkAFFAQAhQRqaCiGsVMqAodRyzR9uRDX5wpWJsxfHRA1IOqUYtAIoFWIqMjSgIUwFpPoHMOc2PsCx+qZ/e3aDIKhjBB1AA2IAJ+oAAUDcMAxF1yRVI0mSIEkDAQzDWJbVDD2VKXi95jvvOnDnXQdsDkbTxYZGX0trGBmqw2MDuGEovKEqaiYl1KoYhDhAugiAghkykqqiUKnIgoAgwikco0kAMAxAGmBWAFwAOZFolSuA17U3T/ALi5nZ6Savo72jKV6Id20bSJXSFUOqAgNjTPGZJSEjBDnfUIgjCELTFENTOROFkNbT2+7zOyxWJpONXrp0ZmRjJ0UZ3d0gGHToxaTTztIUDhg6EVknGObIo4/29PTVJHXT4TvT6fwvnjv+zC9esLubPIG2Ag8QAXTcSoYai4XyhQvzW7dsP3Tori3bdjS34ulM2evz1Kp8uVz2edx+j4vGjPWMNDebgoZtfS0TCICh4abH33tvceLsyKa+e47sffOV0TPHr1hodzlV9dvsw73Ng93OH37nrx68fwtL433bt62sLGAA8dWKokihUCCfTaNMxuFwPPDAA7GFpXw+ryiKYYD//Jdvtba2r6ys5XLZr/y/79SqhY986E6HjfR7zG+9+dt///bX/+zD+zLx9Y7mhhYfEErol8/+Wi4VSsVitVqt25Wz2WyhVBTyebPN6nS7WZbVZRkZEELcYrEEfH6aM6myIksKZ7UnUllNRbl86Re/+s16LL3/voebWnveOH6mWFV0yHzru//la2pJlIy3L0VqOmH1NuJmW03HKrKBsRzBsARF4jgkMIQBFdNlqInAQPAdkEFiOI5h9Y3bULX6/lWXl9Q5ClW99Xl+d9TibfD+7vOgjvF1XVdVWTNUDAMEQUAC1wy9Ioj5cuXeB/crBuQlzeULdPa1O9wemuEAxEe2b/AGfOWKEonmGdZVE3Vfg2/fga1mCyiWEDAUs9uLVImGMtQzQm2ewRFUagyOSKAiVaIInKh3loFb4P33375b9aj/y/r/QO51O9Qtt1Z99GxoSNfQre+rAZABjVsPDCEAjdsPzMaZa5Xq6urq9OTM2OhENBrHIXTa7EiWNV5UeRGqOoUIDFFAJzSVKMi0p7EvXRAThXJHT2++WJZ4yef0qYIiVKqaLFAkVqkUTCbT/GJ8bT0tlNctlHBkf9ehXQNPvffgSH/TH3/4YRPGx8+8YYLySF/nvQcHjr/8Yqvf/0fve+Lx++6fGB99/rlTAq/imNbUFBCFqsNpUxSltaUDlMTl9ezR46vhjqG5tYKKO2hn041IJqMBq4fJZ+K9IQ9dK7RyjEkykgtJnQeySARDsKmlo5gvGaog11K1cq2rvTOfybk8XklFuRrPOX3pqricyM9FErTVYXV6BgcHW1pDtcRyuRAFAMiiWKsK9YlHe1unx+NJJFIYQOl0OptNZ9Mpj8+zd/dWv9/DmaiabFRV5Ao0FGvy6XPTW+5/SNGAjvBKlZdkuSYKJrtFVASL35tIRG+MXW9qay/mi+HmFtZsKc4tM6yVs7hXFtZ1gzQgUy2JgDQBWaNtTh0QBkmH2hqzczOCJFJO78nTl/7jeyc1xMgq0IBJRpSCSEWHCtI1pOqYCrD6FB0DAIMQhxBHGF5/ohnIMIDxDmNj6MDQ6wXXqL7XAwwigBmGoRq6riObzVbjeZ4XWJbFCDybz0GAD20YuPOuA2YLlc3FKRr29LZ197Q53VaawfhKAegyZjGbbeZcJivyvNVk9vhDy3OxbKqqiYahAk3WDU0D0CAIjMAMhERNKxpimhJyuJAGlQReiICzF8/8+jchim33emrFfCyxbvVYM9XSciqWrlYYi50b3EJDM6Ob1kbXR98WbHZO1aSDh/eYOTKeXD556g2bjRLFPEkod9+7972feHJ9XZibAxSp4KRGtgUAMoxU0u/z5OOJK2+/LStaOpP9+7/42pvHTz/x5GNzy7n59dT2fXcNb91BWQBp9p7/9XOZRPmPPnTviy+8EI9GGJIyc8xDD95TzufbWxolXpJrpUIiMreUfere4Q8/ulXgK6lkXlPAnQfuiq2kHD3bzp64+r1/O2MmgFTgO8ONf/6Zj03fuDk/9vb82Ft8dtxqMQWCvkpkuakhlIxHQx2tsiRgdrvP54MmU7lSEkUxk8n09PS0tLTwkuh2eCKrkaGBQZYme7vt+RzweEzNze7J8fNtzZ5P/9HHTp84/ccf+WDQ6WhvDPe0OCfnwDe+9m/Hj75p4ViH1WIgzeGw4zhuAJ0zmyiKggRerVYLhUKhUMBxnLHYgaSazVar1X7t0mWz2Tq/sNLR0x9L6AxrLWRK//6911fj2S133f+716a6+jYG27qLEmAcoCSpS4mUv7ltKZqwuDxVSa1JkizLmi4BQyKQzGAag2sAAAxACAAOIES3gC18l9ixvvHdmjT+gYzw92pC8HuVze/7v269CA0DaZqhIwwQFIkg5EUpmc2NjU+qCHn9gXgyfeXqUjqXUzStUFJiySlRKrqcvrXlQrUMl5ZWdaP2R598uKmTyxYAECpSOj/QO2BhwcH9vTu2eEwk4suGypdUkddkmcIQgUGGIv8Afb9Dzvy39Yeb+P++MBxADAFoAKQbhoY0VVdkVZUJDOI4JHFIERhF4r9/EOTtB8GY7aAsnTx1pSaI5TIQ5al77jigyAJFsCzJqLxMQhInKFzFCcakCSDFg6vXxn0+w+10rcXisqx2tHbPjE+3tbVZzKzZ5iwJmXw2C3EzZ2IE2djWZl9dmqGB6GCtFAZbOj1BO7Z3a+/6zHWfZYRSa93hIBSM3t6RQkEaG5syDKOnx7Z998j45JXXX3/1w0++nyOo1US2JdRx5sylX/5q5okP73Y3NBkcc/n0ifOTK2sL0OJ0eEJ2jw3lF6Z2bN4fxp3X35hhrZTVHP7Ni2/bHbbte/a/9tJbPjvV32HLpqP9fV2DQyOx5EosE+8b6J9YWJ9dvZEqI50QEcEODo8wjGoo+WvXLrhdZkFDOI43NjaKoqhIqiJJCEHDMBiGIXAEMYMXqrJUc/pdmsibTAzGk5lUzl0RKJOtoSMs54oWj7+qqDokNF1xOGy5UkmHUKpVmtpbDcOo8JKoAZyiarKuaIon2FgtC8VqDRAyZ+UMYFgQKekqY3FABBABAYGpqmy1e+RimTM7kzmgszplclQNVke0pmM4rH9XdB1IKgIIWQEACAD4jkZYBwi/JUL4wxvAW5V4CACE3bKBIA3Vsy+QKEk0zejIqNSqqqrarI6e/r7+/n5SSvJCCUGjuaGpuSVkMtOSVNYMERmKKhkkhgOGwTDMxJp4no/Pza7NCy0tfhPjpkyQIBScoiBAmi4pYgmjaBNB4LoOSjmQjlQj8+VUNH724khv/9TM9PJq6v5HDi8vLZptdFN7A81yN24u5bJLeyKVkL/L3r+RHc9ZcVCRS4MDA5lsNJnOOmwwm6llUuAD7z/gsrOhoFMvxZ788KZKKbthsGdx+ooyJncFm2u1Wk2STWb71h07Y7HU2nq8tc1/170Pnb1wc+/Bg7yEPvp/Pmez+22uECRtv3v++Bf+8j2JRGqwt2d6btkbZlYW+Dvu82iSsW3j0M7Nm996/RU+pxwe8j7xwJF8Kv6LlybvOjhcLM9FF7K1svLTb39xZmzeawaZNbChHY5fOb5j5OC//L8PU4RQrs0CIS4IkOO4YqlQo6iW3p5iNNrY2JCYnWY58/ilS263lyCI2dnZsdHJe+5/IJVKNTW2IgRvXLu+Y+c2nq/abTdXl6a2b99O0qZCSbRyoLPDr/Lli6dPjF5LOWzgW//8OE6BaHy+Ui2FextICaTSvKqqNpujWhFz2RJLc6qqi6JYLpcJnKikolanV5XUWoXP5MrxRH7Lzh04QXzhLz/5k1/8fAiS9zyww+tt5LMVhxf/zk9usC00YYYGYeZIcyKepYs1s8vDqypG4rhB4LoBDYDdcnIahg5wnIIQIgDrH0YMAQghhiDE8dscev13dVUMeCfj/L/tkjiO191CAKB6u8ctFE9Tuq6rqlKPzCNIAhnIQIbbHzh9ZtzpmNi9fXsoFMplUgvz6wYCGKWHGmyBQGAtsi7U2GqF17Qxhxd8/FP3nDr1qiLUMI2RBT3oc7aG7MODoZXfzp+vTNMYAAhoCABdVWUFkgyA2G3wjgEEADAAhoHfDwzezc8AAP7XINX6yQfq4fUQ1AWR9YZ6VG+yBBABcPtQBAAg/PffagwjrMuRzPiMGEsBQQE6YBnO4XT4vJ6Q1+U3ZJ1AOG7g1bKgyaCYq5y5MlHV8KVouliVCsWKPxCoVKo4humaBg2dIfBysVAuF6emop2dPS2tXaXszIY+/47NrQEX5Eh+qL9RKkdLyWXKEIBYsuDAEPhtG4Yq6dyNsxfz8cxjjz/e3d1dLBa3btuGEbisqROTk61dPdBkW15LKwjIiFMx87Fz1xBtX06XFiq15UKxqlQpIG1o9tk1YVM4zAJg8HhkrVqVWYevlZdVl9ucT5UiCxc4mv35z56tVnmcon2hhkgqMzYTd/nDFpfVwOnltfi5S5cXlxbjifUNgz0DQ92qqrqcHr/fn8vkW1tbeZ7XdT0YDKqq6nA4MAxjGKpaKvKlQqVa1HSF5KyCAQtVEdFc9+CGK6OT/obmUkXAGFYHOE4zpWrNwLBCpdza2dXW1bkeSxoYGU/nDEgBnKE5B86Yy7y6HEumclUZEYWyoEEKKAakWVmD5WTC5/NRFCVIamdX74c/tCOWVGnaphuUapC6gQGI4SQBcaAhXVT02y262jvimToIukXh1Tl3HHs3grh1n6sh9Z1JlW4YoijeKqg0DJfTMzg81NXVRVEUxA2X2xYM+RBSx8dvHH3r9ctXLsXjEYomJElQKiUAAEmSJtaSiCVeeukVXSUNgzEAiUEGx0mcIAA0NFUyVJHDVByoQCqp8fnU2PnVC0dXzr629YF7f/XcSZ/f09zkOvrq8aHe/r6unlQkQRpEX3vzgd09hoS5XOHC2OLrr5zUZdDf3xkIus+cHhdEwJlxrw8nSbBxuHvD7o3x+PKbb77Q19u85+B2W3uQNUGfz0KYTUA3KJwol8vRtTVV1Tdv3nr2Qgri9NM/vXTyzLmxqTkN0GVBKVbkux947B/+9r2x1eWWhtDbRy/v2DISj6xyNNBFYdNQhybXmkO+kMfW3cLu3rLh0ttvPfvjn37gAwe+8o9/noqL3//Wi9/659coudXNDOglzsEBrZZvDjMMTDrNNUxLuc1GOblms1sFkbdYLBAY8+M3HX3dY2NjJpPJ4fWqqmq1WimbzTCMsTFNluXBwcHp6dmWphZRlBHS49G1u+6/k2NhpZx59eXnH3nqmfvv2fHHH/2QUC0++uCDZgIwEExMTMSj0cja+s9/fi0+P69pGoZhHo+HF0WapusSbJIkvV6v1WoFJGm1WsVKdXp62mQy9fUNjI5mPO7A/OLq+MR0V3dfJlukOdt6LH3+8o2PfOyTjzw4MLsqk4wlnqtCmnX5gpFUOtjQkExlMJzAMAxChEMdRxqGZKhLuC7d7hq9LQyE70DaOq9y29oDACAI4vZWeHu92/B5u7biNkVzuxDSADqABsIgxDGAEXML8y4vzXLc1PT0pStXXC5Xe1u4qcnV1AZUvTQ2Ps2QXoJw9w4MOP00r6y4/NqhOzbrqkY5wolIVuYricSojpZGNm7wODCWBAwBSAzgECmKgnTtv+3RCGL1/R394QJ/mBL8P9dt6QuBAZyAOAEJEiNxqGmKriqqKuuaohuqoSmGpiBdffd/Bptbjp67uGhzgua2QHd/a1tH35VrYxcuXXPYXXarQ1d0Q9blmlRI5yvFSjKW1jAK4Iw3EG5sbZtfqvr9AZ/bYzXbiHqJGsd5fZ6mxsZIBHT39g8NbWRJ1USpQa/JUMptjZ43XvoVUPmd+3a0hL35ZFwTeY/NNj06Ojs+SULswM7d5XKV5thMLlssFgcHB0VR9PgDqVTmX7/5LyqCoUbCF2w8df7qb14cP35mLJUz3vvRj3368/93bj43PNA72N4ctFteeOanDgAwnZpcW9l74L5wS++lazebm0JIB4pYuXHjxsxM7fr164ViyeP1J9KZbbtGvMEG1mzz+YMOj3dxcZFl2Wq17OxqS6wvd3X22Gy2QqEwMVHq2rgxGAxaTGaz2VyXNMWjEZIkrVYrx7E4jlfLJUHRWYs12NRUqvFXro9t2DTCS0qZFys1QUGoJsmMyWxgUJTkfLm0EomyFnsqk6sIUmdXXzSZzheroYaW8anlWCyTyhQgRuZKVQTwclWEGCWpGkJI1mRekBwuVyyR/MhH/5g1AUnWdAMadckYTkACx3CoG0BRwbvL0d/98zbZ99/McrdRvA5ujaTq3x6n05nLlXK5SnNz847du5qamlRVLRaLLEel06m5uZnZuelLly+ePHk8l8t0DQ2VSgVVVSmaBgyjKaqmqjzPZ1LA5QlZzA4MUqqqa6oBEIKGbuiqmaMwqAOhWF2bj0yNZpansVrGT6Py2kqwgRgbn7RarYMbOpGmV7JFDqcxFXQ1d/b2DC0vrIol6fSpC2OLek9v+0c+8qHl5QWrFYTCQFG1WEw/cveArPDJ+RmSAnffcxjHjJXZSSBXnQ6T2ULP37iJ4dBisbhcLoaiJ6amg80t73v/zrdPnW5oBJMzypatO//h/311ailVqNQ0A5o4ysKxQFMPHRj89XNvXr2c8ntBV0dbKhZ949WT//4v33VazdBQf/fb426n+Wvf/qeZ6XNPPP7+g3sGNvb3E4hMrsqk7sY1M26Ans6WoJ8tFJauXHjDacXHrk03dHWSOOFvbkFIF0VRUZTc5GRnZ6fN44murGwa3pDP50vJ5MMPP/zEE/3lchnDMIvF9tyvnj9y5Eghm+vv712bnysUMxBp4ZDv7z7T9uwvLpaL2dja6osv/OZvvvRHBA50XZ+YmGhtbd2922O1mSVZcLvdJEkuLS0RFGWxWKrVajabhRCqqppcXwcQZ70+r9erqnosFvvoR+8FALxx9AZJsy6v7+y5C+0dXb96/tTq2vpvX3ipb3DjPUdGKrwAMbAejVGcyWp3FkoVjKQKhUKpVKzxVVmSdE2FCJEEpCkcf/cHT/89er1t1KzLBBVVvYVI3lUiWv8kv5u9Qe9UZNxG/Zqm1bf+36fdaZqmaTiOc2ZTrcZnMmVVBW2dHb6An2VZ1gzsThNCwOUMP/vzl//tX39+9K3j0fhsKrMAcZkgiMTMsiaDxcUFhtEpumozm1TFEAWgqgCDgCAIksAYhsHedV/8B8z7/9jZ/+fr/+0a8M5ph9fRUD2xHcNxHCdwHMdxsv6cIOo/by+Mc2/QCaukmnHC1tzUkU5nltbWAWt97s0ThK+xa9fh2XxVNVtph6NULWG43stOPLLJ0kaqN187tXew02Yy27yUv50oaSsqxasI5wvASTk//lhbafV4ae35gOD0yU6iQHQ3DZ05N5ZTmODh98Qly408sWq4Y8AVVbAri/OOBsuWPR2ATidq82U1LRmKN9TqcLZLgtnn7vr2N1+4cRGVc5mnnryXwsu93cFHHt4kVQGDkfmJxVf+8ycHt7T1jmy+sBD9yD8/95u16k1AZM3Kn3/6rvcdNkzZX7Rz09Pjo2UKTAidl6LGQglcWxA7+++PrOEbu+4McA1arpaaj9ppaezqsQqvjE4vX5oqHHt1qQxH1OJiR7u9waF/7P2d2ekzscXLtcKKidaHhgbLslFUueU8pTs3L5Qba9b9ZdthUVzRtVRk/QZfjTz43iO5zOrNG+eamoOGYaSSGYLkwo2dvIBBzE6RHpbxy3os1OSoFnmguDMrpnNvZi4dTat57uQbAqaJFpO2tHxZUjNz8xMYZdKRxWINcFaXhgkFYbFnhKlIZz/1qc2VfKwrWGkwVaTUPCiVcBlUagiwtrwOdMNlaE5DcxuKR5fchuBCgksT7ECyGiKtikCTFWBIAOM1rCiDPCZJlKJxMsnWSKbCUjWOlBlDJQwCk0lAOsGuO7d4AwxfTsrZ1LbOztzScqvd0u8zP7C59S/ft+fTD3UP+pPzp75qwUedjTlDnQbiqlzLYTXt8utXvQhvElNhQ+BolmbdAuGK1VCsnBf4VT56Eiz9FpTPXPrRF7nYvLNKyFFbk+ueE2dOtXT6eBnISKkIYjSdDbd0O7wNBGsp1GqyVHnkyUemFs8//MFDHY2AtWVf/eXZ0XPRBruPT4I2l6+/iRRSSZ+ZsuBK0EZgQMCgHPDa0nNTnMsl8KLKi1abk8Ypi8mazhQ2b9326kuvuDzu5ZWFxgbn/UeCp974zbnXfvTQds9j+1qnTz3zu+fONTfuVPDWS7P6ao2rcqa06vj2f/3a5rB3NDIODlSKq96wefhQzxtTU2PpzNi1shn47z38R2aTtXuInSu8XTCdUryZXQ/32Ztaz43GMVtr+4a9sSxpc2xKzXkNka2sV13uHkp3DvTtQQLLACvQuYaGzlwyG3S50rEVXS50d/msnKhJ8Yfv3DzU7Jy/canB31gswmLFdPlq0WbrGd54mDCYf/7791cKMc4kXb6ef/aF//ro5x4o6Jafv13Ly5aR3Q+9dnI8kVWqkibrclNbAGFVqx3nTITD4eCrqKtt+8oCvxadAKQQbvZQDAwGgydOnoqsJw/uHiYNxsk41qbzUib3Fx99cEt788Hhnpkzx6hKza3rrAB8mmKvJf1GGS/EWV1kaQajrRphE3GbCE2KwWkaZagEAnI2l8IJJCliWRZoi1kGUDCgRtAEZ2bMVpJmaJrmWJrEoCbxpGFQGCRxiJCuIUOHAJG4RpECMkQINZwwcFKDpIJwVcM0HccNHNMxZBgQGAwJGQqjMEgYQCqKIaun0xtw4WBPn5upTFvl8cf3e6KrprUVNLJxK19ePLSrobsRJhdAfBG7cq724x9fHZvJiZAINAd9fk842C5kUbd48r4eYMUBsJpKrrZpLSx6R6JFREmSv1ZorhWa+YJLLhg6yuGedbIZQRJB0gCEZmCqDjUDqz8oxkxQHEYwEKchTmMEQ1AcxZhvoS6EDE03NB0aiAQYgeH1nikdIMnQeEMVMUMiocoQuI4wzYCqDhQNU8WqIFRIAkTXlzRVOnd2pa2lsaUpxDJUNLpWruSDQa8kCZVq0UAqTgCrzbG6Fkmls51d3cMbR3QNRSKRUrWmIeByeaampgRBUFQdYoTfH+Q484YtWx2DGzQANAONjpe2bdsmRqM8X925fdv09OTa6vLc3NzBgwdpzoST9NXrN6RKDtfFgZ7WkNfhtlv5Uvnt4ydwCvzFF/dTHD45t4BwslqTbtwcK1eA0+26fPGSw2ZJxiNvvPCcpkgzMdDW1nbnwUOf+dQnvG6b1W5uCPp8bu+uHUMup8lsJrq7m4eHQ3a7fXVtJRKJTE9Pr66ujk+MbhppjUTWBLF2YP8ms4l1WC00gUdWVyZn5pGoeANhhjXjJNkzvKmlo31qZnps/GbA66FJ7DvfuvqZT379Fz/96fzUTRuLd7S2uu02v9vdHA5lVpbFWtXrdq8vL2FAc9qt2WRiZXGeIXCGJKrFAkB6W2OLzAvtbU03xy7deWSXP2iW9LIG1L/6q/uCoY58QYGGZXE+BhGVTaSdVoskSYVs1u500hSxNDcnCrUDe3fu3Gq+MZnjKLIxENZUGSEkyWoiVfb5XRiuAkKHmAIxBRIawlWAqRDTNKTqQAfAQBiGMBxhOI7ROEZQZk7HoajJKtBgvdYRAzgBY9GUhQOPPXIvjrR0NOqxmJAiLc1MHdy3/z2PPrJ7926RlxZm5yqlajadO3/m4n/96OmrR0/oqgFwnCVpzGoZGR4qZnWAGzgJgCQgXbVxZkPTCukiUKGtZdBQwVs/+C+AsGqVzxeLvCTOzs8lYmBqOu4PmDUV+oONJMnqCDAMI4piJBIhSAwwuIklYyuzjz0+0tYabmv39PX5eDHj9YDde0eGh7oHN/SUSxndUOyBQHxlDWhGrSYpKqaURBxju/qHAMbkitVINNHZ3Xv+3MU61qvVap/4xCf6e/tEERTKFbfHv2nrdrc/2D+8OZLNvXbs7dHpGRVBjGZLVX55NboWSRUqkt2NiRJQdeOJ93+gqbn1b/7m2+9/7OCu3QOXLh2/eu3iow89fHB/l89pUgRQLiAMWLdu3re4sKpqciS+wloBRoiqLglSNbY0G24OnTp+lJf4sbGx9bmZXDzuCTXE48nOzm6aZk2s2WpxFvIVpZRvbWumaboq8JHY+vDIkK4DnIKFbLJQzGWyiWQ8xtD4PffaKBr4/O5qpdjpB+VK8cqVK4vzqYaGBrPZms8XBV7KZvMAwsBAf7VUTGcSslTzel2hUAMQRAhxkiQj8Vhvb6+u6z09PZlMiqKoYJB56623BEEgSTKTyQwPDzc2Nja1NAdcOMeRiqzVk6LZW4thWbaekFPv0wAAVCqVTZuGRFEsl2stLS2KomQyJZOJrXd73ULo6BY8hxC+G63X+Znbd6LotvyxTjZit4A8Arccrbe9rxiGsRzt9Xo3bhwiCOB0OuOxZCAQrNWEHbt2i7JSKBRqvKhp2hOPv/fP//wxDOI93X3dPd03bow2N7VQDEcxJkCzOEF39PY++cGHPW5QKfC6UMknVlWxZmY5DUAVAhUABQC9LlGHiADGbVX+7ZuP2+1R/+uq+2y134cw3HqPgiDIslxnqzACh7+PO/59IR+xOD9KYqBWrrU221hK7+8jW5oDxWIy4Len0hGJN4fC/kwiDnScJHEMQk0nLBYbZ7EyDJMtFLOZfK5QYVl269btYxPjTpfH6XQ9++zRTZuad+3bf/706edeei2RqHT1N+49tG/vgU7ObFpZXvT6fHy13NnaggzDZrZdu3aNY1hdQ1t27DSZlYuXrtpIHFd4Q4XjN6+OjWb27+8v1iR3uIl1eFcTudMXr2aLeu+Ay+n212IJh83c6HQ2N3gzqfJffWLn1LIxvH3z668/G/bW9u98GCA0OTrR1DDS2yXLmHPs2kxLk3d+YXZxYdLjNI9sGvB7XeOjY2YO7+5owXGso6UpXyo2NgRrPG9YTMCCJfNlnudddoczHJbzhVKp0tnZabbYU5nckcMHtoxU3zp28uTp2qzj0p7NQ5qOb9k4lEqk+UoRcqoqVBUdQIQBVW4JhbPZbLVcamxuUhSlxldcLldsNU6RrChVCALqMLthpPmNN09u2r6pUBYuXLlotjFev3Npaamnv31VW3GOWExuJ1Yu1EoFSZWCPm8+nws0+D79sScheOXGRFzQWI618jzPmW0kkMo1hSEMhBDAMWBACOCt0TuESNMANHRg4AAiQAAAdYghjNBITJAMBABLUgggRVQUXQK4bmbAgb277DS9vrDgtToyq8s2khvparlw/q2nf/zd2Lq8e6f9zrt2sDjT1hjcuW9nJLIcT8XLmbLbFqrliys338QNvSFIyFoV2BiA5GQi46BCQVeQxDBMUkAyuzKzXslWnZhlZnoxv65xGKiwymf+9EML84uvvnKxr8969uzV3bt3Tk7MePwOgqA27tpRTiYiMzMIEIpcdjmZ6anrRx4+tLhkmp9Dm4ZapmcuOmxM/7Y9tcS62WYBFOn1B3lBcXkbalVe1nAN0fma5rebSM5ut9nOnrt47VoWEdkj9z381Ic+fP3K1VdeOZHJAh1hsUzu6Nf+6+DBzTdSK7IGF+O5ggRsfruGUUAFLEuaaei00lcurPZ0YolUJV+onDt3bWCwcXL65L69eyemxoeHu2VZDftbkUrCcD6+yr+euLRjywDH2uwux9VLb5eKmMMxaGfCQEDZXHZhdYGiKZfH1bxty+TJkxabFQCMppg3Xz3a3NbKMFxrV1cuMyOxoFKtpvJF0uZ47c3LOgRdPf5iISNKVUOXJLHS1dl84dqNxqD7oUcfyuYLu3Zu0fUqjqG1leUnn7xPqAkiEEL+BlURDVWrlStSqnTq9M3hwTazhV6PFFVEEggSJIUgpus6y7I8z1+7cf38xSRn5u69+55EKqUoSjq1JopiOp3OlzBF0TAchwjU2W+SYjiLRVIVDAGADBLdYiHqw0GaILOZDE3T7e3uRDRWFoWNQ32ZQh4AA6F6yZyBAMKQgQEAAW4Yyq3YyDpF844iniDJuuAde6drDCGkGboOdAgBhgPDMFQNYRDWSQwNoXg8mk8ad999MJ9eDni9NT6PkGF24oIov/7W+aYAt3lk+Ne/feH6DfmDT20p10SS4jZu2pZI5teWJjcPdhYSGVXDzp86te3wQ9/4yl98/l9/eWI8PtTVXyjymi5pCJMgNCCCGNAgCSFOIQNhKvhDLdDtN1I/dW6fW7evQfitnMt60g4CyIAIGEa9KhYAUA+v0VS1fgSaIXk7VxI7+to1vxs8cN9IX29juRC3mKAml9OpKGcikSHl8gkM100W1uGxkxTGmZlSTTAwwmS2GQjL5oqSojjd7oamplK5FlmPlyr89ZtjPX3BTZu3Li0s6QjmBGVqDRAms7mtY++B/SsrS/OzU5pcY3AU8DqcdsvN61ccDgfFsAhCWUOLN6/6TUR32KvVirokbN28Zcu2NlnDjp295Ap1GJT92LmrV8YqZhvb0dUHAWam2emJ6YH+VlnI2i1U0Ouhcezc6eN2Gw5RBWDy5o3DFtZiKHIqsfDaq+d7e1sIAiMILBDwOl2OkycuZdLxxx+7C4e6zWpqbgpZzJTLZnZYOLfNHPA6IMXZPT4VYOvJNFA0STOK1arH6wMA2Cym2NpKNr5+3x37nnpvExLk9NqsocjQYhbLBSTLUFVwpJtootHvUoQqayK9LovPYSWRrghVChgkhqCChb1BVaz29IWLfMTdSFe1vLfBf3lsdn5ZyRcYjm2rlUlNINw2N04ywNAR0mvVMlJVR9BL6GIxvk4BedemfgoZDK5j0BDEmsVmN1ldJV5FmAgwEcGagfEGVjMgr2O8DgQNk3RMM3CkQaQYhqzhqkpqGpXlqxVd1gikkUDWRUGuAKBYTdRD997V09pM6qoFA2aoMZqwoTX01m+fffvtm36P/U8/c/fHP/LUyIZNDb4GQ0TpxXjjrsNuiye6sAIqPJDlTGTNzlIP3HVQwwUglwANaQKvZgtANAKeFrerBbC+lekIR9gXpgoms2PH7k3B5ubVVGlmOnn9+hIvANbkueuuh1va+4Khpkq5Fkukyon0pUuXeL5it3GhkMPvN+/duymRuHn48MDmza47j2zq6vK0d/gK0RmGA3ytpBQKZKABAXI9krE6gjhuc/k6IOdcXEtVZBDPlt3e0I6dzZuGw4lY3GWzXzx/IRYFZiu4cGkpla+JOjh25tr58fxMNCdAmrJ7RIzJ8UpZQSog4tlCplj91XP/0tc/+N73Pf7lv//als3Dfn/QbgPZ/Fy5nOnubo6urSIda2nou3EjOTG6fvz4ytM/fvnVVy4899wLgxt67E723IWxXDX3zC8vDt97x2qsOLecTuXToFJsaGp0hhtPv/WWquoBf0NXW8/i7PKZo28HveGjxy42tDZv2jziC/p27emUNfGJjzyZzMT9XsemkQGnwzQ2erm5ybdn95ZYZDmfi6py1W5lS4XUnYcPSYIYXYuePnlOUxAGSYpiRVGulAodnbbevnaCUpdWJjlfKJsrziwscmbrhqGNoxPjNocN4nhTM4jG1hPJ2MaNw0NDg4uLixfOz1+9emNmdj6eSIiigmEYSdZBOgEhUiVZlW+57evqjnc8qKQkibFYbm1lleMYj8uVz2dzuRx4x4L/DrZ9h7PGoP5ONQeO4/U0sTperW+OOkC3d7fbOS0Q4AhBw6jnAOMEgVUqyh13Hnrf+x/72S9PBsNhRTcEQZmbj54+dzGTL4TCLrvLtx6JFcuyxQESmcLIlp3ReCZbqN6cmOF5PZOtZvO1QEf/rjuPjN28wRdSd2zf0B+yq6VYLReR+YoKcQEyPE4LOKPgDMIgCWXWEPD/P+u29fS/vVL3pgIMIggBBhEGAQAIAoIiCYIAOIYg0BHSkVEXvcuqIquKqms6MrAnHu0cGWp/8N6DdhN+35F9h/Zub2z0C3yxkEmaOBonQLVaBtCAUFd0yWRlQw0tvKgWyzzNWliTTZC0Sk2SFGM9Fne4Pa2t7QzDDQ4OJRKp1dV1TTNGdu/74Md2EyZLMbJ2Y/S6KPBWjuRLOdyQHGYmFVmTamI4HBwYGFhdiywur+zbtungnp1OizmTiJ8/e25peTXY3F5RgTPckRb0V9++cGWiaPcBijPHYglNV8N+3+F9I1YT5vOwZhaWC9mGgK9WTkXXF2dnpBunjgKKTqzHX//d8caQ49OfHg43BF0uB8expWIe6TIGgCiWq+XcnQf3zk2NKWKFsJkNVUjF1ziKKGczioFiiYzZ6vQEwsWKwMsaRtGlGm/y+wiCCAZ8Vgu7vDDT2hA4cmgEU3kSYunJaQJgPR3tSNUsLNPV38vRNIVDoZBXRIFlCL5SkPmaw27VJDHgapAFnTMxFaHIOfHjF47mJeO511+tGaTdGxZk68JSeX1VWpxPmCgbn8yvLy0VcnmPy+20Wmqry26O9tuYKyfffPU3R10W0OCzaHKFYxhZUuPpgtMTBkBB9QeUNCBpkNeAqELRIFQdU3UMaQBJGhIVQ1SQIIOCqMhI1wgka2JVKEFM8/sc/b0dQY+9WsjUsqlGr/OLn/3Uxq6WY6/8Nh+N3HW4m6VQLhUr5TJytQoV3YQzPl8jGJ9p8YZNOAVKJY/FtHvrsNfKMlC2utlMLgqQ5PJ7gKJXM2VQRSCvgVgNVPFqRtZEQBImT6jBGQgqEPz058fSWdkb8A5v2m2yuqan5xeX1+YXV2w2uyBI27dvb2lpiUVW+GqBJLRYdLG93RqPj3Z1umwhliD5YNDk9Jpj8VWSxDEcr6yumX0NBGEFrGt5NfsPX/6Rp7GXdYWvjC2MTS997wfnnA7v4lzs7/7qlx9437f+5NOffuKJLR/+0IOf/JOnOLvL7rM2dXWbfKzOmasIzwhKQdQgZ2PsLhHhrNU1v5C7dPXan/3ZX2Sz2c2bNoQC4VdeutzcZBWquS2bOgqZuKGJE+M3Ngz2OSwwEPD7PMDjsdjt5NQ08PhC++5+8J77dhf56kc/uX/i9Jld+4be9+QDq2trr7/6Gs2y6fW17u5ej9vX1tqajKeGNwyZORPQja6+JgPDz168MDk7M7xp4yuvjf/22Z90drV97/vP4lC7euWc024e3jayMDu5ZeeWvbu3fe97r0Mof/AD7/V7nVcvXb1xdSzga1heihCQNjSEA2ixmPYf3s+ZcYBJm0e6U2sRk83Z1t7NmC01UVBVVRCESDQWCnkxDPzqV1c+97nvxGKxu+++GyGQygBNRwjDCIomaZZhmHp8uSSKOA5xAuLYLVPS7dEfTRHQQPfevXf79q3VckUQBISQ3Wr9nyNHAADAbvl9DAgggd+uXqrj9Nuzx/oOCG45P2/NWjFIQIhDcKupiKHA8vLCzp077r6r/+bNmzVe8oeaK1UQiRVtTg/JmuOptIERO/bsGdnansmXjp08OzC0leYcsoYbkOEs3q5Nu5cml4GudbY3J5ZnDm3pu2/PBiFd2tzb6HXbNIiLOFfDrTxuVTAWAEAaKmPw71ZA/rfn797fb2scjPpvcQziGMTx+v6OMCipiqQqsqoomoYgIGnKbDZb7XYNIh0DGkQaRFgutUrjCm4IPqcptr6UiCzfvHrZbbdUSkWO44L+QP1vSIqKESRB0ZoBcZIxEBaNJWfnFgvFCgK4KKk4QfsD4Vg8qah6pcq/efSM0+VBACvUapKhrUbWT58+ZeJot43buWWjncGquYTLYQq6LNs29y8vzpWLhXQ6PbRxY77E53KVYkXq7BnyhZvn1uKJglA1mHhFvTC2dGU6q+Cgo2fQZLIkY1ETSeIAeZzm2PpcMRct5eJ+l3X0+kVZzI9sDLe3gvmZpJrND/YMHtiz8ZGHDvo9IBmL9vR23Xl4P4YjhiE//vEH77vnToBUmoZ+n91l40AhTeOAhAbQZLfd4rbbZmencRwGAoG1aKRYqnAm21okcfnMBRVhpZpotTla2zsSicTUxESguTmXK1SrPMNwAGF+v99qtQJZhhjy+Xy1WjWTyeiqJssyhNDmcBqGEVnNZNIlnOBkHfCKdux8OiuCyXV9PV8tasRSrDg6uSYqkOehrlHlkgQw6A8GgG5AXYOqykJAIG3Plv6+NigWQWQla+Mwj8siSryhAwApgG7rbes2VKBCXYOqBjUDRzo0NIgUA8k6knWg6BAgUM+WEwQeAuD1Wvt62ocHujWp1tEUqhbSRw7tKecTb7xy7KkP3hfy4TeuzllN2J6dG4Meh1QpmgmCNVmAogMdI/wht9kip1M0UG1Oi1zJ6ELB6THTJkyoFKrptIlgHf5WOVp59ts/f/E7z3pNIUrnHrj3bgSYS1dHV5Npa8AWbAh39Q6LCorEUt/9wX8+99sTx0/EUhlw8ULk9dcuLC9Fomuxjo4ukiQxDLS1NlKE6PNwDGOcfuW5zrawqvDxyEpzaxPFcYTLoxlYOpqyOryv/+4NqyOYyYMTl8aLIr6eKT/76zlBBm+fvvq33/7mQw90NobAxXOXhgaGdu3ZN7e4sh5LVWR04dpcQVKKklozYFXRS5Ki4wTDWQiSkmV5z56hZ3783PueeP++XTt9LsdvfvVqdyvXFGgzJLC2tLq6vNDaGuztacxmFygaWawGSYOmttDGTZt37wkU8qpYBMmE1tLZf/T42ZuTs8GmttPnL1Kc2eZw/vTnLwuizJpNuXzG6vf6fa5MOh4MeEwOS1VQaad7++79BsLzxfKnPvMAwLHz589v3dqWzaQ2DQ/19nQAvpqKRa+dOpGOxTxuEPQ7s+no97/3zJMf+vDDDz48PLT54tnRRDRLmp3OYFhRFIWvJFNrAMqNPY0VXmbMZkt7B82ycwvzXr8vGl0PBj0NDaHW1tZ77ulSFLC8vNq9ddtd92wfHPQTNE1SzG0LNIZh9ZoNkiCIuojxllzllkJXV5V8rrR508j2bVuyFblaqQX9fpOJfbcM5jYSr+tebu/4xjuwHSNwwzDQOxfXtV518h3iGHpnC8UgjmEEMJChKTYbdez42e9891uzC3PrEeHosfW5+ZXevo6tO0bWY8nVaMLqcBWrQjpbtFhdsgJEFVy9PnH+4k2Xt8Hta0SQmbo+yUvoG//8kq6pQZeZTy+3OLB2B0gurdbKGQPDJYKrERYB5yRIGQARhkTpovH/ud6tk7nl2wIA/TfPKgYBACRJYsTv+5sQQlp93kBSgCARThgYDp993NPV1SXJotnMIaRbzNz169cwHHg8LpoigsEgjmOapqmSTJJkpVKJZ4y6wKhYymuyEgqFmpubGYaZnZ1tamr4p388CiH49reffP311z0ej9/vz+lYuVgQazm/y3LgnsOpyRv+gLuYils4rlCqels7Th09pQMaI81Ot8/jCwUsOOYPRMZnrk/Oj82sxPI65/GvJovRjMyaWYYzyyLf0hCkSZCJrvf1drmAF+gT73+ocX3+Zld7XyLtfvHNqeVUHmHgnkNga2eoLdwPRFNV1Skf+8PnnrtxFYxsbL/7yIGl+clyIen3WG0WPOx35zMJE0f7PG6e502MSVW1UrHiD4cWVtd1XW9sallcXlmPJPoGN1QrwrHjV7o6g16PXxJqXreHpem21hYAkVitpvJLFEU57fZ4NNbe2lIrlVVJJnDcYrHwPJ+Ip4LhkCAp+Xyxtb2tVqutLGaaO1oUHBEOLlkuf+eZk6IGrPZQMilTwKLWVLeZ9dhha9A02Bvq6gjr9LqjuSk6etXntFI0AWRd5lV60x5jKfPV7/zijXOSKUTxhC0hIMDa85VagKwBaGhIQ8hA0DCgUU8gQghCjMAgbehQV4GuAYAIDCM0WKRJgtAUJOkeC9nb2dHV2eZ22RRN6exoagx5/+Nfvg6larPPEXY7ejraxzNL4zdmBrub79i7x+dzAUWq1IpWrwP47SCfSkbXDE32OxxQkfKJlMfj4e3IZHYXy7okU4HmQQCtF19/++jvXnUypoM7ds1PjR8+eCidyU3NzUeTSQNA3bCLUs3vc/BiwWqm19YzTU20y2XnGCKyHgcQ7NuzsX339qWzbwsiP3hgX25tslapOp1OWZY9fm81X+J50eXx16qSI9jCl8TL1yZcrsBLr575xCf/2B8MP/Dk3xAY+OiHH5gavWHjyI9/8uP/8c9fyWaqf/23Xzx36VqgqePNty+/fWl0eOvuibllQVQUKY/TLM7ZeRXmq6KBYSaaJoFiwTSfGX/wrj2/+cWLX/i/Hzpx7Kiu6263m9X4Ks/7gwGSoSVVGZucqvLAZoOhYLghEHRa7Ug1eju6rKwlsrL64x8+d89TGyVJqlarXR3tk2PjLEP19/WeeOtth4V66MH7SbNJKZYwgCRZMJstc9PTtCUgGwZrtou6sbC4fODwgamxm04rbedIp5l94flXQw32XU98IDY6sbAc5az2M6dHP/zhR6enp2VZbmluNpnYQi5jMnGJ+OrOXdtwpxkV09VqXtMki5XL57P+/n3JuSWBVz2O4OpKfGJ81u127z94cG5+BmKYjsDC/ArA6KWlmMMZXF+P3yjiiqbpEBqQ0HFcRZgOIcQIwzCQYRiaihkGAXQGxygcJ3Bc5kuc2WpgmKCoJMeJBkjn8ghiOEkBDCMwDIegnnQOEMKQQZCYoig4xBiGQQhJkkRAjOM4RZLfAfe/h+0AAIwwbonFIY4DiBk6MnSoSwTU+nvbHCbqyfe/99fP/szv9STjicX59ebeFqfdVkgncKQ2h0O6oeoI+sNNFy9fM9sdHe3t0dWlqdHlnlamv6P5yHvfkxs/R5KkKEo6Rnsb2n/95vmv/mTK1eKIVHGJsGsYhQPEIpEzqpxeIwxZIp3vviO57chF78TLvJuRRwiJhFpnsfB3vF51sEbTdL1Stc7A1EtcAQYpSN6+G8DCgcCmoaGg15+IxqABU4l0a3Orw+rye0OJeK5UFJBBUKSJpM0EZZqcXhjauElWtXK10tbaMbxpM8OZo/Hk+vq6zWaTJOXwYftDDzXUFbiGobMs09rk37Kpz8IQbY3B0uK032OLzU8hsZZLxsqZBEDI53Rmk4mezo6uzs58Nvvd59/+3nef++t/fe0nv1tcLeprBXBxIlWDZsLurAKacwUkHc4uLBWzGaCoeq3I13Jup7VUyO86tH1uenp2eqyrswGD4I8/vvXInQcaw818pgxUwBAkRBJFAYoASwtLayvLLE12d7Zu3bIRhyCZiIRD/vHRm5Pjo1a3R5ZlHMd5no+vRzxm0smRseV5TaiNbBqOReM/evpKOg8W1lIWbwNgXHkRRPLC5FJyKVrIiVi4patUVVhvA8DZ1UhSx0hHa3uJl2qyZnK4ObuTMjsIxpQulCLJrILwUHM7ws1Vibo6Gpf0YJEH6xmQFYBC0gVd5DGprJdWEpFrk1M/fOa1iZl4tlApr8dlSafMzlw8A8w2mmVrl85pUvmv/upPH3+krZBRyvksDVUcKRQGCWTGdTNpWAjAYYiDgIGAApDSDagjYEBQb/GFBMIJhBM6beCsQTA6tJEg6HI2eB0mHJRyGY7CT7994kc/+k+aI2gznigkuza2D+zb+IE//aM/+cwTGwZbrl87c+atlwGQrWEvgArIJCKLszYLg1QBx1ShVpSEYjKyUKlURFGgCCLQ2QPMzqPPvnjspeN37DoiFNTl2XWgMS+/dHRlNZbOF+dXeV5HTo/V7bOFWwJdvS2sjdy1r8vmsHT39hw4dNdHv/xPTz35R+3dW66/fMrjaRkc2pmfjSg1o7mpe+z6ZKXA13I8gbML88sEztgd7kqucP7i5da2tua29i/93V/+x3f/88yZs6HmwHuffOzFl48aGGF3eM4df7u/f7CtNXzh3LlXXzrxy2efnZwcVxQwPz+fSqUQBGYzJ0lCuVzSDY0kcZYkTRzlsHB3HtozO5uLLS/s2ty8ZbDHTmETV3KDHY2GQt24XKBJVpMVh4Or1ADFgOZWB0ELm7YONLY1+MMNc4uxr379+79+/u0du+5IZbVkStF0y+WrcxhpHxze8dWvvi2roH/DEEbgYjlHsWBmbtTc6k/EF7o3dZot7paWHrvD39LSHWpovXJ59MKFy1OTs8iAc3ML3V0NqqS/+r0fuezegC/EUOwnP/W+VDpWq5Z3bN9+5cqV2HqipblDU9GmjduzmUJkfBpabBDD7A4b6bT7G4LRmdlAQ5OJsyRSqVAopCiSKPKf/NT319dXN9xz1/r66s2JdV+wgZe1u+65vybIvCgbAMdJmqApCHFd13VV01SZwCGGARLHSBxSJEnTNMdxZrPZ53V7XA5J4A1NzWYyyXjG63ExDAOAgQEAIXq3D6NeNGAYhmbot5vCdIAghDq6VVv6jmfpFtteJ+V1ZNQD8QDADE3XVA0g4LCZZuZnf/z0j+6974FXXrvE8/rhO+9kzbZzF8YUA7V2dp+/PPXya/PRZObchctDI1uj8cy3v/vWajTx/g/cr+m42xO89NrxRDotSZJQKVC6oJYSYRtx52aGLxRxTDMwqGOEjpM6xBFCAOmYAW6zLv/zyf+6/hucvw3qb6tlbk8v6iheB0hDhmrosqZiDaHQ4vw8RMjr8hKQkAUVIMrva4xFspKA7DZPNJKRRL1YqMmSsWXzzpWVFQghjpOCJN4YvclxXDwRTaVSkiTk89lwONzT0/27F15uDIeRobEMZWbQ6WOvbhrspKAqVgpSuei22/hyye92NYabgCD2Dm1qa+2YnJxm/aGV5bXnz8SfPxOJ8AB3sys5QDgdmNWcqig5EVE2b6pYUwBhNpswTbVSILUaT6ZWNm3cYLU6gahPjoORkf677t598GDnjp3b0ok82dhTzAm5TIH0eReX5psbGasZGBq4dPECjsFQMFDMZ1ia0BRpfHz0yCMPIYTEQoGmaRwjAcBUFZkxUIivhzwup81aypcUFb3vgzumF4E73GH1tqR4NLWaPXVtdmwp9VdfeenHz74i69RqIru6tE7bnN5wc1lUEusxs9NdldWL127gDEc6nIl8aef+wzLC/R093oYGGVL+hr6xycw3v/VCLA1NjsZkUUtVywfu2ct68apRFKFEsJyBAx1YUpliqSZxFrda0xjKBioCUHVzW4vMFw0+9+j9B7Zv4nQJ+KwkC2QglnCFJgxOF3EkM1bWbaLcmkRIAqIpi6ETsqSqum4gVZJqklzWdN5JWCAvI15rcLsGOlpMOJBrRb/Tvjw/5/P5tm7ftu/Qwb13HNh/ZHe8EH3j6K9BPtLQGVbV8tCGjvb28OTopcTkNeCxT12/FAq649EViBmABOlMvFjOkxSmyYi1eRiSE6OZL37gk6+9eFrhtZNHz9y5/267yfP2yeXR0fSla+NLkfzuA8Mmh0OHUiSxPjN3zenhRrb0ePzWxtZQ98YhHKeWzlxeW8uWM7LFElZEKhUt0rTTZgkvzkQ39G0v5kRFwmnC0tszbKhQEBRdA+FwmCRJs8Vyc/T6XUf2nz1/KpXOPvzoe2RNn5hc6+zu3X3fAzdujO7bd8Dj9sbjAEJYqxhmDqyuZLo6Whgac1g4pAKaAC/99leFdNbnthXTib6OJj6f6mkGx9+YslAQ4vrIYOeRffaV6dHezo4PvG9XpVhwe+yapkoSMJtB3+AGQVLMdnsskX7tzWP/9h8v+cMtY7MZA6MlkVN189jo6rXryfX1fCSS6x2gOBPrCQTHpyYkSdANeXBjj55ZZy0YgOLs3PrXv/bDb37zR6dPXQg3tIRDTY8/8YGx0czy8npDqMliceCQcjm95UKltaUTM8jfPP9rt8upKJIoij5v4Or10ZnpeZvNNT4xrarI6w8DWTObbaNjk0KmIFRFSVQAQuVyOZ/PO532Bx64TxBq27eSdrutPDczsnVLU6tzPR6/654Hk9mixRUQZFVFSFZUkqTz+TyGYTiBcSwj8DVdU+tygDos1TRNEASH1bpzx7aW5kaSws0cV9fY4ATGMAxBYHXH6S3BH4ZhJFFP8a07pSGO1ZujqwJPEATAYH3HRwjVt3gEAIQIYBAZUNeRriAMUhaLxeNxQghmZiYpGhAkXItGFBWoCLfaAiaL3Wpng6HG8YmZKg/aO5krVwupTJkz29o6OrfvbLDanMVypaGpOVMoVgWxVBNtdoc/4KWgKpZSTT7rjo2dDAA2Divlk7qh5NJJVdduNXUI4HYPCXjHjaVpmqIokiRJklQv5bhFKNUVjRiOYRheD0OGGFHP+8UJDEAIIQbqWB7+/nWcxHASYgTECMzj9tIUp2sg4A/PzS7bbZ5KWaxWpPGxuabG9nSqgEG6WpEsZufiwipfkzP5jKRKmqaUSqVyubgeWWUYyufzuNxOiiQYmqiUiy2tAZbG7RYz0LXTb/5uda7CF1IBvzsQ8BiqpigagiRwBWjWmo5l07GUhiib01dN5q6NLlZYt2oPFSE9nxQFSOYqCmVxSYikLY6yoGaKFYgTZrOZAMiQAaWDj378vb6At5AT+ZL+yS8+2N7fphqFYjX5ystvtLYM5W6uhzs3TE5OxyYmGJqzO71333VnPgcwZPCV8vr6Kknh/oDXYjHjOAQsO7BheDUSjSczAKM8vnBz79CZk9caAyGzwxmLpnSEeQPN8VzN4gGvHp//ztPPTS6l3zizMB8tn70xW5SARFpfeevE7n13Eoy5WBYMnG4cHuFVjbPbizwfaGpajsW+9NfP/OyXN/7jP38haujb3/rer174zbXRiaMnLkRj0vya4LB3ZbKqzRky2axVubiaSNt8lDtokYDau2HjzGLUAPTqetbmDFV4w+xrBpgZmBxnf/1bi40bG70YaPZ862t/u3+ba2kxp5bSm3uaiuUciyi/w8eRZr6kShWNACaasGgKjgOCwkkcQgAMkkQkaRCEVsuXgah3NjZ0NDbx+Vw5l3ZazU679c7Dh3p6enQE1+LRpejqcnztxuzYm2dm/+mf/r2YWrVa6HhiJTTcEwo6L128dOW5n1w4v7C2towwlM6m8tlMa2fH4MiIu6WtYcO2uWvTv/vN68//6ndel7ulMeR2+GmKO3363KkzZ90ucOiOTRhBYDhIZHI6xHVU27N3WDHUK9cudgy05gpRjNALycR6JJFIFFzuRpuv1e1usjkbEslqPFHSZCqVqCwvptzOppdePLe8FF+YX7t+bWxsdMoRDl+8eHlxcTEaW/P5POcunMFwxLDE//3Tz37961/94hf/9OWXX/nB179JMeyly1dkWd67N+BxOjAI3v/EI34XWFlY9jiY4f7uWhUEPY5nn/mR38VkYiuDvW3nT52dGb8R8tj/67ufPvXW6iu/eJqG6off/+jhfdtpTlxaur5790ipmMMA1tfjaGvrMTRbQ3gok1a+9o1Xf30sZnGCTds36zioKPlIrOz1tAXCXYoCguEugrQdOHiX3eFdWY0EgiHOZinXyqLE4wxB0KBSSAwPjaSSYG4OPPPM5Vg02bX/IMea9+3r6+zoSsRTrZu34RgxMRG1WpwCr9pt7n3799us9k2bNptMpuHhYYfD9uxzN0qVqs3mMBBWrvCqjEpVxWzzclaPqhFmsxmpmtPp7OnqXFlZunTxnNfn6erqUDX51KlT5y9c6uzpLVYEDcN/8esXZAN3ur1miw1hOC9Ibrfb5XKYWc4wDAgRDhCEEAMQvJNEbRgGBEYmmTRUxcTQLEczDFBlSVdU+M4Y9R2C4p3KPQxDEOq3QSy8lRCpv+MIfYdhv8VvqIZuGBqEEMcJHCcxgAEdaZqqakA3kK4DgsK3bt/Wv6Hl6JX1pdWEy+UBEI/EEi6X56FH9suq1t5BWWzmi5evaDpaj0SdbncynaFZxul037g5zkv62NRsLl9kWZalCDMNLTQK2AGfLbSF7ITO+73OUi5DkGQ0KdCmW0Ui9aW8a93KfdL12xfUN/p6zh8G6v+3+vTsFp9Tf8UwDEPTVVlRZVmRpNtMPYSQeOvEyZWV2KaNG0wmk9lql1VktTrT6TRC0GZzJZPxWCzy8MMPJ1Nxw0C1Gj8ysvHmtevL0Xhzc3jDYL+qKhxjN3OMiWVUjmIoolAotDU1KIpitXAsi+/dNtToWQ54HYAhgYCKVd5mddg8lpXpNa+/oSQJugoTRQkjseK1qcUIKJBWADnMQhogb3U61tYibtZKEAROEDhF4hjANVFXNMMwnCbgt5ELqxMLs4XN7X6TzQd4KVFcBBYPL1cjUZBO65nVWhFfmZvPpoXcHe+9p5zXdVnZtsVz6WI24Isevu/J6OyYTiMcxzeObP7Zv/9yZKQ1GGzOZArTsysWi13V8oeO7C0UyrAi9w9vXYhkp+aWsjVtcGs3Y3GfvXCZwGlXKLBz27ZcJhXPXCpU9CN3P2Qb3vC+3v/z7W/de/7yJZ/bMT050TH0R50kkc1mdx46OLhx06XL12Lx5Oj4WEtbS7FcUZH2+tGzySJwmJyVoiSrhizIBESvvnKso42RJaGUAy0eWzQe87vCkXhhYmy9XBC7W5vffO23B3dtDwz3YhQDMLhx69D6zFXCGvjuj7+5+6cv/+VXXsqtzO3s2R5PpXOxDEbRJjOnQKBDA6epXDlLUjjEkW5ISFfJumZW1cyMqyblOZpxWi2lbIkhCJrAc6nU26fPpovFtXhWVkFfH7jrji333L/baWPMGEhEoqHGkJnGamtLCChHjuwqC1VP2O3yuU0Wc7lchhqoiEiXVafHAQra1bPjNmfYzlktIe7Ym5f5ImgJOu0MAyDWM9C1ffee+VjUkKRCsWpzOwuFzJbNPR434faaxVoaw7VKtQgwZACMNdntgZZiIvXC794ql9PnR+UWP/DaAWcCdju2e8/2vt6OjoFhZmm+obsTaOqlEydmZgDNrX/132afeir86U/9MUkxf/21X24Y6ElG1//2r/+DxUHjYf8nPv6xv/3SlzCS6u3trYoKwbDHXn/RUMBwr+cTn/xIrVQ+cfzc+kJ8fu5XwWZfNleo5bMdLR6tnM0kSzdvXv7U/9l29sTlg3u3rC4v+HyebH6ms8e7vDpx8OD+14+dRbopndR/8/xLZRE88Sg2MNRmXl7GKFDTyu0D9OTSlc7ug08/88LunRslEcxML+7cvq1YjFdqEs2YPb6QofMEbVKRiCmKxeYCGChnwd/93Ue+9Z2n51bAP375xV92d2AQjYxswnQhGA4ATZudTyMEVB0traz09g2eu3rT4XD/5KdvNTSwLS2tu/fsk+TjJ06e2rN7pwGI2bnlfQ/cIxfLbe2DiqLRrBsnDWAYlVKhbfOO3/z6mysr4Gu/+PtvfO7vg03WUGPr1dNjTCzf07/dbPdZPaEz52clG3dLYI4Mm8OxtrJqAOT3+xUMJ3CIIWAgAxrv2IsMI51MZTIZWTd0nAAImDlGAYAgMAB/H2yHEDKQgeqtFe+E0OgIYfVaglszJKSDd6IXMXj7bFBUCQKSRCQEEEGoa0g1VEMTvR68tcXrsJuPHVvUte/de/9DsvTm5avjcLLid7va2lrT8YgoyMFgMBRuRDh57O1TNX6VosD5C+P97c6BzpFjJ451tIQIzlwWa532RpLBlVrZ09a+weTsm1rNKrWplZg95KEYytnkU4SK28MRDIEJf8Cz3171e5HbZUy30xTqWzmoR7UiYCCEIYAAoEiyPjfGADQAggasu5w0Tbs9eiUMCHAKlKsVhjP19PVGI3GKZlRN7+7qqVQqMzMzmqbbPc58IW2325Culwo5f8CrGwoOMc5El/J8KNiI41CRBYuJwTHA0JiJJUWhSDCYlaMLWb4h6DVUCVTKsg4Ym0/FmaVoHCPNLlOojIxKVZ9aK1RqSQNgJQmIOJ0tS14Ly1KsocgUBMVM0htuKQgCZ3MjyOo1QdEMiEOEAF9TeS2LSWpz6zBwmmOjJ4NdXsxuufPufd/5t9Na7tSH73sECBlPgHUE7A5XKF5Whod6lhZn3/Nwz8LC7MmXX9m/fzsGZeSy8ZUKw4Lm5k7WZL98bcZqcw+MDADGEr9xYnp+NZYd27Tr8Ox6/sz1VYOmXYGWkcH+u9ytV69eja6svPLa8R3bRvr7+rKp9KVLlzIv/+4f/mFfpVKSRcFiCTucVkATN25eLhRKCBkkw2zctOGOj31MX10XBMHicS8txJ/77ayugo999PFnXzja6G+KpFZITnGbASZrDosJEEohXd4+PCLV1IWVZIUHU3NRErdOzYtW6/JBp3vXXfcBUo2sLHqCAcbGpCfPP3BoU9Bl/fKXfzY2e6nR7ervCmSK1UK1wlntCiDi8SRjNuEAQ7oMdURCjKQMpCNJBBRnoVVJVOSKwFMsDgmYTMazhfLMzCpntw72tTc0ucMNFpcTL+ULKo8sja1NbZ1apTw6PtnT0tyyYwvIJteS66SZm1ta6u7vdzW2Aw1oFbWQzgHKq2eNWl4Pel03RhcKJZnjOCtHiaqCK8bglo3JWPTE6VMMx1Z1I5/LeRsaW7xtp0+fOXBo68raZDSymkzl+vt6qtVKa9fQ2OhbJ//xK7FIPpsD23c4Du8jW1rDI/1dOI47XVYMh207toJqAScwuVIslioMw3z2M3ubO3sP35k5febC1SuXKJqVqtnVhUkW0/7urz9os5p/+uOnr924eXUcOZypwY2bjp84oSOwa+uGUrX2y5eWfvitf6wJ2PbNvQ++5wNf+9b35ldjJps5k84iK85BwDBgZmbKa6M/8KF7f/Xr5yBCf/T5v7izhfzFj5/zh5pHx28KNXV8PJbKAhUBAMC160utbQ28tNzSEU7kE83docuXV9aPH2NZQhTFRBG0tGIUw/7iFy889p47CBLPZCq1Wi4ccmkqpG12QMKFmzcow+Hyet77vnt/8dxrbj+3tr4Y8NrPnD153yP3VSOVayfe2rix2R9qvXDhQiJXbG7r7OoaIElTa5t9aanU1k463S6LzXrv3r3Hjh0dGt7AS/ry+JzT6VJUUlUVhEi7DaWiiYDfpyfij7/nfsMACyeObxppLVTK0Xhs2/bBs5enro1OrCalTEUkWMzl8ZrN5kqlsrIaaW51MQxTqpTTmZTNYiEgBqEB9FuiGQigrutlXhQlYLZDDWC8quM0hwOE4fi7k7dQvUPVQEg3EHqXg+ldYe63UuAhqBc53cbvGAExhEOEYYjAAIlBA8MwDGLxuMKxyR077qlWq8dPLuP4eVmFBGVJpNNLSzG+Umpu8DkcjkDQ98qrr9vdns7OzpujC3aHycySwbBfFIVDh/beuHqxUM0LVWlDXw+0uZEoAF2R+BKUa1//0sc+87c/qslZSagoGuKrSndrWBBrJInfvqu4LXS5vZvXs8/erRHSdLXuYDIMBI16YT2CAECcQAjhAEAAAQAkjtdnqrJqwFsB8QBraG7YuWfHxOyqgSFRVUwWsyAJwWCANbHr0bX5eX3rto3lfMbvddEkZFhsdm7KbGGDAU+pnNMUwe2y2e2WfC5taBJJGKVC2soxhiGZGUpXBV0VrCYy0NZqMplqvIyxDlfnkEq7ZqKV0dXi88dvfPeXR3/5+sWbi/nFJL+Y5JEJkBiu8KIhibV8pppO7xxqddOAVKuEzlfyqWI+ByFO0Yys6BUeqAhs3t6fzOaeefp3L//wJbsrjDlN1ybOeoJOAEAsZhBE2N05lEyLNVkUJQxA16svvRz2BxobGpoaAhiGlUolSVQuX7qayef3H9xbrArpXGVg4xba7Prq1777gce/KjHeOx772PV58Pl/PP7WpUVfW/feux7ffuh+yuTJFoXFxYjV7i7kaj//7ekr56elaum5X4y/8Up604Z+ma86HabWpmBrU2Di9FsBr2Pf7i0WC7EwMyFUClOvv4BbmKNvvHrh5BsOK/5/PrHdRIHk+uVadlUuLtWSORsEZg3Xyxqf5lv8zR1NPpo0GEbpHRj54FNPPPzYUxZX06f/72dlZD566srM7FIhV/AG3JwJV8W8LqSqyfnhNs8z3/7EHVsDkphfWphFWprGxXw2xpeLLpvLTJsoSBGIJDCaoSgGJ0kM0DjI8jXKYa3qWiKfkgytVCstLi/kcrmeni633UMDhoEMoWCI1+2MpbuzT5QwQJiJcPue3QdFSQX5IqDo3gMHO/r7A00ttMkpSlBROcLX7m0cAnQA1625BKoVVLerIZ1SREXlZZFgyYpcO3nu6koiubS+/OKp9Uwm9+STH56fW9w0tKW7szcZT7a1tF68OLFte7/X64YYmhgbW4usX7mZBwQY3mzfvX/nBz783m27RnwNrpXIjKiUM9lILTKXjS4Hu5prtZKhy4Ggl2XpC2dOBTaNJOOpV18au3zx0v7tw3/81HubQ56VxemL585arVZekD732UPdvf3nzp1bX4vNTMbuvmPvfXfs+shDAUrTZV6dvDkztGPnhg0bJAmQGB4O+ys1vam1saklkCtKm7fvGJ2cfPSJ9yKS+KcvfGNxYrq1tdlssimKZrJYPT6nN2BqaW146IH77S73tZs3cxXQ0TuwFI2OTa909roamjzbdw4rKt/XQfX0dgtCbXjjgMsT8PrCJqvH7W2q1NB3v3/8uZ+9JOZ0q62luaf1jdde4Gt5px0wNPJ6zAhId961Ty2nMFzzBpwbd4xQLNSB0tbZduHK+WQin0xmRVElKLD/kYfTuayGjLMXznIWs6ToNUH+9W/edDT1RGIlVecgbi9lMiSOOLcjnYpTJO5sCE9OjY2PruzatYvm2AtXJh573/tFDfzohQs4bYOUeXJpbeOmkfd/4IP+kG9hYSGRSJg4xut2YxjAsHekIMC4LfWzcNBuAw6bjWYohEDdaV/nnW9Tz7e3QgCAqmvaO2VhEEIdoTpnXcet4F2NNPXrOY5jGIYiGYKgcIykCJomGZamKAqIEphfnPMH/SYLOH3m6rXxmXJN7u1tbmsiCYLI54vJZLJQKKiqWqvV7Hbrkbt3dXW14wTq7mpzOE3ZXNxu47zBJowERVGRJbXAy2Kp7HZaH713r5tRjmwLWQ3gN+k6rzQ3+tbi6VRVq3fA/l4J+q5Vt9redn7VB6Q4hASGYQASEMMhhkFYJ9QNVQOarmuarmpI03VVMzTN0G6difX/LZHKpziOy1fA+NTNXTv38BKPAMQwvCaW4/FEXz/s7mkzdEFSda/PUSoXBvt7ADAQ0hvDgfbW1nQmmUxEGArDoKEpYjaT8Pf1CIJgtdA8z9eqRRbXgGHUeDGSLpMmZBaZV49ffv3EmooBUQVreeA216w2m64hDMNoM21kKhYCWXGdIUHIDt57z76TZvyN04u0m63xgoFRpMUpyDxf1jZ3+h6973BzJ3djVMSK0bt2tJk3bDPyJzBGYyxMU0tbeZG7fmN96wZToMGyvFJ6INymRhYYit40PPylv3n6yQ9u2PfA4YkzxwZ3bWnr6Ewmk96Alc/VcvmyYVA0a9+0bdfQZsQF+7IKp1soNqBkJDh3ae7UeDyVrRIE7rCYoaZLvNTd3qgJpc0DPQQO9ozQFIlfPndqaLAHIBUnjY7WULmYYxiGgArrsO/cvSW6sp6KrHht1l3bN3JmNp+PHr57ezjsLFT0pUVwea6wd8QXjxdqFX1wY+/K8iypEo0tLUtLM63NYZw0v33m8urCWjEHWsPc1pGBTZtH7HbgsBuCkBGEEufxBwlYK/NmSuIs4N+/+/l//sevvvx6WlNUCFQGBxRrp03mSk0yNB0ASJIE0FRFUTAIzDTIGgSJgWohXRV0mvVxJOAVSZcxzqRJVZmCpAU3+2x2E1GVC7XswgqyhHVZUGtJT1tfr8+/Nnr5+tjoHXcftLY0sybZIMxcoA1gFlDRFSQQGnnprbfTa6AYFps7elNdIkEyE9OzoiIHvfYn3n/H9cuXo9HYnbv8NqePptm+7v7LF24GQs5UJr2+Hgk10ZOTUzt37JufW9my6Y7MkDI9cwoSIJkrLa7Pdgz4WJYGqNbY5tJglWQ1ksIpNwOQQDMYxPBiqWixeQAA6WtXNgz07d7tqvEix1pzsdWF6elt23adO38JYEhS5HKlOjjYvx5de/DBu0rF9PTYVbfT/MCdu9T9UsHo+vq/fuvrf/t3c6sxXQMUwyWSqbamQCSRYIKuxo7Gq2Pjs5OJgU2bRnbt7urqiq/M7dh/6J/+7t+27ti2vLa4Fi1s3Tm8c8+huaW1Pm+HilV7OPrKjfFqOSfwYNeejdsHrd/4xguhELBZyTNnLxw/dmFkYziTzrYPHPzS5/7s/Bh44i6L12PbsfMg6+/D8XRqacLrtZaKyXvu2fvq0TMkrStyjaCY+fnptsZQU3soEVuKJvLeoIsxWx0+V62iP/vLVx548K5KpfSTb3/nwIF9NEvt2LHjFz9/nqSYhZWYy+V65bnf/eAHoxuHwT+98lrxjWld0yuRtWBXx9rYFJbOPPKZT40efUsUBYRQIOR+5bU3Xb5gg7e0uBbjFcNtNp05d0HTlVwu73a7cRzyfK1a5d0OKwYhMgwMIHSLSYcIIV1DZo4mMOh1uTmzmiqWNR1hBKZqqE7MwLoNCQDDQAirixpvhajc1nfXF4TYu9WEtyeWSNehrhu6BgyAYwADOgb0wQ0+AhdUVQQIq1aB2QTamltX1tIG4ndsGwn6nPOTo8vLy4tL5Tvu3EAw7NlLlw0EPv2Zj/f3fuD6+VO8UJmaXAp4qZWFJZ/HE0sVx8fHhWpx59aNra3NHht95vQbO/o7DF09ejbT5CNJs1mIFyxWO9LLt0cC7/Znqap6W87/++wBhAgCxxAAOIAIAAxh7yTf16/BAarHD+CgXqWJKIDfetcGwlgLLcjVzVtd8YxcqhVxClAMXqoVaBq3O5hde3YUCplYbL1cyTqcZkOXrDYLhsNw0NfZ2a6owtzs5NLCbO+mjYooaKpsYmmHzYoMVRIFliFJAmYymWo6xZlsrZ29rmBzjjfOjy7lJFBDOLB6mtsbrKE2wh4uaiQPuKrB0IZsp4EFV9t9XH+z38+Bu3Zv8lgAEkSOwU0sq2maqgGT1eQKhGwufyafaO0AEgAU6Qa5SqaYbmjxLa8uTU4txxLCzZsrsoY/+vgTGAn4RGFicq1ULP7rvz7tsIH+3j4xlfL7gws3RleW11weX6lcC4QbyhUew+mOngGrzXP0+IVfH7341Ge/fGFG0RhXVWMFyBAmT2ffUFNbF82Ym8JNXqejnEvXcpVsdO2RI3cwODIx+LYDuxPRZQbXtEoe00W3x2F2mpFSy68sFOIrc9M3d2/bqCs1G0tQmN7aHgKwVCvOskTiP7/9mY8/4L55PW02jL3Dm224feeGvY3uBqVW6+1oyGVX0uni4tJ6MgPau8KZooAx1lS+euHKtcXVdYohaQoHfAEoNQrxQMjl44vrS2c//vF7f/7Tp+68o1GVgdWKu+ymldicpiiGhkicZCkTpmNyDRAAeN1WzGouqnJF04sKWE+nJU12ulwMZ5ZqEtQBUIFQFIyaYmfMdpJDvAIMlqXtnnD7+vXxf/7i998+PXrf/fdZw01AQ1aHFyNMAHK55fSPv//Lz//11z72qb8+8folhwUszq49+4uXcYy554EHR7YMaxCYHRZBlVL5dK5kFIvFarX61tHjV69e8ziC3e19LGXuaG9sCDW6XZ5qpdbT26UDPZfPqDqw2smhkdbd+7eZ7ES2HM8X1/wtbowQJK2I07KqVdYXJzO5aDS2TFJYLpcxNCUeTYQCIaADp91VyEQaQ+5iLvncL3925crC+fO5t0+fbW1v//zn/0tRFJvdareZzTTo7WhanrnZ4Levr0fuvvveleW1aCROkIAX5EIFCYq+c/f+Qo13e4O+cFN7j3d8Zh5SpjdOnjl9YkavMA/e98gbb17m+eruvc0d3Z5X3/qZOwDdAUZFtWKtdPFagma9/kB7tcxV+czmrdzgUGNDo7evP5zNgbHx2MiWrYCgnXZnuw9s2Xrg7nvf29ixefnmyvR00u2xbNu6weViJ6au9Q34lhanPN3NY+NXrDZ6NTK/tjYPMc3jdSRSkaXV+aE9O0xmZyYLnvnJ0b2Pv3fbtm2lUsnt8/72dy8+/Nj93kBwcQF0dPa6PeF7720xm71gOenYvAkYWq1SllNJt8s5NTH+4y9/fXCw/5lnjnv9vu7enis3cuvxhKBoVqe7LMqsyTK/sDizvO7xeGiaFgRBUZS25gbwDnMM/qBcAkoSqMvV29tbt2wd4ThGNzQcxxHSEfhfgqkZhrkViPiOMKYekoUQMsCtSeNthyoAQFEUVdd0Xa8z9rpuqKoqy3I6nS6Wqk1NTTt27Bja6DIMICu63xMURfD669evXr06NDS0devWXBFMjI/Hous0Tdx3/5Hz585cPHd2PbJ84eKlDUNNu3fvWFrTA+Emm8fn9IXau3pIli2XSrl0bNdI38bO0AMHtlkpUCuqMzPLFpeHsjjfLX+81RBLEPW03jrivh10fAvLG+gW844QDmBdJHNL+A8AgeEMSXEsazVbrFar02anafo28CcwHGqGRrMUAODUmet/8umnsqmM1WIqFwsOuwVALZvLXTw//+GnDlXKeUUVkrEohLCKUDIRYxjK6XRKPF/LpMqVot1qCQb9jMOmry0XCoWOthabzcKR4TIvCXpZBPpaNnVzIXN1FrS0cfG8bGgyQZO5Qsphdyk67nb5MQC9aplGvFjMBpw4oYlT1y8duu/+7RsbXzgVoVkoqHJFFAMNgY6AI1PIfv1fvvXtF57896d/9GD/xxaWonw65+9rL8trk1Pj2RzosvkXFiKKPHjx0qVrN8D1T3ylxIPhMPjcZz9E0cBkooqFVLC5QZQqfYMDLMuOjc/4Ay2cydLe2XP02Imn/+uK1QZG37jAWbiOPsf4dJyxm1s6exeW1x2Aspk4k8ng+aqi1lBV/sKffHj6+iVNqElilaOx6MRoa1cHkMoYNDAzJ6SSDEtRDivB12xO20BP19zs5IZN29KJpKorHkwR0quD/Q2CrOVSs48/eqfLOrmyKOQS6YG+zbJcUUW9r6v70uU3ZmakFLpW/xQvLMX279k5Ob0YS8Ddu7rnF8c6+/ZM37hZyCR379hHYXgtl/CGQkt8tFqT/IHWQwe3zizELk/pdGnVilsIDBI4YzGznAkvIl7geY4lQ8Hg1TwPgNHS6CfU3NySZsil7cMdThsXWU6TOCeU+cnRsVreAjc2drXbSQZKBh5LZH/2wx8szoLPfmpwaLCT9jqqqQRltdLuwKWL42fOPTs7nS+mgctu4gWdwAiT2VpVdacD+LyBF1988eLl+UOHe9oag/liLluQTWZgABAOh0cn5pABDj/+5Nsv/ExTwfxMZKe3KxrNioI2MOBFCMmq5PUCjMQ0TaE5UlZ5m521UEisZC0eq2bw2VwCIdjU3b40Od3QEF5ZjWVzNacrqGma3W6XpGIxVyzns2+8+vITjz7yH9/7+cI6uOuA2+UJjIxs3rbjmNlqcTvsP/ru85oE2E9oXqctvrp46VJyeS0WzesqBu44cvjY2yefeOJBTS6fOX/hgTt2F4vxbLY0PLghl015AsGZpaXWpqHRG4tf/sYLf/H5e2tq7aWjpyk76QtwseSczRlYWs1oKtjQH2Jp58L8qtvRnlq9OLJ5y5lTl+6993BTU3Nv96Km6D/72c+mJ5d1DSgy+PGPX6YpcM89h2emZ4FhoCplddoH+3tIjgw0hCCBYmM3IGZIcg3HgdfrYjnLjbF5s80cDLcdf+mFgZ4Df/qn7//nrz779T/7sz//y/977tyZA3feWS6Xpqanu7v7n/zwjlg02RAyudy+oaG2U68fs+in/P4gBARfqzm9gbsfeUip1pLJ5B139Z25eGPHgTsee2zrj352ZWTnlkRG4sw2AIDX463VKoqiJJNJn8+NE7BYLGL4HwDV2+jVZAImMyepRmdnp8PnP3/1hpwpYrT27mvqJEvdesow9O06DgBQfaOEGPZOd/b/WDgkAEHhNAlYApG4oQJDwgAWjRr9/WBqenJ9LXnw4MFwMP/S707breEDB7adO3MZ6IaqqpVSafMQE41LOJ2XJS0aXTeZuF8//2pXq3X//u2ELn3jm6eHNnsRhs/OLzUEXVYLffnqNZ+d2755I8SoSCri93d+/nMPf+HrL3o9ZmhzpEqC6X84mOrPKYq6zc+gd4ItMQyrd0hBCDEIEQIYgDiEBgCCIOD1lHpIkSRBURRJkhDHagbQNA0iBAyDwIowYPKLUq2USD72RBeJqblswusJsZw9FkuxFCZLZCIBlhYSOw7uEQRldCFnYgmPg7lj/85qOZmKroa7W/l01GvzxlK1bXuOZCrE2/MrBdE8YQRdZV8zFeTMpmQq3T+8eeb68XTVA7DldK2hICNImXRF9Qb8hhhjQIZRMjQB8kQXQmQZGN1tba6OwLmp60e//S1expwN2EqU/86//sNX/+5vzYK0o8W9fWD71XOVN//iyvv/zv38b/b80f85e3b6zSP73gPj5SN3PvzsD36VA+kiWHl21Hbijan773iQNqU2bSdhIirxY6zFW9Eg6WbGlidC4aZ4ttxgClUky+tvjSWy5VfPPhvPlQQbsIYt92PVC+NCCRP27rBMxKrx4oS30c8BaOQzPhInqhk7qe444Gy1TQ0+QpWrP2sObqVoYGBYrbJmMpM6aaiKzrpD8fViGPPH1ws2a5M/EBLiZ0Al5yOkKmjBeEqtGRhjc/gcK5PjzY22PZvdpDrmdyGEXTP5Xe621l+ePze5LmhWYNbIRx+5r5JPjl27dPXahXsOd1pw/OLrJ4e6++aPFRoDB1RlXkh6JiavOZzmrmBr7mr2xVcu7DwQWlyLHxlqume73elp+OGPX2sIYkDTH7n/7r6O0NrcteXZK1s2dhSyMXatXCiA3ByugNZGEE5ExZczakOrRdURZogus9lMsAWpEMnP2wKUz4R0CaxHlu+4d/jL37oLWFzXfvtq7Vp0/2Mfylyf/uJD/0oAIFSBxwkbGYuQFFrtrjE31PmaGWhUTT738ttWCrQYIHl5trSSiObLGg58LpcGNZqDbptmgvDp//qSqiq8UK3wIF02OzwjHV19iXQVolK5KooSUDXZ56TdDvPa4njzYA8oJFjapxR4Ex4kSRkYUEpiatWqUya/rXV5+rKFlke2DF2/edPt9ehKGgtZkpHycqw2svFgcv1kNZ3LpnNTcy//9Tc/8/GP/K2/a89YDHjdjvYdn3zl1e+vrlxdW8Q+9tHHV2M386X1xZnjXRj4yKam5555viElDOHSa9entu+zcCjqsNr+4R9/qGj2bUd6OBHHaXD0t2e/8p1/iFw9HcBWiZBpLh3ldbZloAvo7szyaiUxcWCDo6dhzmZvyiWWWzlTcSzFZOl9++9IadWvfPafkyqQkB2p7k5bu5GYn/3O8e986f5S8np3R0s0kVlbWRvavGvixqjT7YLAWkwb7QPd2USE0MyFSKUcLbV39Z09fXFyCqxtUXbu2O1ygVRKwzQPXyR/9K2fb9s1EokuxuKrFod9c3N/viTKFfn7zz77yKP32T3DN5ZXhgY6l+OrjN2EajW+VjEzdLOPjXqo5//rmEIASgVTV69u3rkjGa2GCOdaPHNoZNNaNPKxj37s+Rd/J6kgX6p19HSYrabp2RmOY4rVisNk4ThOrFa9LNi5NYgRjMmIVSOJL37isenZle/88FWbg5YNStIwSHNVXtcQabO7dIjMypqkaLKi6hAjaQZgpKobsqbKqkERGKAgQBowNMxQcQzgOMQqmtlBSwjP1GRAQBrHOdri4YjBkCylCwxWoxQjMXXZxnk+8OT+F185sRbJO93A7mOvTJyvVTSMBDvu7tMQwYtaRlA5lWzvHOQL+aVZMeSwHdrRufHuQZKkR2+KhbKIAGV2tIzPznUPwER8WVHVqgabAl2be21nbpSBlPBxbgNjIDA0XYOGjkEdB4jAIITQ0GUcgwBiOgY1A2oAIohDjGB0DbxTro1jAIeAghqNFL+bkiUhlZG37Ogtitro3KoEmGBjiyhlAAAAAkDhWDAYNgwjmUz29wOr1Xrjxo35+fl4MlHXKtlstlKpxDDAYrFolYqu6wO9fX6vb/PWrbIiarLS3t6eTmURQizL9vf3p9Ppb3zjGxcu3ZyYmHjttde/8x9P/+Snz/zsZz8ZG7v57//+r8eOH3/l9QubNvYRhBYIONxuE8vAYi4FgcaxMJMCqRhYi84DVGwM2oRy9qUXzvzFn/7l/p13zoyLpGHZ2NO+urDaHPKbWczjYR1249FH9nVuxNYmXqUcth/958fHr6pzRytLU+TTP3jZ6wHpwtKufZZ7Hmjo6Samxi/ee+gBWvPHommel50u/+ryGoHhmiQLlfLs5HghHeeLqfj63JVzy4V4JuRi/uxTD/zTlz67ZfeWnXvNPQNYNlttbGh+z8MfoHEuGU+YWKJaitOstmVbW293m9PpxCDd0txHALxSrK6vRA0NVKsiabVjOKEh3BdqBFarL9wgSgLQ1YbuTs0wppaXq7WcKJUZlpRlEQh80B/AkBH0ex559CGgi0I1L9XKv3vuheR6moRALINqVe3s6P7Tb/7rT15/9eAd/TTFSrLCmcyCpH7nB8dzxXJ3zwDn9LjcvtmFpQtvnWjv7Pzyl59obm4MhXzNTaEPfuDxPbu2HNjbtzRfes+jDzQ2+KxmZsu9dx46vK+5uVGQ+B98/8+//92/+OD772rw4wZcDgdqjGl5dvn0xMLExNJirrhSqVQM1eyxD5FGTzkTVATY0dK/84mnhGT5b57688WFyP573qNHM28dO6UDYHPhngAu66gqilVZi2czqUS6UuZFQaZp6HaDgcGGx5/Yx5gIs5mzWKjOjiZJqhXy5Ynx671drQcP7K6WyixFr61Jg4OdZs4UDPj+9LM/Hejv03X17KlES6v1wIE+QaghWXQ4HKBaARiGdK0uHDaZTDTDSZKUSWdXV9cTybTN5sjni1euXbc5HJqmD2wYyhfKwUB4bmFRFMWhTW0YCY4cGWIZ7sKpU9EoOHHixBe+8GdPPPbouXNnrl662tjYeOTuQ6++9rLH45uZFsMh7I7DrVOzUxiB/vgTj7Ms6/EAVcevXptbX4s3NTd7fW6+Vhkfuzmyqevgod1GKtLf19La3O73hi2cY352YWpiXpcFi5m227ir14o0yeRE3eQOzCzz7T1dA4N9v/n1Lxq7Wj71sTuCDrBn2xDUhEI26vI4CBJ87+lXfC3tJ0+fRxgRbm47efREqKlVRZgv2NDQ1BZJpGuSUuOlheU1nOYCwUZ/IPzY+zb29XZAqKoa6O1u/uEP/2PTyIaBgb6BjRs7OztbW9q62jsX5lcia/G1tcjnP/8ZhuKc7hDA2Wd+9qaiE/NLEUnFylXZ3jlQrEhWh/evvvRBlgO79zZ3dDbdvDlmNtk29Hc5zaSVIxpC3h//4Ec0VL/6j3/z0L0Ha8WU22ZSagqFqRYSWEgYWU5bGGxTv1+XhJX5qesXzlsY4vTR1+Ra8e6Dg6m8HPLarRzO4qCvs7Uh4IS6gOmiICm6gXCKpCjGAJisaoqma/otTaSODNXQDQMYqG7UhwQBVVVWVZUicQKDsiwZqmJiOQJiX/jCx9xu17VrwsxspFTI5zPp7Vs3mk0ujjVnMxWAaAABSeI3r0+/+cb4ynIMg2QqnVlaXQE4nJ2dFpSaDrRjb7wRXV2JrCwvLy5iyFBkMRoBpUKxq72to72VxGGtUgp43M1NNpbENUlQVVVWFEVTNU1Tld+3TdXnq4ah3eKvDAR0AxnabZqlztvAW53GOsuyFoulvdUsS8L10QW71TI40Le2sgTrohoDQQNhiqZVq3w0Vm1sDNE0raqqz+dzuVy359SrqzGaBiaTSRBqCOnI0Hq7OyuFfKVYQkiXJKmhoaE+lZYllRcEgEGHgxVFQFJYIGBWFBCL1t54fflDTz7+m1//+K6D7deuT3CMqkhZvpqiSZkmVaFcEKrokQc3XLn09IWTPzhyqG9mtuS2kPcc3LA2u+JivM0eq1IELLA899PnhHLR46A2DzXqakTX1jY/0mLxaZH1qK6FTp3NfuFPfv39b54ZvSh4HObTJ776F58/5LQvP/hgp1DKzFy/FrSGt4zsDvvb1ubXaIyOr67bGaaWTe3dMjx26bTHhL/3/gN/87m9X/j0/bsGw4MtFgeWb+rpvOPBB0MtXZJMGCqnCiSFGA7HDaWoKFo4xHR2eexOFuBEuaiIAsWwtmKmlE3krO6QoWJ6Va7yKmlzkHZbKp3RTBzhdAKHHTkcUZ4vkwQyKhSlUSSqlou5eIKhqHwuB4AGPJYPPn5/Z6uf0PkN3a0Hd+6wYkRfk99qov/qC1956tCdP/vmt5qb2inODEmub3Dk4tWpDSM+j7/xzROnx0enOjaMbNi8nVfRqTOnGRPX2dn+3g9/YO/hfSpfXJy9+frL0yYaAK0ccJtjscXF86dOvH3sJz9/02K3GvKaJq3s3hH4l3/56J59jlRmqq1LPHfxa0ff/LN9OwhJrC0upGam1laWxFSUs9CbhSIh5LEf//nXvvLl7x3cfWjfrntf/vnv/vHL37x2bYZmgKzhGM1VZQA51hHwYhzbGLB7rBQJQU9PlySDTVu27nv4EYvDnkgl77nnyHve80Ao4Gxrtj3x6D1ri5O1QmLXrj0EQT7x6L69u3YPD264cPbMzm3EzeuXx0evf+qTe60Wrr216b57jxQKOZvTCpBaH/RBAhdlKZFOJZNJAyBfwA9xTJbVwaHh1rZOXUcWs+Pi5evLKxGfP1yuCtdvTlV5YceOHRRFmSwOkmSfefqUpgBJ4H/57E9/8P0ffffbP/nGz3+ajiXOnjt+5O5D2Wy+oZGyO/z5QmVhaX7X3m1Ts5NTszOqBgAwbRnZ3tLaBQCGk+D5507OTi52doTa2v2lcpph6NFrczRu62ztS0aKNjOkCdlpJz78wcc4ChRyxXvf//Fzo/N//LkPBZtb0tm4hUa//Nb/u3LyWDEK+ppsfgcsCdFA0NXW17GUAVXI1GT4jX8fP3vxxsFPffaZXzwfTxVff+vUeiITS+Z6BkdyZYlXgMnuXliPqZAs1pSbN87lc/+/qt7y3ZLrvNNexbR3bWY4zHxOn2ZUk6SWusVmkiG2g+NkPElmxhzbiWM7iSm2ZMmyJVnMUpOaT8NhZt7MXLu46v3QmSTvda0/YH966tlr/X73HTqwv/mDD7YcDsbltjid5q989hs//Ic3X3vlzUgobqDZw/uPFLKV5fm1ZCw9PrOeyAgXR0BjxyBK2lHGNbsSvfnBNUHCMNIiiMgjjzwhy9D2dlRTEavFefH8VZsRvnp9uJqP7uqtMRLq2y8/m42u6pXyzQs3u+qMbUGXx4Rub5RO7Kl7+Nj+vta6zz3xUL3TWkmVR69egISyw4B/+okHXSjIRsIsponF+NbiRCG+kUqs2lm0KkkqgFCMQkkKQTEIQSEYRnACwKiuA0XVVUVXVE3RgaZDqo6gGCzLsipJGALjKKLIoiKLOAK3tjb/y0+e2r9vzz1H7JoERm5tVfIZrpA7df9HOjp2x6L8xjpXyAGbpQZHrQYDEosXp6aWbQ5fqczVNzb07+rPFTIWp1ETq4lQ2Gu3B1yOxPY2rCh7Bo1Ok0kVBStrtJqMkCojkKIKFVWukpiuQwh0l18GIxACAwSFYOTujdPdCBCGQCiMoDBAYIDoGgRBOgT/59sDgBEYABiGk8mszWxSREGWxB1dtTSOLs5Oe5y2/56dh7e3t2VZNplgI2uGYbijvbO2trZSqdxdxuPxeCwGrGYAA0CSJArBQqWEwVA8HCrks7qm8TxPGY2UwchV+UQ6ZbXaT59+yGw2KypgGQNFUQYaeFxQUwOYmxnF2mrqaqxuJ3A7MJtZB0pOqqZcNiLoZQMeMNjbqXAlnx363tM/evQ4q/J5B0NrnGQjTe21bXyV13nVQjJWmqAQiUBKDF7CjXwhHqpKUiZf3dpKnDzwUEYWJI6q9ztdFselD9599levu73sgZ11J45YMLBpJJOFgsRXtWQ043V4aAi1MVR4dVEsJE8c2NkctGciK7iSN0JFB8kjle3M5lhGFRSKuTO5VChASzOx3/3mlXKmogs8opUaasCRIx1WG2RkUYZhzBY/z2GAk820qbmuDRAmvqoIVR0nDKIoR5Ppiq7qBgq2mQQSy0BakcDyGAajAsmihWK2VCqlklmuxKuSrAnVzNiNjdUxpZoIuo12AyHly0GTH6kgDqvT67bEI6Uf/tslxmACEJEv8cMTM6cff9Tpq3/z7IcVGcqUxd8//1quIh0+8cDRk/dCjEGQxMnbN6Krc7HQcv/p47VuYKaBWs1kUpuNdW6DEYMRcOCehv5jB4G64nSVPU6BJFLRrWlBBboowio0PTk7OakUi8Bqg3ft3X3s5BHGbNwMby1NJf/1R6/84YXo0ix4760bP/jeL1556ebqakUHlMXmLFYkDSEAAUMkCUgiV+WlUoGlMJfNMD669K3v/r3T61NKZYvN+olPfzwS28ymI7KY3zXQnoyuHNzb47SSkA739fRTJLm1sfnySy8qsmizsjPTY3t39Wlq9dTJo22tjRBQbB4nUCWgKQiCwCiCIJimaeVKJV8qcrwIw3ClKqyub2Vy+aqgIDhTlZRUStnYjEAwnUoXLTYTLwoESba1dSwtrSwurPzN1z7R22sYnU7Go5lHHjq+Z1fT5vXr2YzkD1q8fqfL7bWafQhiaGhqHboVqUplksUsDntXX6/R6KcYtyBCgiSiGFTnQ0gMIGjV4cCtNbbmpgaKpPiiPje2WskCQtc1MXtwb+fK4sT/+uszyWjyp8+8ntXIS3cmvvq1H33rO89fPLeYWN8eaLG+9vSTc7fPlbLRne2NZ0cuhjPJ7/7kT5cTeaPdd+bRequrZvv66NmL8rtnb7R1DVodfh2lL1y6sbwZnlvJxjOlqgLHs5Wm9r4vf/mz6+uzO/pb37j8rdWVxfHhKy+98PLffv2hv/jqYVUCzzz1/h+eGXrhD6+sLYr//vOzq0vrMmQ4efqjVy78JFvSXMG2ueXoI1/7ZjzFs9ZAPF1ZWY/wIqhUldqaBl2DKIp+6N4Or5Oud4K+Nr+Zkr1WzELIMJ/+wf/+8mA7WWMn1XzUoCr7msBnHj7RW+/RyrlcaKMl6Hnk5EDQYRayqbOvX16fGXv9hR+qHABC3kZDPht535GddVYGEXOSCkRZ52VFkhUFgiAYBQgKIARAiAZgRdMVFVI0oOmwAhAVQNpdHI2uaIoE6wqJQroml4qF69du1dXbBEGwW62PnN7FGoCBQErp6PUbEzyP1da22SwOTcU2N7LZjEyRztraDl6A0uliOq8ncxmUQspSMVNMURCciUYIACgYLmRykKq5bY5IKBzZDoU3tlCg24wMAXSuoKKagGmiBnQNwDqAAQzd/eUaBHQAQQgMwzCOoDiKkShCYhiBQDgK/0d0UvuvOPxdTavf51hfiyAw1NHSCKkSV8pRqI7p8t0u790DaxqgaLqjo8NkMqk6YFk2HI3cuHGb4ziapqPRqJEBjY01MAzjRqOqqnazKRbaCvi8BIqiKOp2u9fX1jCcQHDC4/XNLsxfvnp1aCheX28bGOhvb2v+/Oee3Lt7155dLeOjt17+9t+W8xESBfNT60IlamF1AyXrYhGSK71tzSeOHx2/c4sGOtheT2yXhLw8dOn26uzEr3/+k72DPTtb2+NbKz6X2WLA6nxOVaiQDAYohCDqJMHk9zW4vcbefoeHVGsChqWZVGo78/ZLN3PbAKABIMonT7TXN1Qz+QvZHIcgtN9bE1rfphBE56temzm6vlrMJKxW1mokAkEXAStdLX4Hi5hQCWLtq/FsuqTbnLU2q9/G2P02t9NI4rrudYGGepOu5SgKqlQqNGkBurGcKzrsXmdzO0jmVBFiWKvB6Vnb2kYoovHkMfdgP+K0ki6Ht7O9ccdgDgBermiKuBUKc7zK81AuyzvsPpjE7T1NlVLkty9y48Nrj5+5r7+1zQhTGwvRRCzJGtjmptq+JsTm8HGCShisGG1dXo+NzixPL29PLG68cfZOQdRtvvrrw9NbkXgxk7PU1/ft6DdS+FuvvqMvTBw7YMF1sDhzO+i3bazOKUr1I09+Ymxq/coH72lSppLdLuWiiKq6rS4PBrIR5I3nxy69t0ohwOc2FcuaAhfb9tR17XYqZJTC/JUC5DUBn8u6uS6WilBtTQ2KIsWKLOuIrEOsxeoLBoxWM21iDBbm4GAXAck0Dn/5Tz6ysbVpcznnlhfLQuW5P7zY0Bj8+c/f+HBImBm/zVK6gVQCLjqTyLZ19WZTmad+fTkZy56+/96p8dwTjz7YUOfFER3DlEoxhSIqkCqJ2DbAYNxiBjCsqCptMPj9fpvDXq1Wl9fWG5tbOru7KMZUESSCNEgStGN3H22wjo7NmsyOgcE9HF+9PTLscntJgllZ3hi+M9ba1Hzf4cad/U1/eP3iiXsOv/n6a3/+5U/HU5lf/uqpubl5BDXqKrW+ETl6okGDeLfPqmhqc3OvxVx77dr0nTszGEFmC8mGGj8MgK7mGQsUW52anBxvrGvPJaTIeq7ebdw/2OUwIUszQ72dddMTo021deG8OrteePGdWRUBRgt4/LHWr/2fr9Q4LOXk1ku//beBFosqZgab6nRUuzoywiNEgVNOf+aLnATGpxZZC1haA833PchanMlMESONVVH7+KeeOP2pz1nsvvvPPM5JIJ2MdLY2zs6MDp994+t/8yUIiF2dnomx25IofOzxM9/95p995lOHU9Gk1w38XnD79vbLr5+9dG00HC+y1sAfX/3g7fdvgrJ6+MTpV948S9CW19/88Gc/f6WxroHA8L07B4VKyWIERkL+9EeP1QUs0c2YVs17LDim8O+9+kyr38rCQmetPWgFj993aHXi1tiVs1tLyzOjwzs6O+Kbq5gq9XU0njzShGiSjcH9dqBUAINpBkzlcjFd5LYjSZSgRaCXebFUFQVRlhRNklWe5yEI0QGs65ACgAahKoSqOizrkKIoKIoiEJDEKtAkA4kjupJNpxkGxTBseHg4n00TGHrmvt5b1yMPHD80ObUwNb1YKkuCAAeDrRTl0oFxYzN98/Y8jDDzy+uHj+1x+DyxbMrXELg9ETfgeJ3XZyApHMIO7Nnf1tRWLQuZVF6sinMz84VszmG3B31uEwNMNCZwBUGSRVkSFFlWNFlRJVVRFE1UZF0D+n8ISTQY0hFIxSCA//+92Rr4r1KrzWxqbvLW+j3peDSyGTOSqIUhFL78369lUJfHzfMciiGSJGmQFolEstksioJSqWRhbaqsdHW529racBwGkiiJPAKVCBxRZDEYDOK4Xq1UUATPFYocjxAG4+tv3F6NAl8AHD96mDKZbA7nxZdeSKcTrJXsbm9xOViryzI5H2tosy2sZWFNNTAGRazmUlo6FgFm686+wXIRTN+8nYkA0gG0KqgUw0cP9wS8xL79zTeWplQp666xd3bUQzqic5CeK8xuhzm5SJKi00bLWnlgwBSsMeZTQOWVTz3xyZZ2KjW2baB1u8+Ujq1pcKa2/qQ76FmbHwW6ur2x4rCxAY+bYZiJ8RmzxSlqaCpZiCaivf3d+VI2lky+dOfa5NQar8JStlytVL1OR3Rt3snyzXV0c71BU0oEBnACXl+NmFhAYKzRYioXc7RWBYTudnsUSdXKHIYSdpcTsCSIpwGFAasPFFNiJW+0u7lsfCuajCSKDoddlLRcLumwe3Cdr65sDjz5xF9Lz69uAQjmy+mEzksH+3aJVm1udjKVVr74hRPDI5Mjd8ZZgzGbykuCvLyt1rsBggAUA4k8/9q7F1taGrMFLjM+PfHr5+tqTfv3D95zqAsC0hMP3//OKy/0dzZVcymKRC1WM5DEljZ/oNbPF/PGxl3GguXa9a21+aydDRYF9ac/e5VECAyjMNIiKMWxucWf/fyfNtcWl5YByM74A15C1/PFqtXqqnDluflti5WplDmS5HheD4W2FFXSNGCxsAisfvDWrMMMDpzq8/u96yvrv33u2eHRNR0FNjd4/vfvferjPen4xmB3MyQUxYpYG2h2VU0fvn8WQ1GXAxw/urtcypy610/hei4T9XusEl8q5IoQrPgDNndPd3j0dqCxDUAQiqIojomigqIoazZ5fb7F5RWft0bSgCCqlWo+lVknSPrshU2mBgQ9dKnM8aI4NDSTz0Xue/AYuUWTBks8Went7tAVxGyAI+FNI0XeunbjxL3toe1cW+sgTtg/vHg1HgsZSO3QgZ65yVGJU7jRGQK3YqhdUeVysVCulggd7N/jx3EZ4KLNQc9M8SaFLGYqPludRmJ3Rqc/+pGDRgIoQmZ+Jvadv//yr/79PU4AHS0syJYGdgSb2zsuvPbmzgN7FZwFmiRxeQ1SMxUuGHTIOgAwgWHMs794ymR3Do9P/p//+9lf/fvvtq4OjY9NeDw+I4mROPXrp14haGjP/qOCToxOzniZHIJA0e14c0NNpZxFIeXBxx+auTMGdDA7PTO/8PYTH/nkD77/nZ/85OeKCjXUI1dnYj9+6vwH750/de8BRUdjKXDhnbMYhra0duQKpZaWms3t7WuXrza3to3evnzw8DGzOWM2N2CIsLQ+295ApDMinw9/+TOnz58/L+Vi3S0tgUBghcFYWKlrqbPt3fHWM88OrSQ7OjMH9h+5fmt4dGQtnAA793E6hj/55GMfXh/iBFXHiK2ttdo6Vy2AtzkcEQRBkFRdVyEYhiBVB4qmoxCsAR3SdRiCYBiCYEgDGtAgWQMYrMMQAJoEqTKKIhDQFQkk48pj97fnkxtcMT89PtbTu/On3/v4r3/zIkHVRqMxRZZkAJxur9fn9qK4vrQs6qoMydVicX5pfXIs5bGDmpqdew4HtViimC95A05O1ba340BXVRlRZUlS5GRG9vAyiuBWqxVDgKCqBAbpENABjMAQgAEEdAjSIF2DgKYq8v8v/363hgohGIarOvjPsa7pmqIpCFCSyWRPezNfrWyHIg4LgrPsymbKbDcXJe0/g0KoIMqKppYyeZONtTHk8uoKwxibmmyqqnIcx5oM7e3NJqNB16rJaBiC9GwyGQh6csl0bWsNULhcoeAP1qxvxWOJclXKSRI4sI/t6N3BlUvzS/Mut/vOULi2Dj557OSHV99v72559d13mupJk9vpcPouXJ6hMMlqoJtcZDqW/Je//J+yWL41VcRhkSFAYy2TT3ELC5XjpwISSPtq8MM7HBRBON32dKaYJKmAxYQRjMzHarwuWZZpVKr1UqkIWcqG6gOsxRScmrlmNLe73BiCU4AiHA39t6+fzUUnD5kJjq/0D3SPDV/J57MkiSO4oaG9P1tFcxJJYqy1zqPQrsuXRm/cyN7RcpWSzNAOSEUYUiXhigrKZ04etLOVPQOBSm7D5/PjRovByOlAYUw0gDW5IG3HUnXNtQqkVTmuWiwGAx6ulFVv38iUKma7zSn7FhZm5xbnXC5HJZlfnN9WgKkkMtlMtVTIeINFt0MDmmLYXNx7eo97euvK+Tdl2e112efm49FEzsJaRC4d9NUMj9xiWHtTa+vCyjmKIDva7DAMV0p52kBuRAvTyyWHv3ZXc5vH48hm8isrkVz6w8cfPqpyFQQg/+PP6lmTicYw0u7ajmyW+FI0kR84eAREidd+fO7WaKSqsnlBEYQUQVt8Nn+ey8tAjqdzGIXKOnr+w7VKEfj9MG5sjiRiEKSbjAZF0QgDa7ZZZanKmjQChYwUiEckmgQIBBS8BDTwxIM+GEZlrhANbz397Ds2G9h3uKO9q/kPL765d6+np6thuLi5vjJ95t6jf3jqfK3fBgP7Ky/d2rPXefrB/al4CILk/r6e8++/HQwGe3ftAar86ksXT5+5l6j1bQ5dq2uqFTn+bixMUZRCocBVeI8n0Mzazp29aLYI5WrZ4/UXSnwyX4FRSteBxeLY2IzaWbPFyqYTybW1nMvl2QpHbt0crqlvm5udvHAl9KefPbi+Mr9nZ1e5mMoqucHBnn//1VudHTtDoVQiqe3ooxLpWENTvcxB16/M2B0Ea/NyW5FIPuvwErlY6aH7Bu/cuLS1ZK71+xsbG+dm43dub4RToKXX+fd//dlvfPN3f//1vV6T7UtP3js2Mnps38Hr1YupaFosAk5SyzLc0r07V9ExFj92z59jDNixq9HudEBAKOSic4mtJpOhu7f/+s1bs7NSR+fCX/+PP3n/nXdbGvzbq0uPP/TA/OwsjgJN1hcWFvYe8szOzo9GtZogeOih3TaLFVLl7kP733n22cEdu0fHZ8489nFZfntq8o4/GDh16ghGkECHcediLpMeGlr//e9vqCo4ecTyxhtX8znw8uVfg2zuN08998XP7n3v3K31+UUDCmA+HYtupjNFu93Q29OOQODmjRGgVqNbK0cP7v7Nb67t7MOtRurQgb2zs7M0gQ/NzSYLoLbZOLsSQklmbiXRtaO9G6csTu/k3JLTH4ykcrmi5PF7GLMZIKggySoEAxSD8f+g+v5nqxNAOqwBcHeyIygM6ZoGqaoCwXdFrBCOYDBQZEFAgGqx4m119rWNzcN7+vOZJJDV1aUlq9Ha1eobv7EFo8BhMeqKGgpvqrrm8tb4A3Xb8Wgyla9vbt3cXLzbJHrlzZGmevR0R//6Zpi1uGW9HIumCIKoqWkr5qOhrWWAQ/FMCVvdpAwmkkaTKYWijYh2l+4LIdDdRpUG6zqsa5KqwrquaRoMQbr+nwQCXYUgBOg6+I9yFqTrEIJAGgTD8NDQeH9PfUd768Ur4xDGuWx0tlCAaPa/hvvm5mYg4JM13WAwmCzW6K3bLpenUi46bR6OKxuNRpvZIooiAknRWJQ1kIiBSMYTbe2NlVyuXM47He5SmWNNFpx2Ts1sNDZi3oA/Hguvbmy4/T5Fqnzxi2dmZsdlQe5u66yWyiaGGThwaDtZLmwkhQpwWQmRF5u6uxMwuHRhFdIADzMOi6Wz10pTldUc9/DjtZyYQhlbV+dAUdz3s397K52O+E1Y+8dOoxhZSIZMeKWYLJpYB59N6DKBKlxvW6PD5RweHQ/UMW6/0WJnk4m0E7OlUtVfPwX8roWBXR09O7okLuX1Obe2NnztHbOTyzDpjCQrRnswWtQ250Irf7w6NVUysqAEMazFvbUZqrFZfE6mmFzzO+Hjh3oWJ687fcHNhUmf06fzkt1hLZc4GOUKyYy10a9FtXw5H0lE27o7gSSSGMSXKwRF17rM8XSyoElqsVgMJ/ob2zak9MJ6rK2tS4LsJSFXqFYzRcgTsFh95kp00mCmauo9AFHyJevw6OTuvfuHFqZY1hDaSquqWl/fcGdkWIUQ1moTBQ2hjOFQxOW2y0DGGerAjsZwLCuliqMjC/W12KOPniznY9FoYnN1o6OtPeCtuXrt5pXLY1/66ucJ0gQJam/v3gvvX+XX3UNDkWQBqHgZBxBMQoQJJIsp2sTQBlu5VFUBgeG+KqcL1apYCeh0HLeyOIboEKiW8oKiAJgAqiALPELpjbV2n62we+eAz+s0m4ylfAEjOYvNde368O//8ObJe7vPXZwJR7fiqc0D+xt3DLbGQmtN9T5YFSOhrSc+uhuFgMVss9tAZ3tXaHMxGHQ0NviymURjoz/g9WmVbDQaffSR07DTMnX2/a7udkkUEYxQFE2RFBwnaJqWRIXjuFIxc/zkiY3N2PTtsYGd+1LpXKXME4Spt9+Z1fBIODJwfw+qS0YaqRSyKIJdvXwrkgAoFjt06Mj+3dIfn3/tL7/8+PbGosdha+qovXxp8qHTx3//h4vZEti3K9jYbDZZTdVCLp8RKcbc07fz9tjU5GwMNwKYFH0s2LVzwGIs1e7onD5/CdMdLW3dnOjAFjaCbq+VIb//zWNCNf3cM7c+99FTmxtrRQb/1JnTJFAuvPfGwO79eQEauTF2Y3gzVQQGC/jNUz8/89CffeVP7pM4cWNm7fQDB/KRbbORtVmsHS2pd98aUfjSnzz52dFbV7vbmsRywcSQxw8NyIC4cOXW8O2bXW3NZDDn9zo3VyPtzS3bodXtrY0D+/fKkkZgcGh1xcTgBMOuLE4YLKat8CLLsv1dTYLoO7S/5+l/f6O7w7gwnwcKOHLYIYfWMLsjsb0Eo8SffObekdFJWVYlbpvy422u4MpSKJ2JMhRtMqG1NTVWKyvy5XtPBMwWdnVj3WZzkAS1ur5R5YSBwwdgDN0KR9LZjbrugaKioij5yvPvqghYO78aDJBZEUSX4i6PKRTOsBa0qEh3Xxf1/6eThhEIhWBYBzqkQwCCYQiF7gLENF0HMI5IiqLrKInDMNA4vszgwG53eLzBdGxlcn755KH9L/7+uQvXhP5eKeB2nHmsYWlhcWs1bSCBIvPBGheMoaVobnt7G2eZYpmXVLB7sCEbX2dtsI7SIiAAzk7MrWWy3MCOPbIsz6ysc5WMgbIhODS7EoqV4X1Hz9Q3t22mZ3lRVu72bREIgmCgAx1omq5Ddx/f77avdP1uU+muyLsiyzoEA6BDMAJBEApBGAQwXa9UKl6vRRTF5MoSUIEuC7GYarXClf+GaoC7e/vOXphqbm5GMWJ8fNxoNKZSKRzHC4UCy7K7BndmMhmbxWSz2SysUVNkE8syFL21tYUiGEkzmUIRo6jN7Ug2X2zv7GAYBkWgqbHV3q62jub6xqDbZfdWinw8mhB5KRqO9XX1hta3b14bmhhecdtRRdSlqrowu0bgBpMZaDqgDUaKNkxOrYYi8aZWiDEaSdowOTt3e3TivfMXMRqoAMkW5ffOXYFYRzhZ3F5M+C0OQtEoqOqxqvt213icULGw7vUj3oBBQ6DpxbjR3vH0i1f/8u/eFGHgCBCxbFyF5HQ+GWiub+/pKhfKN8bmDd6WP5wd+eEzH/z4hWu/eG303ZGSbGHDPDAxNaWs2OB31/gNfCViZ8Gp4104VA547Uujsw31vRBkLuSFaDScymwvLA4Bgw7MOK/xZb5isdswh6NaKgCKpGGd1CVcFUEpZ9TUrvZuLVOEitWZ1fziJjh3ZWZqKbscqsyuZq7cWphZim0sbRd4GUAQ4rIpkFDiUnYXKSnZY4f2EyjU1eZ8/bVXbt265fJ4Vte2jBZbiRfLgqJjRFXUYqmc21Nb4ZWJiZX5ha3aWs/gzsPRWC4Sz2E4m0qXSyXJaHKePvNElQd/9ue//cUvPkilyjhuO378YdKide4MfPbLR//hx3/zjX/4y2C9fc/B3RhFIygjSAiBOypVNJeHC3nKat2RSJijxSgPCTzgOaUI0SppRCBUxAhloLfuG3//V7Ue0+G93aeO7Bzob/Ua0XxsmcRVVS6WC8mjxzoam+seeXRfqcwtLldbm4I1HhsCKT6vs6u7WwEIRDB5Tr11586+fbsymUwikZAVUdekSinrsDJGK13IJzEcymUSyYX5np4ehDFwHI8AFAFwOp2RReluaIwkyVBo69q1a21tbS6Pu1wuwxharlRDkWgqkzUwJoOBvjF05bXXr/t9jt6+rqf+/aknP/ekywnRND0yfFPT+Z5uz9lz7x06cHBuZh6F9cGBfq5SctosMAAoik9Mzjz/wvmz50eHR2cQFH/uuT/MzS0c3Nexa1ed1Yr1dHVWq9VAoOb1Z56LJrMwTqfSeQggrS1NAz2duUSYQNW+3QON9Ug2m1xbK+6qC9hg2QgrZx68n7Hafvqbl84ObSokARmAihDf+M4PAAC//81ZUpdO7O3c2dLU3d7+7ptv1Pp9B3YNfvKJ3SvzS3K1hGji0szk6sJMe3f75Og4jmj3Hj/kdTksJsbG+jIpbmYycnPoDgIghiQsrHFrY7Wrs12VeYomh26MBWsdNK04nTgAOV0qpKNrkFTaM2h79KH7ejvw/h7YYWUELgv4bGOtDZJFTM35rPqZEwMwny9Uin0D/SYLFonHVF09eOjA1tYmhMAoQbZ2dsVTuYmphV89dW1qca1nYC9pdsQEbDlR3S6CtYz8+qXxV85P/fH9m0WAZgXY7KZzEgxohrCa4kUJZkmdsgAYMpvNGIZBMLCYWIpAFYFHEQjWZAwCOAKjQAe6CkP6XW0HBCOKpsqKKMsihuh2m5kgiK3t2OTsvAqTVRlsRhKdPTtoAH74w7PtLa2DuxueeuZHKAEKJUBQ+uLKaCK1yQuF04/c39bWEonGSJoZn1qPp8Dphz4JE9bJpQ0JoVfCmbmNxNx2+tLwwnZWSJR1ATOXZVyBGV7DZxbXT9x7SlSAzeGkKcLEGnAc1XQFRhEEw+4ydxQdaCrQ9bvdJQTSdUmSOI6ThCoMdACAKIoAAANromiDJEn5klosFmEUb2hq6ewMiKJqZACBo/+9v4UmEqnGJnOF41dW51WgWqwmkqStFhtQERzHS6WS2WSUJCmXDhXzBauNjUQiksKjGCRIDqPJSiqKqiMqBKczOZpx9fX3lDmxud5YziZ3DnQKYnXi9kSlVIqGou6ApbGxUQTq8z+5SVsBRSK5sk4QCE6aNQhTFNRgsplNykosHUmqO3v93/2/fzk9fiMaj7z97tX5dbWihLJlYHPQsg5JMGe0W4DD1NTVTMhZR/MgKGai4alsbhWjaa+nxR10a0hgY7vkaRxM5sJ/+3//PZou0CZnVSAtLsApUkmo+GqDEpdTgZ7MFxe3wG4Rkynv7FaSUxGzvVkmpAJCySS3vbXZHvRV8ys6A2xGUOsEh/Y1QEqmfefAzPVhI+vFCeTtt982mbQTDxzkikkmEIitrAR29HLh6Pnz58vlUvuO/szinN3jzsYitkCgxu0CXBXIWQduKG9njt//iZGpf7F52yfnw8lc3oCiZZn84Y9vfOFJd0crLQOSi8Sb+3pqG+k/vvqcyZRI3R6uVFRfrSUdr7AOPjmV6ewdKFalQF19LJaSZL1cEYwm69r6Fo4DSQKajhpN9qqg4yhZ5vTNcEZHmHimmswpLqeXl4GBBa3tNR2du93BYDaVqO1WHY3GS0OX3r9zqciDSAaK5PRwtkIBwmSmVVVoaKxJJzMYw0RS0wRsNGC8DFVhCCVJCNFkRVEwHVAE6O2ps/rZT3z0FCxVR25dbKmvKeRyzT7L0vrcvgP3AEjUdT6eCImS/Fd/9STP5TSlgADF73aoksxzosUR1BCDRhEuD3Ll0rmtbfnP/3SX2QyTFKpqvKMhkN8KsSarpgEdQKsbaw6XHdIhgjQKVVHXdQIjUQglMdxkNOIIyrKs22MaHrktCaLL5RqdnPN4PMl0LptV67uciKoQKO9gExAQFFkxGAznz3145vSjW9Htre3VZDpEMxiDm69du9bU3CZykscRjIaHJzbzXgMwm9mW1l0jt4Y7e+tC68m9e3cHg5XphdW1jeWTZw5nRmMej2tlZdVmg1DcRNKm4Yn51cXCof0PhsNhhsF8Ad/I6Hvri5MN9bWFYu6+U30wLN0ZGioJlViu9OjHP1kUAGo0M85aPleolNMLy9GTJxprrPTTL0z89tuP5iPxfCHX1dlx5eIFo9W8Y8fA8SO7RoauG0nIxtJ1Ac/creu7dnTQDElZnK+8/sq+QwPRUJ6r5vbuGRCr+XA4ajKTpXLBYrFsbm7W1bXs37/vvbMzly+de+CR+26NTg7s6F0bWmcJOJ8K+V3mm1cvnDx2MJdJjo3MRppW4dDKxz/20OWLF21GXbCi779x/tEHehey5VQ2FagJwhBoaWzWFNUfCGZzhVKpcuHDW9/85ufSFWV0bvX2VOFL/2PAGmh97KvfAgBoAJJVXdaBBoCuIkDEeFmBdUgBEC8rOtBRHIcxrChqKAxJsggjkC7IisxjEIA1GYfvgnE1VZEhTddRBMFxmiJhhparSQhGcRxGAaxrKgQDiqIQBt8I53LF8lY0BiP4meNHv/P9wOX3P3juuZc+9tOvnb3wqqyBYB2AdRCL5ZdX8xABRKAGGpobmhryuZSu8X39rShlyWSltvbmZKq4Es1HEmDk9es4AAEHJYn88EzKZAAdXZ7xmSV3UT9Z39vY3Hh7Zg1l8WpFI0nSaDTqqlapVGAADDQjCgIEI5AGNE0DqgJUDYIBDCCGJhGcQHWgaLokScViEQUapMM4BhSAqBpgWZY0mHgdXd+OVKoSRNH/tbkjGNrc3JLL5RLpgsFgoEgGwTAcxw0Gg9lkKpUKGIaVi4VqtYrhCI6hDqfLanECCM4XOVUDAMbLvKQBqLa+IZqIx6MRTRH6uttqfQ6W0JPbK4vz0xSF1dXXLM0vuN2eWDR54qjP7zPRlFkUdVXFMIwRZDhfFQFGsnb3ox85sGtvoLuvNpONr65t0qS9rmaHx+WhKaeJdaKILVeUKIOhvq0BgHJJTDYP7AFpbn50oVgs1jf5A40BTZOy6XihlBi6MwpE5anfvjy3UtARo6RbIbRmLZrKFLmzFy8DDJNkhSTpxic+9vBjh771/Z9tp8qw0YOwXsJWy0PGooQVZeJo/z4hl2rwmQpxxW8Ff/LZA2JlW1UKsaUZA2siahoLRX5xtYxTJPC5uEoGwFo8myzFYlVJ9nqCVqsDoAQOIZHlZVtL08rw7Uo4AlSQXwsd23PEhDKXroxStD2dr9g8Poo0G2yOa2PLwXrM421r6z6MWWsFEaoWCjok7Dtg7R+s72ypc9ogrpRvbjLLoqrpYHF5YWVldWVlRVOB1x8wGo2QBgENwiGkv7dVUwEEsFyhAqEUbbYDzGj11CVLIsBMN0fnaYv3k5/7lNVe+9RTL7zx8tvlkmT1EKwD8ddhbV2GUhWQBKLJ2qHOe9obWyBdKJQ3ZHWJZUNm24bFvtHQmjOxKlCVckkQOF5TFJEDiRhYXQaXP7z84i9/BMlFgUvPTCyNj1y/fX10cmzMYiEoN9vYFMgXkhcuTg7fmZPFksmAeh0mRBVZmiIwkjLYSJN3bCH68nu3zp2/ODEroxjASMxmt+Zy6bragF7MQrCmKkK5XFQUJZlKR+OpTCIrq9BdyZiZMUE6rKsABlA+l9FVORjwGWnqyD0HlpYX/X4visFOp33Hjga+XFFlMRkPud1sU1NgfnZiYz3a19P/xhtvcRzX19/FC0WLnWEthpm5eVXVzbT1xedeuDOU+Ozpge986+tz8zOKDHp7Wssl6TOf/vwzz/7uvQ9e7+1vwQkgCILT7rFarRhOI7iltnEglVVGp3Ks1cxJha6+ZlkqVyuF1eUYCnCT2RqKhg1WOjQ/JuZin3j0ZCIG1tYXv/LnX0IpdiuckhWIZU1ZDjTU+HYOdO5rAufefT+TSJnN5lwu19bWZjIaJZFvqKulCGRqYrwu4A1trgJNokmsVMhaWKPbg6+vrzI0GwzU5fPFTCZFM0R7R3O1WpZl0WQy/eAH5wFt+OY3P5fP52PxsKpJofCaWMmZaNxjN7/31vrBA3tCmxsul6u7pz6eiN2+fXNpdrKh1qPJFbMBueeA22HG7Xa7WOUbG+oJDMcwjOM4hjVeH1q6fjOSK4Jvff/Zo/c/1Dno5lTwzEtvPfLpb6YlJKtgZZ1SKTPKugiLBzE6AcXCjFlFaZhgUJzREYI0mGmjRYMwBIEkvkpgEKzLqsjjqA5pOoloQOQwTTKRqJVlzBSBqjJXKBTSaVkHEIrgOArDQJZFURRVXUdJOl8FEoIVBHBxaPLF198vcOLeg0cOHj5w4fz7SwtTDQ0gnQIoAg4drKmtgVAUzK1sjY7dzuUzOEkQlDGayL/08ruLK7Hfv3p1eHYRZoz3PXJi187+ls52DuAijKgIEAF4/0o8HAeZbLGlpS3o8ze4nU4biwJNqFRKxUKFK8MwDCFIqVKGYATAiA7Bug4pKqQCCAIwjKC6qqqyqKrq3RKTKCsQBDFGE2lgEBQTFbXICVxVUDWAYjhGEnf9U3cPqkNIucrFE3GPx+52u7PZ7F0JCAoRJEkmYlEDhUEq77DbcMxa4fK5fFkHsqQArioqAEFxXNWqNMNyPL+5uU7hjMXjzmXTMFA2lmZoVENxRVaVm0M3P/6pM3OzMzduTO48eJC06Dcn1wBE6gghQ6hY5RRZwiBB1sUO1tLYbPF6DdevX8ikU+3N/eWqoZjfLOVUg91jd1oTMleplipckU+HLQ4D4LIqaiEtflnB83kSZIlKFYFIxGCQHny4c3758pFjfePL510e98KCaCBtFRlXYIPJ6gcagSAEVy6yc/O5XG45AiizwhjYckFOJuMcV/DXBzUVy4VmKpWMkzF//8ef8Nml6YkrOAT1H30wNBsyWCxAqJgDvo987J5Cdi0zMub0BgWu2tbepSmQiTUReKKQqWQTdzp6WtlAYOa997v37wcmZ3Z8kcRtKGKo62od+/3PokmBIrlYbrWjuWd5Zbbeazt95j4Y5rZXsnwl3NrcWBUlTZE/9vEHf/LT57gchaN6X0+bisK8UkUNpkyBhzFgtzoUCUonEwxJGCnczNhWFsNcYQlTwPjUhA4AYwCqBhgGEAQS3ladjqk9uw9RJvCHP75Z5StrG2A7PLFnzwG+6Lp946qGMnaLU6iswIRSyMcS2RgEg9oGZnCndWIiZ6AAQ0ksAVYXVxuagN8KHBbc63H7HTar2cigMA6pBNC2VxchCyHmS8dPtNltFhQAURQRBwYq6T37+n2xQlMb11Df5At4pFIayBVNrIhchTLYMwX59uTi1TvzY5OCBQJdXUhtrV2HNBQFMKKZ/Z705oajqYWLJBAEYlzO1vZuDeiCCFCCqBY5BEEMNqMqi5CmoxDMV8oEhhWyGZohHDZbJBShaKOmKSxrLhRK6Wiyod7htWuxUCgSWu3uaoPA9s2bNx1Wu9Vq5vhyJp/s6tpTzpRq6oKlqvDK82/t3rX/k5/s+8Z3fpwv5tJJ5ejhk1/7y+88cnrgj398JRoDDz3S99unX3nupZ9kSoXpWfNvn331V689e/HlF+OJGAxbS0Ikx5WmF8doYz9SEbIZPuBxOuz+cCgxMiF7g4lan4M26BSu7N0NLy+Pe+rbutrrSxU0k8kYKWVfj3Nm4sah/k89eObIubeuZIvSrhPdr7x+4YmPPfju++/euBn+0Q+fNJvNHR1t8VTCYWEVVTWY2O3k1u//+MLBe47MzC+bIXNXV8PY5OVipdLT25bNxWBEg2DdYrIcO+r+u7/40Q/e+sXHEfDvv3324cf2xROh1sbg2sb69FTi4x9pv3D+Q5PJJCyutDU3+X1uvy8wPzMe8LlxWLeY2Lq64O1bNxp23Ds3M5tJxOPhkMtmVWW5q72DoU23RyfPPDY4Mbd6Z3zmE09+ufT07//txaFGL6FiXlmWJUnide1uQF3RdFXXYBTlqzyMIgiKQpoqCbymqIogoqRelao4TMGQpskcigNUA7Aqum0mSZIkiReFqqYBDQAaw3GGLOscgCEAQQDod4WuGtAFTTM76Dwv6QrAVHBrclGuyoOdbb5AnamxfWNlObYZg3S9s93f3NS2HY4LYak+QGxHyxQrFIs6SaAL8aKRBt0d9dX85s4D+wHMEoy7CgzJRDa1soZo6mBvYyq2zjI6BEC5VHr80Y+hBKVoMK/KGKJhKKwpoqRoJpMFRrF8hbdarZqqaoqqA4BiCAIDBIIBpGkKL6sqQAgUIwBG6JqiQgiMIrKgQRQFo0SxXE3n8lvRZFVSKdqgyf8F8EGj0WilUkJxvbamucwVU6mU1Wq/iyvLZDKpRMJhYoxGjGVZFJG5ci6WSLMmg9FkRkmS4yWhVFla2Ugmcr09g6lUwWHVp8bHzCzZ191WKecoGrv/gUOapgzfuRmObFwfmm1tDfb3D7x3ebzCSShOwxjFy5KiybomK0JF1CrDtzJtjd4CBkhMc1gYRayM3bmZTaYklRI4rlRAcAQlUEIW5FQyZ2d12CLAEqvF0eX5dCglOiweHLWYndXx8bcZO7h4Ze4rX/2zizfOD82s9tXfk4my0wulYnZib5fvg/cu7e1vcgXqyrFEf1fH0YGtOytlvhJnKROKQrQmGJAMV8miUvqjRxvvvafLhCmgWulpbuG4cm5tSVJBsKsO8OLmwjxrNrhsbZqQkfMS7qEUWF9ZW4+GEpAC1QX8oizzOR4pl5tbOwEvJzemXcE2gNsvv31pfe2DT3/6sedfeCWdq/Z11czPTfd3tx49uGdlcZ7LbrXVW3ftaALB3srw9Wh8pe/EsYE+xy9/mvb7wBee/MQ//PifDAweSaVNDkeFkwv5jCgABqdRCNT6A+VCsrPV7rBb6nyucrUMoWo8FeX4iqrrsYIiICDFKS+8cam3q6koqpUS8LhAtQo+ePe9o3s/xme3VbxcKVceeqBh14Gjm+HM6PhEmc/0DAQePL1zfPTSh+ciU8OgrR58+q+PIyBbW1vrcTlkUSiXigik0ziCQrrVwlKopBVTVbnsqfUiMFBVVQciU+8rbkVhzFRb52tsNkq8NHT57Nm3Fr75t8cwClcEEbXQ42NLv3pmQqMBZER2dTlP3X90YeF2MBhUtJzb51IrBYfbDniuwnEOpw/Ims8fjCXTjIGtVLnExrbVaqUIEgANgxEEB0bGYDajmVwpX+aT6dzRo3tGx+frGtsUFQyPrBdKqC6n/u5vPz8zeXl6anbnwI6enq633r5Bsqb5+fmp+eKf/UU/bSDu3JhzGP0ESROQsZgpfvuFf3rwzPHNaPpXv/w/6ytbu3e2XTg7jsHgsUfbjSb4e//wqfGx66k8/8ab5z12UI0m5xaiKEYVi0VvjdXMouMjKZy8sXugu8Yf0BVPMpO02NwUE7a5LVgGvfJu9MTjhs5Of3Eq1N/pvXn9ttdcB5Wlgd46twtNuYQ7o9e5grKVAcPvzGos9sU//fzrb77R0z84tzT6lT9/5mOPBQZ6Wpka99rygqIo25GI0Wq3isjlazd6d+7F4hIn5B88fXzo9vuAAleujhw40MNaWIY03Xv/gyNjT4Uv3nJ4rA+eujeVjAGYUhWYq0h79rQYTXaCTF24lDl2zO8ONi+vLvm8Dru77trQzMF9TQGb8933z9bV1ug8h6hSlSu77RaHybiW3thYX3O5A/39/RDG7N1/KFkULly/ObO86XXjRUlXEFVSZFGW7jpREQSBgAZrGgYjsC4hGsKSJAzjvCBoEmciYE2pAlXSZAGHNVkEisjRGEBUUazIsqzBMKBJEkFxVdVVHUJgADRE1yFV1RGgIgiiAlUQZUmSbR5PNh4BOrAbiCIvTi2tA0UtBAPxqFJfV3PkwClCv1bIlVmD6fFHH85XXtYwnDGIVpt5fj3d43V5PWg2GVtZ3fI59XAiRrN6aCk8M7epAxQhaFjVFpbXgAwgDfz83/72t8/+PpOu1gTcE1ObKQBwCJitgDQaJFmTJAnRgdlmxQhK4gVVUyEA4RiKo5iuqYqiYCisKeCuWw+CIFnVFYmTeYCqEkOTCkBEFVQltSqpnKCqsCRDyH9dy4iiTNN0bV0DazaFQiFeFGiavjvcV1aW8vk8giBWk1kUxXKxCEGQw+lhDKzRYuVFdWVta20jFEskM7nit7/7IdDAl772V4cP7u3uaJWqJQLWjCTa0uafmrm5FVIufjhb32S2Ws2vvfZasVwqVaoIQegIwisqQmAqBgABrD5HNQNcZlc5m0dUMZ8OIVDR40HOnB5sabayRjmT2kBgzcSYzEaXzeCnYGdMQJ9948q/PvPO8HxUwR1V1bS2wYUjUkvLwPAtIHNgZXb+H7/79Xv6YYlfzIkjRpPfF+ybmQ2Xi5qRMFfCMaOJdTDknp42UAW4lHWQFZ+BcxEZsrrSYC798DufaqujSDWf3lwVc2VCxSKbUYvFUtvo25y9tbpyxxM0O73WUqkiVSHMXB/eSvIlZWJ07oe/3CYxs8/T6HbWwQi9uRUlba7VzZCGMVuh+Nn3z1M2z/PXi797+vnWJsc//+PXnrv6mqKDuZmlF//wbHhru62pWyxj8c1K+sq0017T294tRbd39rV9/a8O9fa4V5fnCvkSAskYCsLhtCiJGI7cc/jgxz/2EYYmuWJxe329IRDQRTGZDpEU1N7R1NnX0dHfDRnInACAAegMQ1iIQFMLzhgdHvODp+/p6bFeuLD+u1+/tb2S2VqKjg/HME0eu3lpbux6X2vNz5752T27OkrR1f29bU8+1vEPX+8+tWfwwX33BQiY4QpyIqznUqwmWlEdVwWxnI9tbzhd5mK14GmoyfBlAdbD2ZRMoVx0HaBarpgmKQRBta3NlcYad38XwI0UYA0YgkIAz5fVBA8A5VRpP1etkjQVDAYlRUQxuFTKS7IAcKScSWE4AhPUwuzc+vqWKGkmm7PKq6lEVhaVUqEkclWJF0qFIgQ0DIURSDcyRCGXttusDQ01yXi4ype7u+rbm5u21oVMItzRWldXZ5qdm1hanD9+/DgAwOVyud3gvv/5V8H6gD/oJw2MpAASZsu5itkAZLl4YH//2Oid115902x0/+lXviKJgKIRr99cFZMtLXUvvXheV8Bf/fVflThlaTl+/eYCyXg9wabJ+dTxU05/rTlfSta1t58/d5WmbL0Du06eag4nQv6mxuYeMDx5E8CV3i5bNjrzyPE+N1GpYWWvURq78TaJcblSuq6jw9/q/9yXP0VbHaPTcxjNSgB54hM7GTN46fVwvlR1dHTlK9VgQ9N6JKahuNHhFAAyu7Ta1hFcWZtESPnQ8d0bq5N9g94Sl+P5qqrpQCe+8uXPffe7L5DWYDRSdrub1ldS2VzF4QyubybPXRzK5KQHz/RDuDmZFZ7+3ZVX3riYKciyDkQZyxbECg8wgt1eWWypDXQ01BpQSCgVMF3dWlu+cunD0TvDNptNFEUYweoaWzDGoKNUqiBJYhkCEklARgNupnEjgRgIxEAgQOCsJMpAKibzZgKYMI3UeDuNAF0mcFgSOBKFUAgAFXhdlIkiLAaCxgCqA1hTEE1RJV6slqqlogIgWVVlVYEgCMdxkqQhjNAAXqxKCG02WD0KwmQqIJzQN8Lxte1oIiy++Nz71SL8/e/8tLGm483X3lpaWHbYrAtLZb/Pet/9x7tbPaFIdHZ2O5aScYKyux1DtxdCoS2v329gmVwuJ6uKw+GgaeLk8R2KBP7tp/989MB+v51uqQ3s39G8t99nt4JUVivkSjRFAKCVy2WSJBVFkVVd0XRVA6oGy6quqJqiarIgAk25S/rSNA1BEB2CRVnBaUOZlzZCkfXtcKHEQSiJkZQKUE3X//OgvoAfAMVgMMiyjCCI2+2+GzMqFovxeNLnct4tvIq8JIkigDQYo4qVPMLg2Xw+V8jZPa5gbZ3PD5nYSH2gIb60HNrerPXajSztdXkJljl381pHV4PFEtWAbne77n3goY8++Z2KElY0EkdxSZFFRSYMiKKqNEvsOrhr4qX3UJmw2b2qkPE4GIqonDjWtZUU3jwXdQXNHoz0OOyVVHhrOdHjr4EI5l+ffm/qTkWpgI52pQInNVnmVNTINoQ3opkwuDUNtNKU1Rz84Q++8r3v/kIV4qtbhjpfkCAdD9z/OGKRo7OTprKQqoKA3bSri+EgZmouxdhApx93W5DD+wbvXH/p0QcezCdiVgOLqmo8lO7dd4/EF0tSmrVRpMEoy+VSrsIwRkpmKxvZWDpZc6hz767Dl8++X62oC/PrNIO4GjupXDIcitm9wRKvGCzelQ8nli8vfv8bnzQ5REGSu3prn/rbL/3Fl/dfODuEa/D9x08uTUyaCbScUdb5mCPgLufCW/Gl7v72PaeP2Ecsb779qoEGBEMO1DeMT68oOrm6Ukkl4qlIDNE1SeBddpvZYFhdmCnxak8/j4RVwsg4/K78xHhFAYoKrFZb0FMzOj2dTKY+9fiZyPp8oZj7wfc/c+Xd0brmVpSs5rkkaTA989zkRg5YCWXkjyNdPR2Ut2Nj5Pzm1Oae/ntzKhRZWO/wugvFvJgtUwyNkZhY5mRNxlAUpTAI0gEC6wi0lYz1eXvMmNvW0FBavWUyWXEGk+SqUOVEoeJu7370ofsACgNdg3V4ZXkjmsgHfUbYWrO9kc2Qxc3treYmHy/mGAYq5Qo+t6WSSxvNFoAwgCRhCJVV3W11yJK2vhlCIdhqsqqKqMGwokiZZIo1GVRVrVYrJM3iGLKyPO/y1F67Puvx8fsOHKwUTEZamJ4al4Roc2MQh4xj45FSZf7EiRMCxBX47cyNK6vL876gb3ZkfezO7MnB7uaGRl4pp1IhSVeDvo77TpxSBPTyxesiDy6cm/3ODzoAhi6uzBMYKJZAw86d3/vaNwtlRQPGmbmQgRVrGihvwG6i9OWpxej6+uqavHsPlsuW2zs73jv/ZqVFZewmnEEG+zphGN1aja9MRpp87ZPRaH672NVg2wyF9584OrmY+eBOZCF25eff+/w3vvHt7RDwB7Z//Zsf0yypcoWKJE9cH2rr7acNhmBd88pW6NZk7MzjDw7dGTVYEJiQp6aHegfqq3yuc9/epTtTBI7iOEkQhnKlaLcSP/rWP//Pv/uLp3/3s/sffDAf1Z/+7fMzG4AlAGsp/d/v/+mHH178xneeJXCQK6mGAu+pCcoA34ikDhw+ubI0jyOaAUc1GIqHwkq1arHZu9vbwrFsLLX+3W///gt/9vjb777nrGmu8qICkw3NDaFIBMVgHEEhTdV1XdcUTdMgXZcrUrDOU8jl08kCCQRC1wROQjCdpWkUg7lCwcgaUa2MAtDWVC9Vq82NDaur62trm6WCokMKDAOSRBiGKSmyBqC73icd1nUA3SWqlwVZAbAsqRaC8tX6aLlarBTHp9fLmDmULlXS5xjUUMoLXe19vCxVSqUvPXl0bm3z3LkPqrzMsvTuwebF2RlBEJaXOVUFQ0PrJnuYq8IulyMZjwYC7d/4nz9cmR+pZiO1Ae/PfvwKhIBHTwdxACws5vO4h26OxwuAlUQCx8ucIIqyKCmQDiEYDmuapNwVBwIERnUNUDQO4SQn6YqmwShOoqgqwThB8qVcIStBEEBJBMZJFCc1GAVS9b82d4fDIctyJBIpFAo+n6+2tlaWZQBAIpFQFODzee5CywiCoChSVzUEQWRFw1ACQXFRkf+jQQBAW2tHc3Pz3PxMV3t7XU2NhWXLhbxSLLR3NDU01hw4uAuCVQC05/7wB1kGGgQQBIEQWJAlWZUADFUlHqOw7r5ulmTmptZojFFFobuzeX192mzWt7YnVRXgeBVAFZYhVUldWw699drFr/3FLy9frjDGjrqW7mRFSZRXOgZNA/sacAprbtj7lSe/vK+xUSh4Xvzdm/PTl7//Tx9jrIBmHNdujOzZdYQx2kbeO58IR7//rYlkJCSW80f3Dz5y/+GgEwx2uT/+0JH+VledEwl4aAhUHCYql0qKnOzz1QNOUhRNVSWM1EtcJp7YiibCt27ePn/uyvpqxOPyJTfCjXUt/+fvHpZ4RdcQtyuolHmby1OqisOTkxevXMMYw2Of/HT/rsHZlfXlhfFKOQkA99RTk4cODBw+NLAY1l556UWGNMq8duGDG3NTi4DXVFlrqAlqIr82dL2pv3vXjgGGxggS01Wlvb2V53nWBHL57PDI/OOPP04RWDySuTV002Iyd3WzDQ21kUgokU7okF4sA4oFKAklsuloMmVxOBubGm8P3wlFI/fcc8/4+JiiL3DVGVHZCgSMDbU1j585+NDOHUjVu7PvY0reDRLE9mLOyfqVssRiOAVrsCoxEHAwtBGBt5eWL529PjMxrmuKJFQXFxdxmpIUmTIaNBQt8sLKzAwAYGN7HYahVCpB0WR3TwefSVfLeSUeBdmcLMtXrl+/cjWkwxRBWxmz68S9xzAM2w6HaluaFEXx19XefVxSZFnhecBxtQ31wWCtgWFHRidfe2OZJhm7zYajBEWSBIbrmkaSJI6jRgNdLpcVRQoGg5lMqr3DZ7GaCoXc1OQEy7Jupx3DQCIelRWxu7MD6CrP84lEYsdg//Xr17O5nKIoMIo5HcTE6Mz4yLjVag363RfPj7/8yh/z+fzVS9dyudKXv3ymtg4oqjB088rtmzfKZfB3/+vPr77x5uj4KkWbHY6Aw+krVriu3k6SwblqobW1cXNz8+/+7slYIrmwtEwbDQ8/+sCH169/5IufV2F9c2vl7NnLka15n5Xw2+l9fS27ehppXKUIcP78JYCgn/vSIwdPPnDxw6v1Tc11TZgn4Epni6oGQxhuttgAQmxuhSLReKFciSWSn/3c4089++7Arj1T06Nenw2j4CtXL/pr3MMXzxsMdF1Lk6KBK1eu6xr2t3/3jbnZ5OZ65Av/65ujI9MLi2uNzc0fOd3dv8PX1duRzZSGh6dgDHA8YFibIEPzC6FcUZAUiGBYs82tK+LY8K1SLl0f9Prd7s211cjWViadOnnsSF0d+Od/flWW5XfPTmIkVSiWk+k0hcMkCqMIQIAG6RIKNIZATAYy4DIMdLc1NwSMJLAxpN/lcFkxq5EysozNYoURwBgoI00wNFJfW+v3ekShSpF4Q31gz+62/Xu7mxv9KAJnsiXw/6hbiqqKoihJkqIBgKAIRuK0AUbwqqTkSpVsrqjDSF293+9uumdgZyEr/eJnL7771sTwnfFz5yaCweDC3KwqyRDQO7vaWdbQ2tpqYI2ioj72+P6RxPj//j+fSaUklmU//vGPqwCsLi9959vffvnFF1LJBGtgvvftz7Q3G95589Wt9ZWl+bmu7o77Tx3zWIEiShCk4ygKAJBlGcAQQRAohqu6JkuqrkMIRpjNtNPptNvtBEH8J+0dAFAoFGRVpwyowUQSFAPBqKLpsizrMPSfB7XT2Xg1ajPYgk5bphhNxlcxzFrIw0tzvMvZJOswzuZFJI3hZqVi5rJGk3vDUWe5Mz2hoWxKhUERtNT51XLSDqOGcuZ4h39rezYnEpABpQPmMJfZKtiMJns0XlznAzfuyPEEn+LsCMZqMAqqGAkkCEGkYslkYnUN/scf/RJWzPGM0JQjTMBP6R4PoU1e3qomaKCXlsJIWTduKjKKNi7nuWuJsqwTuMteAnGYL7f5mF5fe2hqtbUFuIINw6PzI5OLC7mUIoMnjtaZddeHT733Px9xZ8QqxdQ3tcgVPVqwur73280zp2scO0/evDEEgXgjAf73Z49wxYRFSGbi24qdbqijRT5ho70ajNpq/MV8yOQy6ZWMLqks0xLayE6O52enw2YDs2fP/lA5TWfKBFbUGR23yKceO/nqK+/Ey6mOwfqZ1QmnrzbOe2aWMfH5UCG7et+pRtaUnzq7sXdvNyhk//JTTS/97tVkWdl7pDGdL9yuhhZmI7UegBrhW6GkziGN/nYYphrt4cjl9w7taOsJGp9/61Kt3wmZvDfvzLGe2gpsYlrs55YT46kqhyBWX3Czki9OlBKV4vJy8fSDeynRb5YpWRI1RaMpwalUTBCck4u3RtJ/8vkjMGIqVvONjUEYpfMZvpJT2jpMfhexc0cwlU2NTvymo7N1O57oP/gEAqFzcwsUSXV2tvz0Bxd2DPY5nOyVK2fT6ThBgXYju5aNdnW37mweyKeSJMm21bpULj9z89ZDX/hMcbJoUqpEFvFbrCA6B1xWUIloqKEEGAg4Lk5HMpzt6B7P5MiSH1/vYA1ShCHqkIZma3Thkq/RtL00W1PfnsuqTp9HFNTNcMLhqTdbGv7lX1/747mlDlfjWm2RSt4pzoSOPHZ6YTpVTDk6Ox+5cfm1G5G5xx/bixb59PmJMs603LdbIsoL41c5jfno/Z956qlfHzt6/IP3L37ksR0L87N1zXgscq2hoanOW5sr2GQFPPXUe34f07t3x9O/u3nq6KlMPrka2VpPg+NH/XemzwsaaG3x3vPIke/9/O19hzSaGTA4ogNHSoupxQs3VmlPANJ5ryMb39zq9cKmUqqjuS8mYuFonCB0Fc7ZnSoByqWNDVkQant3vPvuyKsvr6EQ6Ol273/otN1mrJTTBCFfGb2z/8Be2pZ79ZUJo7ZweLdzeuoCa4hSJssX/uyTifzC5Xe+E/T3iLInk2ZqG3wwFawUqGq50FofGLnyhkUCqbExV3tDqVyx49bu1sa3/3j29IO78rlMbmPTZHby5UnYybMBU083GBt7yeGtTIzOdLJut8WZQ9jOI7vGZqa+8U/fK2xn4SzY3QYYPlfh8Pa+fTMbq/U+s5E1sww6u94Y8BvfvPah1wWCOABG282FnIQHL78fdjUct9FrrAF8csA0c2sK5kG9sboimzSF5+WyyYpgOK3I2HYo19fR84N/+N+KGP/RP/6PHS0g6BRRBU1WMYvBmWNwX41xA+dRPWD1+rfDl83UfK1NufpBxMFSlMIf3HVfseocnoxnixrCxgiFFgQBJ6hUKktRuNXCVnI5i5EQhDJf4BEEYRhGh9ECQnAAK1Shr3/0ntujY8BCxHmRdplHOLWsaRvjcQomdLnCl6sMmkMU/PfPveTyuUSEe+13Q2b9G7s7Gl7/0Wf+6d+eu/7BLxubHZwKX13eqDEhA3VuBofnpsfLslahPVsc/Fg3SmwPfXFHrz4MVkJSCZFcbvd2SYcwi66JCF/CoQqNaiJJcSiRgzGgEnJVBrAiqRKGqTAiAQDLsKZjmNlo53m+UiozFGoyGCFR4jiOpjFJklAURlAILRQKNE2jKJrNZqtSlaIoGMY5XgEAWK3WWGzLZMJqgu5qQZBlGYLQSkVYXA3nstXa1qCkYBAEsuk0BWm6riZTcdJrD9bWFYXi2OKcT61vH+gzSv7JqfmRkanl1WxVQDge13QChXRZljRI1yBRVmSgiFBFV1QAgOoizEK5kM4kCVpNJBIQpKMoOr+Q0HWAYZgBNyi6rqgqgSAYjkucznNVlJDNdiNJ6hcujO7pcxhocn5yIhHPBIPBjwXrJFFoq/caaGCzWxwOU1d7X3QzDAGtWq0O9PUfOzxjNZvy2Wwmk45H0k4zrfB6MZtGgaG+vh7SgcnqBCKWyhRwzKBUdSNjB5KOIEy5kstNr1isHc/+7p22Jur0A2dWlyfvO3nkwpV3OtrqWaPpe//8LImAJz/72an5sfGxydp2X7HK37gxDcnm4eHhVDxz4JAbJ8S6el8kGs8shflqBYGB02bu2bnPVxO8dfvm6nxkawNgSt5us6zFYq79NWvTM3at6G9u4rOZQrl05sEjk2vh55+9sBYDZlfY5CJSifT5swkSVYOBGkFRllYKva3esYkVh4PIFfIe0XXk2NGh69cqpXJ9Q8Od22sDfVAg4NspiS67LZfLud1OoZpU+QoE4S6PhyCIBqfv4uUr14Zum2zEN78ldnYCRQVdnW2KqKgqlIon+gZaM5nIb5+5Y7aAhx/dUeXSLo+pf0cnwOGp2zdqamoQVyA8Oq5r0EMPP5Zd3K5WsUCNt5wOGSE9ls2xsmhwejPpEiApA2vZjset7mA8UjI77fFsuqvDF42Gd+076HRCml5Wqzm/Pwg0SFX0fCJtCdQiIIXC4Jv/93tjE2B3o2dxbc3MNva1dpwbCZUiYZpm24/sis7OBurqzux2ZIuR5flYtyNA2b3Xr14bONIJaZDbab9161YhL2MI2trkn5mZ6e7qyKSSsA5omhaEKkNS45Ozu3fWl7lqKh7btbvuZz//JUFBCyv6D3/4sTtD1z760TOh9bUat+8n3/ruzlZw5/YI63B7gjUinPzg3If+hl2aUN7VPbAyddPvZ91OQ39//61bN1OZlKSAgwf3Xbp0ye9z+fy+cjnPlUr2tg4axzUFWBzA7XT4dgyuXjk7Mz1qcxhMJtPS0lJrW+eOHa5UmisUCgBCVFU3GAxXr15t7XYfO3bP8mJ2fX19Zna1scVkMBhU0a4IqCcIl0pqWxu4776T2WQ8mYxZLRRO0Z3dNblcQZYkmqZXlpbu/9jHC6FYcWvjq1/9RK5UHL1z+9jxVm0TryCkxAkAgKGh0c4GW7EIdncBl4311bWMzq+vrq5quvTII4/8/pmfNgZstfVH1lbGW9sbR++saVqMIB3LK0qwTV3f3Lo1s0aawe6ddXv27Lp3/8E3f//6jZGo0UerGjCwIJmtctUyjoIarxfo+pOf/Vxri9Xj8YjVuKqqbrv95pUlllpJIGBsEjgcgEKJgKvhgfvvJej54Ruzf/O1T1w+P3r1xsrPfnbWXxfQsYCu64IMiqUiSZIIgths5rvLryhKqVTKaDTefVn8f/5VSNM0URTffOftfLmiaxCOY7IsC5IEQRBN0xqv0DSNQXAul5MVkSBwXdVogiT1yj/86/tdHnD0np6jR/dcuDOdSqftvtquzrbI7GI0nFgltConNtbVejv3iqhJWn/l6D0Ha9z2++7rXf7VlNkCIsUCgCww0GEAwQhANEiH/+PfBgrBuqJyHKdoqiRJoizrEIygKAzDug5tbkZsFqPFZEYAVC4X89mCxWRCEIxgCF3XZEWERVGEYViSJJ7nEQTRdV0URQzDNE2DYTgaTZbLZYIkBUG4q3CVeEW5ZclzAAAZ0klEQVSR9LamFp/bpyqSrkmqJrrddtZEu1wOBEUzuSJFWwZ3HvB6G1ZXogtL25evjoxPZcs80GBUR2AYg1VIRggIwQCKwhiGIAiiq0AWNFlUi8Uix3GxWLRSKYVC2wgKBQI+sxkIIigUSpIkVLiSKPIwDCiKIEki6Pe6nY7V1Vw0nHfawe7BHQSGiSK/e3BHc2OD1WIWea6Qy2IY0t3Z4W6or2bTBIlBuvbhxfMcV96za6csy2++8XqVK7scjM1qTiZiKALZzKbG+lqzhU0lswhKM4zNYvFWeRi21QHVyHFEY8MgSXt0YPR6AU5ZFxY3IIgaGZsym6zr6xsjI2N1dURjo8/f22uzOjo6ujY2tm7fnkyngcPhcthdfX2+YrF8c2giHE9woqBpWkdHu9dtd9rYVHTzvdf/ePq+I1/94on9u5hiDnzjG8+8+8Hw+O07BrOZNlsAhFIG9p13RjmufPqjj9X6QH8bIGA1Ew8DVURQYLPbVzc3puZCNg++vBFzeEwYxUzPL5778ENFhU49eNoX8G5vh81mwJoMe/futVhNL/7xtUw2kYiHrTYXa7X1DQ5StCGWSC6trk1OTS+EweKcCACIJ8DGKnj15cV331ldX115/ZUPDj94mKIEowF88hP7Dh3Z1dXd3NRQm04kgAaCNU2QTudX4x5Pm8EQBP7udEa7NX5nfHrMYDUDm8NgseOMqVQWcJOddQXvTM7xABMRJFrMJ6ul+p52mYAsdlaUqnNzM6Iii6KMsFa5KnncAYvVkY/EKYKcGh/bt6vNZgHJWLwl6I2HY+l4aqAvWC5XPIGAIIp3JsbWo9FcpbIW2irxAKCwqqp+jx+DsWpRPXhwPwKBh04fXt9YxXG0qbH+4vkLAGhWmyUWDmXSSYoiYRhAQCdxjKKJg/v2ehymrU394dMNOIoODcVqa2owDGNZM0EQH//EJ+1Ol8PtuT506+VX79AGplKpDA8vvPfee/Pz6cbGRgiCQqFQJpMpFsETTzz69ts36+vre3p6dF0PhUJ9fX3rS/M//5dXG+ugz33q8R29vSOvvxwJb1uspraWZrvN0tnZWa1WcYw4ePDg2Pik1+vFMTIWS7S3dWYyuVQq09/fD0GIKIL5+eL169GJiekqz5lMhiNH+j/5qSdGRoZtLg9O0OWquLyyhqBkPJFiaCNpdVAUVQmHaZLQVS2bSbEM4bBbaQwbHp4RBGH37t1GoxHHQWdn58AAU1fngyAom802NzePjKQeeOCBt956y+l01tXVbcdSkURqeX2rvYsRZCDJ2sHDDclUrqGhqabOOTjYrev60NBQIhZ3O+3tXsRlNaKQzBBoQ41h14C3tdFX6/clYmESxw4dPIiiyNWr2uDgYDwev+9kb0tLs5XFdRnoMhjo68ZQcOf2DZokdg26w+FtQeT37aupqQEQBK2ur4VCcZqGTCaTwWDI5XKFQiGfz2ezWaPRYLPZVFW9a8C4e9dx13jH8/zC4nKhVERwDEZRDegAhmAY1jRNlmXWYEQgeDuZ12TFajZl0xmaJCgG66oHNid28eL00NBti8Xi97pJAsumkl0dfrMJe/dyanqqmM8k33/rjasfnq+rDTQ1BDVFaG1paKgFKAY0RcBRAEMAgfT/MOoBAEMQDCAIAASBNFmCdM1goI1GIwpDuqagKIrjqInFbVaLrEiFYp4kCIfNQlFEMp6RRQXSEQRgKIIgsizIimaymUgjFY1HKhXJafXSNJ3NZikKMxgMmqoSBCFWYRzHjZDFa6f99U3biXQsEu3p6WFQVNOqRY4TNYWwmRkDC2OGXCGvCaigU3/44weLSzyAgMtt5CVElzSMwmVNRxAdhlUAQziCaZoCAAx0GQC4VM57LbSmKZqu8Dynqordbrv33sMblavTEYDynAgwjKRkRdNgCMdRSaxSpOK0g/Y2z84OLwxpIs8FvZ7N7S0Jokic9ns9bc1Bh52Q8uHZoeGu/Ue25pYw0ljMZSFVSSViW2sbQb+nWCw+eOo+hoQn76QDbXV+n0eTqkaGvj4bKWRBR8Nui7cZVERQlLMc0Enr9Ezs7OWJ60M5ngcGBrnw4a22Fs+7H0RPP1iPwMrGxtbJk/flEtUbb77FiZXadu+d59O5Mtiz2y9X6fpgw+7B+mT6JkHAjMnKy/Lc/Bpr8W6shhtbOgN+m9UAWETqbgr6rcS/LLxrZsHgjvqbI3f8vto9rU43y0Cs5QtfOrWysV6JbP7Tj795z/Fv8whAKL6+tiEUSeYKeQXAJK1VVUAaibIgcRne57WmsoV3Pji7b9eO7t7+0ObqytLy7dtLuUwiEioYaNBQXzM9PT0yEYvHQDAYvnQ5xxiAKIHWdvuRHYQglRubgm63w+/zDF2/kc8XkzHFyABQ3maN2r33eltavdnUNoFDRqcNyenVfNlq9fEVSeB1wuC/8tbr+qV5AOAzH31EFYU33n/ryMFdGGmcXlkZvOdEKlk+e/aqv7GPhza2N8M7j95z6+bY+Vu3d+zoGuisc7ptZT6NYarI60CFqhXZxGLlQoUhaaMRSybT++9/cGlx+87t6tf/+gtq/Ux+ftGF4BVezhZLNGTde889sAu/HrqSKFWaGqnu7h3nx2Z4o37twpWPPnBkYmxUEHgUUgb7ukOhLY/LjiIgmYgpitLZ0V1X33Ttxm0M1kW+3Nu/8+bQLZMlc/DAXqdrMRWPXrty+cc/+sq5c+e6W9pWV9fvvf/Uy6+8de52urV5Scdp2ggImuWq1cHBVqmYDNSSLMvOrUylE9GvfuXJeDL2wguv+3yE1+sNh8OpcIgkyWq1OtDT4bKYy2VubXm2q6Mz4HOXKxiJQ/OzMzX1NVtbW4oKIvFYY0tve3uHogMMwzEUlMtVh8OVSK5p8ubx48cnp5ZCCYCj4PFPntg9ePjFV39c4bPf/scjwrnR+eU1gmFxAtFUxWAyo6iKk1R0fc1gMAjVioE154spDEUMVosxm0IRDQBw7dqMr3fPC6+8vGNH3+zs7N6Opo2pqaDbRNFEsVr1eIDJZCIIIp+JrK6K73yQSqXB3/3N7vs+ceqp73y7q2/H7HKRMUoTCyuAJpCoShEiA6m8UK2vryU09MWL406vyeO0+Grc8UR6dHl9W4oRKN3Q2hCNhg8fPGgzX//1b27uG3RjJGEy4zWoE4DI/gN9E8Mj2bTQ3WsMbay3NjlTkYQqK7W19f27Dkt6zUtvDl8Zu1jhtEQybbebFUWxWCwYhqVSKV3XeZ5XFAXHcQCAoigAgLt7rSzLOEPBOCYJPCfyCE1RDCNJiizLBIEVCoUDe/clE7Hl5UVdUjAIcMVSuSjv3+Gq9VrrasTR6Q0SgvL5/M59PVfXV11tvp0NzVjpMgCAIdHIVpK0iTDckUlHGVi3mOh77+3/p6cnYALgGKrIKtBVoOkQ0HVIh1QAIAgACIYABHSaoix2m66BRCpZ4asoBEqlEooi5UIeg5GyKCXjSYvJWKpyJsZE4wZJFoSqAN+FbzAMc/c7RhAEBEEcx9nt9kwm09bWFgwG77Ld7zInGdKiiCAeii8vrigS8Ljsui7EY9uiUCZIBMbQCieqOs6a/YJMT05vb4Z4UQUQDopVJZUpcJIAMB0giqhUBLksyVVVVTUVqLKmyjBQcdZkqK0L2h1WgsBcbgcE6cVSvr2j9fDhvTQNIFhDEJgg8Gq1UqkUdaBCury5EW6q9+3dPVgX9FYrBQgoU5PjDI2bjIwqS5sba4sLc7HNddxsam1pAjhus5hJAs9m9I31ZYHncBRqqKt1OewmlqmUCnabSVUkRRLL+RysaQ+eftBu91ptXkBZNWCcng7fur0yMRH9wwsfrq7lbQ4LQdLxZLlQ1mYXo5/45EkcJ33eQCJevnZ1yGg09fUODvTvvHzpqtkM2tvR+vrG0ZHJ27eH3333/eXlFafT7fAGSjxf4SV/wN1c52sMOtvqHA+fOb65OKZUEu0NPqCCL37pFIphSxuZt8+OvX3+cjSV215e4fhq747e0OaSnIn8/jdf3Dtg43J6eHNN4CuCLGI0w1gc6YpEWWzpIm+wmNKFMsYYKaPpxdfvzC0snDh5H0Eg3d2+9fUCz4Ejh3fOzowtLsRwivX4GZPN8dBjPU9+8bGjx/uOHL1n165dAACr1dze1vT0U2/ls9lvPvPrv/mrj/7Vn39uZuJKMMgeOzooVFMMqZvNdHxjlWbNE+Nzv/rFc2trCUtdz9CV6Zde2nzvvfVMFkYZPFXM7Ny/FyYNJVHFDPbQdtbsrJMRs4SaRhdjI4v53732dlbkkjLQWOL5P74Tim7VtLVIksRxVSDpRoO1nK0YjTbc7r3wwfs+h1mObXzmEw9/7S/uhbRsIhSz0CwKYy6v7/v/+M5ffv3fXj97VqOIBz7ykeNnHoBoamphAcVIC2utFkEunqmr8T//4vbE2ExdMLC2tLA0P+e0m/u7OxtqggxNJmMxI0Xu271rayNTLma9bkdXW+P68sKZU/ft2b0zl0m98tIfR26vdHd3221OhmZ5XhzsYhdWxKW1vMXBJLKZYrGo63o4nI/F4ul0uqGhwWikstksTdOqCjweT7VaDYVCBEEYDIatrS0unyyko+nYdnNd4MOz78p8hSvmb1y/ms9lcBRuqKvftXOPy+Wx2RwkbdjYDNfVNuXz5fm5RUVWPR7v1lZodna2UACPPhywWkEiGfN4HTSNr6yAXHQLw0E0npFUeCsSU3S4XOENRpPBwAIAVyqViYmJaqkAVLWQy+qVoipVlxdmvv7tv969u+n7P/i10WhcWFggSGx1ddXnt7W3t9+6tVhTU9Pf3/HpP/uFwWA4ceJEJpP53J/86X2nOuaWN0OT8yVOCScyVUmrigpBGQK1tbFoNput5HPZa5cvzc1Mb6ytdLfVPXDskMNC06jOkEhrk0+T9WDAIwn81MTIwsIcrIO6OuDz+bLZ7NjYRGdL3QMnBrZWF4HMHz24t7u9abCvJ52IYwjs97ij0SjP89FYjBcFkmIECfT2dgaDwf/IGsoyjuM1NTU7d+68yx27my/870JqQZElTRdVTZCBrKkwityFjBoMhlQqf8+RQ1/8/BdIFONKZZfNrknykcNtBtaUL5SMBpPZTJZKJRjSG+pr25rqhm/PuqzmL3zuvjo/YcD01nrKYaJGh0eKxbTBZaW89p07umkCoAhQZF5XFV1VgaYA9T/ikJCiAVWDVEVVJE2WUF1HIA0COlBVoMkuh9XMGmBIPXn86On7TyIAILBmMxnsNpumqqVCMV+qoBzHOex+DDeWqiWhWLXZbDCsbK4mMcTB87zX6zUatWwmymB6Ps8pVYhQZL4o8gpnIJigV4eArMgVr8dsxTC3wwlUOLkakVAbYmbXN6MvvrwqGQmc0iVNKxd4WQNGA6VBGidVEQTRNQgFMIagOgxrOooCGIMxmtYQRLdYTIiWCwb9OKJlilnSWVNTG5SVWxIsSBAEIEqSeRWGMRJHUKilwc0aqFQy2lvfquCipko4ChXzWZONgTUVUmWGJmRRAKqCAj25tuIK1CgSBBSQTiYCbm82U5ydnty3Z+/Swjymyzv7++OhlVIuZzUxJIEB2siyciicvPju+8W85Av418LhC9PZjhYqEucpGiUoo6rKvX39shS7eOVqJSvu2W1vb6+fn9ow4AtORzlXypAknc8DI6RcuXw1XQYOCzw5Mf+JT/fv2lm3vrrp9gdsNk9dTSODk16PPbaxkNiYgSGts2cwGY0du4dxOx3Pz7yfKwGHHTiCdS+//d6ff+VTMOAArLkshhuXzxrsdZ//+MOh2DNT65rVbRR0JF8qEiyDs6blzVhne3OpkEvmZNakGCiSNYHx6Y147BepmNrXaz92zFYuZHx+t66JTocpUBuQJf2DD66aTY6xiQVRkFO5bEdb44MPnopE1pKJWGc7+8C9JydffnFtZb2lpaU2YC9VyoSjDudypMUIMFRPpzOJhK4BrgImp5YqHPn+2Rt2J6irbTRZajK5dF17a2Y7TNK0LEOyKgQH79FL6uj0+u/fGidZ1m8hFhbTKl5q6nK98+FYhwqGhq7W1B9VVdFoNAFJg1EjjurpUNJiF/bt3E3Q6MbKtNPd4HMRbheFkjVORSnNzxMI8fDj3b/73czF29tR4ukfXP5tj4ucfe3K2p3F0x95eLGa3NHTdu3i7OB+6pMfcZ4+df/P/u1fb1wHP/nn+qrXEY2EOI5ramiYm1/KZIslr/fg/nabxby1sXnx3Acum2V1ce72zRv3nro3kUgYyOSHFy/Hw8lf/PysKIGBfXWHDnvXYvEszxfKMo3Jm5ubHR01DgZUKhWM0g8dOmQwGGbnZ+677+D6+rqmaT09PRQMzc9OtjY13Zkcvvfe+xcXVm5dvSRWtWR0u6m5ob7GjRHw8sZaVZByE7PP/yGczb9fLIpeTw1JMrU19aIA37hx8+SD+2iavnDuhtsN7dq1S1XFKxfn2pov7d4z6AlcK5Xy8UQYplpWNkLLixun7+/Ii3lZohwWs8fjkQXJyLAUQabT6ebWJmA24mF9oKcLCDyGIwwDNjc3dAyenEzuaUMwzJjNZk+cGNR0dWZmvtkFLly42dX40OHDh7/yk+cbgtahm8na2rnPf/mr58/fFmQ0lkgXK7oHJYsVgMAgoVURDuxuc/Y2t10eWaQxkNhaX10STTbT4b1Ht1beqJYK0VDmyNFOVZFGhkMff/zA2bdv2Ix1+w8dhJRyJLKCQ2omWRQqRSNpXFocpXFoZnJl766D2VJudHT00o1oOIdgLIzjYGpqjiRRTdMYhgEAlErS9PSC1Rq+e/P8n2P9bgQFRVGuUqUsqIm2KlSFV9QyxyMQZCQoVVVZA3Hl0mUax2oCgXwhm8vmezs7FVUlUMThcLIsO9C/49r4vCJKf/jdszUem4EEiC7ROFLjd8moaT1eXA9l6i3A47ICqQxkHYH1o/fUX1vMzoZKCGWB9P9Y3mEIQJAOwTrQAIroiK7JAl8uFQAMabKAIhCOIflczmq1lCrVrc11AsNhHfBlToA4gCmSJLndjp1BPwxBEIIgFEUBADiOw3HcZDIJgpDL5YxGo6IooihqmlYoFEqlUqlUqhR4A2VmSNrr9vg8Xokvw5Dc3FhDU2g0tCXxfENjazrP/cMPf/fvvxmCYFAqozJgJIVUAcGarThD8bIgqyJOohgBUBSgKIwhOA6TGEpRuFGShEQy5nDYFUXSdc1oZGiGUhRZ0xSuCjRN4XlOlkUEgSiKIEg0Gg7v37e7saFOkYViPp3Ppavl0sHT9wNN0zWpkM/xXNlqMhMYCmSZ5yo2i1nmypVy8d6T7T1dnYosJuMVoGsm1siVizCkswbG43LAQLOYWYAhodC2xWpVVX16Zn12Lnzs5ENHjp0hAVhc5VUdhQlTc0cfShsqgvixT31yMyLu3u1HEcznDXR2NLe1tVerwqVLYyxrfuThwdaWBpvNcXRvX21tHQSBTDq3sLBY09RUU99AGZhz7793++ZVVSiiSomBRRsDAKmlI+tPfvKjvoaaU6eO1DXQdo+nLMqtXT1vvff+ufPngSIgkHTPiUNeO2ukwBc+/dGdvW6uWgon8waTibU5spyA4Kig6nNbmWC9H8apoZmo2+cIBJ2aDjU1GWdnpw1G2mYz57Mpt9NisRrSuSJOMRRDl3lhbUMuVsDKSginSKvV2tTUEN7eaKjxO+zmK5cvPXjqeHtzAxvwpeOx0PjY7VtDibUVOZP1dnTabc6du/b9yVc+zwvyK6+dTaYEtzfgDzbKMrS6uvL0L395+/bt4TtjJGGqDbY99f1/OXrs62trhWQaiDI2tpBuaPOkChqn8L568s+/epg0EIVCzu5yMXaPIutyRSIQ0mZxhDa2TTbr5tpiS2+7xcGkYitCJVrMFPQKz1ps6XS2rauLMgGCBazToeSy0XjU7HTu3ddhNlvfeetWJVca6PAvLcwcOXggk051tDf//d8OTE6McaWi2Whw2W1D168uLix5XA4IaA67NRmPBXzuxrrA6O2pQwf3P/LQmc21da5UvnkjPjR0K5XODAx4v/mtL4TCkUQqLSs6gJGmtsbjx49znJTJZBRFMZlMmqbxPD8yMuL3+59++vrJkycTiYTRaKRp+u4ieXjfrltXP1SFyoG9O/7izz574+okV8xVy6XRkREcRaamljo6uo4ep9bWEk6nO5nOJBPpRx55VBLlTAaoir65ud3R3ul0Os+fP3vo8IF7jrYBSIvFQySFywrf0tI4O780MbmRSAJPoNbrC4qiXCxz21shorZ2aWlJFHm71TI3NlpYW/a3tyoCd+nD8z6f59Spg+0dLQSJtbezLMs2NDQ4HI6dO3eOjo6eOHH0i198QlFAJBJ9//3LsXRxK5Y6fbqeF7WpueWbdyaffm2YZCys2ZZJ5zAUWC3A4cB6umxen7tcKaQiW3K1cHDPjqCHRVTRZCDra33d7S0dLfXDt+bS6WRzMzM7O/uRjzyRTqeTyeTawtwDJ48OdLUacLAwPZGIhx+474QiVREIiLzAMEw0GoUgyOP2GUxmXgTt7c02m81qtd5d1c1m0m439fT03J14qqrCMAxB0F0/NYIgCIbBKE5StMFoxElClmVeFFUNVKtVu9X22gcXXnjrfbvV6rI7ymWltbFJ0cHy0urFS5PbkWg4HJ6fzwMAaIrYXI8f2tftdzurpezegZ4z959oa6l1moHPA4wWg5CNZ8NrslTZMdBjMZmAJkNAhQGEAAgGOgIABAAMYARACKTjKEBgoCmSpsg4hpAYigCdwmGf2xX0u2dnptLJRF9vi4VlWIaSpSqCqHt2D375T77w/wEkwYWQPOLT6QAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=500x375 at 0x7FD255F9B6A0>"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "img = PIL.Image.open(fn); img"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(500, 375)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "img.size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "size_d = {k: PIL.Image.open(PATH + k).size for k in data.trn_ds.fnames}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "row_sz, col_sz = list(zip(*size_d.values()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "row_sz = np.array(row_sz); col_sz = np.array(col_sz)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([500, 500, 500, 500, 500])"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "row_sz[:5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAD8CAYAAAB+UHOxAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAEQNJREFUeJzt3X+s3XV9x/Hna/zSqJEidw1pcYXZxGAykTSA0ZgNYim4rCxBU7OMhjVpsmGiyZatzGT4iwSWTCaJ4pg0K8YJDDUQZcMOMGZ/8KPIbxj2ghBogFYKqDGyge/9cT6XndR7e+9tb++5h8/zkZycz/f9/Zxz3t/7Pe2r5/v9nttUFZKk/vzWqBuQJI2GASBJnTIAJKlTBoAkdcoAkKROGQCS1CkDQJI6ZQBIUqcMAEnq1OGjbmB/jj322Fq1atWo25CksXLPPff8tKomZpu3pANg1apV7NixY9RtSNJYSfLUXOZ5CEiSOmUASFKnDABJ6pQBIEmdMgAkqVMGgCR1ak4BkOTJJA8muS/JjlY7Jsn2JDvb/bJWT5IrkkwmeSDJKUPPs7HN35lk46HZJEnSXMznE8AfVNXJVbWmLW8Bbq2q1cCtbRngbGB1u20GroRBYAAXA6cBpwIXT4WGJGnxHcwhoPXAtjbeBpw7VL+mBu4Ajk5yHHAWsL2q9lbVi8B2YN1BvL4k6SDM9ZvABXw/SQH/VFVXAcur6tm2/jlgeRuvAJ4eeuwzrTZT/Q1n1ZbvjeR1n7z0IyN5XUnjaa4B8MGq2pXkt4HtSf57eGVVVQuHg5ZkM4NDR7zzne9ciKeUJE1jToeAqmpXu98NfIfBMfzn26Ed2v3uNn0XcPzQw1e22kz1fV/rqqpaU1VrJiZm/V1GkqQDNGsAJHlLkrdNjYG1wEPATcDUlTwbgRvb+Cbg/HY10OnAy+1Q0S3A2iTL2snfta0mSRqBuRwCWg58J8nU/H+tqv9IcjdwfZJNwFPAx9r8m4FzgEngl8AFAFW1N8nngbvbvM9V1d4F2xJJ0rzMGgBV9QTw3mnqLwBnTlMv4MIZnmsrsHX+bUqSFprfBJakThkAktQpA0CSOmUASFKnDABJ6pQBIEmdMgAkqVMGgCR1ygCQpE4ZAJLUKQNAkjplAEhSpwwASeqUASBJnTIAJKlTBoAkdcoAkKROGQCS1CkDQJI6ZQBIUqcMAEnqlAEgSZ0yACSpUwaAJHXKAJCkThkAktQpA0CSOmUASFKnDABJ6pQBIEmdMgAkqVMGgCR1as4BkOSwJPcm+W5bPiHJnUkmk1yX5MhWP6otT7b1q4ae46JWfyzJWQu9MZKkuZvPJ4BPAo8OLV8GXF5V7wJeBDa1+ibgxVa/vM0jyUnABuA9wDrgK0kOO7j2JUkHak4BkGQl8BHga205wBnADW3KNuDcNl7flmnrz2zz1wPXVtUrVfUTYBI4dSE2QpI0f3P9BPCPwF8Dv27L7wBeqqpX2/IzwIo2XgE8DdDWv9zmv16f5jGSpEU2awAk+UNgd1Xdswj9kGRzkh1JduzZs2cxXlKSujSXTwAfAP4oyZPAtQwO/XwJODrJ4W3OSmBXG+8Cjgdo698OvDBcn+Yxr6uqq6pqTVWtmZiYmPcGSZLmZtYAqKqLqmplVa1icBL3tqr6E+B24Lw2bSNwYxvf1JZp62+rqmr1De0qoROA1cBdC7YlkqR5OXz2KTP6G+DaJF8A7gWubvWrga8nmQT2MggNqurhJNcDjwCvAhdW1WsH8fqSpIMwrwCoqh8AP2jjJ5jmKp6q+hXw0RkefwlwyXyblCQtPL8JLEmdMgAkqVMGgCR1ygCQpE4ZAJLUKQNAkjplAEhSpwwASeqUASBJnTIAJKlTBoAkdcoAkKROGQCS1CkDQJI6ZQBIUqcMAEnqlAEgSZ0yACSpUwaAJHXKAJCkThkAktQpA0CSOmUASFKnDABJ6pQBIEmdMgAkqVMGgCR1ygCQpE4ZAJLUKQNAkjplAEhSpwwASerUrAGQ5E1J7kpyf5KHk3y21U9IcmeSySTXJTmy1Y9qy5Nt/aqh57qo1R9Lctah2ihJ0uzm8gngFeCMqnovcDKwLsnpwGXA5VX1LuBFYFObvwl4sdUvb/NIchKwAXgPsA74SpLDFnJjJElzN2sA1MAv2uIR7VbAGcANrb4NOLeN17dl2vozk6TVr62qV6rqJ8AkcOqCbIUkad4On8uk9i/1e4B3AV8GHgdeqqpX25RngBVtvAJ4GqCqXk3yMvCOVr9j6GmHH3NIrNryvUP59JI01uZ0EriqXquqk4GVDP7V/u5D1VCSzUl2JNmxZ8+eQ/UyktS9eV0FVFUvAbcD7weOTjL1CWIlsKuNdwHHA7T1bwdeGK5P85jh17iqqtZU1ZqJiYn5tCdJmoe5XAU0keToNn4z8GHgUQZBcF6bthG4sY1vasu09bdVVbX6hnaV0AnAauCuhdoQSdL8zOUcwHHAtnYe4LeA66vqu0keAa5N8gXgXuDqNv9q4OtJJoG9DK78oaoeTnI98AjwKnBhVb22sJsjSZqrWQOgqh4A3jdN/QmmuYqnqn4FfHSG57oEuGT+bUqSFprfBJakThkAktQpA0CSOmUASFKnDABJ6pQBIEmdMgAkqVMGgCR1ygCQpE4ZAJLUKQNAkjplAEhSpwwASeqUASBJnTIAJKlTBoAkdcoAkKROGQCS1CkDQJI6ZQBIUqcMAEnqlAEgSZ0yACSpUwaAJHXKAJCkThkAktQpA0CSOmUASFKnDABJ6pQBIEmdMgAkqVMGgCR1ygCQpE7NGgBJjk9ye5JHkjyc5JOtfkyS7Ul2tvtlrZ4kVySZTPJAklOGnmtjm78zycZDt1mSpNnM5RPAq8BfVtVJwOnAhUlOArYAt1bVauDWtgxwNrC63TYDV8IgMICLgdOAU4GLp0JDkrT4Zg2Aqnq2qn7Uxj8HHgVWAOuBbW3aNuDcNl4PXFMDdwBHJzkOOAvYXlV7q+pFYDuwbkG3RpI0Z/M6B5BkFfA+4E5geVU921Y9Byxv4xXA00MPe6bVZqrv+xqbk+xIsmPPnj3zaU+SNA9zDoAkbwW+BXyqqn42vK6qCqiFaKiqrqqqNVW1ZmJiYiGeUpI0jTkFQJIjGPzl/42q+nYrP98O7dDud7f6LuD4oYevbLWZ6pKkEZjLVUABrgYeraovDq26CZi6kmcjcONQ/fx2NdDpwMvtUNEtwNoky9rJ37WtJkkagcPnMOcDwJ8CDya5r9X+FrgUuD7JJuAp4GNt3c3AOcAk8EvgAoCq2pvk88Ddbd7nqmrvgmyFJGneZg2AqvovIDOsPnOa+QVcOMNzbQW2zqdBSdKh4TeBJalTBoAkdcoAkKROGQCS1CkDQJI6ZQBIUqcMAEnqlAEgSZ0yACSpUwaAJHXKAJCkThkAktQpA0CSOmUASFKnDABJ6pQBIEmdMgAkqVMGgCR1ygCQpE4ZAJLUKQNAkjplAEhSpwwASeqUASBJnTIAJKlTBoAkdcoAkKROGQCS1CkDQJI6ZQBIUqcMAEnqlAEgSZ2aNQCSbE2yO8lDQ7VjkmxPsrPdL2v1JLkiyWSSB5KcMvSYjW3+ziQbD83mSJLmai6fAP4FWLdPbQtwa1WtBm5tywBnA6vbbTNwJQwCA7gYOA04Fbh4KjQkSaMxawBU1Q+BvfuU1wPb2ngbcO5Q/ZoauAM4OslxwFnA9qraW1UvAtv5zVCRJC2iAz0HsLyqnm3j54DlbbwCeHpo3jOtNlNdkjQiB30SuKoKqAXoBYAkm5PsSLJjz549C/W0kqR9HGgAPN8O7dDud7f6LuD4oXkrW22m+m+oqquqak1VrZmYmDjA9iRJsznQALgJmLqSZyNw41D9/HY10OnAy+1Q0S3A2iTL2snfta0mSRqRw2ebkOSbwO8DxyZ5hsHVPJcC1yfZBDwFfKxNvxk4B5gEfglcAFBVe5N8Hri7zftcVe17YlmStIhmDYCq+vgMq86cZm4BF87wPFuBrfPqTpJ0yPhNYEnqlAEgSZ0yACSpUwaAJHXKAJCkThkAktQpA0CSOmUASFKnDABJ6pQBIEmdMgAkqVMGgCR1ygCQpE4ZAJLUKQNAkjplAEhSpwwASeqUASBJnTIAJKlTBoAkdcoAkKROGQCS1CkDQJI6ZQBIUqcMAEnqlAEgSZ0yACSpUwaAJHXKAJCkThkAktQpA0CSOmUASFKnDl/sF0yyDvgScBjwtaq6dLF7eKNateV7I3vtJy/9yMheW9KBWdRPAEkOA74MnA2cBHw8yUmL2YMkaWCxDwGdCkxW1RNV9T/AtcD6Re5BksTiHwJaATw9tPwMcNoi96BDYFSHn3o89OShPi2URT8HMJskm4HNbfEXSR6bZtqxwE8Xr6sFZ/8LJJcd0MOWTP8HaGT9H+DPe1/j/vOHpb8NvzOXSYsdALuA44eWV7ba66rqKuCq/T1Jkh1VtWbh21sc9j9a9j9a494/vDG2ARb/HMDdwOokJyQ5EtgA3LTIPUiSWORPAFX1apJPALcwuAx0a1U9vJg9SJIGFv0cQFXdDNx8kE+z30NEY8D+R8v+R2vc+4c3xjaQqhp1D5KkEfBXQUhSp8YuAJKsS/JYkskkW0bdz0ySPJnkwST3JdnRasck2Z5kZ7tf1upJckXbpgeSnDKCfrcm2Z3koaHavPtNsrHN35lk44j7/0ySXW0f3JfknKF1F7X+H0ty1lB9JO+vJMcnuT3JI0keTvLJVh+LfbCf/sdiHyR5U5K7ktzf+v9sq5+Q5M7Wy3Xt4hWSHNWWJ9v6VbNt15JUVWNzY3Di+HHgROBI4H7gpFH3NUOvTwLH7lP7e2BLG28BLmvjc4B/BwKcDtw5gn4/BJwCPHSg/QLHAE+0+2VtvGyE/X8G+Ktp5p7U3jtHASe099Rho3x/AccBp7Tx24Aftz7HYh/sp/+x2Aft5/jWNj4CuLP9XK8HNrT6V4E/b+O/AL7axhuA6/a3XYvxHjqQ27h9Ahj3XyWxHtjWxtuAc4fq19TAHcDRSY5bzMaq6ofA3n3K8+33LGB7Ve2tqheB7cC6Q9/9jP3PZD1wbVW9UlU/ASYZvLdG9v6qqmer6kdt/HPgUQbfnB+LfbCf/meypPZB+zn+oi0e0W4FnAHc0Or7/vyn9ssNwJlJwszbtSSNWwBM96sk9vcmG6UCvp/kngy+3QywvKqebePngOVtvFS3a779LsXt+EQ7RLJ16vAJS7z/djjhfQz+FTp2+2Cf/mFM9kGSw5LcB+xmEJyPAy9V1avT9PJ6n239y8A7WAI///kYtwAYJx+sqlMY/ObTC5N8aHhlDT4vjs0lWOPWb3Ml8LvAycCzwD+Mtp3ZJXkr8C3gU1X1s+F147APpul/bPZBVb1WVScz+A0FpwLvHnFLh9y4BcCsv0piqaiqXe1+N/AdBm+o56cO7bT73W36Ut2u+fa7pLajqp5vf6h/Dfwz//9RfEn2n+QIBn95fqOqvt3KY7MPput/3PYBQFW9BNwOvJ/BobWp70sN9/J6n23924EXWAL9z8e4BcBY/CqJJG9J8rapMbAWeIhBr1NXZWwEbmzjm4Dz25UdpwMvD33sH6X59nsLsDbJsvZRf22rjcQ+51H+mME+gEH/G9qVHCcAq4G7GOH7qx0/vhp4tKq+OLRqLPbBTP2Pyz5IMpHk6DZ+M/BhBucxbgfOa9P2/flP7ZfzgNvaJ7SZtmtpGvVZ6PneGFz98GMGx+c+Pep+ZujxRAZXAtwPPDzVJ4NjhLcCO4H/BI5p9TD4j3IeBx4E1oyg528y+Ij+vwyOW246kH6BP2Nw4msSuGDE/X+99fcAgz+Yxw3N/3Tr/zHg7FG/v4APMji88wBwX7udMy77YD/9j8U+AH4PuLf1+RDwd61+IoO/wCeBfwOOavU3teXJtv7E2bZrKd78JrAkdWrcDgFJkhaIASBJnTIAJKlTBoAkdcoAkKROGQCS1CkDQJI6ZQBIUqf+Dyks3TjebrteAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.hist(row_sz);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array([ 135.,  592., 1347., 1164., 4599.,  128.,   76.,   62.,   14.,   11.]),\n",
+       " array([ 97. , 185.5, 274. , 362.5, 451. , 539.5, 628. , 716.5, 805. , 893.5, 982. ]),\n",
+       " <a list of 10 Patch objects>)"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAD8CAYAAAB+UHOxAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAADy5JREFUeJzt3X+s3XV9x/Hny1Zx04QWuSFd2+zW2MzgEoU0WOL+MDChirH8gQZjZuOa9B+W4WLiYP8Qf5BAsoiaTCKRzmqMyNCMBslIVzDL/hC4DIfQSnoVHG3AXm3BOaOz+t4f51M8tL2795bTc0o/z0dycr/f9+dzzvl8v/20r35/nHNTVUiS+vOqSQ9AkjQZBoAkdcoAkKROGQCS1CkDQJI6ZQBIUqcMAEnqlAEgSZ0yACSpU8snPYD/z7nnnlvT09OTHoYkvaI88sgjP62qqYX6ndYBMD09zczMzKSHIUmvKEl+vJh+ngKSpE4ZAJLUKQNAkjplAEhSpwwASeqUASBJnTIAJKlTBoAkdcoAkKROndafBJYWMn3dtyf23k/fdMXE3lsaBY8AJKlTBoAkdcoAkKROGQCS1CkDQJI6ZQBIUqcMAEnqlAEgSZ0yACSpUwaAJHXKAJCkThkAktQpA0CSOmUASFKnDABJ6pQBIEmdMgAkqVMGgCR1ygCQpE4ZAJLUKQNAkjplAEhSpxYdAEmWJXk0yT1tfV2SB5PMJvlGkte0+lltfba1Tw+9xvWt/mSSy0e9MZKkxVvKEcC1wN6h9ZuBW6rqTcBhYGurbwUOt/otrR9JzgeuBt4CbAK+kGTZyxu+JOlkLSoAkqwBrgC+1NYDXALc1brsAK5sy5vbOq390tZ/M3BHVf26qp4CZoGLRrERkqSlW+wRwGeBjwO/a+tvAJ6vqiNtfT+wui2vBp4BaO0vtP4v1k/wHEnSmC0YAEneCxysqkfGMB6SbEsyk2Rmbm5uHG8pSV1azBHAO4D3JXkauIPBqZ/PASuSLG991gAH2vIBYC1Aaz8b+Nlw/QTPeVFV3VZVG6pqw9TU1JI3SJK0OAsGQFVdX1VrqmqawUXc+6vqQ8ADwFWt2xbg7ra8s63T2u+vqmr1q9tdQuuA9cBDI9sSSdKSLF+4y7z+FrgjyaeBR4HbW/124KtJZoFDDEKDqnoiyZ3AHuAIcE1V/fZlvL8k6WVYUgBU1XeA77TlH3GCu3iq6lfA++d5/o3AjUsdpCRp9PwksCR1ygCQpE4ZAJLUKQNAkjplAEhSpwwASeqUASBJnTIAJKlTBoAkdcoAkKROGQCS1CkDQJI6ZQBIUqcMAEnqlAEgSZ0yACSpUwaAJHXKAJCkThkAktQpA0CSOmUASFKnDABJ6pQBIEmdMgAkqVMGgCR1ygCQpE4ZAJLUKQNAkjplAEhSpwwASeqUASBJnTIAJKlTBoAkdcoAkKROGQCS1CkDQJI6tWAAJHltkoeS/GeSJ5J8otXXJXkwyWySbyR5Tauf1dZnW/v00Gtd3+pPJrn8VG2UJGlhizkC+DVwSVW9FXgbsCnJRuBm4JaqehNwGNja+m8FDrf6La0fSc4HrgbeAmwCvpBk2Sg3RpK0eAsGQA38oq2+uj0KuAS4q9V3AFe25c1tndZ+aZK0+h1V9euqegqYBS4ayVZIkpZsUdcAkixL8j3gILAL+CHwfFUdaV32A6vb8mrgGYDW/gLwhuH6CZ4jSRqzRQVAVf22qt4GrGHwv/Y3n6oBJdmWZCbJzNzc3Kl6G0nq3pLuAqqq54EHgIuBFUmWt6Y1wIG2fABYC9DazwZ+Nlw/wXOG3+O2qtpQVRumpqaWMjxJ0hIs5i6gqSQr2vIfAO8C9jIIgqtaty3A3W15Z1untd9fVdXqV7e7hNYB64GHRrUhkqSlWb5wF1YBO9odO68C7qyqe5LsAe5I8mngUeD21v924KtJZoFDDO78oaqeSHInsAc4AlxTVb8d7eZIkhZrwQCoqseAC05Q/xEnuIunqn4FvH+e17oRuHHpw5QkjZqfBJakThkAktQpA0CSOmUASFKnDABJ6pQBIEmdMgAkqVMGgCR1ygCQpE4ZAJLUKQNAkjplAEhSpwwASeqUASBJnTIAJKlTBoAkdcoAkKROGQCS1CkDQJI6ZQBIUqcMAEnqlAEgSZ0yACSpUwaAJHXKAJCkThkAktQpA0CSOmUASFKnDABJ6pQBIEmdMgAkqVMGgCR1ygCQpE4ZAJLUKQNAkjplAEhSpxYMgCRrkzyQZE+SJ5Jc2+rnJNmVZF/7ubLVk+TzSWaTPJbkwqHX2tL670uy5dRtliRpIYs5AjgCfKyqzgc2AtckOR+4DthdVeuB3W0d4N3A+vbYBtwKg8AAbgDeDlwE3HA0NCRJ47dgAFTVs1X1H235v4G9wGpgM7CjddsBXNmWNwNfqYHvAiuSrAIuB3ZV1aGqOgzsAjaNdGskSYu2pGsASaaBC4AHgfOq6tnW9BxwXlteDTwz9LT9rTZfXZI0AYsOgCSvB74JfLSqfj7cVlUF1CgGlGRbkpkkM3Nzc6N4SUnSCSwqAJK8msE//l+rqm+18k/aqR3az4OtfgBYO/T0Na02X/0lquq2qtpQVRumpqaWsi2SpCVYzF1AAW4H9lbVZ4aadgJH7+TZAtw9VP9wuxtoI/BCO1V0H3BZkpXt4u9lrSZJmoDli+jzDuAvgO8n+V6r/R1wE3Bnkq3Aj4EPtLZ7gfcAs8AvgY8AVNWhJJ8CHm79PllVh0ayFZKkJVswAKrq34HM03zpCfoXcM08r7Ud2L6UAUqSTg0/CSxJnTIAJKlTBoAkdcoAkKROGQCS1CkDQJI6ZQBIUqcMAEnqlAEgSZ0yACSpUwaAJHXKAJCkThkAktQpA0CSOmUASFKnDABJ6pQBIEmdMgAkqVMGgCR1ygCQpE4ZAJLUKQNAkjplAEhSpwwASerU8kkPQKMzfd23J/beT990xcTeW9LJ8QhAkjplAEhSpwwASeqUASBJnTIAJKlTBoAkdcoAkKRO+TkAjcQkP4Mg6eR4BCBJnTIAJKlTBoAkdWrBAEiyPcnBJI8P1c5JsivJvvZzZasnyeeTzCZ5LMmFQ8/Z0vrvS7Ll1GyOJGmxFnME8GVg0zG164DdVbUe2N3WAd4NrG+PbcCtMAgM4Abg7cBFwA1HQ0OSNBkLBkBV/Rtw6JjyZmBHW94BXDlU/0oNfBdYkWQVcDmwq6oOVdVhYBfHh4okaYxO9hrAeVX1bFt+DjivLa8Gnhnqt7/V5qtLkibkZV8ErqoCagRjASDJtiQzSWbm5uZG9bKSpGOcbAD8pJ3aof082OoHgLVD/da02nz141TVbVW1oao2TE1NneTwJEkLOdkA2AkcvZNnC3D3UP3D7W6gjcAL7VTRfcBlSVa2i7+XtZokaUIW/CqIJF8H3gmcm2Q/g7t5bgLuTLIV+DHwgdb9XuA9wCzwS+AjAFV1KMmngIdbv09W1bEXliVJY7RgAFTVB+dpuvQEfQu4Zp7X2Q5sX9LoJEmnjJ8ElqROGQCS1CkDQJI6ZQBIUqcMAEnqlAEgSZ0yACSpUwaAJHXKAJCkThkAktQpA0CSOmUASFKnDABJ6tSC3waqpZu+7tuTHoIkLcgjAEnqlAEgSZ0yACSpUwaAJHXKAJCkThkAktQpA0CSOmUASFKnDABJ6pQBIEmdMgAkqVMGgCR1ygCQpE4ZAJLUKQNAkjplAEhSpwwASeqUASBJnTIAJKlTBoAkdeqM/qXw/nJ2nUqTml9P33TFRN5XZx6PACSpU2M/AkiyCfgcsAz4UlXdNO4xSK9kkzyy9ejjzDLWAEiyDPgH4F3AfuDhJDuras84xyHp5Hja68wy7lNAFwGzVfWjqvpf4A5g85jHIEli/KeAVgPPDK3vB94+5jFIeoXp8YaOcRz1nHZ3ASXZBmxrq79I8uQkxzNC5wI/nfQgTjPuk+O5T16q2/2Rm+dtWsw++ePFvMe4A+AAsHZofU2rvaiqbgNuG+egxiHJTFVtmPQ4Tifuk+O5T17K/XG8Ue6TcV8DeBhYn2RdktcAVwM7xzwGSRJjPgKoqiNJ/gq4j8FtoNur6olxjkGSNDD2awBVdS9w77jf9zRwxp3WGgH3yfHcJy/l/jjeyPZJqmpUryVJegXxqyAkqVMGwAgkWZvkgSR7kjyR5NpWPyfJriT72s+VrZ4kn08ym+SxJBdOdgtOnSTLkjya5J62vi7Jg23bv9FuBiDJWW19trVPT3Lcp0qSFUnuSvKDJHuTXNz7PEnyN+3vzeNJvp7ktb3NkyTbkxxM8vhQbcnzIsmW1n9fki0Lva8BMBpHgI9V1fnARuCaJOcD1wG7q2o9sLutA7wbWN8e24Bbxz/ksbkW2Du0fjNwS1W9CTgMbG31rcDhVr+l9TsTfQ74l6p6M/BWBvum23mSZDXw18CGqvpTBjeHXE1/8+TLwKZjakuaF0nOAW5g8OHai4AbjobGvKrKx4gfwN0Mvu/oSWBVq60CnmzLXwQ+ONT/xX5n0oPB5zx2A5cA9wBh8AGW5a39YuC+tnwfcHFbXt76ZdLbMOL9cTbw1LHb1fM84fffDnBO+3O/B7i8x3kCTAOPn+y8AD4IfHGo/pJ+J3p4BDBi7ZD0AuBB4LyqerY1PQec15ZP9JUYq8c0xHH6LPBx4Hdt/Q3A81V1pK0Pb/eL+6S1v9D6n0nWAXPAP7bTYl9K8jo6nidVdQD4e+C/gGcZ/Lk/Qt/z5KilzoslzxcDYISSvB74JvDRqvr5cFsNIrmbW66SvBc4WFWPTHosp5HlwIXArVV1AfA//P6wHuhynqxk8IWQ64A/Al7H8adCuneq5oUBMCJJXs3gH/+vVdW3WvknSVa19lXAwVZf8CsxzgDvAN6X5GkG3/p6CYPz3yuSHP38yfB2v7hPWvvZwM/GOeAx2A/sr6oH2/pdDAKh53ny58BTVTVXVb8BvsVg7vQ8T45a6rxY8nwxAEYgSYDbgb1V9Zmhpp3A0SvxWxhcGzha/3C7mr8ReGHoUO+MUFXXV9WaqppmcFHv/qr6EPAAcFXrduw+Obqvrmr9z6j/CVfVc8AzSf6klS4F9tDxPGFw6mdjkj9sf4+O7pNu58mQpc6L+4DLkqxsR1aXtdr8Jn3h40x4AH/G4PDsMeB77fEeBucmdwP7gH8Fzmn9w+AX4/wQ+D6DOyAmvh2ncP+8E7inLb8ReAiYBf4JOKvVX9vWZ1v7Gyc97lO0L94GzLS58s/Ayt7nCfAJ4AfA48BXgbN6myfA1xlcA/kNgyPFrSczL4C/bPtmFvjIQu/rJ4ElqVOeApKkThkAktQpA0CSOmUASFKnDABJ6pQBIEmdMgAkqVMGgCR16v8APnl6vn44LbsAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.hist(row_sz[row_sz < 1000])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAD8CAYAAAB+UHOxAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAEAVJREFUeJzt3X+s3XV9x/Hny1bYokaK3DVNW1ecTZb6h0gaYNGYTbK24LKyRA1mGQ1r0n9qosmWrcw/cCoJLJlsJJOkG82KcSJRCY2yYYcYsz/4URT5OewVIdAArbaixsgGvvfH+dSc1Xu555Tbe27v5/lIbs73+/5+zjmf9/329tXvj3uaqkKS1J/XTXoCkqTJMAAkqVMGgCR1ygCQpE4ZAJLUKQNAkjplAEhSpwwASeqUASBJnVo+6Qm8mnPOOafWrVs36WlI0mnlgQce+GFVTc01blEHwLp16zhw4MCkpyFJp5UkT48yzlNAktQpA0CSOmUASFKnDABJ6pQBIEmdMgAkqVMGgCR1ygCQpE4ZAJLUqUX9m8Cnq3W7vjaR933q2vdP5H0lnZ5GOgJI8lSSh5M8mORAq52dZH+Sg+1xRasnyQ1JppM8lOT8odfZ1sYfTLLt1LQkSRrFOKeA/qCqzquqjW19F3BXVa0H7mrrAJcA69vXDuBGGAQGcDVwIXABcPXx0JAkLbzXcg1gK7C3Le8FLhuq31wD9wBnJVkFbAb2V9XRqjoG7Ae2vIb3lyS9BqMGQAFfT/JAkh2ttrKqnmvLzwMr2/Jq4Jmh5z7barPVJUkTMOpF4PdU1aEkvwXsT/LfwxurqpLUfEyoBcwOgLe+9a3z8ZKSpBmMdARQVYfa42HgNgbn8F9op3Zoj4fb8EPA2qGnr2m12eonvtfuqtpYVRunpub8/wwkSSdpzgBI8oYkbzq+DGwCHgH2Acfv5NkG3N6W9wFXtLuBLgJebKeK7gQ2JVnRLv5uajVJ0gSMcgpoJXBbkuPj/62q/iPJ/cCtSbYDTwMfauPvAC4FpoGfA1cCVNXRJJ8C7m/jPllVR+etE0nSWOYMgKp6EnjnDPUfARfPUC9g5yyvtQfYM/40JUnzzY+CkKROGQCS1CkDQJI6ZQBIUqcMAEnqlAEgSZ0yACSpUwaAJHXKAJCkThkAktQpA0CSOmUASFKnDABJ6pQBIEmdMgAkqVMGgCR1ygCQpE4ZAJLUKQNAkjplAEhSpwwASeqUASBJnTIAJKlTBoAkdcoAkKROGQCS1CkDQJI6ZQBIUqcMAEnqlAEgSZ0yACSpUyMHQJJlSb6T5Ktt/dwk9yaZTvLFJGe0+pltfbptXzf0Gle1+hNJNs93M5Kk0Y1zBPBR4PGh9euA66vq7cAxYHurbweOtfr1bRxJNgCXA+8AtgCfTbLstU1fknSyRgqAJGuA9wP/0tYDvA/4UhuyF7isLW9t67TtF7fxW4FbquqlqvoBMA1cMB9NSJLGN+oRwD8AfwX8sq2/BfhxVb3c1p8FVrfl1cAzAG37i238r+ozPEeStMDmDIAkfwQcrqoHFmA+JNmR5ECSA0eOHFmIt5SkLo1yBPBu4I+TPAXcwuDUzz8CZyVZ3sasAQ615UPAWoC2/c3Aj4brMzznV6pqd1VtrKqNU1NTYzckSRrNnAFQVVdV1ZqqWsfgIu43qupPgbuBD7Rh24Db2/K+tk7b/o2qqla/vN0ldC6wHrhv3jqRJI1l+dxDZvXXwC1JPg18B7ip1W8CPpdkGjjKIDSoqkeT3Ao8BrwM7KyqV17D+0uSXoOxAqCqvgl8sy0/yQx38VTVL4APzvL8a4Brxp2kJGn++ZvAktQpA0CSOmUASFKnDABJ6pQBIEmdMgAkqVMGgCR1ygCQpE4ZAJLUKQNAkjplAEhSpwwASeqUASBJnTIAJKlTBoAkdcoAkKROGQCS1CkDQJI6ZQBIUqcMAEnqlAEgSZ0yACSpUwaAJHXKAJCkThkAktQpA0CSOmUASFKnDABJ6pQBIEmdMgAkqVMGgCR1ygCQpE7NGQBJfiPJfUm+m+TRJH/b6ucmuTfJdJIvJjmj1c9s69Nt+7qh17qq1Z9IsvlUNSVJmtsoRwAvAe+rqncC5wFbklwEXAdcX1VvB44B29v47cCxVr++jSPJBuBy4B3AFuCzSZbNZzOSpNHNGQA18LO2+vr2VcD7gC+1+l7gsra8ta3Ttl+cJK1+S1W9VFU/AKaBC+alC0nS2Ea6BpBkWZIHgcPAfuD7wI+r6uU25FlgdVteDTwD0La/CLxluD7Dc4bfa0eSA0kOHDlyZPyOJEkjGSkAquqVqjoPWMPgX+2/e6omVFW7q2pjVW2cmpo6VW8jSd0b6y6gqvoxcDfwe8BZSZa3TWuAQ235ELAWoG1/M/Cj4foMz5EkLbBR7gKaSnJWW/5N4A+BxxkEwQfasG3A7W15X1unbf9GVVWrX97uEjoXWA/cN1+NSJLGs3zuIawC9rY7dl4H3FpVX03yGHBLkk8D3wFuauNvAj6XZBo4yuDOH6rq0SS3Ao8BLwM7q+qV+W1HkjSqOQOgqh4C3jVD/UlmuIunqn4BfHCW17oGuGb8aUqS5tsoRwCnrXW7vjbpKUjSouVHQUhSpwwASeqUASBJnTIAJKlTBoAkdcoAkKROGQCS1CkDQJI6ZQBIUqcMAEnqlAEgSZ0yACSpUwaAJHXKAJCkThkAktQpA0CSOmUASFKnDABJ6pQBIEmdMgAkqVMGgCR1ygCQpE4ZAJLUKQNAkjplAEhSpwwASeqUASBJnTIAJKlTBoAkdcoAkKROzRkASdYmuTvJY0keTfLRVj87yf4kB9vjilZPkhuSTCd5KMn5Q6+1rY0/mGTbqWtLkjSXUY4AXgb+oqo2ABcBO5NsAHYBd1XVeuCutg5wCbC+fe0AboRBYABXAxcCFwBXHw8NSdLCmzMAquq5qvp2W/4p8DiwGtgK7G3D9gKXteWtwM01cA9wVpJVwGZgf1UdrapjwH5gy7x2I0ka2VjXAJKsA94F3AusrKrn2qbngZVteTXwzNDTnm212eqSpAkYOQCSvBH4MvCxqvrJ8LaqKqDmY0JJdiQ5kOTAkSNH5uMlJUkzGCkAkryewV/+n6+qr7TyC+3UDu3xcKsfAtYOPX1Nq81W/3+qandVbayqjVNTU+P0Ikkawyh3AQW4CXi8qj4ztGkfcPxOnm3A7UP1K9rdQBcBL7ZTRXcCm5KsaBd/N7WaJGkClo8w5t3AnwEPJ3mw1f4GuBa4Ncl24GngQ23bHcClwDTwc+BKgKo6muRTwP1t3Cer6ui8dCFJGtucAVBV/wVkls0XzzC+gJ2zvNYeYM84E5QknRr+JrAkdcoAkKROGQCS1CkDQJI6ZQBIUqcMAEnqlAEgSZ0yACSpUwaAJHXKAJCkThkAktQpA0CSOmUASFKnDABJ6pQBIEmdMgAkqVMGgCR1ygCQpE4ZAJLUKQNAkjplAEhSpwwASeqUASBJnTIAJKlTBoAkdcoAkKROGQCS1CkDQJI6ZQBIUqcMAEnqlAEgSZ0yACSpU3MGQJI9SQ4neWSodnaS/UkOtscVrZ4kNySZTvJQkvOHnrOtjT+YZNupaUeSNKpRjgD+FdhyQm0XcFdVrQfuausAlwDr29cO4EYYBAZwNXAhcAFw9fHQkCRNxpwBUFXfAo6eUN4K7G3Le4HLhuo318A9wFlJVgGbgf1VdbSqjgH7+fVQkSQtoJO9BrCyqp5ry88DK9vyauCZoXHPttps9V+TZEeSA0kOHDly5CSnJ0may2u+CFxVBdQ8zOX46+2uqo1VtXFqamq+XlaSdIKTDYAX2qkd2uPhVj8ErB0at6bVZqtLkibkZANgH3D8Tp5twO1D9Sva3UAXAS+2U0V3ApuSrGgXfze1miRpQpbPNSDJF4DfB85J8iyDu3muBW5Nsh14GvhQG34HcCkwDfwcuBKgqo4m+RRwfxv3yao68cKyJGkBzRkAVfXhWTZdPMPYAnbO8jp7gD1jzU6SdMr4m8CS1CkDQJI6ZQBIUqcMAEnqlAEgSZ0yACSpUwaAJHXKAJCkThkAktQpA0CSOmUASFKnDABJ6pQBIEmdMgAkqVMGgCR1ygCQpE4ZAJLUKQNAkjplAEhSpwwASeqUASBJnTIAJKlTBoAkdcoAkKROGQCS1CkDQJI6ZQBIUqcMAEnqlAEgSZ0yACSpU8snPQHNn3W7vjax937q2vdP7L0lnZwFPwJIsiXJE0mmk+xa6PeXJA0saAAkWQb8E3AJsAH4cJINCzkHSdLAQh8BXABMV9WTVfU/wC3A1gWegySJhb8GsBp4Zmj9WeDCBZ6DToFJXn/ojddbNF8W3UXgJDuAHW31Z0meaMvnAD+czKwmyr77MmffuW6BZrJw3Nfz77dHGbTQAXAIWDu0vqbVfqWqdgO7T3xikgNVtfHUTm/xse++9Nh3jz3D4uh7oa8B3A+sT3JukjOAy4F9CzwHSRILfARQVS8n+QhwJ7AM2FNVjy7kHCRJAwt+DaCq7gDuOImn/tppoU7Yd1967LvHnmER9J2qmvQcJEkT4GcBSVKnFn0ALPWPjkjyVJKHkzyY5ECrnZ1kf5KD7XFFqyfJDe178VCS8yc7+9El2ZPkcJJHhmpj95lkWxt/MMm2SfQyjln6/kSSQ22fP5jk0qFtV7W+n0iyeah+Wv0cJFmb5O4kjyV5NMlHW33J7vNX6Xnx7u+qWrRfDC4Ufx94G3AG8F1gw6TnNc89PgWcc0Lt74BdbXkXcF1bvhT4dyDARcC9k57/GH2+FzgfeORk+wTOBp5sjyva8opJ93YSfX8C+MsZxm5of8bPBM5tf/aXnY4/B8Aq4Py2/Cbge62/JbvPX6XnRbu/F/sRQK8fHbEV2NuW9wKXDdVvroF7gLOSrJrEBMdVVd8Cjp5QHrfPzcD+qjpaVceA/cCWUz/7kzdL37PZCtxSVS9V1Q+AaQY/A6fdz0FVPVdV327LPwUeZ/BJAEt2n79Kz7OZ+P5e7AEw00dHvNo39HRUwNeTPNB+CxpgZVU915afB1a25aX2/Ri3z6XU/0faqY49x0+DsET7TrIOeBdwL53s8xN6hkW6vxd7APTgPVV1PoNPSN2Z5L3DG2twrLjkb9Xqpc/mRuB3gPOA54C/n+x0Tp0kbwS+DHysqn4yvG2p7vMZel60+3uxB8CcHx1xuquqQ+3xMHAbg8O/F46f2mmPh9vwpfb9GLfPJdF/Vb1QVa9U1S+Bf2awz2GJ9Z3k9Qz+Ivx8VX2llZf0Pp+p58W8vxd7ACzpj45I8oYkbzq+DGwCHmHQ4/G7HbYBt7flfcAV7Y6Ji4AXhw6nT0fj9nknsCnJinYYvanVTisnXLf5Ewb7HAZ9X57kzCTnAuuB+zgNfw6SBLgJeLyqPjO0acnu89l6XtT7e9JXzuf6YnB3wPcYXBX/+KTnM8+9vY3BFf7vAo8e7w94C3AXcBD4T+DsVg+D/1Dn+8DDwMZJ9zBGr19gcPj7vwzOaW4/mT6BP2dwsWwauHLSfZ1k359rfT3E4Ad71dD4j7e+nwAuGaqfVj8HwHsYnN55CHiwfV26lPf5q/S8aPe3vwksSZ1a7KeAJEmniAEgSZ0yACSpUwaAJHXKAJCkThkAktQpA0CSOmUASFKn/g/PJt7HkTnc+gAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.hist(col_sz);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array([ 235.,  733., 2205., 2979., 1807.,   98.,   27.,   33.,    7.,   10.]),\n",
+       " array([102., 190., 278., 366., 454., 542., 630., 718., 806., 894., 982.]),\n",
+       " <a list of 10 Patch objects>)"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYEAAAD8CAYAAACRkhiPAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAEa9JREFUeJzt3X+sX3V9x/Hny6K4qZEid01t62513UxdYiENYtwfTiYUXIZLnIEss3Ek9Q/IdDFZ6v5h05FgorKZODIcnWgcyPwxGmjGukpi/EOgTAYUJFz5MdoUeieI28yMxff++H4qX2kv93tvv/d+aT/PR/LN95z3+ZxzPudwyKvn1/emqpAk9ellk+6AJGlyDAFJ6pghIEkdMwQkqWOGgCR1zBCQpI4ZApLUMUNAkjpmCEhSx06ZdAdezBlnnFHT09OT7oYknVDuvvvu/6qqqVHavqRDYHp6mr179066G5J0Qkny+KhtvRwkSR0zBCSpY4aAJHXMEJCkjs0bAklemeTOJP+RZF+Sv2z19UnuSDKT5CtJXtHqp7bxmTZ9emhZH2v1h5Kcv1QbJUkazShnAj8B3lVVbwU2AVuSnAN8Eri6qn4NeAa4tLW/FHim1a9u7UiyEbgYeAuwBfjbJCvGuTGSpIWZNwRq4H/a6Mvbp4B3AV9t9euB97bhi9o4bfq5SdLqN1bVT6rqUWAGOHssWyFJWpSR7gkkWZHkHuAQsBv4PvDDqjrcmuwH1rThNcATAG36s8DrhuvHmGd4XduS7E2yd3Z2duFbJEka2UghUFXPVdUmYC2Df72/eak6VFXXVtXmqto8NTXSC2+SpEVa0BvDVfXDJLcDbwdOS3JK+9f+WuBAa3YAWAfsT3IK8FrgB0P1I4bn0QluevutE1nvY1e9ZyLrlU4WozwdNJXktDb8S8C7gQeB24H3tWZbgZvb8M42Tpv+zaqqVr+4PT20HtgA3DmuDZEkLdwoZwKrgevbkzwvA26qqluSPADcmOSvgO8C17X21wFfSjIDPM3giSCqal+Sm4AHgMPAZVX13Hg3R5K0EPOGQFXdC5x5jPojHOPpnqr6P+AP5ljWlcCVC++mJGkp+MawJHXMEJCkjhkCktQxQ0CSOmYISFLHDAFJ6pghIEkdMwQkqWOGgCR1zBCQpI4ZApLUMUNAkjpmCEhSxwwBSeqYISBJHTMEJKljhoAkdcwQkKSOGQKS1DFDQJI6ZghIUscMAUnqmCEgSR0zBCSpY4aAJHVs3hBIsi7J7UkeSLIvyYdb/S+SHEhyT/tcODTPx5LMJHkoyflD9S2tNpNk+9JskiRpVKeM0OYw8NGq+vckrwHuTrK7Tbu6qj413DjJRuBi4C3A64F/S/LrbfLngHcD+4G7kuysqgfGsSGSpIWbNwSq6iBwsA3/d5IHgTUvMstFwI1V9RPg0SQzwNlt2kxVPQKQ5MbW1hCQpAlZ0D2BJNPAmcAdrXR5knuT7EiystXWAE8Mzba/1eaqS5ImZOQQSPJq4GvAR6rqR8A1wJuATQzOFD49jg4l2ZZkb5K9s7Oz41ikJGkOI4VAkpczCIAvV9XXAarqqap6rqp+Bnye5y/5HADWDc2+ttXmqv+Cqrq2qjZX1eapqamFbo8kaQFGeToowHXAg1X1maH66qFmvw/c34Z3AhcnOTXJemADcCdwF7Ahyfokr2Bw83jneDZDkrQYozwd9A7gj4D7ktzTan8OXJJkE1DAY8CHAKpqX5KbGNzwPQxcVlXPASS5HLgNWAHsqKp9Y9wWSdICjfJ00LeBHGPSrheZ50rgymPUd73YfJKk5eUbw5LUMUNAkjpmCEhSxwwBSeqYISBJHTMEJKljhoAkdcwQkKSOGQKS1DFDQJI6ZghIUscMAUnqmCEgSR0zBCSpY4aAJHXMEJCkjo3yl8V0ApnefuukuyDpBOKZgCR1zBCQpI4ZApLUMUNAkjpmCEhSxwwBSeqYISBJHTMEJKljhoAkdWzeEEiyLsntSR5Isi/Jh1v99CS7kzzcvle2epJ8NslMknuTnDW0rK2t/cNJti7dZkmSRjHKmcBh4KNVtRE4B7gsyUZgO7CnqjYAe9o4wAXAhvbZBlwDg9AArgDeBpwNXHEkOCRJkzFvCFTVwar69zb838CDwBrgIuD61ux64L1t+CLgizXwHeC0JKuB84HdVfV0VT0D7Aa2jHVrJEkLsqB7AkmmgTOBO4BVVXWwTXoSWNWG1wBPDM22v9XmqkuSJmTkEEjyauBrwEeq6kfD06qqgBpHh5JsS7I3yd7Z2dlxLFKSNIeRQiDJyxkEwJer6uut/FS7zEP7PtTqB4B1Q7OvbbW56r+gqq6tqs1VtXlqamoh2yJJWqBRng4KcB3wYFV9ZmjSTuDIEz5bgZuH6h9oTwmdAzzbLhvdBpyXZGW7IXxeq0mSJmSUPyrzDuCPgPuS3NNqfw5cBdyU5FLgceD9bdou4EJgBvgx8EGAqno6ySeAu1q7j1fV02PZCknSoswbAlX1bSBzTD73GO0LuGyOZe0Adiykg5KkpeMbw5LUMUNAkjpmCEhSxwwBSeqYISBJHTMEJKljhoAkdcwQkKSOjfLGsPSSNb391omt+7Gr3jOxdUvj4pmAJHXMEJCkjhkCktQxQ0CSOmYISFLHDAFJ6pghIEkdMwQkqWOGgCR1zBCQpI4ZApLUMUNAkjpmCEhSxwwBSeqYISBJHTMEJKljhoAkdWzeEEiyI8mhJPcP1f4iyYEk97TPhUPTPpZkJslDSc4fqm9ptZkk28e/KZKkhRrlTOALwJZj1K+uqk3tswsgyUbgYuAtbZ6/TbIiyQrgc8AFwEbgktZWkjRB8/6N4ar6VpLpEZd3EXBjVf0EeDTJDHB2mzZTVY8AJLmxtX1gwT2WJI3N8dwTuDzJve1y0cpWWwM8MdRmf6vNVZckTdBiQ+Aa4E3AJuAg8OlxdSjJtiR7k+ydnZ0d12IlScewqBCoqqeq6rmq+hnweZ6/5HMAWDfUdG2rzVU/1rKvrarNVbV5ampqMd2TJI1oUSGQZPXQ6O8DR54c2glcnOTUJOuBDcCdwF3AhiTrk7yCwc3jnYvvtiRpHOa9MZzkBuCdwBlJ9gNXAO9Msgko4DHgQwBVtS/JTQxu+B4GLquq59pyLgduA1YAO6pq39i3RpK0IKM8HXTJMcrXvUj7K4Erj1HfBexaUO8kSUvKN4YlqWOGgCR1zBCQpI4ZApLUMUNAkjpmCEhSxwwBSeqYISBJHTMEJKljhoAkdcwQkKSOGQKS1DFDQJI6ZghIUscMAUnqmCEgSR0zBCSpY4aAJHXMEJCkjhkCktQxQ0CSOmYISFLHDAFJ6pghIEkdMwQkqWOGgCR1bN4QSLIjyaEk9w/VTk+yO8nD7XtlqyfJZ5PMJLk3yVlD82xt7R9OsnVpNkeStBCjnAl8Adjygtp2YE9VbQD2tHGAC4AN7bMNuAYGoQFcAbwNOBu44khwSJImZ94QqKpvAU+/oHwRcH0bvh5471D9izXwHeC0JKuB84HdVfV0VT0D7OboYJEkLbPF3hNYVVUH2/CTwKo2vAZ4Yqjd/labq36UJNuS7E2yd3Z2dpHdkySN4rhvDFdVATWGvhxZ3rVVtbmqNk9NTY1rsZKkY1hsCDzVLvPQvg+1+gFg3VC7ta02V12SNEGLDYGdwJEnfLYCNw/VP9CeEjoHeLZdNroNOC/JynZD+LxWkyRN0CnzNUhyA/BO4Iwk+xk85XMVcFOSS4HHgfe35ruAC4EZ4MfABwGq6ukknwDuau0+XlUvvNksSVpm84ZAVV0yx6Rzj9G2gMvmWM4OYMeCeidJWlK+MSxJHTMEJKljhoAkdcwQkKSOGQKS1DFDQJI6ZghIUscMAUnqmCEgSR0zBCSpY4aAJHXMEJCkjhkCktSxeX9FVAs3vf3WSXdBkkbimYAkdcwQkKSOGQKS1DFDQJI6ZghIUscMAUnqmCEgSR0zBCSpY4aAJHXMEJCkjhkCktSx4wqBJI8luS/JPUn2ttrpSXYnebh9r2z1JPlskpkk9yY5axwbIElavHGcCfx2VW2qqs1tfDuwp6o2AHvaOMAFwIb22QZcM4Z1S5KOw1JcDroIuL4NXw+8d6j+xRr4DnBaktVLsH5J0oiONwQK+NckdyfZ1mqrqupgG34SWNWG1wBPDM27v9UkSRNyvH9P4Leq6kCSXwF2J/ne8MSqqiS1kAW2MNkG8IY3vOE4uydJejHHdSZQVQfa9yHgG8DZwFNHLvO070Ot+QFg3dDsa1vthcu8tqo2V9Xmqamp4+meJGkeiw6BJK9K8pojw8B5wP3ATmBra7YVuLkN7wQ+0J4SOgd4duiykSRpAo7nctAq4BtJjiznH6vqX5LcBdyU5FLgceD9rf0u4EJgBvgx8MHjWLckaQwWHQJV9Qjw1mPUfwCce4x6AZctdn2SpPHzjWFJ6pghIEkdMwQkqWOGgCR1zBCQpI4ZApLUMUNAkjpmCEhSxwwBSeqYISBJHTMEJKljhoAkdcwQkKSOHe9fFntJm95+66S7IEkvaZ4JSFLHDAFJ6pghIEkdMwQkqWOGgCR1zBCQpI4ZApLUMUNAkjpmCEhSx07qN4alpTSpN9Ifu+o9E1mvTk6eCUhSxwwBSerYsodAki1JHkoyk2T7cq9fkvS8ZQ2BJCuAzwEXABuBS5JsXM4+SJKet9w3hs8GZqrqEYAkNwIXAQ8scz+kE1aPP5HuzfCls9whsAZ4Ymh8P/C2Ze6DpBOMwbd0XnKPiCbZBmxro/+T5KFJ9mdMzgD+a9KdeIlxnxzNfXK0bvdJPjnnpFH2ya+Oup7lDoEDwLqh8bWt9nNVdS1w7XJ2aqkl2VtVmyfdj5cS98nR3CdHc58cbdz7ZLmfDroL2JBkfZJXABcDO5e5D5KkZlnPBKrqcJLLgduAFcCOqtq3nH2QJD1v2e8JVNUuYNdyr3fCTqrLW2PiPjma++Ro7pOjjXWfpKrGuTxJ0gnEn42QpI4ZAscpyboktyd5IMm+JB9u9dOT7E7ycPte2epJ8tn2sxn3JjlrsluwdJKsSPLdJLe08fVJ7mjb/pX2cABJTm3jM2369CT7vVSSnJbkq0m+l+TBJG/v/ThJ8qft/5v7k9yQ5JU9HidJdiQ5lOT+odqCj40kW1v7h5NsHWXdhsDxOwx8tKo2AucAl7WfwtgO7KmqDcCeNg6Dn8zY0D7bgGuWv8vL5sPAg0PjnwSurqpfA54BLm31S4FnWv3q1u5k9DfAv1TVm4G3Mtg33R4nSdYAfwJsrqrfZPCwyMX0eZx8AdjygtqCjo0kpwNXMHgB92zgiiPB8aKqys8YP8DNwLuBh4DVrbYaeKgN/x1wyVD7n7c7mT4M3gHZA7wLuAUIgxdcTmnT3w7c1oZvA97ehk9p7TLpbRjz/ngt8OgLt6vn44Tnf0Hg9Pbf/Rbg/F6PE2AauH+xxwZwCfB3Q/VfaDfXxzOBMWqnp2cCdwCrqupgm/QksKoNH+unM9YsUxeX018Dfwb8rI2/DvhhVR1u48Pb/fN90qY/29qfTNYDs8A/tEtkf5/kVXR8nFTVAeBTwH8CBxn8d7+bvo+TYQs9NhZ1zBgCY5Lk1cDXgI9U1Y+Gp9Uglrt5DCvJ7wKHquruSfflJeQU4Czgmqo6E/hfnj+9B7o8TlYy+AHJ9cDrgVdx9CURsbTHhiEwBkleziAAvlxVX2/lp5KsbtNXA4dafd6fzjgJvAP4vSSPATcyuCT0N8BpSY68mzK83T/fJ236a4EfLGeHl8F+YH9V3dHGv8ogFHo+Tn4HeLSqZqvqp8DXGRw7PR8nwxZ6bCzqmDEEjlOSANcBD1bVZ4Ym7QSO3J3fyuBewZH6B9od/nOAZ4dO+U4KVfWxqlpbVdMMbvR9s6r+ELgdeF9r9sJ9cmRfva+1P6n+RVxVTwJPJPmNVjqXwU+od3ucMLgMdE6SX27/Hx3ZJ90eJy+w0GPjNuC8JCvbWdZ5rfbiJn0z5ET/AL/F4DTtXuCe9rmQwbXKPcDDwL8Bp7f2YfCHdb4P3MfgyYiJb8cS7p93Are04TcCdwIzwD8Bp7b6K9v4TJv+xkn3e4n2xSZgbztW/hlY2ftxAvwl8D3gfuBLwKk9HifADQzui/yUwVnjpYs5NoA/bvtnBvjgKOv2jWFJ6piXgySpY4aAJHXMEJCkjhkCktQxQ0CSOmYISFLHDAFJ6pghIEkd+3/4emtzWkWzEQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.hist(col_sz[col_sz < 1000])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(8178, 10357)"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(data.trn_ds), len(data.test_ds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(120,\n",
+       " ['affenpinscher',\n",
+       "  'afghan_hound',\n",
+       "  'african_hunting_dog',\n",
+       "  'airedale',\n",
+       "  'american_staffordshire_terrier'])"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(data.classes), data.classes[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initial model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_data(sz, bs): # sz: image size, bs: batch size\n",
+    "    tmfs = tfms_from_model(arch, sz, aug_tfms=transforms_side_on, max_zoom=1.1)\n",
+    "    data = ImageClassifierData.from_csv(PATH, 'train', f'{PATH}labels.csv', test_name='test',\n",
+    "                                       val_idxs=val_idxs, suffix='.jpg', tfms=tfms, bs=bs)\n",
+    "    \n",
+    "    # http://forums.fast.ai/t/how-to-train-on-the-full-dataset-using-imageclassifierdata-from-csv/7761/13\n",
+    "    # http://forums.fast.ai/t/how-to-train-on-the-full-dataset-using-imageclassifierdata-from-csv/7761/37\n",
+    "    return data if sz > 300 else data.resize(340, 'tmp') # Reading the jpgs and resizing is slow for big images, so resizing them all to 340 first saves time\n",
+    "\n",
+    "#Source:   \n",
+    "#    def resize(self, targ, new_path):\n",
+    "#        new_ds = []\n",
+    "#        dls = [self.trn_dl,self.val_dl,self.fix_dl,self.aug_dl]\n",
+    "#        if self.test_dl: dls += [self.test_dl, self.test_aug_dl]\n",
+    "#        else: dls += [None,None]\n",
+    "#        t = tqdm_notebook(dls)\n",
+    "#        for dl in t: new_ds.append(self.resized(dl, targ, new_path))\n",
+    "#        t.close()\n",
+    "#        return self.__class__(new_ds[0].path, new_ds, self.bs, self.num_workers, self.classes)\n",
+    "#File:      ~/fastai/courses/dl1/fastai/dataset.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Precompute"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "37d4e87fdf1c46da8dd3e1797eae3464",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, max=6), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "data = get_data(sz, bs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn = ConvLearner.pretrained(arch, data, precompute=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "26a4c64d91254eae8c4a74659bdcb33a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=5), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch      trn_loss   val_loss   accuracy                    \n",
+      "    0      0.956455   0.400646   0.905577  \n",
+      "    1      0.439589   0.301357   0.918787                     \n",
+      "    2      0.297356   0.274035   0.917808                    \n",
+      "    3      0.236814   0.258365   0.920744                    \n",
+      "    4      0.18122    0.252791   0.921233                     \n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[array([0.25279]), 0.9212328809698034]"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "learn.fit(1e-2, 5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Augment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn import metrics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5f61f22e0e7942b381f82f63e7281886",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, max=6), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "data = get_data(sz, bs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn = ConvLearner.pretrained(arch, data, precompute=True, ps=0.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f8ad15c920194d82b9a47843b06a95d0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=2), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch      trn_loss   val_loss   accuracy                    \n",
+      "    0      1.14865    0.445329   0.892857  \n",
+      "    1      0.528676   0.312621   0.911937                     \n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[array([0.31262]), 0.9119373855058928]"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "learn.fit(1e-2, 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn.precompute = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "aea3158a0b6444a997d80aaf3adc01ee",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=5), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch      trn_loss   val_loss   accuracy                    \n",
+      "    0      0.448036   0.281107   0.917808  \n",
+      "    1      0.434155   0.267041   0.917808                    \n",
+      "    2      0.365258   0.259955   0.915851                    \n",
+      "    3      0.366941   0.248325   0.921233                    \n",
+      "    4      0.331771   0.250866   0.918787                    \n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[array([0.25087]), 0.918786694858872]"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "learn.fit(1e-2, 5, cycle_len=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn.save('224_pre')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn.load('224_pre')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Increase size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5e7d8715b1b54106a744dda22d4d8af1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, max=6), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Starting training on small images for a few epochs, then switching to bigger images, and continuing training is an amazingly effective way to avoid overfitting.\n",
+    "\n",
+    "# http://forums.fast.ai/t/planet-classification-challenge/7824/96\n",
+    "# set_data doesn’t change the model at all. It just gives it new data to train with.\n",
+    "learn.set_data(get_data(299, bs)) \n",
+    "learn.freeze()\n",
+    "\n",
+    "#Source:   \n",
+    "#    def set_data(self, data, precompute=False):\n",
+    "#        super().set_data(data)\n",
+    "#        if precompute:\n",
+    "#            self.unfreeze()\n",
+    "#            self.save_fc1()\n",
+    "#            self.freeze()\n",
+    "#            self.precompute = True\n",
+    "#        else:\n",
+    "#            self.freeze()\n",
+    "#File:      ~/fastai/courses/dl1/fastai/conv_learner.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OrderedDict([('Conv2d-1',\n",
+       "              OrderedDict([('input_shape', [-1, 3, 224, 224]),\n",
+       "                           ('output_shape', [-1, 64, 112, 112]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 9408)])),\n",
+       "             ('BatchNorm2d-2',\n",
+       "              OrderedDict([('input_shape', [-1, 64, 112, 112]),\n",
+       "                           ('output_shape', [-1, 64, 112, 112]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 128)])),\n",
+       "             ('ReLU-3',\n",
+       "              OrderedDict([('input_shape', [-1, 64, 112, 112]),\n",
+       "                           ('output_shape', [-1, 64, 112, 112]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('MaxPool2d-4',\n",
+       "              OrderedDict([('input_shape', [-1, 64, 112, 112]),\n",
+       "                           ('output_shape', [-1, 64, 56, 56]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-5',\n",
+       "              OrderedDict([('input_shape', [-1, 64, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 16384)])),\n",
+       "             ('BatchNorm2d-6',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 512)])),\n",
+       "             ('ReLU-7',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-8',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 9216)])),\n",
+       "             ('BatchNorm2d-9',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 512)])),\n",
+       "             ('ReLU-10',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-11',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 65536)])),\n",
+       "             ('BatchNorm2d-12',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 512)])),\n",
+       "             ('Conv2d-13',\n",
+       "              OrderedDict([('input_shape', [-1, 64, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 16384)])),\n",
+       "             ('BatchNorm2d-14',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 512)])),\n",
+       "             ('ReLU-15',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-16',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 65536)])),\n",
+       "             ('BatchNorm2d-17',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 512)])),\n",
+       "             ('ReLU-18',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-19',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 9216)])),\n",
+       "             ('BatchNorm2d-20',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 512)])),\n",
+       "             ('ReLU-21',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-22',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 65536)])),\n",
+       "             ('BatchNorm2d-23',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 512)])),\n",
+       "             ('ReLU-24',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-25',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 65536)])),\n",
+       "             ('BatchNorm2d-26',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 512)])),\n",
+       "             ('ReLU-27',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-28',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 9216)])),\n",
+       "             ('BatchNorm2d-29',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 512)])),\n",
+       "             ('ReLU-30',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-31',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 65536)])),\n",
+       "             ('BatchNorm2d-32',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 512)])),\n",
+       "             ('ReLU-33',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 256, 56, 56]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-34',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 512, 56, 56]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 131072)])),\n",
+       "             ('BatchNorm2d-35',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 56, 56]),\n",
+       "                           ('output_shape', [-1, 512, 56, 56]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1024)])),\n",
+       "             ('ReLU-36',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 56, 56]),\n",
+       "                           ('output_shape', [-1, 512, 56, 56]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-37',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 56, 56]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 36864)])),\n",
+       "             ('BatchNorm2d-38',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1024)])),\n",
+       "             ('ReLU-39',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-40',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 262144)])),\n",
+       "             ('BatchNorm2d-41',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1024)])),\n",
+       "             ('Conv2d-42',\n",
+       "              OrderedDict([('input_shape', [-1, 256, 56, 56]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 131072)])),\n",
+       "             ('BatchNorm2d-43',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1024)])),\n",
+       "             ('ReLU-44',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-45',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 262144)])),\n",
+       "             ('BatchNorm2d-46',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1024)])),\n",
+       "             ('ReLU-47',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-48',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 36864)])),\n",
+       "             ('BatchNorm2d-49',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1024)])),\n",
+       "             ('ReLU-50',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-51',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 262144)])),\n",
+       "             ('BatchNorm2d-52',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1024)])),\n",
+       "             ('ReLU-53',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-54',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 262144)])),\n",
+       "             ('BatchNorm2d-55',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1024)])),\n",
+       "             ('ReLU-56',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-57',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 36864)])),\n",
+       "             ('BatchNorm2d-58',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1024)])),\n",
+       "             ('ReLU-59',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-60',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 262144)])),\n",
+       "             ('BatchNorm2d-61',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1024)])),\n",
+       "             ('ReLU-62',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-63',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 262144)])),\n",
+       "             ('BatchNorm2d-64',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1024)])),\n",
+       "             ('ReLU-65',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-66',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 36864)])),\n",
+       "             ('BatchNorm2d-67',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1024)])),\n",
+       "             ('ReLU-68',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-69',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 262144)])),\n",
+       "             ('BatchNorm2d-70',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1024)])),\n",
+       "             ('ReLU-71',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 512, 28, 28]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-72',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 1024, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 524288)])),\n",
+       "             ('BatchNorm2d-73',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 28, 28]),\n",
+       "                           ('output_shape', [-1, 1024, 28, 28]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-74',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 28, 28]),\n",
+       "                           ('output_shape', [-1, 1024, 28, 28]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-75',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 28, 28]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 147456)])),\n",
+       "             ('BatchNorm2d-76',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-77',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-78',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-79',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('Conv2d-80',\n",
+       "              OrderedDict([('input_shape', [-1, 512, 28, 28]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 524288)])),\n",
+       "             ('BatchNorm2d-81',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-82',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-83',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-84',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-85',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-86',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 147456)])),\n",
+       "             ('BatchNorm2d-87',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-88',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-89',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-90',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-91',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-92',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-93',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-94',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-95',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 147456)])),\n",
+       "             ('BatchNorm2d-96',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-97',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-98',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-99',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-100',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-101',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-102',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-103',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-104',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 147456)])),\n",
+       "             ('BatchNorm2d-105',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-106',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-107',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-108',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-109',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-110',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-111',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-112',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-113',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 147456)])),\n",
+       "             ('BatchNorm2d-114',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-115',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-116',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-117',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-118',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-119',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-120',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-121',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-122',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 147456)])),\n",
+       "             ('BatchNorm2d-123',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-124',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-125',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-126',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-127',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-128',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-129',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-130',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-131',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 147456)])),\n",
+       "             ('BatchNorm2d-132',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-133',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-134',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-135',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-136',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-137',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-138',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-139',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-140',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 147456)])),\n",
+       "             ('BatchNorm2d-141',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-142',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-143',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-144',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-145',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-146',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-147',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-148',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-149',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 147456)])),\n",
+       "             ('BatchNorm2d-150',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-151',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-152',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-153',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-154',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-155',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-156',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-157',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-158',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 147456)])),\n",
+       "             ('BatchNorm2d-159',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-160',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-161',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-162',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-163',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-164',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-165',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-166',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-167',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 147456)])),\n",
+       "             ('BatchNorm2d-168',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-169',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-170',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-171',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-172',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-173',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-174',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-175',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-176',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 147456)])),\n",
+       "             ('BatchNorm2d-177',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-178',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-179',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-180',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-181',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-182',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-183',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-184',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-185',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 147456)])),\n",
+       "             ('BatchNorm2d-186',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-187',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-188',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-189',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-190',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-191',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-192',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-193',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-194',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 147456)])),\n",
+       "             ('BatchNorm2d-195',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-196',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-197',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-198',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-199',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-200',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-201',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-202',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-203',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 147456)])),\n",
+       "             ('BatchNorm2d-204',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-205',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-206',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-207',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-208',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-209',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-210',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-211',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-212',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 147456)])),\n",
+       "             ('BatchNorm2d-213',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-214',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-215',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-216',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-217',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-218',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-219',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-220',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-221',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 147456)])),\n",
+       "             ('BatchNorm2d-222',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-223',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-224',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-225',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-226',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-227',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-228',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-229',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-230',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 147456)])),\n",
+       "             ('BatchNorm2d-231',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-232',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-233',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-234',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-235',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-236',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-237',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-238',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-239',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 147456)])),\n",
+       "             ('BatchNorm2d-240',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-241',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-242',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-243',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-244',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-245',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-246',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-247',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-248',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 147456)])),\n",
+       "             ('BatchNorm2d-249',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-250',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-251',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-252',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-253',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-254',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-255',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-256',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-257',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 147456)])),\n",
+       "             ('BatchNorm2d-258',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-259',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-260',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-261',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-262',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-263',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-264',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-265',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-266',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 147456)])),\n",
+       "             ('BatchNorm2d-267',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-268',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-269',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-270',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-271',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-272',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-273',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-274',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-275',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 147456)])),\n",
+       "             ('BatchNorm2d-276',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-277',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-278',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 1048576)])),\n",
+       "             ('BatchNorm2d-279',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2048)])),\n",
+       "             ('ReLU-280',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-281',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 2048, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2097152)])),\n",
+       "             ('BatchNorm2d-282',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 14, 14]),\n",
+       "                           ('output_shape', [-1, 2048, 14, 14]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 4096)])),\n",
+       "             ('ReLU-283',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 14, 14]),\n",
+       "                           ('output_shape', [-1, 2048, 14, 14]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-284',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 14, 14]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 589824)])),\n",
+       "             ('BatchNorm2d-285',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 4096)])),\n",
+       "             ('ReLU-286',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-287',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 4194304)])),\n",
+       "             ('BatchNorm2d-288',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 4096)])),\n",
+       "             ('Conv2d-289',\n",
+       "              OrderedDict([('input_shape', [-1, 1024, 14, 14]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 2097152)])),\n",
+       "             ('BatchNorm2d-290',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 4096)])),\n",
+       "             ('ReLU-291',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-292',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 4194304)])),\n",
+       "             ('BatchNorm2d-293',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 4096)])),\n",
+       "             ('ReLU-294',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-295',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 589824)])),\n",
+       "             ('BatchNorm2d-296',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 4096)])),\n",
+       "             ('ReLU-297',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-298',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 4194304)])),\n",
+       "             ('BatchNorm2d-299',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 4096)])),\n",
+       "             ('ReLU-300',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-301',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 4194304)])),\n",
+       "             ('BatchNorm2d-302',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 4096)])),\n",
+       "             ('ReLU-303',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-304',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 589824)])),\n",
+       "             ('BatchNorm2d-305',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 4096)])),\n",
+       "             ('ReLU-306',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Conv2d-307',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 4194304)])),\n",
+       "             ('BatchNorm2d-308',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('trainable', False),\n",
+       "                           ('nb_params', 4096)])),\n",
+       "             ('ReLU-309',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('AdaptiveMaxPool2d-310',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 1, 1]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('AdaptiveAvgPool2d-311',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 2048, 1, 1]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('AdaptiveConcatPool2d-312',\n",
+       "              OrderedDict([('input_shape', [-1, 2048, 7, 7]),\n",
+       "                           ('output_shape', [-1, 4096, 1, 1]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Flatten-313',\n",
+       "              OrderedDict([('input_shape', [-1, 4096, 1, 1]),\n",
+       "                           ('output_shape', [-1, 4096]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('BatchNorm1d-314',\n",
+       "              OrderedDict([('input_shape', [-1, 4096]),\n",
+       "                           ('output_shape', [-1, 4096]),\n",
+       "                           ('trainable', True),\n",
+       "                           ('nb_params', 8192)])),\n",
+       "             ('Dropout-315',\n",
+       "              OrderedDict([('input_shape', [-1, 4096]),\n",
+       "                           ('output_shape', [-1, 4096]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Linear-316',\n",
+       "              OrderedDict([('input_shape', [-1, 4096]),\n",
+       "                           ('output_shape', [-1, 512]),\n",
+       "                           ('trainable', True),\n",
+       "                           ('nb_params', 2097664)])),\n",
+       "             ('ReLU-317',\n",
+       "              OrderedDict([('input_shape', [-1, 512]),\n",
+       "                           ('output_shape', [-1, 512]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('BatchNorm1d-318',\n",
+       "              OrderedDict([('input_shape', [-1, 512]),\n",
+       "                           ('output_shape', [-1, 512]),\n",
+       "                           ('trainable', True),\n",
+       "                           ('nb_params', 1024)])),\n",
+       "             ('Dropout-319',\n",
+       "              OrderedDict([('input_shape', [-1, 512]),\n",
+       "                           ('output_shape', [-1, 512]),\n",
+       "                           ('nb_params', 0)])),\n",
+       "             ('Linear-320',\n",
+       "              OrderedDict([('input_shape', [-1, 512]),\n",
+       "                           ('output_shape', [-1, 120]),\n",
+       "                           ('trainable', True),\n",
+       "                           ('nb_params', 61560)])),\n",
+       "             ('LogSoftmax-321',\n",
+       "              OrderedDict([('input_shape', [-1, 120]),\n",
+       "                           ('output_shape', [-1, 120]),\n",
+       "                           ('nb_params', 0)]))])"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "learn.summary()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "83b3f75dbbfe40d6adfb9b708c986b13",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=3), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch      trn_loss   val_loss   accuracy                    \n",
+      "    0      0.303971   0.242417   0.921722  \n",
+      "    1      0.309993   0.239827   0.91683                     \n",
+      "    2      0.288534   0.23499    0.919276                    \n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[array([0.23499]), 0.9192759310662629]"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "learn.fit(1e-2, 3, cycle_len=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Validation loss is much lower than training loss. This is a sign of underfitting. Cycle_len=1 may be too short. Let's set cycle_mult=2 to find better parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c51ed2c06bf346059f494514f5b93a1a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=7), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch      trn_loss   val_loss   accuracy                    \n",
+      "    0      0.267461   0.235228   0.924168  \n",
+      "    1      0.270705   0.230974   0.922211                    \n",
+      "    2      0.240056   0.230974   0.923679                    \n",
+      "    3      0.238908   0.232905   0.926125                    \n",
+      "    4      0.223686   0.229831   0.923679                    \n",
+      "    5      0.212009   0.227405   0.924168                    \n",
+      "    6      0.199683   0.227282   0.926125                    \n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[array([0.22728]), 0.9261252481176895]"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# When you are under fitting, it means cycle_len=1 is too short (learning rate is getting reset before it had the chance to zoom in properly).\n",
+    "learn.fit(1e-2, 3, cycle_len=1, cycle_mult=2) # 1+2+4 = 7 epochs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Training loss and validation loss are getting closer and smaller. We are on right track."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                             \r"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(0.9315068493150684, 0.22650256548463946)"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "log_preds, y = learn.TTA() # (5, 2044, 120), (2044,)\n",
+    "probs = np.mean(np.exp(log_preds),0)\n",
+    "accuracy_np(probs, y), metrics.log_loss(y, probs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(2044, array([19, 15,  7, 99, 73]))"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(data.val_ds.y), data.val_ds.y[:5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn.save('299_pre')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn.load('299_pre')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2e6a5ce515bd4b24b5a665e696228964",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=2), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch      trn_loss   val_loss   accuracy                    \n",
+      "    0      0.215887   0.227493   0.926614  \n",
+      "    1      0.21398    0.224618   0.926614                    \n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[array([0.22462]), 0.9266144826337549]"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "learn.fit(1e-2, 1, cycle_len=2) # 1+1 = 2 epochs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn.save('299_pre')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                             \r"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(0.9334637964774951, 0.22243022015961378)"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "log_preds, y = learn.TTA()\n",
+    "probs = np.mean(np.exp(log_preds),0)\n",
+    "accuracy_np(probs, y), metrics.log_loss(y, probs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This dataset is so similar to ImageNet dataset. Training convolution layers doesn't help much. We are not going to unfreeze."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create submission\n",
+    "\n",
+    "https://youtu.be/9C06ZPF8Uuc?t=1905"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['affenpinscher',\n",
+       " 'afghan_hound',\n",
+       " 'african_hunting_dog',\n",
+       " 'airedale',\n",
+       " 'american_staffordshire_terrier',\n",
+       " 'appenzeller',\n",
+       " 'australian_terrier',\n",
+       " 'basenji',\n",
+       " 'basset',\n",
+       " 'beagle',\n",
+       " 'bedlington_terrier',\n",
+       " 'bernese_mountain_dog',\n",
+       " 'black-and-tan_coonhound',\n",
+       " 'blenheim_spaniel',\n",
+       " 'bloodhound',\n",
+       " 'bluetick',\n",
+       " 'border_collie',\n",
+       " 'border_terrier',\n",
+       " 'borzoi',\n",
+       " 'boston_bull',\n",
+       " 'bouvier_des_flandres',\n",
+       " 'boxer',\n",
+       " 'brabancon_griffon',\n",
+       " 'briard',\n",
+       " 'brittany_spaniel',\n",
+       " 'bull_mastiff',\n",
+       " 'cairn',\n",
+       " 'cardigan',\n",
+       " 'chesapeake_bay_retriever',\n",
+       " 'chihuahua',\n",
+       " 'chow',\n",
+       " 'clumber',\n",
+       " 'cocker_spaniel',\n",
+       " 'collie',\n",
+       " 'curly-coated_retriever',\n",
+       " 'dandie_dinmont',\n",
+       " 'dhole',\n",
+       " 'dingo',\n",
+       " 'doberman',\n",
+       " 'english_foxhound',\n",
+       " 'english_setter',\n",
+       " 'english_springer',\n",
+       " 'entlebucher',\n",
+       " 'eskimo_dog',\n",
+       " 'flat-coated_retriever',\n",
+       " 'french_bulldog',\n",
+       " 'german_shepherd',\n",
+       " 'german_short-haired_pointer',\n",
+       " 'giant_schnauzer',\n",
+       " 'golden_retriever',\n",
+       " 'gordon_setter',\n",
+       " 'great_dane',\n",
+       " 'great_pyrenees',\n",
+       " 'greater_swiss_mountain_dog',\n",
+       " 'groenendael',\n",
+       " 'ibizan_hound',\n",
+       " 'irish_setter',\n",
+       " 'irish_terrier',\n",
+       " 'irish_water_spaniel',\n",
+       " 'irish_wolfhound',\n",
+       " 'italian_greyhound',\n",
+       " 'japanese_spaniel',\n",
+       " 'keeshond',\n",
+       " 'kelpie',\n",
+       " 'kerry_blue_terrier',\n",
+       " 'komondor',\n",
+       " 'kuvasz',\n",
+       " 'labrador_retriever',\n",
+       " 'lakeland_terrier',\n",
+       " 'leonberg',\n",
+       " 'lhasa',\n",
+       " 'malamute',\n",
+       " 'malinois',\n",
+       " 'maltese_dog',\n",
+       " 'mexican_hairless',\n",
+       " 'miniature_pinscher',\n",
+       " 'miniature_poodle',\n",
+       " 'miniature_schnauzer',\n",
+       " 'newfoundland',\n",
+       " 'norfolk_terrier',\n",
+       " 'norwegian_elkhound',\n",
+       " 'norwich_terrier',\n",
+       " 'old_english_sheepdog',\n",
+       " 'otterhound',\n",
+       " 'papillon',\n",
+       " 'pekinese',\n",
+       " 'pembroke',\n",
+       " 'pomeranian',\n",
+       " 'pug',\n",
+       " 'redbone',\n",
+       " 'rhodesian_ridgeback',\n",
+       " 'rottweiler',\n",
+       " 'saint_bernard',\n",
+       " 'saluki',\n",
+       " 'samoyed',\n",
+       " 'schipperke',\n",
+       " 'scotch_terrier',\n",
+       " 'scottish_deerhound',\n",
+       " 'sealyham_terrier',\n",
+       " 'shetland_sheepdog',\n",
+       " 'shih-tzu',\n",
+       " 'siberian_husky',\n",
+       " 'silky_terrier',\n",
+       " 'soft-coated_wheaten_terrier',\n",
+       " 'staffordshire_bullterrier',\n",
+       " 'standard_poodle',\n",
+       " 'standard_schnauzer',\n",
+       " 'sussex_spaniel',\n",
+       " 'tibetan_mastiff',\n",
+       " 'tibetan_terrier',\n",
+       " 'toy_poodle',\n",
+       " 'toy_terrier',\n",
+       " 'vizsla',\n",
+       " 'walker_hound',\n",
+       " 'weimaraner',\n",
+       " 'welsh_springer_spaniel',\n",
+       " 'west_highland_white_terrier',\n",
+       " 'whippet',\n",
+       " 'wire-haired_fox_terrier',\n",
+       " 'yorkshire_terrier']"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data.classes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['test/ab2520c527e61f197be228208af48191.jpg',\n",
+       " 'test/8ffc8a83bb9ac7884a9420c97b23940c.jpg',\n",
+       " 'test/9f4bbcd8a5b189514d3098516983621a.jpg',\n",
+       " 'test/f77793be1597dd1ea50b22532b38bd23.jpg',\n",
+       " 'test/f719b425410b6eb3e3132702150affd6.jpg',\n",
+       " 'test/adfe7237864e2c4e28a0627f97527fa2.jpg',\n",
+       " 'test/7fec33e194124a985167075c40af7702.jpg',\n",
+       " 'test/2ee0a2da17019b2c95f5283c15a692ff.jpg',\n",
+       " 'test/c6d49ce66e3fdae87e2be8ad8fd402b8.jpg',\n",
+       " 'test/b6d38beff7efbd38934e383eecf063be.jpg',\n",
+       " 'test/0829420985a1d5b647b969d44af3e844.jpg',\n",
+       " 'test/07ad25df7e380e29aa4a5788a96cef73.jpg',\n",
+       " 'test/ab3242753d5b6a79985112a3cd63908a.jpg',\n",
+       " 'test/e9b105a5b7873f33477f777d5a9447f8.jpg',\n",
+       " 'test/d0d7f99b88dab4f9fc97be9af2cffde2.jpg',\n",
+       " 'test/59f8e54314ff4f560d615af6476c69cd.jpg',\n",
+       " 'test/af01e814dd0a625042c1abda80671bf1.jpg',\n",
+       " 'test/05fba1b035d12542ad00a38461b10c17.jpg',\n",
+       " 'test/a4116ec18c342040855024b6940a234b.jpg',\n",
+       " 'test/0bb63e30692f00bc7bf0ab5ac787b162.jpg',\n",
+       " 'test/e2f853c8345758faf5d9b2075f196fd3.jpg',\n",
+       " 'test/e66e1f3be08028cc17ea788657e014fa.jpg',\n",
+       " 'test/f1b2c118e65c95ba1a00d102787d19a6.jpg',\n",
+       " 'test/da23c55978faa8bd88db953c1f264549.jpg',\n",
+       " 'test/0e826c710afd789f8db9ff522a7a04c0.jpg',\n",
+       " 'test/1ba6e093c8af25d01a3602382312c339.jpg',\n",
+       " 'test/1c647b0875674bd1aba3153e6fc951c6.jpg',\n",
+       " 'test/1acbf4637bcce746291d39e8147efaa3.jpg',\n",
+       " 'test/9d876a62e20c672a72f8212c022f55d1.jpg',\n",
+       " 'test/f6244044c1433c7067e3129486612ee1.jpg',\n",
+       " 'test/cb8323065d4827069d53e0ffba2f0c84.jpg',\n",
+       " 'test/d8a6e8ffcba849cedc4c186eef224c65.jpg',\n",
+       " 'test/8594ae6003221de99ffbc5d9fa357e34.jpg',\n",
+       " 'test/e9615e7f30ffcf6d705ce9cbcb6d688c.jpg',\n",
+       " 'test/3728d6b1b7c0ebd9e4722ae7e709ec45.jpg',\n",
+       " 'test/b3346fab09a796c121e0dffe84268e73.jpg',\n",
+       " 'test/7478402a790ae8a04b5f3c4e2768c4cf.jpg',\n",
+       " 'test/c5e43e81eb8a4fd5a455898b9a858d18.jpg',\n",
+       " 'test/b3bcc2a3a94c70497779eadaef668d3c.jpg',\n",
+       " 'test/0328ce0d5f48e3dbaef86e830e2e9241.jpg',\n",
+       " 'test/6ae186b904e3cc8528591a3e50a48f20.jpg',\n",
+       " 'test/a8aa29593077a6407c7834eb6fef3c7c.jpg',\n",
+       " 'test/2269b48ab82d6b6feeb462c5f867819d.jpg',\n",
+       " 'test/f90ac8934d1349d115a4961c20ee447b.jpg',\n",
+       " 'test/7b37af62f102cef63ee44361b2a4bb2d.jpg',\n",
+       " 'test/d14bc7e00b69187953e6ac38209ab19d.jpg',\n",
+       " 'test/551ce3484383dc77bd5cb563a50bad46.jpg',\n",
+       " 'test/42feb15909b1a7da5d85bc1a2baafe47.jpg',\n",
+       " 'test/8646d62c1e40c6a1806b472508200b89.jpg',\n",
+       " 'test/c81cfe1f3434bb984f43cfb74600ecff.jpg',\n",
+       " 'test/2f90d005ca7d718be9377b94091849ba.jpg',\n",
+       " 'test/34a6fa4ebc327fc03164793636b1bfbe.jpg',\n",
+       " 'test/29e85e7dd33b3d55c72ff8cf8878a3fb.jpg',\n",
+       " 'test/5fedefbcfd02cc6570cc2a4dbc0c0c13.jpg',\n",
+       " 'test/a309c2637a49acc6accfda9eb230803f.jpg',\n",
+       " 'test/7937d9e90e6960aaccd74675d26d90a7.jpg',\n",
+       " 'test/2162f28a3151f4ca907a8a9d79492618.jpg',\n",
+       " 'test/291956adf955ac9e9776a8fe0db8745b.jpg',\n",
+       " 'test/b52c5200163243ef1aec04f34a68050d.jpg',\n",
+       " 'test/4d2c5271ca71c95234b78bc0910f3d04.jpg',\n",
+       " 'test/657459acdc17b85c06af605c1ab723ca.jpg',\n",
+       " 'test/025156133d8d8700f6c7027371b1b8e0.jpg',\n",
+       " 'test/29548de9a7435fccdcf228afe5fd221f.jpg',\n",
+       " 'test/5e193ae2c366405e230a53daa4fb7721.jpg',\n",
+       " 'test/b44cbb609e863c0aa906322507df3e3c.jpg',\n",
+       " 'test/21174614214935ba20a7be058b29033e.jpg',\n",
+       " 'test/d21a8021f66adc2ea042290d5e1d97ca.jpg',\n",
+       " 'test/eeffe08e577ad8dda81bbfe12bf8faea.jpg',\n",
+       " 'test/a97fbce11cf35df434835888150ceae6.jpg',\n",
+       " 'test/9bc5701373a8e4cb3d64d75322a19f9b.jpg',\n",
+       " 'test/8e38a2da3dc51eedac2153c37b9b2ad6.jpg',\n",
+       " 'test/0e8d997db26798c7c1612847319973e5.jpg',\n",
+       " 'test/8eb4d197b67a2ee9670ab5576d568328.jpg',\n",
+       " 'test/69e231ddd06ed66f4517f695908c7e6e.jpg',\n",
+       " 'test/d049461a887cfddf49953b3e56d89b9e.jpg',\n",
+       " 'test/3740097cc690e3a0ef05e078cc6a37c5.jpg',\n",
+       " 'test/3b2642968aa7fd5883577aca00ad1458.jpg',\n",
+       " 'test/aaae20eed76f8015d6994955bc30076c.jpg',\n",
+       " 'test/72470246b6d48c951cbc8c853c5a6bba.jpg',\n",
+       " 'test/42c10d2fdabe41a8d0f3120025737fab.jpg',\n",
+       " 'test/2f7b43f07134ad69bf36ada8d90939ef.jpg',\n",
+       " 'test/3a6122ad0c4f104d1d36b3cf644896da.jpg',\n",
+       " 'test/db3b5c710e99f6a5d09b8fda8eeff5a7.jpg',\n",
+       " 'test/1b220f74609a8f2015ea898471c0674d.jpg',\n",
+       " 'test/bac5e3f6454352aec23245bff7a10612.jpg',\n",
+       " 'test/d7cbc532e819d760ab9e418654cef03f.jpg',\n",
+       " 'test/3ee1025997b782f6eb2ddd20cd0965c1.jpg',\n",
+       " 'test/322543f668826f158650c94714a832db.jpg',\n",
+       " 'test/b9005a0f449a339ff21a3bfc0068cf45.jpg',\n",
+       " 'test/87e316f956ffcd34bda2dc49d84a9739.jpg',\n",
+       " 'test/ef1710d5cb79a5e0b46f7b9a101a25b4.jpg',\n",
+       " 'test/0d5b801bfeff4eefb3994b8fc59bc2ff.jpg',\n",
+       " 'test/eab189c5274b79b36dd566fea4e9847e.jpg',\n",
+       " 'test/ed67681e7935d75f9ce011dbf8474fe4.jpg',\n",
+       " 'test/7b3a9c2f5f01acd4846bdc65f4190ece.jpg',\n",
+       " 'test/2e87338a89f13b429485cedf8ee89206.jpg',\n",
+       " 'test/6f5b716569f463d9a0519f3d8ce0d33b.jpg',\n",
+       " 'test/8341f50a86c819b3cb8828740a97e7ef.jpg',\n",
+       " 'test/940d587d69cafcbc7bdd88ecc5c82829.jpg',\n",
+       " 'test/c2c9364fa0fb2347fef08f172bcfecd8.jpg',\n",
+       " 'test/3a98899438c614970758846618857045.jpg',\n",
+       " 'test/87f26de902396e2db022e604ae91f15e.jpg',\n",
+       " 'test/ddd7f84a932ec7213b9c1f6de8c09262.jpg',\n",
+       " 'test/2a83319c4aacda676534a6b77b2ceb20.jpg',\n",
+       " 'test/2f1b46804087ade2b6c210125f34323f.jpg',\n",
+       " 'test/de327414ced20d4e6f786a68bff82e10.jpg',\n",
+       " 'test/2753689addaba82e4a90e51dd832d11c.jpg',\n",
+       " 'test/978860f8b3fc9f0af9041d1285179206.jpg',\n",
+       " 'test/87e67ad3d0620a61ea7cc95a3e17f123.jpg',\n",
+       " 'test/5c451b205045be2ba89e5308e0ab505c.jpg',\n",
+       " 'test/1b176552396034ed1c864c3adb6cd16e.jpg',\n",
+       " 'test/4252288f9a9b3d363b17060ef0f5f99e.jpg',\n",
+       " 'test/7ec8e254a7a22d7302c101b814cb48b4.jpg',\n",
+       " 'test/667c969a3a1d19c86ca7e6ab2f877832.jpg',\n",
+       " 'test/0684c3415499ddfd78e945c725066034.jpg',\n",
+       " 'test/6479fb9f458435d91d0d066004c2fc33.jpg',\n",
+       " 'test/53cb184b5e5ce7ef5488fc21f6c32ec2.jpg',\n",
+       " 'test/902b5ce26b286ed9883a9b6a5cc814d8.jpg',\n",
+       " 'test/e47bc25097050ba689b64de02c725837.jpg',\n",
+       " 'test/9810389b3ae0ecc305e4fde32397874f.jpg',\n",
+       " 'test/fefafa1c1b5877561330d0a0fd4d5440.jpg',\n",
+       " 'test/3b48fe220307f1b42003918b0fb48a84.jpg',\n",
+       " 'test/515e5d592804cbf2b8a5d446eb194468.jpg',\n",
+       " 'test/32d1d7ac227098b3f964705d5f651236.jpg',\n",
+       " 'test/d2dec608053c1cf80cae8116cd470cda.jpg',\n",
+       " 'test/13557ec58aad7410efbc8f843754988b.jpg',\n",
+       " 'test/9eb06361f4acb2c2213e5ae32e640653.jpg',\n",
+       " 'test/4777d63bb8201678d8de585843272ff5.jpg',\n",
+       " 'test/463ffe453648a5cf157f2d24551b2b1f.jpg',\n",
+       " 'test/725eb0f0b9b1cd56bc1715b8d86fa845.jpg',\n",
+       " 'test/9bcde951cb5d820636881a8e81eb7951.jpg',\n",
+       " 'test/65c792d01f8d25d7f6aa45a679261340.jpg',\n",
+       " 'test/fc28e20d3e3ef312a15b2255e0ba77a6.jpg',\n",
+       " 'test/459ae8de71479f5bcc14ffef240dfead.jpg',\n",
+       " 'test/4909fc5b89f974fa007c12ba62ecf785.jpg',\n",
+       " 'test/197b591a10fe82030b1db2c3bdee8102.jpg',\n",
+       " 'test/40bed16bb4157c6d9a2fe340d563ff35.jpg',\n",
+       " 'test/61dd794deb9841564d9643dd5737370a.jpg',\n",
+       " 'test/4f0b2dbc23fdef5f939144f456a62140.jpg',\n",
+       " 'test/85624000301b28c675b431de0b67a98a.jpg',\n",
+       " 'test/8e7ca18f952999b5f678f7f7843d9b6d.jpg',\n",
+       " 'test/e3a55cc9c91da472abbced51d98d6ff6.jpg',\n",
+       " 'test/03205e3e568c87e1568a8415272a8da4.jpg',\n",
+       " 'test/084585fd8a9fcef3c7261669cacbc1be.jpg',\n",
+       " 'test/d2f9fbdaa33d1bc99a4366b350022994.jpg',\n",
+       " 'test/905267bd815441ff829cce3be24c6d71.jpg',\n",
+       " 'test/3836dac7313ba15526cd031b72af37f1.jpg',\n",
+       " 'test/4a346ac767ff900e8cc4c4352b57d6ee.jpg',\n",
+       " 'test/5d10fc611701eb7d1fb8bf2cf4df7aed.jpg',\n",
+       " 'test/e15513ca7ebb4730731f34c25e906502.jpg',\n",
+       " 'test/71d8ea950f6312b766d75d6ad8ac3ba2.jpg',\n",
+       " 'test/57c8db20a559e22dcbd7b7363c378287.jpg',\n",
+       " 'test/e1b0cbcf3235fe9a7b35c1652081ff8d.jpg',\n",
+       " 'test/7613042504cd73273ab2607cf518ba92.jpg',\n",
+       " 'test/b49d77d44fff249f62118af19f3468c2.jpg',\n",
+       " 'test/58657786baaa98ea777000c3a3b4e899.jpg',\n",
+       " 'test/5489187518477ed3110942da76c30f91.jpg',\n",
+       " 'test/57ff0f64f17597e00f58aa6db0392f83.jpg',\n",
+       " 'test/00225dcd3e4d2410dd53239f95c0352f.jpg',\n",
+       " 'test/c90109fe5971384b82dc9d4085609d5b.jpg',\n",
+       " 'test/3e764ad13028326c980cdb1263e70ef0.jpg',\n",
+       " 'test/69be99b844287176383f857ee406df75.jpg',\n",
+       " 'test/9cccecca16c742f03c63da72b19e4d0b.jpg',\n",
+       " 'test/214e5c3f441c8608c29eb76182b3f66a.jpg',\n",
+       " 'test/aa8175f0fd2d1a16d75dbb339b372a5b.jpg',\n",
+       " 'test/b9e8990b15b719aba1e1621cfa63f636.jpg',\n",
+       " 'test/4e06ab5e4129cd603e8a5df22ae9dcfc.jpg',\n",
+       " 'test/0e0ba1c25d4f30cd8a6b87ecc54f38b6.jpg',\n",
+       " 'test/2dca1e75b099224d925c3512a8bf252b.jpg',\n",
+       " 'test/7d48bba12b3f425324b987bfc3fef74f.jpg',\n",
+       " 'test/d6434ecc4fcc7c8fe4b463e956481de1.jpg',\n",
+       " 'test/d9d9c99f2c03d23f178441f8713798b6.jpg',\n",
+       " 'test/05eb4d66296f21bc9782688414fdbe17.jpg',\n",
+       " 'test/8f7822c77aa8149639490731c09b478a.jpg',\n",
+       " 'test/61307a91fa0311f071c568faf1a372c3.jpg',\n",
+       " 'test/452e58a7cfc482391e5ed7a25201f446.jpg',\n",
+       " 'test/844a8bc3ae10f267e8838fecfa5871fd.jpg',\n",
+       " 'test/9a9f274697e2d195724c3e9f466eef25.jpg',\n",
+       " 'test/dd2228d2fbb3ddc8fb350106c2d989ef.jpg',\n",
+       " 'test/ed0c3f827519441d3d542944978aedad.jpg',\n",
+       " 'test/d354419a80463739ce343ad80c3a906b.jpg',\n",
+       " 'test/70b9453812ebb5a91dc7860b2b26ab87.jpg',\n",
+       " 'test/e4b7ff61849485992246c0f2ab7e8804.jpg',\n",
+       " 'test/1439e842cb9f8b2c3fcc64806cf82728.jpg',\n",
+       " 'test/8ea913fc454a2628a5012d0dde92678c.jpg',\n",
+       " 'test/98ab98e40fc6786a5441eb6a1ef628ca.jpg',\n",
+       " 'test/84706e80023d20f30f1cf4f69741f9dc.jpg',\n",
+       " 'test/dce8d03553ab29570f67a28bf0ee0709.jpg',\n",
+       " 'test/45d5e4a25b7fc78c4439f6be2ffd4540.jpg',\n",
+       " 'test/df9ee3c663b1f2ca84781c09fa8c31f8.jpg',\n",
+       " 'test/762c598988525da91610c46e7a690343.jpg',\n",
+       " 'test/969b6b76b1e57682cb66eb18d24918c9.jpg',\n",
+       " 'test/7ebdd13f29a86637dffab6a2bf6945a4.jpg',\n",
+       " 'test/3bf061e6985f4b74f622cc54bb1cd5fd.jpg',\n",
+       " 'test/e43f6e621469f438f351d31d889b839f.jpg',\n",
+       " 'test/94e6990e098745b875219aa29b53e05f.jpg',\n",
+       " 'test/61a2bf4fc6f35bff211a298b6fc23d8d.jpg',\n",
+       " 'test/fcef727e767ef68b3973bfd25ad41305.jpg',\n",
+       " 'test/4c7fc253026fa9f6bc8583123692633b.jpg',\n",
+       " 'test/c9f781b5b98e347b854fb8cfaf0328d2.jpg',\n",
+       " 'test/693f2b472f62bfb69ef2a443175df06d.jpg',\n",
+       " 'test/ca8bf19cb287abbbf9cd8e1d8ea41355.jpg',\n",
+       " 'test/61e105759437e35bcb9630bca0e6bc7d.jpg',\n",
+       " 'test/23a849cf21f4a759477f1013997af060.jpg',\n",
+       " 'test/615499312d797d41a24a386cf7049b31.jpg',\n",
+       " 'test/dcddc9135d0a138bb83a55bbc06adacc.jpg',\n",
+       " 'test/bcd3f3f8402b5b476ca6d6c5fe1661bd.jpg',\n",
+       " 'test/d16cf4793e35e275e539cadfa7d1196d.jpg',\n",
+       " 'test/bd324712e1758b65a450dd065b384b1b.jpg',\n",
+       " 'test/fc0f848abb459c9dc98c455356788516.jpg',\n",
+       " 'test/e1e6d180a31b0a9c0d741d0f142ea6af.jpg',\n",
+       " 'test/90e3c749b540a5399091d9aa79c6498f.jpg',\n",
+       " 'test/10c4c824396380cbc41c36f28b1b9baf.jpg',\n",
+       " 'test/4e5db847af4d184dfc7a2ccee550432a.jpg',\n",
+       " 'test/bc7fbe41176e246289fed59d47af17d7.jpg',\n",
+       " 'test/4692b7d214fafbff4266a3a8678a1fd6.jpg',\n",
+       " 'test/2cc09f27c6e1e8e88172367cea8c3780.jpg',\n",
+       " 'test/6d1f9d9b9da664c396aef5cad54a8ed8.jpg',\n",
+       " 'test/e35b90290702042d17ceee2aaf2d1475.jpg',\n",
+       " 'test/90a3e77e8802823f857c32d281f3397b.jpg',\n",
+       " 'test/5bdecbb70e574f7427bfc869a7311ff3.jpg',\n",
+       " 'test/d4084988b2bc28dcc901be3666bee7f5.jpg',\n",
+       " 'test/7ba0334452749bbb7c49cf75c8a5e949.jpg',\n",
+       " 'test/988d031d16dbc136432726cb3bb53294.jpg',\n",
+       " 'test/9cc2fe1b331667444eb25b60deebf645.jpg',\n",
+       " 'test/436905a18153b169c71cc3ab7fb2091c.jpg',\n",
+       " 'test/36ad4269f38b87653eb7aeb70101f0ae.jpg',\n",
+       " 'test/9eaa7a13f259e77cd0b57e824ac7cd8f.jpg',\n",
+       " 'test/77c922894ce01be17d3016a377f985d1.jpg',\n",
+       " 'test/9a5d178c8e74fcd1363759ff679989ae.jpg',\n",
+       " 'test/f9c1fec06778d69677c24dacfb9f4840.jpg',\n",
+       " 'test/32c9cfccb110a85a09a1f5ad73bedaf4.jpg',\n",
+       " 'test/97d4ed796a33f67ebbec96b7ecc2dc22.jpg',\n",
+       " 'test/4d306cc7f5b127fe31f6094c0f3fbc09.jpg',\n",
+       " 'test/426dfd819da9c855bc00123b2cb2aa09.jpg',\n",
+       " 'test/29ee32e55ed89846115db9088e4cbada.jpg',\n",
+       " 'test/2972fed195a90795186fabc9ff7e409c.jpg',\n",
+       " 'test/a0b7a24c1fa6ddbb4a648ea7b8fc4eb0.jpg',\n",
+       " 'test/d18faeca0980bb364e31d69e662b3511.jpg',\n",
+       " 'test/0a0b97441050bba8e733506de4655ea1.jpg',\n",
+       " 'test/c01ef8dd3edaaa5cd03cab3b9a4a7fd2.jpg',\n",
+       " 'test/78eca7a75e7f42a5699e5801eb56a46f.jpg',\n",
+       " 'test/3ed792220e96f6c5eddbc4681da9b2a5.jpg',\n",
+       " 'test/f681821203c5ff0a675b6f998767e4ab.jpg',\n",
+       " 'test/3e45415cd08b2cef738fe2e373123daf.jpg',\n",
+       " 'test/890bf4dfb17c971e1303d7f57577c841.jpg',\n",
+       " 'test/522b3f3f94bb5deebebe2c43fb2e70c2.jpg',\n",
+       " 'test/6d41ac100737f33db95996bdae59bad1.jpg',\n",
+       " 'test/6d68a6ba3914c95014efc8dbb1bc2c72.jpg',\n",
+       " 'test/a3dbbb37c62f7cfd4e1b4d2795aaf7de.jpg',\n",
+       " 'test/3a43689ad0c3a2a3989cd670697fb7de.jpg',\n",
+       " 'test/5ba6afea1f5e415f5a6e762f4fed0344.jpg',\n",
+       " 'test/42d47502a728ebb752db63871329f09a.jpg',\n",
+       " 'test/129107cbe7b96bdd10d61811c8f70686.jpg',\n",
+       " 'test/283109fef09eb536e61f334e6945c7eb.jpg',\n",
+       " 'test/f7fda1184e21dcd0cb94086cac9ee762.jpg',\n",
+       " 'test/cbf2d65fae046a5aa45bb3ed58f838f6.jpg',\n",
+       " 'test/35a0b143e2927ad5d6125e6b33312c9a.jpg',\n",
+       " 'test/6236d7ce8173737bf3caf7270184bc76.jpg',\n",
+       " 'test/02804190c4ffc82b073d9f0036f66bc6.jpg',\n",
+       " 'test/9bdee231306efbac04ef1280c2ab2fa0.jpg',\n",
+       " 'test/7015592b41f682ee0604ab1024fde5ab.jpg',\n",
+       " 'test/8ffb64ee0970306a0b01f7a2a8da73eb.jpg',\n",
+       " 'test/0656e4606d4a98f2e8c8452416ac1ea0.jpg',\n",
+       " 'test/58c35fe95f8466c8136550467d5121a7.jpg',\n",
+       " 'test/578bd79f99ac25b93362847a6e505e21.jpg',\n",
+       " 'test/6c750aa0f0f37f89d942b674279b3bac.jpg',\n",
+       " 'test/61bca8b109157bcd0bbcc083b6590e3b.jpg',\n",
+       " 'test/e0d51afc60c25eb2205be1644af09cc5.jpg',\n",
+       " 'test/15e1e7f0c942bc77e04097abcf18f6e3.jpg',\n",
+       " 'test/93102b5b9f01ffcf30ddf0fe2cb17a59.jpg',\n",
+       " 'test/4068db24e52f8d67c667d6b035036b19.jpg',\n",
+       " 'test/d5292fc676d046dac6c1d29e2a03e3a2.jpg',\n",
+       " 'test/fdf6e6be8630044c6d14df570849cf44.jpg',\n",
+       " 'test/37e091359191cf82e1d2adc38d5f0c64.jpg',\n",
+       " 'test/e65d6492c026c925660d80543664b8a7.jpg',\n",
+       " 'test/3f999cf1693fa903bf7dd6164dd46e59.jpg',\n",
+       " 'test/8e25febdc662f5e500efe8ba2cf44cae.jpg',\n",
+       " 'test/4ef2b99d3028844d067feda58dc5f1f0.jpg',\n",
+       " 'test/feb308ce2a7ad3d84e84807efae21518.jpg',\n",
+       " 'test/ca97512cc0f458942025ee480023bc95.jpg',\n",
+       " 'test/14c184c41c90fdcca3411e730ae4737c.jpg',\n",
+       " 'test/8c543f881fbed3b143f8eef96968514e.jpg',\n",
+       " 'test/8aa49bb2a9dddc1b22b98c31689f9e38.jpg',\n",
+       " 'test/b7b0553cd3215f530ee06bd126630c3a.jpg',\n",
+       " 'test/8e649b689c5f156ac0c0d0a7ebadf965.jpg',\n",
+       " 'test/fa717a1532249d9c0532378c80c46c8e.jpg',\n",
+       " 'test/37f91f5de2d6ecedb6abebff33d7fa17.jpg',\n",
+       " 'test/52c2021a5ec2aa05e841df52b6a97d41.jpg',\n",
+       " 'test/a04ec5d3e358109699247c1d60dd6d2e.jpg',\n",
+       " 'test/83b3a854863d6e7047bee089969663ff.jpg',\n",
+       " 'test/59f49b780e38528b3234abc5842eff67.jpg',\n",
+       " 'test/379c3539bed019806f08b52163cbc2d2.jpg',\n",
+       " 'test/3c12e379d2378cd7a996bdeb825e3c10.jpg',\n",
+       " 'test/065e0b70a690e06a826885b454622928.jpg',\n",
+       " 'test/53d336cdfe574e917155b300ae3e5cca.jpg',\n",
+       " 'test/95e14fef6ed902998eac129ec69fb805.jpg',\n",
+       " 'test/2775e3092b56166daec6df4a38a14368.jpg',\n",
+       " 'test/50f60661565a02c5b96f446f089832e6.jpg',\n",
+       " 'test/c4e5a86214f9ac9b28c7381009b708ca.jpg',\n",
+       " 'test/496e85b1192c522cae8b0a7919ff6ae9.jpg',\n",
+       " 'test/4384fc6887440d1d46dafbd0a6bdad71.jpg',\n",
+       " 'test/ef9432cc6dc7ab7ba38d18abffe6d1a0.jpg',\n",
+       " 'test/7cb70171e113b88bf215260c25f55d2b.jpg',\n",
+       " 'test/35aaea679a279ceec46f649f0590f325.jpg',\n",
+       " 'test/4a5d85b5525bf424f90a2928a13b047d.jpg',\n",
+       " 'test/d00a9cb79ee6edbdb0e683de51a8f50a.jpg',\n",
+       " 'test/20d1255f2c5c32baa6c0a6cbb659a184.jpg',\n",
+       " 'test/4d99cb036a4b902a121201ffaba48965.jpg',\n",
+       " 'test/f73c6b6891b3e40a6bc9dd26f4e65767.jpg',\n",
+       " 'test/174e1bc31c5da607dda786cc43eeaa50.jpg',\n",
+       " 'test/38727f56b82312db412d2df2ef718bb6.jpg',\n",
+       " 'test/d6cad6b7f0a8a36e58a1f98d71e823ce.jpg',\n",
+       " 'test/ef4c9b0875ec51068b2720a01fa36b65.jpg',\n",
+       " 'test/6063fa5fef88446f86b8081bdf12d9e6.jpg',\n",
+       " 'test/09cbd98c55f58ad0535b5066c72e6e42.jpg',\n",
+       " 'test/f4a2ee1dd5542da8b0150fe8f7a2b7c3.jpg',\n",
+       " 'test/09612c47e84bcdf06c8e5a99ac1a8bd2.jpg',\n",
+       " 'test/6cd1a9cbd3d52ed1fd1c07630dd77505.jpg',\n",
+       " 'test/6d15ae3e88e32472a777752502f5ef61.jpg',\n",
+       " 'test/afb7f1305285c47c360c2a21284425cb.jpg',\n",
+       " 'test/4ea0130ffbe06871063bc51d23894b12.jpg',\n",
+       " 'test/18c3a6f7569d115f3663e75677565550.jpg',\n",
+       " 'test/63f945388f3013dc10f8e2c740ad9552.jpg',\n",
+       " 'test/e06fdea86b416e992137ad52bb5da5a8.jpg',\n",
+       " 'test/22dfa94e131e840a76e4961c3455004b.jpg',\n",
+       " 'test/ad889aca15b6168db4dd7133ac5a8ba4.jpg',\n",
+       " 'test/51dc2e213c35d513d9759a29eb652472.jpg',\n",
+       " 'test/da7be6ae218a4e5addcaa34cfb2d4fa3.jpg',\n",
+       " 'test/0854e34e53c9dd84579d4c37086dbdf5.jpg',\n",
+       " 'test/fb0416a56859decbc1f5f6994687b16b.jpg',\n",
+       " 'test/d4b35622d0df5814f4056812d7507e50.jpg',\n",
+       " 'test/f56b4140707da82fe91cb9e5df4ce68c.jpg',\n",
+       " 'test/ef413ae9b0de80605bc95de2d12a4082.jpg',\n",
+       " 'test/2bf6d0177046ba8936973513f3eafce0.jpg',\n",
+       " 'test/6dde5ecd74b830cab77c57dad4f39024.jpg',\n",
+       " 'test/f10c58048410333d9c4156046b0ea54f.jpg',\n",
+       " 'test/b1040aa860eed1715e03883b94764c4a.jpg',\n",
+       " 'test/3304bb6f7dba8b14fb7ff61bef70cea9.jpg',\n",
+       " 'test/e55534e27f92b4c8177ed2beb1cbba7b.jpg',\n",
+       " 'test/eb8473f9fc102c45e0c0abd07de20a2a.jpg',\n",
+       " 'test/f90ace46a8ccf051f6f7ec783ad8e258.jpg',\n",
+       " 'test/33d4943b93b8c14459ec8a7c5d35cc25.jpg',\n",
+       " 'test/420ca2f011341d6e70558c6e2b46b258.jpg',\n",
+       " 'test/ff357aadc868c7b38e17bd5b87de31be.jpg',\n",
+       " 'test/06e9d34793f7cb6915f3f2b2e6f7fabe.jpg',\n",
+       " 'test/5ef10a9edd5c5bb11c1cc4d5a4df566f.jpg',\n",
+       " 'test/429003ca7c11f0dca8153c427316baeb.jpg',\n",
+       " 'test/9e1198eb00e2bb4cf66dffdc0abfdcec.jpg',\n",
+       " 'test/3fed2e25badf7b5e8c12a4b71098e132.jpg',\n",
+       " 'test/cd0a8261be06236f76518a976d38c071.jpg',\n",
+       " 'test/0954e09deca15b755d04a7826264da61.jpg',\n",
+       " 'test/c4011f49046784b517ce9e0a47ed3013.jpg',\n",
+       " 'test/c6866b837d54f3f136250e02a79976a0.jpg',\n",
+       " 'test/eeb73a13b70170c416aab67eac15fdfb.jpg',\n",
+       " 'test/9f57531651e9b35af426537ad10fbc57.jpg',\n",
+       " 'test/77fbc571d85238151072c9ef7d0f4c9e.jpg',\n",
+       " 'test/6c4a4565e1d0906cb370d01efe64ac16.jpg',\n",
+       " 'test/9d6923ebe18f316321de8b27da18ed5a.jpg',\n",
+       " 'test/5bad43e776606caab0912c9e7f0e75ff.jpg',\n",
+       " 'test/89838ed67f3fed8e3c66a2d697de47d8.jpg',\n",
+       " 'test/d90cc1b8fe0ac4fddc6241579378103c.jpg',\n",
+       " 'test/e91ffd67dd303f59029d041ff4fb65b8.jpg',\n",
+       " 'test/6dc95536e52a5b170b7ae72b6a1fee58.jpg',\n",
+       " 'test/f45014f665123584d3588802ee020bce.jpg',\n",
+       " 'test/518e16d098116b14a9ce2fdc4b80c06e.jpg',\n",
+       " 'test/b7389c527b5ba629b036d30bd74a49ec.jpg',\n",
+       " 'test/82ec6bdf968a14923340179515ce5546.jpg',\n",
+       " 'test/88acf79ce25c72f682e272e658725726.jpg',\n",
+       " 'test/7f55af43e287c09bf1b1b2423c1942ed.jpg',\n",
+       " 'test/364c84967c6ecf534c54cf06e20fc3fc.jpg',\n",
+       " 'test/cb54c8c517dc12da27e5a3b72f1a1411.jpg',\n",
+       " 'test/1cc56ea149a97f5c3b7844bdfda095d0.jpg',\n",
+       " 'test/c55000d37452394e64cd05c99a645e4c.jpg',\n",
+       " 'test/7edf77f00dcc7151013e71828cded079.jpg',\n",
+       " 'test/5f571aa094aff976ca384870f58f21ae.jpg',\n",
+       " 'test/6423e27d0255a4e237adb4993c229d26.jpg',\n",
+       " 'test/e3f04efb648b110b2eb04b9c041504d8.jpg',\n",
+       " 'test/3bbdb72ff6a0ad3b87077ff38b3ec468.jpg',\n",
+       " 'test/1b6828700205a5552e8ab2464647021f.jpg',\n",
+       " 'test/afdf981978119904e3303015913f4a79.jpg',\n",
+       " 'test/01cb4c4d181a23e157429168e948fe5a.jpg',\n",
+       " 'test/069f97f28c811705453d84528a7af240.jpg',\n",
+       " 'test/df86ba50c4d0b597af0d23bda37eb10e.jpg',\n",
+       " 'test/9d5350d6dddfb91fd8929607358de3a3.jpg',\n",
+       " 'test/d6312b7f6caf8db9d5fc88bba505813c.jpg',\n",
+       " 'test/c22ae24c27a5cc9096f25f1fe438259f.jpg',\n",
+       " 'test/22f8e7b687205a4a6a6f0ffd3bc507e1.jpg',\n",
+       " 'test/e71d9f32ea6eb1c2d944e8f4e811c209.jpg',\n",
+       " 'test/7328b1eee0be05c80f119753aa4623de.jpg',\n",
+       " 'test/f928a71d3356833e8c46734938c04cd7.jpg',\n",
+       " 'test/df577444ba8b7733f42c49e9d42111a9.jpg',\n",
+       " 'test/e4729bf465eac43afb6b04687d4703c3.jpg',\n",
+       " 'test/4d87c82f9698058f80a90e55e6376c3f.jpg',\n",
+       " 'test/1fdcbe1bcd80c118461512790a250e67.jpg',\n",
+       " 'test/3b81256ebf571a6af1f7be482b50cc7f.jpg',\n",
+       " 'test/c8a02332902fb932af7edb0675ccbf75.jpg',\n",
+       " 'test/0c6176b396e31ce7666185aa435be7e0.jpg',\n",
+       " 'test/6afa4800e25bf15e88599895e90b67b4.jpg',\n",
+       " 'test/3d1a15fec91e3648daaf273373a1c03d.jpg',\n",
+       " 'test/32df03ced7bcadd5594e95c2f461c05f.jpg',\n",
+       " 'test/2a23d2cc0635ee44798c5a0497927ac6.jpg',\n",
+       " 'test/722f83aa7a932ed3d8b3f7dade17a456.jpg',\n",
+       " 'test/86ca8cf0f5a914825f88d62908d5cb55.jpg',\n",
+       " 'test/ce28dda9cd9cd616d38527b263bc292a.jpg',\n",
+       " 'test/b19f7853f6b2b84a99fc3b7c8a8eaa64.jpg',\n",
+       " 'test/7852e7963247e079c2df5b542ba5db89.jpg',\n",
+       " 'test/4df248dcad4b6629b1a830070900d321.jpg',\n",
+       " 'test/9b348ce9f36574e99cc664f5aa8cf5f7.jpg',\n",
+       " 'test/fc50b817f059dbfff5fa1857d7769cc2.jpg',\n",
+       " 'test/f0ceb5eb780eba366f9a077486fe003d.jpg',\n",
+       " 'test/43333944508ef210c0a8dc5c3700a90c.jpg',\n",
+       " 'test/e440ec011c3c7ea94838ab5fc466159c.jpg',\n",
+       " 'test/08b34271d7d196d13bbeeea99504e099.jpg',\n",
+       " 'test/8b842f121c77fc2ca1eaac41fea241cf.jpg',\n",
+       " 'test/3d47c7d4b52c2d609d318dfcc416f839.jpg',\n",
+       " 'test/3b4bb3f2db01a65beee775a04313b25c.jpg',\n",
+       " 'test/255a2dcc7259be7f3591dad9c9043366.jpg',\n",
+       " 'test/92d8c1fd586f6565c82d6828335cac14.jpg',\n",
+       " 'test/6a44393dbb58504bd749db6cc825255d.jpg',\n",
+       " 'test/92c5cb90c59782ec6b87ddad45216295.jpg',\n",
+       " 'test/8d243d285e72a16d8c266866f5e6738e.jpg',\n",
+       " 'test/f83d03d1949ebedbbe8bb49debac8af9.jpg',\n",
+       " 'test/d07116a8e1777f6d360aa434377f32f1.jpg',\n",
+       " 'test/1cb17b18aeb47d13e7bec401cc42e79e.jpg',\n",
+       " 'test/5e071adbfa8d739c1fa3d5015ec6028f.jpg',\n",
+       " 'test/09d5118c848bc579eff8cfb669fd7aa1.jpg',\n",
+       " 'test/6a7c935d30ed7694422f5e74093082ca.jpg',\n",
+       " 'test/6f789dbed826fd84e76b697730f6e70c.jpg',\n",
+       " 'test/c2cfcfebb375fde437807ded4c172460.jpg',\n",
+       " 'test/7b1883b3c99c234dc623b842ce5cfb63.jpg',\n",
+       " 'test/e9b16b4bdf5b0561fc7c69b2f36e1a7e.jpg',\n",
+       " 'test/75eb74a82c3dfd4d8b20c8165f273707.jpg',\n",
+       " 'test/94cd0c3d8776791a957b9c8e53bbdf6b.jpg',\n",
+       " 'test/78e0d148de61ae803d373c5a7e65a228.jpg',\n",
+       " 'test/ec25ce11616bda2e8b7669c415128768.jpg',\n",
+       " 'test/c10d6f9e470ee1be933d81f8388c92fb.jpg',\n",
+       " 'test/dd3eb4338145e614d325a917a35e5a1e.jpg',\n",
+       " 'test/2f1ce585a580daa2d3ccdc51bc8b66ad.jpg',\n",
+       " 'test/d9ad7f21c3efa2f7a9bf39835214b5a5.jpg',\n",
+       " 'test/05bb6919c2dc679ea70ffc632f68ee2b.jpg',\n",
+       " 'test/3839723ca994957060885ee8e69c97c6.jpg',\n",
+       " 'test/1a38ab01d6a18a4693a57125fb7f0370.jpg',\n",
+       " 'test/6951fc251261f1c8148a518bee464126.jpg',\n",
+       " 'test/a562ab222aa5c4ea685da464c74ec8ba.jpg',\n",
+       " 'test/fb0aa9d598d54e50963be105661944dc.jpg',\n",
+       " 'test/1aa65d339d033885cabcd9ea067cf4f1.jpg',\n",
+       " 'test/950618805a891d92ba13229d237a0b86.jpg',\n",
+       " 'test/5a87f43ce9ff04627459d1caddd8c36d.jpg',\n",
+       " 'test/86584e58605edfc9ef50fef65beac0e2.jpg',\n",
+       " 'test/f86aa3a7e56a78d9931710865d05632d.jpg',\n",
+       " 'test/8d4c922dc3b59b2ad867ebeeca0d187f.jpg',\n",
+       " 'test/e4c743b9aaf615dd5fe162bf25f82fb5.jpg',\n",
+       " 'test/176db83947685a07cd11fa338bc629d6.jpg',\n",
+       " 'test/e411a1b3681604f6321af7cb8e8f2de7.jpg',\n",
+       " 'test/28e205cf6a6ff6f12b261eef8305766f.jpg',\n",
+       " 'test/3a438bd21a911c958c26351f8c65863c.jpg',\n",
+       " 'test/f37106dba00385993428e7c557b15805.jpg',\n",
+       " 'test/926655bc5ed1284e29fbc8d6e232757a.jpg',\n",
+       " 'test/32079b3920b2060221ea265401d93b62.jpg',\n",
+       " 'test/8a8dda8d9a2747ebfeaedb7bfcd38e19.jpg',\n",
+       " 'test/1be3650327dcff01488a0764353215ee.jpg',\n",
+       " 'test/6ae629d5ce69859d99f19646b9480910.jpg',\n",
+       " 'test/9dcd7b11a8912762da46d5f69732e505.jpg',\n",
+       " 'test/5f341ee24ded57979d4cd6a0839de824.jpg',\n",
+       " 'test/1eaa414c22931039f4e8b9502f88daf9.jpg',\n",
+       " 'test/4c2d4c51a554a781b69adae6f7c27643.jpg',\n",
+       " 'test/1ae26ef205f733fbb084c8aeae253b25.jpg',\n",
+       " 'test/cd3a666d082b6cb9a44ddb1dca5eedc9.jpg',\n",
+       " 'test/d8e7a8dd3d639116edfad1a9d1463130.jpg',\n",
+       " 'test/0dc570ec7086bab004a7e357164c04b8.jpg',\n",
+       " 'test/24f3f3e9af7ab0f4aea5b1b9cb0c0ab5.jpg',\n",
+       " 'test/55cffce6ffb1167881fdefe1615dee87.jpg',\n",
+       " 'test/4ec9d65e78c1c468ce371c4141d0d301.jpg',\n",
+       " 'test/b3076a6451bc471a6e2f05961de08aee.jpg',\n",
+       " 'test/f1fdf296d0252b3dfb46f1bfc37bcb63.jpg',\n",
+       " 'test/df2ce797bf398414aac7e20119c17cb6.jpg',\n",
+       " 'test/4cf0fcba95a9fbadc5a7ca4d7d01bbe7.jpg',\n",
+       " 'test/6f7c713bd7dec32b0a8d07dd4822d256.jpg',\n",
+       " 'test/e3982348ad8b974cef2298f741bc3c99.jpg',\n",
+       " 'test/223d756d28558360245944689cc2a988.jpg',\n",
+       " 'test/79829c383cbbf0aafafc5baefabd69ea.jpg',\n",
+       " 'test/d15e9804516670c47818f0f8258192eb.jpg',\n",
+       " 'test/525fd146a1434d54b38e75ca89e7c066.jpg',\n",
+       " 'test/dcdffa00518844bd21499db49979f9c8.jpg',\n",
+       " 'test/c24dd508285cd0484772e5a1abd87d3a.jpg',\n",
+       " 'test/bc6fc592b894e75a837a9c31bfec8655.jpg',\n",
+       " 'test/eaa65260eb9a2f7d3b5484ac97962788.jpg',\n",
+       " 'test/2fe3402ae5732b553ee6cb6076544fec.jpg',\n",
+       " 'test/a561fb8f5db3f033a2d01fefd097c94e.jpg',\n",
+       " 'test/c69c44572a5df3b7a9ac93e9071453dc.jpg',\n",
+       " 'test/d6d08fe634318194555a9419180d4ab0.jpg',\n",
+       " 'test/16c99eae8d1d81d632d5a76fa9448a68.jpg',\n",
+       " 'test/5cad010642dd82c686e4b8415eeaf347.jpg',\n",
+       " 'test/151b1e8efd6f63184058b983e10ff829.jpg',\n",
+       " 'test/70ef7f40159718bfb3683dec7c125b4b.jpg',\n",
+       " 'test/13b6f9b3dcbab9a4ba4b5c3de3cd5f6f.jpg',\n",
+       " 'test/4ec6fe076b150ca77641a4bf676d89c4.jpg',\n",
+       " 'test/329d3d6fea50b2ce65c611fd5b31d1d2.jpg',\n",
+       " 'test/bb0c7d7af4bdc0d3646afaf1339a15f2.jpg',\n",
+       " 'test/0110fb82ad93572bd6f5dae4b048037d.jpg',\n",
+       " 'test/e2888231cedd08540816e629c0733922.jpg',\n",
+       " 'test/cc8599c4a791441bd97a511a9474403d.jpg',\n",
+       " 'test/f407f19970c6d8d516722e899adc599c.jpg',\n",
+       " 'test/85c78df191958f1751aa118e6d3021aa.jpg',\n",
+       " 'test/f96722fdd8a6a0e9ff86eee619cec34d.jpg',\n",
+       " 'test/faf757243722ea255b9b190cd251b9d6.jpg',\n",
+       " 'test/db11b427fa998df38056fb050debd8eb.jpg',\n",
+       " 'test/565205413fb320b9387a99d344545b2b.jpg',\n",
+       " 'test/9dc6dbeed6a6cfc487456999acd35ae6.jpg',\n",
+       " 'test/25ba0484e0c90b93cefc170e5489c2f0.jpg',\n",
+       " 'test/768d51ef6eaa0b1ecf85b59f0fb832ab.jpg',\n",
+       " 'test/e2b4d6b6590fa2941e74238248093eb3.jpg',\n",
+       " 'test/574953f707e8c12b0349ca4c6fea9e3a.jpg',\n",
+       " 'test/b370ddfbcc1d5f3f694d424a3a9d096f.jpg',\n",
+       " 'test/74a50646dfd99459faf8c1a626c53795.jpg',\n",
+       " 'test/000621fb3cbb32d8935728e48679680e.jpg',\n",
+       " 'test/a1cb6364a59b4820943d1b4ff58800ec.jpg',\n",
+       " 'test/3a81b80e36c91964a3f01e5813a22a79.jpg',\n",
+       " 'test/610555087abc35e584044750d7154609.jpg',\n",
+       " 'test/56d6c58aa719ec8d4f8f513800578f8c.jpg',\n",
+       " 'test/67d17625287f1a4b64124f6065ec8701.jpg',\n",
+       " 'test/517ecc5a496cfff2b6372c26abe4c91b.jpg',\n",
+       " 'test/91faba2e7bd694aec44c6d91e386445b.jpg',\n",
+       " 'test/1228d5ff93a39830f6c36012a106f4c5.jpg',\n",
+       " 'test/9e72af813948e3349bc6b3454b4a6e52.jpg',\n",
+       " 'test/5c4503ac01840e7a9307b5e33acae248.jpg',\n",
+       " 'test/7b1fddc813adcb2b3519cb590d82f62e.jpg',\n",
+       " 'test/982457d7157c74ceeef40725a8412002.jpg',\n",
+       " 'test/7b4a5c0a390fc553a71bf4fddb4b05aa.jpg',\n",
+       " 'test/a0d9fe41fcaae599e8e133cd8a0ee688.jpg',\n",
+       " 'test/ff8f9a768544fda79ffad62576f4d129.jpg',\n",
+       " 'test/5325c84dafeec70d457b992795294317.jpg',\n",
+       " 'test/4de2ba963d28c9ade288ec40ba54afb9.jpg',\n",
+       " 'test/ae9b177d97d0d08bc6f1fd5a592ccc13.jpg',\n",
+       " 'test/538e7a043f4435bb7b4be8fbdc73f2d9.jpg',\n",
+       " 'test/9041d7c2bd1af2418962950cd8a2b885.jpg',\n",
+       " 'test/3fbeb111e0468e8c23f5746738054efa.jpg',\n",
+       " 'test/93f5a3810fde3ddc40ccccab4dc0487b.jpg',\n",
+       " 'test/48a865b32601a719b6748c194c8351bf.jpg',\n",
+       " 'test/dd7bf84df93991b7c15ec739c82acc04.jpg',\n",
+       " 'test/a2e03e4bca79b6858bdc707142dd8391.jpg',\n",
+       " 'test/6a393de9df49d1e313f0a3dd42aa2815.jpg',\n",
+       " 'test/7ca5580d25264b2454908b5346ff3281.jpg',\n",
+       " 'test/0a51fbac72fac75df279e18e4b1c042f.jpg',\n",
+       " 'test/e3c97ed588b32f49c7aae65cf91f17ba.jpg',\n",
+       " 'test/03af64f714d918ca61ba22d011816beb.jpg',\n",
+       " 'test/71cd1ef653a545062093510ab36004b7.jpg',\n",
+       " 'test/900c2fdffec1ca6956208ff7a236926e.jpg',\n",
+       " 'test/e17512584de423da7fc17bfb2c7548ae.jpg',\n",
+       " 'test/7cf2350be70ed2d335a54952fc6bb30e.jpg',\n",
+       " 'test/10dbf30635323f90703abc5d76493902.jpg',\n",
+       " 'test/1bf8b6d0b362943130a9fd6b2751913c.jpg',\n",
+       " 'test/0ae4367c7f7149a43b0e5b1c07ce7ed9.jpg',\n",
+       " 'test/d5029b3d5fb11beb988ea56e0f19e2e1.jpg',\n",
+       " 'test/7ee7bb563c55c1e40edc29928a5c0162.jpg',\n",
+       " 'test/65bd5879ec1bd32bd87a1c1ab54a0014.jpg',\n",
+       " 'test/c2d87315df1b02017edd04f30f8b60fa.jpg',\n",
+       " 'test/7490f284d304412d3641a67d298a094a.jpg',\n",
+       " 'test/7046540577c4b66cf19936231d391b8e.jpg',\n",
+       " 'test/dff6d0e5746812e0e5808c0e69a20574.jpg',\n",
+       " 'test/cedd6b0da3b4070ff7c7a185b85c7504.jpg',\n",
+       " 'test/49c5c75c9477167654a1c41937a866b7.jpg',\n",
+       " 'test/201bdc6f7a8b0fde297d1291fcd31380.jpg',\n",
+       " 'test/9bf93ac268122f8985cd9dcafa2e3a85.jpg',\n",
+       " 'test/3affbc524a54d1dcdf58bf0c3b96153f.jpg',\n",
+       " 'test/1c082570531b3fb68e82f06695d89de8.jpg',\n",
+       " 'test/067e053858f0cdbc2417c0ce58cdfafe.jpg',\n",
+       " 'test/c72a0bdabba7a8c21f04683e98794a23.jpg',\n",
+       " 'test/683036e204cc9f8ddfbe56c3d63ffe01.jpg',\n",
+       " 'test/b9aecb05c7f833a31f5e7e9399812332.jpg',\n",
+       " 'test/d9ff293c85c9263083b0369b9bad654e.jpg',\n",
+       " 'test/86c2d71776b76d0c7acdf34a87b7f9c7.jpg',\n",
+       " 'test/6544e8463854c7d6ed90258bd413ef63.jpg',\n",
+       " 'test/73bd84ab7916a285734b4a89a50ee247.jpg',\n",
+       " 'test/6e6a470bdb033d53a5c997833d86c6f2.jpg',\n",
+       " 'test/6ddb1d1a49efa4b83d83f30ffc409458.jpg',\n",
+       " 'test/52154f155ae6ba4b812cd18113ad7453.jpg',\n",
+       " 'test/e4ba350279796ff15c3a634037a6f88e.jpg',\n",
+       " 'test/c5120a58c8b044f3968bb8bf8c281ac0.jpg',\n",
+       " 'test/53ef70b153e67576e282924876d3f27b.jpg',\n",
+       " 'test/e427b9e1ab1b7f09cfb02ac073f56f2d.jpg',\n",
+       " 'test/204c040a1ddbc2aec6d5e4b4d0e03c7e.jpg',\n",
+       " 'test/b0362cd1e195639de7b1fcf70324d40e.jpg',\n",
+       " 'test/8d7be90433c849873a2917b4cd0b9885.jpg',\n",
+       " 'test/769f02384fbd98f2963699b8cd891572.jpg',\n",
+       " 'test/15eb91d38d13be03d41639899e923053.jpg',\n",
+       " 'test/77cebfd9254b131e6d25ec7ba5195276.jpg',\n",
+       " 'test/4c4cc4c7b3fa4f5b1567ecfce59bf34f.jpg',\n",
+       " 'test/c17f8c8203cb68424ae67a010c354924.jpg',\n",
+       " 'test/bdebc49101b9af7ba9e46182661dc4b5.jpg',\n",
+       " 'test/a354ad4e3e240da15462005e40b4583c.jpg',\n",
+       " 'test/c156f32e908a46a6b4bbef72f6223905.jpg',\n",
+       " 'test/ae323e40a7e64968fdb2650078de7cd7.jpg',\n",
+       " 'test/d472bed5237cc2cce18007ea5ab43d4b.jpg',\n",
+       " 'test/3e2c021f8d38b7e434b926e12424a016.jpg',\n",
+       " 'test/65bd007dd322ac49c62bb86195e529ed.jpg',\n",
+       " 'test/4beff00d6b5285d5dff491a494da0220.jpg',\n",
+       " 'test/d4bf6045e3453d9a2cc117d3e86a1e00.jpg',\n",
+       " 'test/52b0846e26f28f8f1a1899ad98481782.jpg',\n",
+       " 'test/30ef42c5c84b11fa3052524706687bcd.jpg',\n",
+       " 'test/cace8abb5880d8042cc79832eedbbc8b.jpg',\n",
+       " 'test/46782af314bc08de257d893c3128ac4a.jpg',\n",
+       " 'test/d814acb8ca7e3288d8ac5ed47407f662.jpg',\n",
+       " 'test/89262d9a1f00dc5aa300905f58cbde69.jpg',\n",
+       " 'test/5b3c30550768b2ad4a53fcd023e8cbb4.jpg',\n",
+       " 'test/4bf924974410498a1d52d9eb45eb0703.jpg',\n",
+       " 'test/5028d2d148171673158c6ec80c03d8e7.jpg',\n",
+       " 'test/df47feaaf3dfb33cf712cccdddc8060e.jpg',\n",
+       " 'test/1c84ca95720f4b60129fd44085fdaa40.jpg',\n",
+       " 'test/3a7d676acddfbd7f5cb3fceab8cd3aa4.jpg',\n",
+       " 'test/8356f99f79e539a97028b1e4af918c43.jpg',\n",
+       " 'test/bddd379859e4fa187b1874b9e061597d.jpg',\n",
+       " 'test/75f8a13ae05b56eed204a33bf99287ed.jpg',\n",
+       " 'test/f7d150e11c972c850159603843939b28.jpg',\n",
+       " 'test/8bc098fd981ba69ebb346b6a1608b0b5.jpg',\n",
+       " 'test/a78056d00ebb14a104a5d7438319e81d.jpg',\n",
+       " 'test/28f7fbb3750d3256de932c58000a4c33.jpg',\n",
+       " 'test/0db3f774655ada5d6f78f2a3c31fd295.jpg',\n",
+       " 'test/3707f315aececfd4d4bf7953b75bc68a.jpg',\n",
+       " 'test/d7759e463e93114b57e12c56e7a13289.jpg',\n",
+       " 'test/c627411dae091af961dab2988c35923e.jpg',\n",
+       " 'test/9d97ca8c85b481e7b1245cd65ec8bd5f.jpg',\n",
+       " 'test/0cfa9ee8a8e0912bb06bfd575f70bfb7.jpg',\n",
+       " 'test/9ace4c5cced4fb88678a5b0a9b3f3cf1.jpg',\n",
+       " 'test/0cc2a9144cd3a2292a108a28d68c17fe.jpg',\n",
+       " 'test/d9cc62cf60266f824731f8a4e70ba718.jpg',\n",
+       " 'test/ff766d48f0804590391df24f73cb2118.jpg',\n",
+       " 'test/959bc1618cb81e9aa244a52db1246076.jpg',\n",
+       " 'test/54c746a1470981b3e80893a0c8a5f973.jpg',\n",
+       " 'test/f10241d199251db359961e814733efc5.jpg',\n",
+       " 'test/5dac8f13467994de6ba778df1cdba3fd.jpg',\n",
+       " 'test/da18208afba4420b0333c7fef7642ec7.jpg',\n",
+       " 'test/0f21800e7f10cc35725b82d34da94ce8.jpg',\n",
+       " 'test/58885a79643c3a480aa9dc2ebef7672c.jpg',\n",
+       " 'test/32b4850ac87ed096cfe5d583ed95f156.jpg',\n",
+       " 'test/5cf394488058748c8bf816140dd02107.jpg',\n",
+       " 'test/04fc2616e5e491538a989b7eb80d7860.jpg',\n",
+       " 'test/d16f5acab90d41f1ac0014944027d490.jpg',\n",
+       " 'test/1b3f21283d424bf4034571b58b9530bf.jpg',\n",
+       " 'test/c52df09d15f0e89580a937fb49e01a6d.jpg',\n",
+       " 'test/2de3603e679bd3174a0a2464611bf21e.jpg',\n",
+       " 'test/0630bc53549c1169cb9c081907a8cb05.jpg',\n",
+       " 'test/8584099bbb10d51cc5b88ef5c8645198.jpg',\n",
+       " 'test/ffd06687c72445b0c6e8a130a0a8711a.jpg',\n",
+       " 'test/0298eb3d74444d2c405639d51c220bc2.jpg',\n",
+       " 'test/1cd2f85ce25710e78d9531ac24f46746.jpg',\n",
+       " 'test/fbf4abbd32d544ff9b5df6af25eec3e3.jpg',\n",
+       " 'test/f603da0e3cfff2ea4d792c96fe5ebac6.jpg',\n",
+       " 'test/957379d51e207de4885b41d0b1758d8c.jpg',\n",
+       " 'test/0169ed6715e26c0c5fb460941c8d3bee.jpg',\n",
+       " 'test/74e40c5277dc098324dfba2ae27c4b22.jpg',\n",
+       " 'test/5e1940d82de5036864fb3a44fa49bd7c.jpg',\n",
+       " 'test/8534fce6132c02ccb01f71ff64a80b16.jpg',\n",
+       " 'test/4e3440f75b37f3d13c0d8c025b30d337.jpg',\n",
+       " 'test/f28b4d5899f9db2a2caa7a3361c847f1.jpg',\n",
+       " 'test/f2e4e4f1ab9d156443682dc4653f23e5.jpg',\n",
+       " 'test/fde6a7af1944348eb4ecd1268f49a549.jpg',\n",
+       " 'test/545c3279db44dc7c00ccded6eb2ccaa3.jpg',\n",
+       " 'test/9f6611b8dc4ef5b77e18135f713f8a4d.jpg',\n",
+       " 'test/9b5ff522c48a66c4a85eb418ad4a0ed0.jpg',\n",
+       " 'test/4dc316028cd0fa65ba6bf0f65f40c62b.jpg',\n",
+       " 'test/f1167eabf53759dad015f0abb813a451.jpg',\n",
+       " 'test/56e9e806e409775f6d292b66b8855b1e.jpg',\n",
+       " 'test/534c23db9b723108381515a30c3ccb6f.jpg',\n",
+       " 'test/581b48f1991aa16b4a365716fd4f03ff.jpg',\n",
+       " 'test/8217c57f3ce8505a6a262a0583720f13.jpg',\n",
+       " 'test/e806fbb5ca4dd3a094f7819bd810cc65.jpg',\n",
+       " 'test/3006a0d7c9e93709001323cccda8998c.jpg',\n",
+       " 'test/3510f5450c79d0ba4083a1b92195fd80.jpg',\n",
+       " 'test/341bd8a802798866f6fc1d13bfe53a34.jpg',\n",
+       " 'test/a4086a730b6c5011be6eee3bb3b92463.jpg',\n",
+       " 'test/cd20118a162237be1423e800a6e5094e.jpg',\n",
+       " 'test/ff1ed16edf355507ee740a67a6391d48.jpg',\n",
+       " 'test/12c3287c880cb83dfbc9cbce3d2952be.jpg',\n",
+       " 'test/e2a9a7580a1424bc6531b2b7375338db.jpg',\n",
+       " 'test/4f7ec53fb020dfd90ac36227ab8233dc.jpg',\n",
+       " 'test/66d14166c9c17b9915c8b8bd515c04a3.jpg',\n",
+       " 'test/2046b1decc5a575e3a48b42c88adcd62.jpg',\n",
+       " 'test/831ef824af939f9754e3593638933b64.jpg',\n",
+       " 'test/03a6a4c713d657d53a804ebe1fb2b02c.jpg',\n",
+       " 'test/c0d45b04b7b427c973c71ad23b6a77f4.jpg',\n",
+       " 'test/7261882b948e7bd67aa9bc550bf02b18.jpg',\n",
+       " 'test/0fe91bc1fe542f04aaf9a010ef37c2b6.jpg',\n",
+       " 'test/699dcd6bebbdc49511b62dfc6facc779.jpg',\n",
+       " 'test/2f8ea7b3242838538dba2a258b3a24fe.jpg',\n",
+       " 'test/1509e27988119ea9293c2df2fc1b4b45.jpg',\n",
+       " 'test/6548529f17b333f7db091b2f181a64c6.jpg',\n",
+       " 'test/193f80c24606fdca6179eff987fdab9b.jpg',\n",
+       " 'test/3feace6790ba6eea2aef34f198e43025.jpg',\n",
+       " 'test/37d4c66da9bd8843fa926df8c62ae26d.jpg',\n",
+       " 'test/48b28d4c1e91b59599d38edb646b9d0a.jpg',\n",
+       " 'test/f7b0596d6f3a5fe9006f04de9cf4ab0f.jpg',\n",
+       " 'test/70cc4624a1eb9b0f0587045819143b62.jpg',\n",
+       " 'test/f13011a399f175d88c17d2bd1785625e.jpg',\n",
+       " 'test/e0806e5049519130d459dd7bd640a092.jpg',\n",
+       " 'test/ac606d827479c6635a287e7af1b7d434.jpg',\n",
+       " 'test/84e3a6a1d53e886d97f65411489969f0.jpg',\n",
+       " 'test/af3bb35fbb65c50b2e707ff686f98f9d.jpg',\n",
+       " 'test/768f4beef760032a8808c6a84ac03d77.jpg',\n",
+       " 'test/27ccf0e035abc33fb6a1e8bdf23c5f86.jpg',\n",
+       " 'test/3dd28f8e10a898adef51f60755f87091.jpg',\n",
+       " 'test/4afd081346193226bab3dc456d80bd3e.jpg',\n",
+       " 'test/e85291fc6ba44e39defc7769fa020646.jpg',\n",
+       " 'test/dcbe4226672aa4af80c1e52a9bb78268.jpg',\n",
+       " 'test/9ec7ae3455863d4df0a46f4cf597a574.jpg',\n",
+       " 'test/34394cdd71e596d6e80f565e98201cf8.jpg',\n",
+       " 'test/a139581faa6b04f7d4c0e87107e33a01.jpg',\n",
+       " 'test/d5c2ce713cfdb56cfbb9aac676aabbab.jpg',\n",
+       " 'test/1cf32e9b62b2f1a60a5d009dd57cfe5e.jpg',\n",
+       " 'test/798219c15b8a5ba54fa5d09772e9e1ea.jpg',\n",
+       " 'test/967898f6705e9c4dd97ec7c8f8b1956e.jpg',\n",
+       " 'test/0dd0c324a6f4a599756b3b750165c41a.jpg',\n",
+       " 'test/2072d74918f4fe253aaa75388822d81b.jpg',\n",
+       " 'test/7d9da7c2bba40fde7997ce09bd2737dc.jpg',\n",
+       " 'test/8d18204baf2bb27dc39b00aa763c784d.jpg',\n",
+       " 'test/f51f6aeea8a23b6bd62728fde8f04ad8.jpg',\n",
+       " 'test/7dde52cb616a94fbadd8b077c8e8d920.jpg',\n",
+       " 'test/4969b10897e61fd900c75460de04d6ed.jpg',\n",
+       " 'test/9c4b7039ae06959859cb1369d6450079.jpg',\n",
+       " 'test/b65bf33d0e0f70e3fb54e6868d800842.jpg',\n",
+       " 'test/3968abbce18a685b3e5089dc6e212f12.jpg',\n",
+       " 'test/b6198ed26acdf1a18797f6f0403217cb.jpg',\n",
+       " 'test/f3ea1d71874433a4fe775deb9e95923a.jpg',\n",
+       " 'test/0c84d273699cada291a635c6edd33390.jpg',\n",
+       " 'test/11a126ba3ccaed35f95547b5f787ea61.jpg',\n",
+       " 'test/04d36eed15fe648c54a88e0b5c49deb2.jpg',\n",
+       " 'test/c7f10024f9092537b1601bd02980fb83.jpg',\n",
+       " 'test/b1caee92d84ce6c100413a1f5cc32460.jpg',\n",
+       " 'test/f8bfe5da20567378b885109a0c1f1483.jpg',\n",
+       " 'test/40f82d80552497163082195b42365163.jpg',\n",
+       " 'test/bf9a109dd391229fa06b3a34bc1470bf.jpg',\n",
+       " 'test/c0871a1b55afad116c7e5bf1d1cd0906.jpg',\n",
+       " 'test/f15527e7a063275291e469b4e5db751c.jpg',\n",
+       " 'test/5ab0a6516922e1cdb1091f054fbefff0.jpg',\n",
+       " 'test/4caa48ba96c55c71aa0edeeb738bc080.jpg',\n",
+       " 'test/3a111de3db21bfd37e6a6e0089f794c6.jpg',\n",
+       " 'test/01d333d5c288be97bffd76005f559f41.jpg',\n",
+       " 'test/1f77317084a554666f37473a8a95d91a.jpg',\n",
+       " 'test/b117274991d2dc1ffa0ac863f16f11a2.jpg',\n",
+       " 'test/983a02132f38c20bc351b99ed83eca64.jpg',\n",
+       " 'test/02b9adaa40397a4977b9646cc6c939dc.jpg',\n",
+       " 'test/83a8010c4b5ab0747059400f473ac668.jpg',\n",
+       " 'test/ba57c17dae7055ef1c54c479262fee4d.jpg',\n",
+       " 'test/2cc021273be838847ed66f9bafc21cca.jpg',\n",
+       " 'test/af0a63ceff8e64c65e48ccd7e9500499.jpg',\n",
+       " 'test/81fcf88f635727bce89a31142c8a4007.jpg',\n",
+       " 'test/180f2e2e8067fe2213130b1fdc469b26.jpg',\n",
+       " 'test/17a4665e63f73d0f01089a4e153c33c4.jpg',\n",
+       " 'test/a6359b148d774fe2b542e4c1b9369c02.jpg',\n",
+       " 'test/6cdff5325cb35cfd44447b9e4f6cb7b4.jpg',\n",
+       " 'test/c87b574003ac9568970b70f29702bf85.jpg',\n",
+       " 'test/5310f15815c30b6c5b337356b36cb454.jpg',\n",
+       " 'test/97a0a4b27e8f12596482e4f6487786cb.jpg',\n",
+       " 'test/8dc7ff54ae077a63cd489faa94684709.jpg',\n",
+       " 'test/c0b5a7f03d80626d3c13d37ab78544af.jpg',\n",
+       " 'test/fa541fc080cdeffb4dd98da99f673a59.jpg',\n",
+       " 'test/985ae7fc271ac4a0d131e546c0f95bb6.jpg',\n",
+       " 'test/d4b63ba8b6558b29f55bff96af795d09.jpg',\n",
+       " 'test/9ec769e34bc902bd9de458103e9347c8.jpg',\n",
+       " 'test/62cc5d37bc91403eae2561975c414579.jpg',\n",
+       " 'test/6a9316ea62029983934dac25c7cfe48e.jpg',\n",
+       " 'test/2a1c9159aa46a15c749c1013e733adc0.jpg',\n",
+       " 'test/6715a492eda68acd37e28a54218c2504.jpg',\n",
+       " 'test/391ec9ea882a52642e078ca64df2563d.jpg',\n",
+       " 'test/02efe659755a4c9d2da69035c43fa5fb.jpg',\n",
+       " 'test/e12731c30619c3fa4b0d9d9a76fb9d60.jpg',\n",
+       " 'test/5711e271dfb897a1a13d2d94ecada80e.jpg',\n",
+       " 'test/223a2071464f05c2ae405762b9ca3af6.jpg',\n",
+       " 'test/836aa8b45420e8bd70b9cf2eb4f9e093.jpg',\n",
+       " 'test/b52332e896a5a47cc4d2c0dc15af0359.jpg',\n",
+       " 'test/74d2b7992b831108009f6aeb36fb9181.jpg',\n",
+       " 'test/36edf3ddc4934b2d84cc940d4f6e8c99.jpg',\n",
+       " 'test/e246de79e4efd1145698d9c21466bbaf.jpg',\n",
+       " 'test/cff15c13208f1b99912a8a5aa7e4b96f.jpg',\n",
+       " 'test/cb2c1164402b5dbbb3eac54d3a4dfc49.jpg',\n",
+       " 'test/9a2e6ecc4f7bd1578d8c55f8eae0dad7.jpg',\n",
+       " 'test/aac5caab05224706d9c24f294a71f247.jpg',\n",
+       " 'test/2d7c2ac3fe912d9545ba692490b45d00.jpg',\n",
+       " 'test/f57f8ce3fe1d928828e37a9bd78574d9.jpg',\n",
+       " 'test/60a1d91ee68cef5501a0d692cf43a7f9.jpg',\n",
+       " 'test/b3bdba23a9105fe502fc2b661f215cd8.jpg',\n",
+       " 'test/c52405e4e5afb93a6ca775008480a41e.jpg',\n",
+       " 'test/cc91dc262bbc0c73241ecec6ed53449a.jpg',\n",
+       " 'test/463dc2054f543877c4225543ccc16a4a.jpg',\n",
+       " 'test/f6bed54631ef1691d12509f5516ce979.jpg',\n",
+       " 'test/fab7c38522b8bb9e71626f6f1a384d8c.jpg',\n",
+       " 'test/2e3ccd5230893d0e07e9ecf6d58be3d1.jpg',\n",
+       " 'test/09db0bb220cdbbc0adca63e38e64ab38.jpg',\n",
+       " 'test/324c9e2d778e15146858832009999fbc.jpg',\n",
+       " 'test/4bddac4bf91f5b45dc8104db791deb97.jpg',\n",
+       " 'test/4b3f79ad4f44d990cc7456b2d50309e6.jpg',\n",
+       " 'test/3c70bfb583de9c18043aa1f33765521e.jpg',\n",
+       " 'test/a87389ccf3e82e66fcbab9426d4f50ab.jpg',\n",
+       " 'test/d51d2d0962d57067d5ec9415a5af46a1.jpg',\n",
+       " 'test/6da8dcfeceb87b99ea1426189512c2de.jpg',\n",
+       " 'test/2fa13e03954dee3e1816a5b4ee1bb75b.jpg',\n",
+       " 'test/04c7f6600b20b9255b04a76fe6e55023.jpg',\n",
+       " 'test/ec363521d5ebd5260944823f86dc5a8c.jpg',\n",
+       " 'test/69e9ebfeb9dff1365e790a3c71c484ea.jpg',\n",
+       " 'test/9306ca2491832795f90dd0cfe4e54e4a.jpg',\n",
+       " 'test/8f87f0bac19b72a9919681fe3d4922e9.jpg',\n",
+       " 'test/ba0875164edc17285ffebaaefbfa030f.jpg',\n",
+       " 'test/ab3c567523ef87f50bfb41c1308732af.jpg',\n",
+       " 'test/b3ce3ccf5096e1c894595bb1f3b467ed.jpg',\n",
+       " 'test/b5f8d1f0aaad28634e56139bd630de97.jpg',\n",
+       " 'test/64081b6b6635b3a772e3b8252d67ec08.jpg',\n",
+       " 'test/6a04011c7f2dd08d455247ccb8ee7ab8.jpg',\n",
+       " 'test/bd80f2d9d300a2162291270312312980.jpg',\n",
+       " 'test/6d311b0eb375237cf49c7918600019ec.jpg',\n",
+       " 'test/0c82ccebd8e7cf9b232fe9b294863c69.jpg',\n",
+       " 'test/0a28fe94aa27ebd0fa587c8a474117a1.jpg',\n",
+       " 'test/07e4edc428816ffe6b8dd1024bed2782.jpg',\n",
+       " 'test/f7ee03c39d8a094c75de991e24e4ea55.jpg',\n",
+       " 'test/add5d56a7c6f2691ae9df6e79851d404.jpg',\n",
+       " 'test/735325a42aca71ebe25d7e9b7d86fc91.jpg',\n",
+       " 'test/218af675b2c2ca9b86f1362c32705930.jpg',\n",
+       " 'test/63d381a8b806b56e3c155dd458a66646.jpg',\n",
+       " 'test/f5dcef15272a806b4f0824e9199e9dd5.jpg',\n",
+       " 'test/e96fd30110107e506de94d81af346238.jpg',\n",
+       " 'test/744f9a2330a9a44c500905a4dfdeb377.jpg',\n",
+       " 'test/01cb83d33e905e825df41b88dd4ef277.jpg',\n",
+       " 'test/2ac416c42469d263085206aa28509a2d.jpg',\n",
+       " 'test/e6a544a538088cc3f73b432a2da90134.jpg',\n",
+       " 'test/9049b9691e1712142a78812d1b70fc08.jpg',\n",
+       " 'test/c60d1576b160e11ec84cd1009e275485.jpg',\n",
+       " 'test/667b068c74813ece3880ba1a1253f9bb.jpg',\n",
+       " 'test/ffbcda9eb84339cc5be15fd9900596a2.jpg',\n",
+       " 'test/d730341f7447906720fbf47286796f7a.jpg',\n",
+       " 'test/0467770f34410f3fafd2482342d69f77.jpg',\n",
+       " 'test/f6b8af035c42b6836bbf90d0a457bcb4.jpg',\n",
+       " 'test/dc2b0a19e725d1a257411433277f4d89.jpg',\n",
+       " 'test/7ed71c10cced08b6b069a5b7b5785932.jpg',\n",
+       " 'test/d6b0ead1d782826364fe2f6a149ab372.jpg',\n",
+       " 'test/388edf10377674a40c25915d64f4f377.jpg',\n",
+       " 'test/82d61a26d714398bea3d82e5ace7538a.jpg',\n",
+       " 'test/99bd95316f9796c59072e84932ad33f9.jpg',\n",
+       " 'test/995839654892fb3ec7b8d98529bd43ba.jpg',\n",
+       " 'test/ddf0164ab3a269b179051bdecaea34b0.jpg',\n",
+       " 'test/49a13d472605473ef3f9b2e4f638d700.jpg',\n",
+       " 'test/94a681f65f37fb3666c07b89d4d7a071.jpg',\n",
+       " 'test/528f88ec0b2777c70694d7c776733e56.jpg',\n",
+       " 'test/25d0ef34c87dbdf118fb714f0bc3e59b.jpg',\n",
+       " 'test/5b0e3a9551edcca11fcf565bb78d8c49.jpg',\n",
+       " 'test/beeaa698e9965aee5ec860c59af3faee.jpg',\n",
+       " 'test/c67c132d99386fba1e1884a850d1ea98.jpg',\n",
+       " 'test/416085f568b12844c1f53173f9343396.jpg',\n",
+       " 'test/ffd304c521f43819f3824177fd9efeb0.jpg',\n",
+       " 'test/283a2612ccccf684b2796dd8e4a5ba13.jpg',\n",
+       " 'test/b2193a53c04ea9192860fece3f4c2d99.jpg',\n",
+       " 'test/a408e776f8b93ce22a3542a89218820f.jpg',\n",
+       " 'test/992e80ea2cd1549a5f71b04e4430e529.jpg',\n",
+       " 'test/606aef954ca30806168d0d08e52a4dbf.jpg',\n",
+       " 'test/59fa36da3bd77c415052d8f88ccaa309.jpg',\n",
+       " 'test/077b4c62007a362be52711169abfa4fd.jpg',\n",
+       " 'test/ea057ca7f831d161d456091bf293e4b1.jpg',\n",
+       " 'test/f1f42942df460f38181e12ebce695b5e.jpg',\n",
+       " 'test/f09826fc9cb9aa425caae5f8aaaa8bef.jpg',\n",
+       " 'test/ae5309aba5975d0829624bdced152bd3.jpg',\n",
+       " 'test/e97a63b529b7b274eeb605391366b576.jpg',\n",
+       " 'test/dcfd3463e1d23d51b309b0385292870b.jpg',\n",
+       " 'test/62f0755b86cceef4244c9bcbce1b68e5.jpg',\n",
+       " 'test/68ec9cf5b73b91f6506ed9e44e8260af.jpg',\n",
+       " 'test/4f5f35204ad2b401c1d00557a1dec1c3.jpg',\n",
+       " 'test/b47d3815322795664fe4b6dbef27b6dc.jpg',\n",
+       " 'test/6d1eb0d0f02a3cfabf08e5b84ed54eca.jpg',\n",
+       " 'test/1e2dee5f2da505e30bfdfcc7eb89797a.jpg',\n",
+       " 'test/2630ca901a4718100cdf780996c13da7.jpg',\n",
+       " 'test/6969c077141fec2c23f4b0857056fc9c.jpg',\n",
+       " 'test/3a1c97e85aaaf6810c1f5a8c9250a6a7.jpg',\n",
+       " 'test/bba293dd06d11a8b7dc78bfca28059be.jpg',\n",
+       " 'test/796cc4fe56597d3e8cfc9595ca1454de.jpg',\n",
+       " 'test/023c0a9675c4e09e7de76be0fad3d52f.jpg',\n",
+       " 'test/bfc8e5fe6c364c4aaec8d053047f0449.jpg',\n",
+       " 'test/09ef5442c370eb7eeb08e6796c5ff5b5.jpg',\n",
+       " 'test/cc5a5b9075877cdbd4b8466baf984eca.jpg',\n",
+       " 'test/89d11c210c761b3a76b8eecc307b5610.jpg',\n",
+       " 'test/4645835f6bf0933136a1b1cd0f6bfc76.jpg',\n",
+       " 'test/dacf001ddba61650b7cc587b8db2f50e.jpg',\n",
+       " 'test/b4e2d6ecbe6598c745494980f97a02bb.jpg',\n",
+       " 'test/03a6fb1fa2d7812587004a60ade66fed.jpg',\n",
+       " 'test/f1af835a9146d6ec0da8059b3a55c030.jpg',\n",
+       " 'test/ab065f522488afe09494c124342957bd.jpg',\n",
+       " 'test/7ac0624c677fdd6a38956d720c27b0a2.jpg',\n",
+       " 'test/2fdbbd37a896ffa757fedce3c3816aca.jpg',\n",
+       " 'test/7155718b5d167587c440f5f0ecccb872.jpg',\n",
+       " 'test/38374ec73cff11ea2be55ab8b4c54dac.jpg',\n",
+       " 'test/387a2439a7a65ea7ae52a2029339d55d.jpg',\n",
+       " 'test/de3fbd6fb5444fcf14390ac90545c2f1.jpg',\n",
+       " 'test/b1aeb449e903e417bb1a0cc677912336.jpg',\n",
+       " 'test/8a90cb35ebeb872781026fc3e28a3dc5.jpg',\n",
+       " 'test/c970c9cf57b8ff9eccea685bfd6f240e.jpg',\n",
+       " 'test/b89095325ba8d3d588834e35f65ca99c.jpg',\n",
+       " 'test/fdedb2f8f3687f8e51e84236c65b65c3.jpg',\n",
+       " 'test/ad57aa30eb969a3a70acc9504a73a82c.jpg',\n",
+       " 'test/1638e407075b037a3f024fedaaa0953d.jpg',\n",
+       " 'test/5d1e83adfaac47f754f16021615fc8bf.jpg',\n",
+       " 'test/207d0a7a27d3e4d9ab33860a18b78383.jpg',\n",
+       " 'test/42541eeab49c96ed08d45d209644d72f.jpg',\n",
+       " 'test/f863758735a6cc504d4a80477591eaf6.jpg',\n",
+       " 'test/93fa4194758960a2fffec91162579467.jpg',\n",
+       " 'test/b19a8a426fe7b91c890e33f5622fcced.jpg',\n",
+       " 'test/7603a1e5ec7825b354d3d9f2dc0f6059.jpg',\n",
+       " 'test/8a6f0c3be55e8f27fe5bc3b45562fc90.jpg',\n",
+       " 'test/cff0b4780b519e569f3478550504b02f.jpg',\n",
+       " 'test/9f04a42304ebbc558a5cf0c3f46541b3.jpg',\n",
+       " 'test/4ead408f81b09e617882bcad28bf7593.jpg',\n",
+       " 'test/5b31ecb5b59db8f507a274b00346065d.jpg',\n",
+       " 'test/4a692ed4c770d44d6ad825b7f43b31ca.jpg',\n",
+       " 'test/b964a6ca60f81c19e84ad0aaa9ed6f88.jpg',\n",
+       " 'test/8c5d04891180854184b470daf88efb96.jpg',\n",
+       " 'test/401536ed0da2548536a4d27ff1c0a463.jpg',\n",
+       " 'test/1119c5511941dd992da0f8f66b34e55c.jpg',\n",
+       " 'test/6038406f41bc0e669f4226c5e85dbcd0.jpg',\n",
+       " 'test/38ecc3fe3e67ea1b84f57148e9d0a7b6.jpg',\n",
+       " 'test/16816a9d4db979b3abc8c92404ab67e3.jpg',\n",
+       " 'test/35dacad1732794561c26e1fbf41aae8a.jpg',\n",
+       " 'test/bcf559a914a8fa20ebd5375c48edd8cf.jpg',\n",
+       " 'test/54b9c175a57ae7c7e6882a7528c621b9.jpg',\n",
+       " 'test/e090f0f0ebc83ddf5f649a841493868b.jpg',\n",
+       " 'test/f90b4f4adae580c4a2ec4fd9abad05da.jpg',\n",
+       " 'test/4338b655b34c0548b089958e1574d7f1.jpg',\n",
+       " 'test/00c610a43b661e4fc612d06db96ce258.jpg',\n",
+       " 'test/55df5326067d640b519c4378142b7509.jpg',\n",
+       " 'test/a62f5e5d7278699eefc195d747d71b7a.jpg',\n",
+       " 'test/86ca62033ae44453b422ebac07cc5678.jpg',\n",
+       " 'test/cb1ce9f296f8f6674a580209897ee2b6.jpg',\n",
+       " 'test/a72f76609d31cdc67067eadcae0c25cc.jpg',\n",
+       " 'test/9de87aba130f43ecffe870790873e219.jpg',\n",
+       " 'test/fce0949968f07d3aa97fe09c9a8829b5.jpg',\n",
+       " 'test/c909aced4dfea056bfdefd302aacdb84.jpg',\n",
+       " 'test/fc9f45447f2f2bd82a6072afbddfd78d.jpg',\n",
+       " 'test/5f96e33cb76a8432116d5ebdc0ea82cc.jpg',\n",
+       " 'test/87023197f17451a7e2a4bff944933f3c.jpg',\n",
+       " 'test/2dede0cbedc90b1f8cebd7fa22860536.jpg',\n",
+       " 'test/329b1ef3e91e807eb6135475ee947e30.jpg',\n",
+       " 'test/e6999e18a8e98f7fc33cf520d26ec521.jpg',\n",
+       " 'test/c769a926643b01af05e875ac984fd581.jpg',\n",
+       " 'test/12e5137dc606e09c78c9b27a1891ea87.jpg',\n",
+       " 'test/80da6ae51731dc301360a3b59e061fa1.jpg',\n",
+       " 'test/91d861224055c595b63e569d41426637.jpg',\n",
+       " 'test/b62ddfd5351da8588789b51fd8536e03.jpg',\n",
+       " 'test/36939316bd5dc74df7e0c33e76074408.jpg',\n",
+       " 'test/614ce0f96addee018f3a67a1353b17ef.jpg',\n",
+       " 'test/a51d3e5b0a81f025f424fa4e8b107b4d.jpg',\n",
+       " 'test/8e78fefe5b7612a131e66a7fe616309a.jpg',\n",
+       " 'test/f409b8113b2c2ab861131c4bd1c0b029.jpg',\n",
+       " 'test/40f063eb33c657c5acf19d7de03a77f2.jpg',\n",
+       " 'test/d9b0c0bc4de8b19e3452fc477ebdf5a6.jpg',\n",
+       " 'test/138a5ce524f0ef30818208492eb169e3.jpg',\n",
+       " 'test/81826a3ca9365bed0cad9483709b8ede.jpg',\n",
+       " 'test/2b560c80aaede000ebb101ffee26bf14.jpg',\n",
+       " 'test/51372c1a40ee47e4377de1c2b6a6a250.jpg',\n",
+       " 'test/fa85d9951d7996c4c92ce5dc41d87dcd.jpg',\n",
+       " 'test/28dd9823c2208e68fd2f93c152e2a627.jpg',\n",
+       " 'test/4b2467c1983c45f0805f2b7e3d0ffc39.jpg',\n",
+       " 'test/75102525aca966cdf5d1dbaf0a3f8ee7.jpg',\n",
+       " 'test/c7232f1365c363c18453cda2063f59a9.jpg',\n",
+       " 'test/e78d3997b4e7f4abc1299f81b8e3b2d9.jpg',\n",
+       " 'test/74b133bbc2d4ece626394bdec13d702a.jpg',\n",
+       " 'test/0e7c2ef54e84c8d021e1c0ea96cad523.jpg',\n",
+       " 'test/45668507c4840614dcb05e8b894aa6c8.jpg',\n",
+       " 'test/59c8495a3ce67b86d473f57e29078ec1.jpg',\n",
+       " 'test/0609652d9cc0aa749ec8995ca35fd370.jpg',\n",
+       " 'test/ffb55dbaa32939c109ef42df0668e077.jpg',\n",
+       " 'test/70c49ddddd138d434b33d1e2a1331a5d.jpg',\n",
+       " 'test/18b7dd028d5537cf5e02885bb18ae82d.jpg',\n",
+       " 'test/1432736589ff3278a536203f0725fcba.jpg',\n",
+       " 'test/c7de91df0ee7f9e871deefb4de110201.jpg',\n",
+       " 'test/70efe451ba9832194a9fb10d577914f9.jpg',\n",
+       " 'test/cfff42adc2db5fe6d452d17d13163e87.jpg',\n",
+       " 'test/6b7c98326b6a8ab0c0d0210a36f25246.jpg',\n",
+       " 'test/fa98e0dd02c4fcc5b5155a1fdaa2cb13.jpg',\n",
+       " 'test/8e0d7d2c224de1d5716d7a69d7854d06.jpg',\n",
+       " 'test/f20017c781603ca2d286361592b12dc4.jpg',\n",
+       " 'test/f5fb580dfd19890f200eed7010cedc3a.jpg',\n",
+       " 'test/443245a5bba869e596fb05d2d0eb63e1.jpg',\n",
+       " 'test/e24877545b682257ca77ae600df1fe37.jpg',\n",
+       " 'test/b79c8019e5558042de2fd1105defec28.jpg',\n",
+       " 'test/812b49cbbf51b0088b0a0c5b3f87958d.jpg',\n",
+       " 'test/2a6a5308f9d82b7d881cc02e13ebb41a.jpg',\n",
+       " 'test/e061b8d24e7b1324a6ac92ae81fdda19.jpg',\n",
+       " 'test/6aa7ea7a603a49723643c2fcf923dc1f.jpg',\n",
+       " 'test/fa9f99318fc70441c150beb46013e63c.jpg',\n",
+       " 'test/8b0bb138f43faaeafd1c52ed79ce0067.jpg',\n",
+       " 'test/9b0551f43a078d038a235b928cff6134.jpg',\n",
+       " 'test/1bc84bac2727d3f657e923df00a7bfef.jpg',\n",
+       " 'test/899205b9082a382bcf11ddffd0799c41.jpg',\n",
+       " 'test/2126c54600e6166617024e79e99b98c0.jpg',\n",
+       " 'test/81d8b3e2791c6ec14f67b7069874ac60.jpg',\n",
+       " 'test/2106ac37944c94f7c1392030bc5160b3.jpg',\n",
+       " 'test/c0135fc7aa154a17bfe4f626e9dd88a8.jpg',\n",
+       " 'test/e1f7ec4bd372612f53411026aaabf233.jpg',\n",
+       " 'test/dd7867245d5c104fffb5afe027e41cd1.jpg',\n",
+       " 'test/b7651433f6a59fa4032e0e689714c65b.jpg',\n",
+       " 'test/6fdc2563e0d2f4a2bb3dfd173740503d.jpg',\n",
+       " 'test/3e28214a2703c23fea7489ef20810dfb.jpg',\n",
+       " 'test/e4e57083c3b68e91760ce6f5fcd0a2f9.jpg',\n",
+       " 'test/8de2344aa5abe9737fa484afaac5d4c4.jpg',\n",
+       " 'test/dd9d222a481e6cbea922a1b601a55a38.jpg',\n",
+       " ...]"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data.test_ds.fnames"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                              \r"
+     ]
+    }
+   ],
+   "source": [
+    "log_preds, y = learn.TTA(is_test=True) # use test dataset rather than validation dataset\n",
+    "probs = np.mean(np.exp(log_preds),0)\n",
+    "#accuracy_np(probs, y), metrcs.log_loss(y, probs) # This does not make sense since test dataset has no labels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(10357, 120)"
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "probs.shape # (n_images, n_classes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(probs)\n",
+    "df.columns = data.classes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.insert(0, 'id', [o[5:-4] for o in data.test_ds.fnames])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>affenpinscher</th>\n",
+       "      <th>afghan_hound</th>\n",
+       "      <th>african_hunting_dog</th>\n",
+       "      <th>airedale</th>\n",
+       "      <th>american_staffordshire_terrier</th>\n",
+       "      <th>appenzeller</th>\n",
+       "      <th>australian_terrier</th>\n",
+       "      <th>basenji</th>\n",
+       "      <th>basset</th>\n",
+       "      <th>...</th>\n",
+       "      <th>toy_poodle</th>\n",
+       "      <th>toy_terrier</th>\n",
+       "      <th>vizsla</th>\n",
+       "      <th>walker_hound</th>\n",
+       "      <th>weimaraner</th>\n",
+       "      <th>welsh_springer_spaniel</th>\n",
+       "      <th>west_highland_white_terrier</th>\n",
+       "      <th>whippet</th>\n",
+       "      <th>wire-haired_fox_terrier</th>\n",
+       "      <th>yorkshire_terrier</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>ab2520c527e61f197be228208af48191</td>\n",
+       "      <td>7.957505e-08</td>\n",
+       "      <td>2.723862e-08</td>\n",
+       "      <td>2.435847e-08</td>\n",
+       "      <td>1.173262e-07</td>\n",
+       "      <td>2.351215e-08</td>\n",
+       "      <td>8.401931e-06</td>\n",
+       "      <td>1.372760e-06</td>\n",
+       "      <td>6.317406e-08</td>\n",
+       "      <td>3.063393e-08</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.080939e-08</td>\n",
+       "      <td>2.456473e-07</td>\n",
+       "      <td>2.722122e-07</td>\n",
+       "      <td>5.030101e-08</td>\n",
+       "      <td>1.900935e-07</td>\n",
+       "      <td>6.053991e-07</td>\n",
+       "      <td>3.839476e-08</td>\n",
+       "      <td>5.778787e-08</td>\n",
+       "      <td>1.575098e-07</td>\n",
+       "      <td>1.075539e-08</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>8ffc8a83bb9ac7884a9420c97b23940c</td>\n",
+       "      <td>9.668808e-08</td>\n",
+       "      <td>2.355516e-08</td>\n",
+       "      <td>2.087995e-07</td>\n",
+       "      <td>6.298836e-08</td>\n",
+       "      <td>3.269388e-08</td>\n",
+       "      <td>2.796247e-07</td>\n",
+       "      <td>2.439702e-08</td>\n",
+       "      <td>2.535878e-06</td>\n",
+       "      <td>1.824919e-06</td>\n",
+       "      <td>...</td>\n",
+       "      <td>4.051576e-08</td>\n",
+       "      <td>3.540100e-06</td>\n",
+       "      <td>2.388073e-07</td>\n",
+       "      <td>9.832689e-01</td>\n",
+       "      <td>1.823956e-07</td>\n",
+       "      <td>2.486797e-08</td>\n",
+       "      <td>8.325348e-08</td>\n",
+       "      <td>9.363868e-07</td>\n",
+       "      <td>2.608415e-07</td>\n",
+       "      <td>3.851193e-07</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>9f4bbcd8a5b189514d3098516983621a</td>\n",
+       "      <td>4.214103e-05</td>\n",
+       "      <td>2.804878e-04</td>\n",
+       "      <td>4.817631e-05</td>\n",
+       "      <td>7.178330e-03</td>\n",
+       "      <td>1.471457e-06</td>\n",
+       "      <td>1.140446e-05</td>\n",
+       "      <td>1.950280e-04</td>\n",
+       "      <td>7.519415e-06</td>\n",
+       "      <td>1.821058e-06</td>\n",
+       "      <td>...</td>\n",
+       "      <td>5.793181e-05</td>\n",
+       "      <td>9.164357e-05</td>\n",
+       "      <td>1.187949e-04</td>\n",
+       "      <td>6.772134e-06</td>\n",
+       "      <td>5.031822e-05</td>\n",
+       "      <td>4.772470e-05</td>\n",
+       "      <td>6.114125e-06</td>\n",
+       "      <td>2.762433e-05</td>\n",
+       "      <td>5.382648e-04</td>\n",
+       "      <td>2.682866e-05</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>f77793be1597dd1ea50b22532b38bd23</td>\n",
+       "      <td>2.568105e-07</td>\n",
+       "      <td>2.491144e-07</td>\n",
+       "      <td>7.142457e-07</td>\n",
+       "      <td>1.466020e-06</td>\n",
+       "      <td>3.212435e-05</td>\n",
+       "      <td>8.274229e-08</td>\n",
+       "      <td>3.600422e-08</td>\n",
+       "      <td>6.044879e-08</td>\n",
+       "      <td>1.201969e-07</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.627351e-06</td>\n",
+       "      <td>3.965855e-08</td>\n",
+       "      <td>1.560448e-06</td>\n",
+       "      <td>6.965169e-08</td>\n",
+       "      <td>1.856623e-07</td>\n",
+       "      <td>1.051336e-07</td>\n",
+       "      <td>1.763770e-07</td>\n",
+       "      <td>2.664481e-07</td>\n",
+       "      <td>3.316928e-08</td>\n",
+       "      <td>9.700193e-08</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>f719b425410b6eb3e3132702150affd6</td>\n",
+       "      <td>6.095974e-06</td>\n",
+       "      <td>2.696717e-06</td>\n",
+       "      <td>4.131879e-06</td>\n",
+       "      <td>6.457446e-05</td>\n",
+       "      <td>1.191631e-03</td>\n",
+       "      <td>3.560664e-05</td>\n",
+       "      <td>3.274512e-06</td>\n",
+       "      <td>2.229157e-06</td>\n",
+       "      <td>1.317608e-06</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.345266e-06</td>\n",
+       "      <td>1.053057e-05</td>\n",
+       "      <td>2.322353e-05</td>\n",
+       "      <td>4.169483e-05</td>\n",
+       "      <td>1.918868e-05</td>\n",
+       "      <td>5.647749e-06</td>\n",
+       "      <td>5.437289e-06</td>\n",
+       "      <td>5.297930e-06</td>\n",
+       "      <td>3.867970e-06</td>\n",
+       "      <td>5.011518e-06</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 121 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                 id  affenpinscher  afghan_hound  \\\n",
+       "0  ab2520c527e61f197be228208af48191   7.957505e-08  2.723862e-08   \n",
+       "1  8ffc8a83bb9ac7884a9420c97b23940c   9.668808e-08  2.355516e-08   \n",
+       "2  9f4bbcd8a5b189514d3098516983621a   4.214103e-05  2.804878e-04   \n",
+       "3  f77793be1597dd1ea50b22532b38bd23   2.568105e-07  2.491144e-07   \n",
+       "4  f719b425410b6eb3e3132702150affd6   6.095974e-06  2.696717e-06   \n",
+       "\n",
+       "   african_hunting_dog      airedale  american_staffordshire_terrier  \\\n",
+       "0         2.435847e-08  1.173262e-07                    2.351215e-08   \n",
+       "1         2.087995e-07  6.298836e-08                    3.269388e-08   \n",
+       "2         4.817631e-05  7.178330e-03                    1.471457e-06   \n",
+       "3         7.142457e-07  1.466020e-06                    3.212435e-05   \n",
+       "4         4.131879e-06  6.457446e-05                    1.191631e-03   \n",
+       "\n",
+       "    appenzeller  australian_terrier       basenji        basset  \\\n",
+       "0  8.401931e-06        1.372760e-06  6.317406e-08  3.063393e-08   \n",
+       "1  2.796247e-07        2.439702e-08  2.535878e-06  1.824919e-06   \n",
+       "2  1.140446e-05        1.950280e-04  7.519415e-06  1.821058e-06   \n",
+       "3  8.274229e-08        3.600422e-08  6.044879e-08  1.201969e-07   \n",
+       "4  3.560664e-05        3.274512e-06  2.229157e-06  1.317608e-06   \n",
+       "\n",
+       "         ...            toy_poodle   toy_terrier        vizsla  walker_hound  \\\n",
+       "0        ...          2.080939e-08  2.456473e-07  2.722122e-07  5.030101e-08   \n",
+       "1        ...          4.051576e-08  3.540100e-06  2.388073e-07  9.832689e-01   \n",
+       "2        ...          5.793181e-05  9.164357e-05  1.187949e-04  6.772134e-06   \n",
+       "3        ...          2.627351e-06  3.965855e-08  1.560448e-06  6.965169e-08   \n",
+       "4        ...          2.345266e-06  1.053057e-05  2.322353e-05  4.169483e-05   \n",
+       "\n",
+       "     weimaraner  welsh_springer_spaniel  west_highland_white_terrier  \\\n",
+       "0  1.900935e-07            6.053991e-07                 3.839476e-08   \n",
+       "1  1.823956e-07            2.486797e-08                 8.325348e-08   \n",
+       "2  5.031822e-05            4.772470e-05                 6.114125e-06   \n",
+       "3  1.856623e-07            1.051336e-07                 1.763770e-07   \n",
+       "4  1.918868e-05            5.647749e-06                 5.437289e-06   \n",
+       "\n",
+       "        whippet  wire-haired_fox_terrier  yorkshire_terrier  \n",
+       "0  5.778787e-08             1.575098e-07       1.075539e-08  \n",
+       "1  9.363868e-07             2.608415e-07       3.851193e-07  \n",
+       "2  2.762433e-05             5.382648e-04       2.682866e-05  \n",
+       "3  2.664481e-07             3.316928e-08       9.700193e-08  \n",
+       "4  5.297930e-06             3.867970e-06       5.011518e-06  \n",
+       "\n",
+       "[5 rows x 121 columns]"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SUBM = f'{PATH}/subm/'\n",
+    "os.makedirs(SUBM, exist_ok=True)\n",
+    "df.to_csv(f'{SUBM}subm.gz', compression='gzip', index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a href='data/dogbreed//subm/subm.gz' target='_blank'>data/dogbreed//subm/subm.gz</a><br>"
+      ],
+      "text/plain": [
+       "/mnt/disc1/fast.ai/fastai/courses/dl1/data/dogbreed/subm/subm.gz"
+      ]
+     },
+     "execution_count": 59,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "FileLink(f'{SUBM}subm.gz')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Individual prediction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'train/000bec180eb18c7604dcecc8fe0dba07.jpg'"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fn = data.val_ds.fnames[0]\n",
+    "fn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAJYAAACWCAIAAACzY+a1AADvg0lEQVR4nES95Zcch6HE29w9Pcw8u7PMoCXRilm2ZUtmjiFx2KEbvDfJDeMNOjEzypZkSbaYcZkZh5lnmuF9yHvn1f9QH+pUnV+BJ364/+b44N0P3nX4w7fWtbfYDI2Kco3e+dCtgfPnrv6fw7vOhcefvnfduy/+vX1PVw5zXDuezo+HGA2/zFscNq1ZC/bUuLoaG0togWXSxRSg01rLq8zxTEkCkMHhSzpH3FmuMMs1MC5hZB4UKl45cl7ECbvRkxyJextbOXzo6L8Cnuqem2MXdbQlqQL31DtCc1M5AEuAmiZjiYfV14dzkhoo8MFdpvraqq6jAye+/JNtC4UrNhJ64UeIp4asdSllQTnrD9Eiv627wYyLR05N3/1UW7IwwmSIfZ3/HeZvTC5cV5GFSpuZz5dq19dNTPnT06jSiFl06S1bts0u+EPJTKpEa8h6EEhXOav7L87EfP5te5pszVhKTOei2TKTbnBw0Nvg0dv0l85MXb/k+863v/Z5n++OvXsS4xclbYbECxJbPPL+UnX9rscev6uYySEAaDI6ABjP88tymgyORQp0kCdSOY4+f3rxe9/+xeL8FaMJtLo7zr3x1/be3gwb5anS3M3A0jyrbl0jwsUvPdY4PT9cV7NXr+tIFgcWA2dJVaTOfiAS4FD18sjtHBQryfc9/lzTmq3xJKAzN5y6MHXtajxVuFQsnXnoQO8dexbvuKt8ednRuOm/RqTyC+fit/piKVcdK5trW7QyCGzZeP+NvsE4M4tDkFFDzI6Pnf70ajGtQnFWr2f27eu0avRpXyHDZs9eDvaNyeeH5jymnlycMBlrKmorZ1eG0jlGY9QWmKIAgIgC1elgQabsHpveZs4zFC9Wc5xBodQAoqxSqMJS/kbw6C9f/67W3nnH5m+mk8bKtmpAA436ZmZXgxQvO1xeHCNxTIHCqnB09K77GqsbiBwTLKui73u0/a77O9Zuq27dWH7txGBi0QCBii37m3vW2ynaX0zmmFTurs1rywlCmVdIEUyLAF94xltMn1+cf3dw8tPqztYjl6e9dR6Z7/7dLy+FAtiff//hS++dd5jLlACeTnOh1XiJxuxlPQpVNZeGXn75ZbVSAYNQNpHMxLM0RYgCxHKcUmXv3fJoZ8v6px5/yOebsrmdFA9l4mc7a3pvfLaoFDVXzoxyFN/W4tUoS3ft2ZQIcg5jFQoAufSCJIRXJjJuQ102nhYowaStrvCqwW/tr2lvb71544bESLUVdaBDdd+jT8D4VP/lIzALNdbfHYgmV3In3fV1i4vaQn+AAPTrDmxeunRaubH+4skhnNeYjflte6o1aAUOR3wL4c/PzLGAcv99O27fOnHvgb1L49FCWoyDYV5qcFfVjcyOVWo15wcH23t6ynVYmg3oHcqxi5GL1ydxrarNUT0bm9tQU5GMxBdipbiscClK6ZKPB4gSz7R0VD/5xNdAVAmbIIRZUsyjCSClq17PcoWPDh8+8vpFCCEgSbxvZ3dLte3mWL/N3rV9f4PKvLq0fN3phDTqFkFSrPj7Kqu0SOzAsfcnW+ojtesUVILz+6J0Bl2eipbi3PP/tS8UyiKI++NPP3z86425FGV1H/jgdNrgjWKms/WO1rH5/k/eAhyGsh13gHvv/Kfv+oXF8YFsLp4DkwqzElQ7U7Pa7GxQWyfcs2dncGGZwPTXBmaNlQkDBmlhZHY+QqidHdVrDWbV/MqC0mTvWr/pysf/sqFQQTSPjkXCwYyFFHA8Ube7J58FDIQGVYBGo9kXWA3HR8pM2zS6pYmxSZuzW2O12Gx5pMGjSa2O3rO9e2Hav2FdN9jGnLjyC4Kt9mg6FMrY6Mq0gPgifnj4xmRv+5a+aNCMZyN/7a9pdgeuzImJ5S9/7am5ubliBMUsEKoAc4XIF7920JfOKM2rh56sEujhsjqzSe01VD18++b5Tz59FUFcTevrzw5ee+3Nj3BGXLe9zZbNx9NRRAHni7QvtFyiAQlQwxifzyURDWlyymrRRKrrBBHY0Lum3OUJRtIgm5+7+Z57xVi0mFCbaaIveO5YPy1CGABKnCChKKbR6I0NrZ2m0ck3t+2utxhdJumpSrdhePKww9qQTeUHhq7lCs5GV4tHP/3e7VMPP/T9j/4127WmWiwurGTG1U5iYnLKVl1+44ZqzcZnffSnHdtn2JTZhD7MpHCLZclqYdkU1t3Wszhy8eax140kqtNpomna4DLH06nOjvUD0Xg+z+g1ZtFScjorX3rraAVbaaiylnhqU8++RAYK+aYVmJkrZVp61k5PT8lQUx6ejHEpUa2MpaJWLcmKRV5ILc0HzR2NJG7Op5OFREoJOArJMMLn1rbVJEpCOpNJx/zg7Mt75qbHIZhM5eGuDfsXgaFQcWZ1rHXfhj3DA2/EAW1FlZWAwMGT+cVszNrblE+EkJVwQQv++L77jbpYMTsxu1hCySaFGSs3IzPjsxxJqLzquC+2sjJ+x97tVe7W9945SiiZ+x8sxzjDzGAcIpuf/P7fUqzJgFoj6cXvfuvB2aGr0Yw8MhXZ2VE1MJXa2FzlsWmGJgacleUilZEha/8QY/Vqv/rtBw+/9QtvW6miRtuQ9ZpWZuaNnZcKiYtv+uJFkIKLBEoggPjbPzy/dVtbOq0//OrrtV6+ph6ornMvp99tqz0wP1xQ6kheZq7P5+r1WjcQsjSuuTF5ghMBj6tWI6KBsamUUedywbPjoSbHw++9PIKvudHR3J6aIMCsAWRZqdzXsck2OXfUQjRKeU8unIuv5McmZ7/zPz/wtLQfefdPbR3V+bThdt/sjC+7q6vWo0fLq6pLuNGm1GfCK9lYENNoeURhUJFCMak3kKBJmSrmFufTeqW+hKki8elzH0zooewd+2qyaNFlrqPSS6Wc6pOPD9dUWnHAXVON5qKBTC66+eCDrq7toxfOIBPzQ7t2bfaHM1BSHvEv5wsIoG/62ncf+OitdwmjPjdWuLFMJYvje7ZudXHWRCS4sbkyU2kiUKWnXW3XGv/yu8Pb7roX1tlmZkfnfdzp0/Payio+lDjU+0Qx5zpxMoQgl7TasrnYwptvLtgQB5hPRhlW5oBMjgfxPK4GX37hnb/8+ut/+NtbBrUeg2ST1YArpIX5Wz/5wZMtnfWj/RP/+Nfp+qbqODv42Y3/2bLbi5sokWUjc1Ewx7z+2SVsc0suj/GwgIEwKAMgBEwvznXvaOI0I3fcV9PZpAmsfJ7L+Q3oEzOD41waqfF+qe9cwKD7EwTwk/PpmO9Ni9taohxq9Zf8c5fDhWth1liiCP88riou89SFx7c8o9UIWQymswaOBx0VjSIFN1rVICX0j/lLxXROqBANpr+/P7TynRcO3lVP+UJtvb2Q2p09ORIOJZQidrv/9sEvPR8PTQxcubpv5/Y0l4ax7KkL88VgAgZ4W4Nuz0N3GdQVgeB0eUO37xjty666GyscFU19Vz+NhUSHTjs5HLRZnZu3ti9NZxGE15BODDK+/fanBwhPOlsAF37Xlc+BgKv2nc+uPLD7wRc+PY/p1KQRiiZmOS791PcfunH8lirfHluKFNOTdW3mh55+MJnREUqPRZ/7xZ+/cc/j22SQQEATXQw0lVXbcLt/JX97cBbV2W2V7oXA7F271//tz78BqhxEUV1t05QZLH9+88qtvtVcCYFxBgURVnI4iaV//f65b/3wL22bDk6MD2/r8X712TtRpAhCPMS4DBbFmb7bRfVgEeufu1G5vmvTGmPv0tE3RBW+5eCXnd1PsYSSlzIEgitkkJMIixHa1azCDEaQsD73rH3mlh6xlFe55WysL+j3FcWKyrpdsdy7GtscLFvMxKMKWzUD6RNMGuYm+dBMYlLhMOtNFco0PW2ilukyxJDdePrFqZouxLM+ryy3B/qniJxmoH9IZQRvFsrGrrMaDWMx6grBzOMHdlRphXN9p5/89S8AyJkPLoFMAceUkEL/2fufaijl5ZPvC2oJs5c/+NSeoRMfErQhBGQe+s6uG9dL23fhyYQPgSu4gjGbK5VV14SkNGiAgGQsMqjdtb4RgPI3R9/GpmyBVMhe5c7nC1qVATRXIAEeXVz1Mzmhur35+nj/jgNGT+XaX/z2DaelymzU9H+2CghmQSHVblRnl8qffObg8NjtwQGfQW/N0Lknn3ySAsIyhDIlXq3VXbvVv76hF1Xqw/GEmErP+WdoiX4tuvjY40++ce5sR1trPDgiwGhZWdm5C5MoZubFEgLDJIbkSuypi7etFmMxGQXYzJee/TYgxwqFrEar56FJVnb/6Tdv7Hxw/dVx4JvP3uV2lL3+tw/XW7QCAn/568+zogSBIAwCoigKEiBIQi5Hu8saQCV5ZWDigyMXdq79KmQpXR8Y3bO9Ki9Smzfc7YvAWrzNYtkASXpEVtGlGxBZRRV4iJF72w+BTfTotRtl3howljcp8RxqN1mcJeiwP8tDKVXaH2JWkmrWzfF2BNVMn1yq8PSmSgsr2QLPpm0V5fnofHv3Zt9iWGtEFDgmiejy6sqSf2DfgT1IDk3GZmdjc5lS/s3X3itTCHqdZvvGzr//6xWJqXO5vN4yr0ZTE05nJJrOhH0as44vQQiob6s3Dva9nY1TmMqCKQhUi2lc6Nj1mVZHJ4yI4N4u6OF9+y3VHlxPRqbmHDVZGHeXaPfJo9e1ShNYomIwkmW5rlaxOLt47/13ijRc5vJcuvI+r6yrrtMX6TDHoRyrIjRJEtI6tbUcA+sNZgxnCxxAS/Kb770NgSKixL76xa9MTJ+anb196iQ+NBIusYQEFVAQ4bMIpBI0OmhdrUfJi44yxcMPNwFIihdJra5Bo2EQ2f3Tn52aDfq//J3Hr534OBANIQLZUVN2bXhqeDpAIU5WFEA5h6FKRJQYCScJ+usPdGWLqpPXpn/wwx6rQeVur5oeWPKUQcF4WGVpZyRTLh2xG1xKQIfAIUV6FNNWBlkoHg2U6T2Dt9+usVXprRXmyiqSljO8QihNl3LT82HK4F6nZC7E/ZG1LYfyrMnisUVu9CscCtTB5yVAa92/PDrkhOFSgQoWip+d/1himKa6xgcfeEylteS5eGIuE1mZNHiM1e2bCEoCAGb03GVbtzMkrKjoKgwAstksolA2u7x+33g2Fzh3qc8fllRGe1cjXOONScU631KV1ZMbWrxgbVSxPD47FbOb6qBtm3fNDo251OTmbetsSv7CWxPXj91A6aVdvSQBXRuZu5ijaKet0gLWcMXs58fPDE8m//nOZW39+vGZsWKxeOPSNYATCpmMUiqJxQyJQATIaTABlAoylzPpFA8/fOgrX//Sow9svXr182w2q9TYGxoaZFnmeR6GYQAATBoiT4s5XpXNCxadRotpcAjTkHoUMZ38fOSrT739pSf/ONR/Zevmqkvn39/Z0t1VXl3rNnOSFMgDLKrJFAooAuEwAoIgAACiLEcTOYvTrlLq1nTuUGDtMGg5cXjUaVCTINRcW8cX0wRQgkQ/TV2ymOYSvtto3jRyYXzg3AmHqQhC848+8JhIs/GQDwBFkYBITUSlA22e7nsO/by391tGdA8itJw+vVhVv1dj7JwKgGqzy6zxlutqcSDRWu+kSlmDgoSyeYtGtXnDRppiYRjOp9OczF/uv+auL3fXejiA+uH3fvTJy+9funYNURIWS7kS5yQG0qmchRzFwBALAyAhl7nLy63Vt24vxlNAjtIMjPoAbXZlddRi0eCAOhuBEqt4XaMX/O2DdVsqa5diS0qnLrC8YLV6I9lYls1v7t0CAdDZCTabl7jiytpyo1qvnV5cnQ2TrsZ1l8c+39mGrG+r6mooz2Ry/kjKqS34A/zqolhZUe526E01FobiIQjhUW5kYqizu/zKpSBGqt5+61MQ8g4MBUVQx8tZBIBVIpSSYAHDdEJhT3cTlUk53IDepOwbWamo3VSMBkQa1puAef/SK6+9X5q9HYv669oqr48kn/nde7IoCRyvJBAUFAUAATi+JOMylJk4/9IHh/9y6Es/1YDi8NV/79rzYyk9mc75YBz55W/+dt99T4SioWIcSYeyXT1AMhG4+5Evnvzs+OZNmz5+89Lo+Ni3Hnt8YLzftrYR0Wsr1FV0Hnzv/U+9bd499+3UKyv9Q0euXL6uUlZcv369akcZnx3rrGrx6HTxHBpZiU/dnq8wlRXy6fL2+tqm1rff/wiG4S8+/VicE99+6f216yq71jfxgKLvs6HEcipbWFVXq2vaOjNLQ0rUe+zE2ed/+HwehS1GMpdYaW3eOnIr+Mbh8yiX2LuteWRk5eBXDNQcJ0EKCHEH5tnlmXTrAQSyO63JbGExkotx5HIRb9/affALj27ad//gVFZE6qACBaf8jWV4EeLnY1yS5t1OJcHGKnBApdNarVa6kFcgQplHCyktlS1b1I6WGX/h6JlbWYpHUVTiiiIdIeDc7FR0YS7CU1CZq3r37t0oioqiKP1HKEjiMiazIowMzIc0Ls9CQIinNDhZNre8CuBsJhtfs6buxJHjOoWrsrutfcN6hVb1wmuHARlBURQBBUBiYRiV/z+hOPb8975TX931+KOHTh19e9f9G3715a8ODfbDADY1MtHg9LR5ypaHllya6pSfb63r3n3fHa+/8a9KjwMq8murux48eM/Rt9814MqJgem+/rkrZ8dnJ+cbGqxKLHn2+Atnz3w5Lh+z1fjSqUtb1hvd6pZa653LY0b/vLG5uiUdL7V3bYtm6GyRXp1YNBK6DV1rKz3O8OrshSMXhKwwPzIRXpy/euq4IBa279ppNOiq7J6pW9NOq6emuvy3v/lpXWNjVU2ZWq2Zn4386Hv/Pbs8uW1ja5VXVcr7tQos4J+lMGUR0nuqutUGjT88oEAIJMQWw1F2lUXTNBnV1r708TAN5vJidn3PxhU+yMfPOxBDe+3OkUxD0DeqcjhcaKlGW7ij3D1AoNevXz+0tVOWizgB//HNC4lsvwTU4LBQW1kBoAoAkEQ2b3JAt/pnb9wKdnRsj0UiTCnT19cHgqAgCDAOIyDCSRyJYzDLFnhoJcsZYj4mL6sKiqXgYlt3HUmpHQ7m/oc2A9AcK5BRBDHqTdFYajUl8RyLoIDVqCkWi6IsybIMyLIsy4USdeCeBz97GyD4lrErmfs7QskxiXzWeOz0Gb1S4XI4X/33Pzs7WlnpuKSeY4QdRnz73j2NyfD5S2der7U2MkVhbXuNQqEyAsbFPC6rluqavTIgX7+WTCc0xUZBa/RoMYNFsrjlOqdtwmBpfWv80tXBazeGr1VVrpnxFx//2g91ajk3Pv6X3/zl4WefAPhC3L+wp+euAWCE4qbCC/MujdFb366SDbt2bh2YuI3RmMyqEQgKhUKffH7hjod2ggJ25/b7SeDSqfOfEwJx/71Os45J+9lmZ7e+/cDUaFxU6Vt6Pf4kwhQ45M4d646cnUynAnLUt3VDg1RKNjY2lTgqlqBwXFFz513tnetoDt6ksOwna0Oh0MzSxwll8nd/Ha0pqy+zQVqzK5Tkrl7zey2bRblQkgkDoViZDi4O5vZsqkmmElnEpe38Eu972+FwhG9k9IYmSIdqF+MpPw+DAMTJICRzPCRDSkhmQYlLr2TLGr2wQdxa0ZWJRvQykCdCp85cuWP3AVQQ7GCEEYCjx4fjDKVAUZ7laBSDQAIBQREVZUGCZVmH6PIhVqedbbRaC9jSHz7L9H55qy+5bCyDw9NaBFI09W5dSSXgKd2W8k262kJ07E2LeyPqfUit6inT6bmhywuLp1rLgLvaNn88RTWahdnw8rlrwz/66h8Pv3jKyq2JDQinPzvT0NpodmEqvfnkuYESnfIgelmjqCv3mPV5pZFOMWmtF6/d0vzPV15/8qHHq3c+wIJSd72VnbBRyeDlwammTlmlA1785Dqp0hNmzFNV5VzTWshT1/vGBz4d3HRHl69wXQaCdzdvfTU1KJYqfNHInm+syUuZ9390uKobOXPqZbOkw2mJT2nA975TtVpCOnbvPXnjs7Wbmzymeli2ooQWIal4ciUXyaG4UFnp9Pl8Jp2VoYWl5QuYIl1Z3nHig2NNDfv7biR/9dMXv/2Nr8sqJkmVzOUmSEj+4PkvfPbBWaOeU5D0zGqgac3aUERMRCUVpvcvLt5zsPe9w30ffT4GojIqIigsIQjKCRLF8TCMihLcWW8sUxa+cnBzGSn6OUt5o11v1776z9fHh6e//cXnLg8Ovfh+X0gylZgsgiCAwGvVaggGcqzAFfIgadBq8LXlWO/apuFRHFNQZtPq4/euTbCSyMFOu8mkt+CIlpXFvtPHYImHCFNlVztLydcufuRxCXG/T4E3lZSWMAsoYNkiZc0S722vvDBxI5th2Rwgl2wsLzvdjpqm8jPnTu3ecvdqLF9XVUMlgrdj0x6boxjL7u7acv3MRVZYQE0eKsWzhdIXf/WdeCygVtg+/fNvq+1GhdObTGW6Nu5Q6iyIWg2wHMAXLg5eO33yuB5Fe7rqjp0aNru6/IvX1rcIGw79cPXEGaMJy+gZrVtjlpkzZ/LltRUek0HN1p4aPIF4mhrqHRW+dGLHxjYMY1gqTyjBUGyFVBKQDPKAAIoMR1NKjPzk6ItdbZv1ZLPbZfvo7U9s2o1aXWttBxfPRbxe01IuCPGyxWKw6AyvvP4iIep233tnda1NeO3diQu3cqJd56mWQKDSYweKiQqbTgVLRUniBQgCRAkEZRCSZZnhWITQ5jLZbbu3rMzNuBrdZTUuDuBjyVxb1/qWtg1sEUYQI4hpCjlGlEQMwlR6HV0qgYDEy5gMIqAMiaJYWVPt84GhWL/TKVt0ppsXRjm1Rk3UzM+dqqtrcBi7z1/796atTWeOjqamyip37Fag1J6da3L5ydqGzSDa8/Hp6wpSt7axVvRNBIanE+lkS28NoSWDgTCYbugbHg0nww1keVmVxReIx3LM5csvW/VYFouWO5UgnProk1e3du+YmvRnktliklfBCJXNA4CUzSVcbjOCyH1D/Rt7tmgNWgERVmZGOKp0rW/MbFNv29SbCftEmDl46NAvfnN0w/qaAw+1Xr4ywRS4ksRJINK6vROO3baZjP/++wc//em3Q1EfLwtIUGekwjE6mVpbVxmenJhJTDVvVM9Nj7aV3+efl70d1jNnzuDdm/JxGOeaCMCdToZW2cnebSqjjUnSL1ZVkIHCEocFmrvL49FibCVZ1b0mweamV/pPfK5b/ftqjcbS27TnzVOXGND3q5/+nKRZSA5NjH6OyrwkSSAIAzDEchyCExhJcAVKARUR1DjqK7nMDZ8GITg1p7dZABiJRzmNQpteXJ6NJyISVII4NYzJMMTxPErgAsdgIM4DNABIDE19/3vPkwbV6vyATac+efi1yjJkNWFMxZgsx5d7YX8oTsUsnAw1blCyjnAxt6wAEYAXNLra1aB8fuBKHVFUzA/F568XlJVlnroMm1CIykwk0VBbefEzf3ljlc5kUapJDJaWJwZt9gojLnW3VFXb7Mv+Yaddc315jiKa7t5x8Hzf6PTiLKIgA+MzpgobX6ICqwvt9bVV3iqJS1++8nF5YzUo8wuToypSZyEI3+qcIAkmvbMk5CqqOBDF3n47kI3n67ta08UUDqBnbkd811a9XkvX+t3XxqL7H63gb1RBSYpK05TR5lxeCcdihX2bt+sVFqvGNXRj+Pa5K9mViEen8c0MU7lgY0d8Kfyy1ZHjSvzCVPazT4lcoC43D8cjYZ1bEU+EE7GwDsenRoayqdiaztr68spStFhd2aoxuPRG3fe//CWgmJVELhNJlJWVwzCCKzAUg3lRABGY43mWZSEUEQWGZYX51WRK1kRBUzwNTc4krt9eXA0U+4bmJiLR+ViSkQCZpSVAZhimxNCcwIuyjIIAJApKHFWTyJmTR9944+v//uu/c0ENU8JU5jgApgHEr1aZorF0trTStVGDymBb7W4Icn325gs2FaE2uUu8oqK85cH7DlSXeUS6pMBRhVrF4Aipt0ZXS41lPUsj0YY1tYRGBRPKTw+f3LJ2qwhzu3dua6mthyVgftJXX92iwIh77rnHZLQvBoLxdM5bUUMzzNGjR4eu9SMSYDOY/MurGlKHy6LHaQIEppTJ+OdXOps8/pmxUiqF4oRaQWgUsFYDNNU3+PxFFMb6Z2cUZhuJ66bHlydm6Z6eLRajbnZ2/sjxz8LpGGLgGH8pgZdbOaUaN1YurkRGF0Cr4/6JifdqK/VAhDMhnLdFqTaIBWCbEp9YXUxIpSqF1KK0C4PnAk3GNVseuPvjE79zWNQuq7252onAaZVW/+6xk3pQ6ij3hsOhHF1s6arHijkCAHK8gKsNmWKY4WURlBAIxQglRdGSJHOiBEEIBaCFEp2Nx3ORkAgKKkEro6jJZJqfndKryVSRmZxegHi9iRMZAhBlCQIgmqYVCpyAJEKJy6AASYyKAOqr9u7qkpRIKbBC7T9wp7f+pjoTS0caGD5fVwtBRfrU+zP3Hnh2+x2t4os/l9IF2aITFAkJDC+Pz26743HXpnsHrp5rNsmOxg6hJM32T8/15WKroAwurVl/VzYp6giTx1571zNf4GR1dWNPS2PV2bGxC0tTNqPdyKuvfTbg7bL2+Zf4JHNgx1ZNrb5KYeIytIYgeR6YGZlRyyVKBzlqqvAigdG6+fELRhx1mcpptY4qhX2rnEp2f37irNogPrT/6Zdvf3775ukOW7lFAXbet/2N/ztHQqmH9u680p82rEchPWN3Wd1qo4KligZQe6Gvfyyw0rewYjS3cHknD6Freu++2Z8ZuUrNTGY4iUz5EmQx46wKqUPCs/cfQrW0JOecSg2YqQ9PMgaCCk068mm8x7tnpj9lrrdVCmJkKZpIcmOry0WZJzEclbQwSim0PAKaQJkTJVAGIAzDQFHAIBmCsFihIONYPl+EKH4l6c9QyWg8nMik/fFkoYgwrJIG+BwqyLKIwCBdohAYFXkZlwEZ1xNKo0dvPX965LXf31jJJ0PZ61LBh5W8C6tVJlt1zyZ4y+ZGUHAnY1UFXv+Lv3935Pq5gtJ87uS51OkznjyLMor+EXp40q8zu7q6dg5PjEAmmecTjpbKmt72PCkKJe/op5/q09PdO3UfDv5vdWWNs7LxyrkbH7z1zonDx5SEssSif37l6CITkXUO/8ryPfc+DrnSJYq8sgQ898x/Mz44MkOhGWEZ14HojqU58NOhi3hHVTSmx3H90O1rRljiaKFYyMsA4/J6DK7yoeVpm6TYtmYTYXXKJWTk6u0UvVzdvfb6tSm3CoEmw+DRv3TdHJUm5/x37q+WmJuLgU7E7IknI14D4lDK2axMGDiX2+yfifoTblS32mzVSBGY0wcoulqnUjocDkCpvTk8OTE0a7cW1nV6Ecguoun8IrC0sizWEMY8lrS49WzEbSjval7jtBnAghDIZZ/9wR/DaT0MMlme/k/Eh2FYlmUYwUgUMqpVVr3aaNDlS5woilVVVcvLywzDLKwGWBCRQUBJgBwjiKIIgCDNsSiK6nBFgRU4juuusty5uXNuZL5jv0qFogWfPDsd+MUfviZz0ve/97PyJkVdu05i6vxLhTWtGFrgJ4OZRx/5yunTn6pNQCSZ3dCxU6VXqe2Vn7/9PgmtlFS6HCUcfPDZY6dOqjRKDzCiQ03hkP7yMpdHRTsG5otFPpzSqMlkCbC7FJ5y68ljty0W012HeniWO/zOsN5V0Kt6rw98+vSuLaWpPgCFYL0BNJWrwIqVlTFUyylIK4LkNAIviZzeZSL1yls3pwNBoMDBWjPp1oMMx6v1eq3eeOXadTidu/vQHSWuhGG4JCJDI1eR65cLe+5d53TSRgKbGjMyGJ4NhG12xOqEITG9ulB0qNWzq5FKb9vkUkKFw4N9/V5Fde+6HdESsbS0EJ2cTpfEXfvvMSoAk81nVbu9NQa/T1FPQhpV1RCbcjaLMSnoAZTFODM4OKnf1kGIkMWsU5NwYSWP4TCpxLLZLEEQJKkQBAGUEZFjKYaO5yVIgafSeYZhYJzwhyMKhYLhWB6UEAwFZVBPkCIglxiagyEZBlJUAUQwGRJRAmM4FsOwuC91fWEln8TWNHXPXp/VG6DH7zugdWqWIiMt9TVSOlSmNwVDfQSA/f1vr00Ggxan/PXnHr/60acUl43FiwpCd+ddHTFYPX7pxulLpwVUyMmljG+lJKd9IUOZZ8NUzI9wcHOj5/rKZE1dx97O3X0D51S4stpbEQr5SJG+PdqHISqXtUrm0EqPEifpDE5jWrJpY0MxS4zcGE2FA2gKVeuw5s1mjIZammuzdIJHlIce7n73zTNtzqrrfZcysLhr125OkAhSef2GuKalZWSwX2NFz18ZbGh2d23shbRVzvPnl25fy+XympVMmoEyTCkklfKZWM7laiiJebfbXSywozOrFk+ck1dhjCVJYrQ/ffHKZRBDQolYfV3TzUs39Djc0bpmZYnq679++J0rgXigosJTbbeELt+uzMsKSCoWOJvdMz4y6k9FJpfGK5vsAsFxJCayrAJFnVarXq3WkKReqdRptAIA5Wh+NZ7MZPOZbD6VzpJKdTZXIJSkQkmKvCCLogbHnQaj22HXkAoUhko8h2EIjgLt7a15hk1kQT6s8bi2Rkv6lVUqHqfP33jv+vhH/3jlleq6/f6FTGNV18nD/WP9s0YeVvPY81/+7y889LWZ23OspK2qaqmvbXJ5G4b8ed94tMropXxRM6LI+CKobtet4YRZqy3MnbYVbrXVN167dLLco2tva3zr9ZduXL2CgigswyoSj4wVIBFNZ4tKUqEnF0GaVSm0amuZobx+Lp5ZmhnLpCZNBtJqrigW6OY1TcYyMw2xZ6+eYyAOwJme3pr+/uMKOLvqm9fplSginTpxdPO6ztbt60UV1LC2/iv/80jLvva6mgrwm1/pAHKo2+JKZIM8WqzvaJsbmVUhaDoZtjtMeSq7rqf1wvmrnd0HJpaPm6w6s0iiGd1iDNQ6EJPNanW6lZj1tRffNpL5xs6K4RHf9t11cyNCIR7Q2fOaOmAfsO/aLGRakzp9du7g3fd11rtfevnfTV01PKl9+KsvpCnQDCJKpdJmswEAUCwWOV7ieF4ERY7nVVpNpd2eyWSi0Wh7e/vw8HCB5wilDoFgRKRdOoNaq4EIrEBT8ytLMkzSxVxrQ1V7XRlP5aeG43c0ewKyPBGMV2JEc2O+uso2OeN/8mtP8kjmnT9fiwYzBiWihhMKEFRoax/+5o8ypYDI0W9+eHrk9pkdvT2uqlZtjS056WMK6WgsZCxzrt25fXa2b01FxdCZydhywu7UBhEFpuV0ABgMJURYHwwv4JjC7WgV5azv1krjLvsb781s3Og4tMXz7ofDnQ3Ns5MTtmrvranRGjXR0lKl1VVf6VtlZaGyHunpqsvnkjiqmFpZLeZ5h6XMaXdZzXqNXsfRzD///sIP/+dn+USaItBU1F+iYxPLsxqHJTu8ghgATcc6oKVRP+c3nb2eDS0XC9ECz+dNDlJNymoAN4H8E3fsOH2pX69zDlxbaSuv40urnIFcmE4EIlpnMmZVVaC8qFRDviWt2iWPTaZRlASglLPSpm4kIuP++UwmNaj5/f/9GTCagOUAt5yULZq8tPzbrz/163+8icIqgiBgQMYwjAGBIiyBCCYzLIYoUAD7/re+YTKZfv7zn8/NTNoMWi5fFARBAkSjTpMq5BCSIFGEkKG2itqF5ZDTbLOqVal0AkIAlZdgqHjT+u6R+NT8XLimvGusP+Cy1hIFg291dWZloWdrrcAzOKhb29Y+Nx7+zS+ey4iSybvuxtXJvRvXW0gFQjMAJ2RkeWh4bFtXlyiT/ZemOa50IzY9MrEKg6q66vZobHRhNqHIsx0d9QkAKK/eGAzEeUFcWJ79rx98EatjPzwbwWDTXP+Ex+EMh2KtzWs/OHG0qbvDrpOLcE6Ci3FCMngMty/f0mgzLFNK+uF4hgUgxKBy/v0f/+pa12nSaRdm5w4dum9qYDQeTSicxsEr17QIpjPao6Ol3fcehJqbSnAB+eSV68GF5UzpwpbeO773zR+VuxxWkzKVWrlzz87w8mIxmTCpCIux1mVr12nLHnzs4ce+eOjhhx5gqILLac+mkxLL7rlj+/x8NBCdB2BSpcUAMKTX1s7OK/R1Osva3Lqu7Z8ePfrZq6/89Q9/6W3psJPaeocrF/Tb1EoCx1EEUZIkCAAIDCtUSgAACILEcXzzxs1dHR3lHk9DXZ3I8xzDoDgmSZIsy7Ig2hzWIlUAZZFU4GpSUeUp16lVgMCDMJAtFRaDM2arKpXx68zw3r3eyCKwd8eG+elrfecmLx4O/OoP/0vLca0TM1eZ//Xhx3q39u5De1AlcWV4sruzy2rQBxcXfHPTIlVYiUUP3H8fKwKRaFIG8Xp77/x4zFnuvfPJfecnT9JiUac1b9u0p76yIZ5Kjk9PYAqCYpkSQ5+6+PHEXF+OyosC5rZUATKv0apxHN+/d19jbU0ilTHajBIOfeOH312/e3MmWbJY9WoNnknlZR6nc/zqcsRsdcdiOW9FxY4du27cuGUwGBxW25EPPiqz2JWyMhfIk5wqkEogIFx/Zu6Go8wZyGTu7NmL56/dnLztadb5lpBCqnLwylDfArWrtn5TLRZnYuGIL0cnbw2lNSbizGcn68qrgVQkGi4hJkuOYfc94JmZX08qikoNQgvVbFhxT91alJXtGd7mTSMUDTDyms2tJy73sZM5lcggKvmhg3vePj1EyBCJ4jGa4jCIRABaEAEIchqMj92zXyAUPJ+rsJqUpC6DomSJwjAZxKAixDO5ottiL2QzIAwQWlWVwaQxG1eLqTJHpSoSXC1EkmYLJGn1TKz32Q0VKrvRZfrZA3dygfxccoamF8xwAxY3DQ1Pb2m+/73Xb035bpRXlt+/fT2VW54Ico1r7hsfuqYen9PGoyuXi+VVNQmskORDoekpkxpkQnPcgu3JLU/dHLtcVqYaDfVfmEp1dTRjRPXg4HRVRQtbqCe1ZWf+7cdLiuGpgDQP3o7PddU3lpVzmVD0wpWZL37HC9u1Y6MnnYGAqUBW11UmphVXzq3otGVM0VHdk2PRwEM7f3bq7Juvf3zKq8L8y7GJwZiBL5bby2709amsTSNDI194fH3y5BVIRFCFWv3AAw+4HNZb168MTUzML0S1GgvDxtvbzenpYGu53aJFPjl+VmQ063p2yyLAFfMmgnjxp0/XuxCHV4urURQEPj8/OLMQL9F4MMCsLBUcOmtzZRMhkQCFddaugwBIb7QqjAZ9hYuiCx6vJ5nNcDzDFAuyKLECn83nWJ6DYZhl2f/4DEEht9spCTzPsyqNukRTRYriRYEXBUmSUAhGYTifz2M4juO4yPFam7rElAhMy3Kc0oSXu9TFVGlmZLGULi3OLP71L38PrIYvHzkb8MW379z74ssfroTmfInRnBgJpLP2ci8OQ26jIRcMbmtrx+loMdK3rtGiZJl8iSky9I2+28UiNTc5f//enToFVltefuGzz//1pz8F+wND16ZWfOmRpfCpS0Ovvf0JTij37NpJFbNzqzcbmit4DlSSporaxr133lNZ2eZx1KaTqzt2VbkMG0spvK1p/epKIZcnt22prq2xNdRWmPUGlJxpaFTu2bNp4PaIlvC0eDwmnb2meZPK4DSplHw+2lJVgYFsU4Pb6TQ5qlHwJ8/vA2WJKeSZRFKHYDRa3tPROXDzIoawHpcZE7MUHs4xJUwqDy2G3GXm8jL87ru3JZdm/aUc6Swbmg1OX/VRweKXv/9f/3jxNW9FdTYVtRo01d4ileC3bWzjRUGW1KjaIRnJgdHR4NLqPXferYa1ElPyp1df//jq6ethXhJFUSQ1Kl4UQRAsUTwoA13NDX/7468lDJZhbuDUla//6H9jIGxBEQxDAVAi1SQK4jzLqZQ4AgE6rabaa6GSiQILi5Box1N6c0UqSo+P9//xL18vq2GuHY9Ewmm3u/rk8ROPPvrosbOXnnluP8UkPO7al1/5fHx06q5td908f86u13R0NIYTM64yzdL0fCHIr7ljXyoRa2lru3K7L5IrbltbWUjnTxw9/ptf/v4f//inx9aksRoCyZDeYf70Uv/+XTviq4tOo54kVa9+8JpbX4YZKpaiM49u8Vqbq7JLMh0KJPPTjz372NNf+/PGuz2VayAr6TxzZNhm2giwvF6tkwUQRyLlderZ1fjcuGN+bqKrQp3n8BCri4RTd7k4o12t91acHx5d37sm7J8uYClkdTZA07QSxYvRHGqxGsvwkYFbTClrcesikRVKA7bVOkJDQ/t7OjUdmkA0sLG3/fR7xw2wTd7WrXSX31G30yF+Ti/7rcrAD76+bSkUWlooIRDlC8q4QK6G82Vlzskp/5Gz7/3sr3/esXtfPh5jRJqXSzAuGb2up597qm/qnxTP5osFCQBgEORFkSAwlmFopoBioABJvMAbDHqcIAWKYUEeRCAchWEJgBGIFgQUV2MQyNFMLk95babPz17UWiw2h8JqdI0PXti2o0mlSa0szU+M52SeOLCnU6/TXrx8pqXJMT48Mjo8D8krG3fUb12/dvDirY62xkQkfOHmsN4CJmdTd+69m00gJq/1ViqyMD9e4XY+cN/Wf73y603bth946nF/LrR2V09N/frPjxxzGtTh2Vmjzl7KlErZjK2uymix7d7wiFNX3j87ytE5jUHR3UZeXp62uVTry7eODvX1rnvaPzslcsJILGPX3BVOcS6naXhhqLnBKWaly1emYNJQ4uKcHNeqbGpM71/IigKDq9WkTnOrbxLTkOXl5ZDIZc7noPv2rP3597+2prHabjXqNXqnLmvShpzO0txCf01tBVVgGyra/ud7P3M5LUffSUyOwjlQjkP+DDYfjwtfefD5v37z16ml1bJqh5h0ACX33JwkYY377v/ZtXE2D1benMqilob1dz/565f+HUkX0smCXGAhtihQJUkQZYqGUulSscgJPKoiMQKHIEgU5VKpxLIMy1GpVJxjSgxbxAicEXgQRRiW5XmeZVmRFxQoptPpYumkDEMiLySiLFdI/e8Pnqzy2PIZaH5xxWIz3XVwC04YbpwH81mORAy//9XvV1Ym7n1k+/z1uH8oXmkz2q0zNgXjUkk9Ld540uesq9p15850nt2556GJGX846f/33/+ciK/u2bl+4PLZ/MqKAbYgkGZociZdjPduaLl68wZN07lEyqggx67fmO3vIwX2zPFPFhYWgit9CNjvcAz95a937tpTeeODy2g6nwlP5JLLTqtZX1OSQMo3G9VCJJ0Mx4PhG9eH6qrax/pGvTW1Dz7y9f7B0PDUVIbhGtd0qRC6yYU21RpDTHE+x9C4J8difcPT589MZrUWKBEcu3T2g3hsvrLSLgD08LUlPWa16msVYNWVs+H7N+zQC+STD37/2uDVTXeuvfeZg1Fe5FTlSykD55898forBkpY09wBqjUrkdkUG9mwr6f34BZaI/z7g78/8c0Hnvz2vSl5KZwfYREomc298q+XLp08reQlDQCpZJhgpexyAEdQSZIkWSbVKkmSRFHkeT6fz4IgyLAUQ5UYipYkSa1WAwAAIrAgCCiMQBAEyoBSqVSqVAAAwDCsVpjT8cjNqyeYYp4uyoMjt01Ww9/+/q8Tx0aOf5jy+ULnT1945KGHYEQ48dkH9x6sba61F2L5uvLmt1/++/z47Uwy5PMtSQjEFKMAz3z0zkeoDHJ0squz/Zlnnnrz9Zf27tj69isv19trxm+ObVizFuX5v/3ulw/e+wWr1j4z65dx7Q+//fyapjqQpb78pS8xDPOD53+Xj7OH9j2cDsC//+m5+DRkIyq1CkWpkFRriK6tNaFYaM+2u/giX2537N1Ux6VjMCM41FYOzB098emXvvItTsT27rnvxtCIwOY3ddbk0z57ZUUoWyxJijwNrKxGqyvX5B0AQogay1pls7lGWoZH3plkLOpAcLZn94G9ZRVVFmOo6PvrW5+YXWUNnpb+4aH1D35V5YNY1jcjxNF86tPDr+9/5p7I0oJWARflTD4C7el9fHxilkvGM1jk5LGLEI8aFXjIv1TesNlZpc/QS3Dd2lKR52EGlDm7xXj86gc4wJOsyFDSSmoFICCmWAQlBQIoG+pbOV4UWB5haZrKmlRIMlGSFUpZlrMMT8tQnomQJcJuNisRmOVFSFVUAY5cmrt+a7q9tV6Hu2GBcWnMsZD/+7957sTHf3RVOg2qeI2s2br5uaNHP+FhQwEnWADrqClLrKwCtkpPVxOdC5Ak7iXU6zZuICrMOmOLGpHfeunXXgMRnR03KomB8CKdl8nziwVq7Fs/+d787MiOXXvdaqSELdTUZbQbem4M6JazgQoXcjv8q3X7uq9/NtjcVPHoFzqmpwOL0XwhqQ/NzkUonz+b1+WRxOSKq8yE27l4OFW9yao2azBpz2eXboTlUstm8flNveMUf++mu5LUgqznsaJGx9GlFd+u/XVjs7xG4crQtMNdRBobtr58+Pfl9SaPrqz1zlp9Q9vC2I1XDh+xGpwencZTYXnu64+BUH5m4o3ejQ+89PffydlSt6NRylFla6ooRsykshiGiyyHE0qLWjs7O6tTa5QYKaOkA18os3s3rt934vPzaSDe3bU5m8j7lgPVqMZW0cTL8ut//UdzU/tAYCiZLwkgKkpSKV+EZUSWAQRBOIZORIJak0EuFWiWKjIsJ8o4BHEcxzAMQRAwjMggmEqlIL1OEgQExXEU4BgRQRCWZQoZSVGDbNvbiagphWnl97/91uhA6Pzp481t1bl0aP/u3bcG5xur6oduXVhj0Qd9CdLMG4waC6kamR88tOdALpP1WEwiyx4+8rGp0kPaAANMJuBlKhdvbDS5FVI4XP3977y4Ycc2jDTyNNNS37oQnmDmRysc7XwmokTVZKp8bvx8d7tLVKSWQiiCqFkJEnFM77L50nFAqXd3103nwpva2jAcLK1mlQA2dvGKXuEV8nm7Q/PeP1/thpx5AbjJX5vzD1lckADBBWARVfEqDbhtS8e5C7fjyYKnxQb96S//3Na4yYaYaUB0bG8k3MJUeOyFN1/+wleeYSSqd3fLqn/FZKgZHWF1VsxuVpXXlM8n/DVNFTQjaNWaYjaVzWaLnOD0VAsQhBFopdtj09msCqzDBtFzZ5ZHzhTTK0IqG5sJ2CDNzuae6VvDOAtc+PQsTwudHesBGJJxVMQRmMBQFGVYEYBhVuLmZiYL8cjq1EgpHU0mk0WWpUEIgiCFQoGiqCzLxRKF4wqFUkUxbJGihofHcgVm0RciFBhTSFh1EgLgqSA4M1A4/MKN2ZGLKC91t27O52gAlGPBwO5N626d/by3fR0vI7hatX7Xhl3376UV4t77740z9HIs9Ld//vn8yff4eBDE0bRe6wdZS5Oz3VNXSCcNVr2lrOahLzy/Or8AmlXXZ2YTEXD6Zuzm0Uvc8ggphmJR39RSzODRQJZ8TAzkUZLPK3zLKa3ZqrfYFSqNxBcdLWWjmZWSLKuUxlg+z6/QtUqyGBt45MAunUht72kE8IIOpRCM2dK7ZcvG/eFEoXxNxReee+pG/9WJiQGXTefQK/f03AnefuWb6chKdWPt7cUle+ua2NKp7GpMRKu/8tSzdGxlKX+LygqzY/kd2/eH05NVVVUr/nlQYrUIZFc2FIvFWCwWikYwAl+Ih8KlZJahxQTbWdaiVCo2Vmln+8+rPXWw1s5zqra2Voktnj5ypKm2ZWQh5KqoiEVWRZ3nlTN9vkSKAeBCoUBiCEOLlAjjiFxpIO7fvZEkIJvVtBzNvvTx2WCGUWLwf1bbuVzOZrOAkqwiCL1SiSIQJ4Ebaz3+VX+O4SodCo1SkIvA2p5KGRaSKdltzgwNMjvauzv3d8VLsamBgabaBlBCSnlGgEoL8/NZPeZnC2ZCg0hAYjTtsBo1dmjq2siOxg60ynF5daK2wuPR6Y785lIBgWwG3bPffPDc8IXjb55ov/eutVWN/r4RO0LRVKaqRnXLdzNQ0JTsSq/FAHJUY1Mzi2nGXh6CQUuWja/f2hgIhwFYv8JmTS57cc6vBwjEoMUTqBPLQSZhLFLceWDz4NCFtbVtDKC+ebW/vaObophf/uz4k19rOHH0PCjLm3t7BRoIBeP33rUJZAZ/8fqrh42GylRWllG1BZ88f2ykorM9Gpvdt7m+tfP7v/jv73e1bShJKUGT1qF48/qGBBOglqeZgMZut/AQ37S5dzESyXH8XGIBQmS7rHXLlt/98Nhde3qYwqrJoHS73TKEhFIZtQrfsr6jbzigd1U43LaP33/h/ue+vf+5nxYkIFGiJZa3qFTFbCYNIDKMkCL9xB07xVJOrSR4jDh6adCfKmAoCIIgQRAcxylIkqYoJY55bPZ4JOxwV3VVO65fvdG9oYtkQy3NlTRVkJAZGV6pqLRMXvKcuzL2zWfvxc1KVXkZmM031bg+PfLR2rXbkiLCFLL/+vDFjbu3KwtAYjWMFlTuGqfSCxRCwfDQFKJ2jS6ne7pa17RV3zi/8tGpW3atZudOs8ELQXQ5aCT9gzN8lq+F2NVMOI7H63fWRlM4UyWxfoWSMvr80229hsWLObO5BiVFJS7IFDi3kpEw3qRTtbirp4cnAZxXKFskbrBts0lr3MBwaVqM6UwmiCH/9sJ5swa2WVTnP8256oE79u9yOC0IiooCbHOU3Tz2LnTp3M2uddum55YJSUyODmVWhA3NXaik+953f2iymHh24J79ZRI3DAMTTCgW6JsurTBayV2j7JIpqpSLgSAbTKyG8nFCp1CZ1aRZARMgTkC/+N/HnXVmliQDK8HEoq9/eDEQo9ftuOfK+MJHn5578Y33vvujnxSLhY8+eguHEFAGZFGCBMms1TtMGggUAQgEUTxHCTCmVSi06UROiRMiTf9nr43jOAzDmVxelCSSJAVRBEEQxxUwSmAK1dGjn37luWduDwy++97p5WV5TeuhpupDB+9/sqWnQdbkcmDMl/G3rN/siwbueejAD/73F9ks19Gydv+GnWYeQ4IFDQ+ua2zr3bDR7rYZXfqm3Z2ImlQIKr6ABMKZ2l779/90j7e9tGfH5n17nhoZH3Or1GVaTXVFxWqBjsjKjQ98lQfdizd8k69NtEDuMkjjREzzg4ntTxxov2uzu6dB5bE1b+hlcE0uRW/r6r1y6QoHSE61ylxRoaqwudvKmJT88StHZ4dXPO7a4aujwRjhqqi2u3CrU3R5yFXfogQI84F50kL6swHcbEQo1gKy3A+/9qh/JjTOAv6V62aPt6WnWViVy6jNHx05Q+jA3nvuzkSzfTcveHfaOW4xfDlvAhFnhTJOaCyEI9Y/lu/GRB7McUUTpFZJ0vzgpebubSpacBh1zpZmh9tR37xx6uoNNWkOR9mIiXjqzp39H76V9afbutcgiiwkFTWkDIgpIy5mIJsyK0qgUO21NLS5Opsb6QJXz8GBdz8IZuOyhGogtRlWiaQQkwAAADQKJQjDiVwejvsaTGiVQWdQND3z7Dfv3r2m2tpyrm8RkLMPb5bi1om2nYwMlpavRR7Yu27Vt4DoA5fHB9/861sv/OnfF/9x5J4D2xrWlb8X/7xn85Nzp0+LK9OAKqdba5lYXdBrrb95altwefWz81cQVKUixS2WpqGzp4j+Iw9vPvTPc29XVDkbGqyMAu8wr210toE8XbOVfaR68+W55c/OXP7lD3/2s7/8ikhEgiaqRnAFbkc/S12+f9+mtvbGN37241CwsPvb/3fj5Z8Zlf2usrL8qmU5OWGtrFcT3g//db7M2dzmWB6LAfdkUKW24AFge207w6N19d3JfOlm/+02jwGRAWnJt5pJx1OhLEyqzTZvMs3lxyftWp2UzGaoDI4hy37fGy+/99WvP44p6Qunz3TVbJBz2cBqrOO+bUV/2mr0SCgGSgpZgyE8oCKxHKIKBmK5ZInAFHSxMHTrloPi17XXX7j4uVqtPLCul0+kNCq13eHVqAwQvCIIAopiAoLnaRZAcAQGa2rq7ty7yWUil/0hrsTV1rUdvOeeaDq1vBomDQYJkBlJRBCEIAhBELLZrMFggGTBqFOaUOS+nu5UeJwvJvJ0SqcUqXSskJLHZoTe7bsba5rdeFSjr4qnB8o91Tm1+dK14wqzhFHI+ML8YnSalKHV2RsoSrkrvSq7dqoY0VfV5sPg5ZlJOp2TdBouLUyFV2VUV6JyaoY7/tlvur6wh8oUl8f8VNXqPMOCFBAQV5JK9oNjxwCb/dEvPHL5yrmWxprhm6Gsh75x+dzjm/fOg5GX33qhe65Da1dvKK85c+FEyO+7t6vOZtTrNMaZwdkdW+89f+ZqY4OtkIxjUKq1dSO4MAlhurLK7nO3b1d4HOBUMbi6aNSRQXIWTJz6GwBR5y+dDfjjld4mC4xfPtPvXV/v9kA4m1TWda+EV0itKhVN6XQamg3LnCCkUTGf1/G2C7GxLz/3uBfQhymGQZhoPscI0tzt0bs37/7ss8+e+erzr/769zoMUBEwydGDIt1StyYfy6tzwnx4qbancTmRgSDd8anIYjxREGQFjGowlEShjs5uh93qMOlnRgcvTk5wxYLX6e7o7uAF4fjpswILyTIKakmZoguFglqtZhiG4zglyn7v/r0TVy7t3r29woqGwsylix899rVvXbx4BY0Hx2L25vVlb39yrLba9fSTX66yJ2HRq/Q0zK5+qIKgt9+7IhRVXWVWOJLMEqs0A7R2bCatZYjJielZZ8OGT3/4o3K9wehtuXT+DOhUAUpzV3V134Wj9lbjwNzSYzsfOXvsWt0mby4GKiFDIbuiVKqn4ysMSaxt7ECT+avXL7bWPnLOd+uujTVtleZFNoRDBkngFWIhxRC/ffXYxtZGfuWWSWuMUQqtQr+6nHI5nJ4yWRJ5qZQMuCp2q8xha83ytcGNB9alAyuXPnx9x5rWUjyUbDFAfafOjly5qZaxh+85WO6w5diYzqzlZCTHSDP+MAfRIg5Ec2m9yzJ0q0+Dq3KxdHg1bLd5CnRp+45eX3qlJJQWBmeOvHvEhBnL9J6ujk2D4/Nebz0gIb1btw32DdPZbI5SeNs7cnwRFYtMLqnRkiGu8PR//wS2uhQEQpIkJ4hFTsjTrJLEzTpVKZOem5peWPQDqFKhsyQy2VvXb3BFqsxmxGBBhqV0gUrlsxACoyiKwgiB4XUV3sfuu7uUjkaXJ6cGrg7eHOhu9ZZX68Krs03VjZA8rVPFHnqwTkQSS5GRuaEJ39x4YHWhqqYLiEmFYP7xZ57KSSmVhS83VUAgTsOy3mtbji9nZ9NAkgV4IBaI3D53TVZTao/y4DP3gRpMJpHWDVseOPjA54c/MinECGJrPfgI1FQ5wixc8V/bf/DeHft2oSTMsDmlAgsGJrd3NfT0NBakUlVN1fiNoXOHT48OTS/PLKMpVoKxzet6NrSvATgkkCnp7OVZThhbmm/d0FNnq85nmLnVwDuffPTFb3/FQIhWvapIAYNT0ZFF6uZ5Dhz8wb2JVNJoNccy6XgqKSiLpai09cFHvI0VxUSUIVOkwcFDaLFYpEYWx0avMKnCvXc84/f7F4OTGw9tX8wGwBJM+fI0jm3o3gAKmMADhQL1X1/9gUZLaFWK337na2+9+ELbHd9UdpqWrp3q0GvLy1sGl6bVLVUvfHxudjapAYih+WVEo2PyhQq748DWdRiC+IPBWLqQozhQa+B5WmZKZrUalYGtvW0j41P9E/PziQIsCxiGqTACg2CGotsbnP/+4dO//sE3tSqtmIus3fJYSx2wkkz6gwUwURgILJRX2Hfvv/9mnz+RlbY3YQYDf2k6FEwqnBkqmC0+/8fnENQH0YWpK0AyHx+a6zvwzN1xJMtTLk6r1pOUnC6OjkerzNmW9Z0Uq077oi0NrjiDBsbGs2OTDJsKS/Mw7pAxa6WtfO7a6mopteHA9rmh4dWbo088+czi0hSuAEx2YyLPRNKl7TXdQklSutXHjp755qM/+PuZt5p0DCwDSUbz3vWraqULBqGyCuDQPXcvvHDqlVT0zgpb0Kx1laIbu5rd3oaBqWhD+9bv/+R/q2wqZC640tHZ9e4H7zscdqVatWHDISGfIAxMKDrF5otOvZGmOYRQwDIqgyCCIFs3bXv/g49hHNO7BP/sCmY20BrY1mnF9EpfdNU/utq7bpvZqv/zn3/li0UxBB6dX2rpWZ9IzgVGFptr6kdv3QwWpI5NawGDpqWm8eKFj2iMBAAJASRIpFtqXDaTSaNWjE+OhdOFcI4mc6V0IaNVkiIjwaKsU2k7W1pIjS54/DwHwv9ZL+aLpUpPuQyhoXiqvq1drbHgElOCgKHxFXNlTXPXGjEdOza8/MQTB8WsNHpt4Ldvfjx0+gWeh23GMrPFuWP3xrMnjv76f7+xpt0dWMg+9bW/aJYXWrtqMSNGmLT5DJnVKiiwyIj8hgf2QomxlRU/whnC4ejFqyfW792t02sXCwVKotUd20TMPJ8oMphSs3Zzt38W58UnH33sttZ9a3ia5/N7N3bPrs6NLPpUCju5Fkc0Cj8bN5Sbf/nLH0lmdaHO3tRYl5v302xWYBGTzuZfiV+9OFytJYSksKZ73QevvHLqf3/0i7/87s5DylOnL834ooJcLHNoIYXHPBJY3Hr3fsJqiJSSM6MUIqMEEbe4OIU+f/LIsXw8nYqm8qk8aTVsu2O/pcyV4zlEp7n/sQf5jNzgWY+Y3XkdkSMoSSV6vBZeyMtySaNSVtfXRTJpSobC2cLONXonypRSyY13HJpcXvngnY8UAnruvU/MpAaAYLfbjaGASY2vba2r9paXue1aky5VyvsyGf/yUrFYjKdykWTW4fZ6XeW969bu37VNhcKCJEogIEgiSZI6rbZr7YbX3npn5x0HTd76szcn9j/xxNFT1+MZUGFw6N1Os8eWyKzk8kONdaXvP9Ly7rHjOFq9PE1NjV373jv/s/XZLc996e6uyhYhpH/yJ8++feTN2MrqP373t5df+VA1NRs7czp46cIarcGYo6MUqMStRsiEQOpt++82OMWF1cny2iZfGjDlmrMzLFgMEurjFPCn0OQsVGLmJ6bjyYwAq8zGLkxylzkb17StM6p158bOWurNzp7yTfdv6t7eyiayI9P+F958H0Kl5599Yk1NBSFIP/76T0Yuj7NgpKzK0tjQXOVqmry8rHM05UrA048dvPTpez94ZrtZb4WCgZX2+9YpNzj1DdZqV5n3kOeaOjuWR09+PLx4M6nQlQegfEwMl8BSDBAljYUjsHu/sP3hL+8bLUbDCv7Fo3/PJqbqdPZCMqk3W/Vme3h6gZ9ePPb24UufXGhr7RQLiw1EKhKQzr93Proau3j69HMP/5eYK/3ut38s8h4ZIQBECQAIAeKEhAolSeWwpTIsyhMqGRLSCUEURQngmKJRCdh1ciAVl/Vqk7vcZbGRsIpUaEQMVujIH//ku7t7uguUnCkE/cFb+vLa//vl/+3+3ldNeCE7euYmPVswM3PlmHERNuWc3gce/vN7HzM27Re+/tD6nt1bHT0PbHsU1DfnDFUbnjt0x8YnQ7z+h4dPQ87We1vvn/fndHm1KmHNp0RUVzTyan8iDaOmNQb30sWTdKqmd+3jWkf9E48/NSZP+9EIncPXAV8FFjYYmhTFdNCmVPd0t2xd681klyuf7NZv0VhrsUefuKvKXnur7yK4Ep67cLN1U3NRSrU0tSayUWO995N3Ri6cuWa3SYc/eqGywVSq7C1lYMZp7bSKFEbfsb+71lQ8e2N4w4GHhBJf6awEB79zCO5yJLQiLYqFWFqpZHGV9tZnQ3V41eTlscd/9MwMuCDheR6TrPPGVCSytq2VR/ib08Ouzia6CEfYFJ0N6SNwcS6Zodjnvv0tGRY/O3GEDxSqWtYlIP7uh3ae/9XP+qYCJbH49FefCiVCV04Ntfe2Hz5/M0l5i3yRKhRtLptOp54Y6vvGc1+s7eiYH55eXQ32TU5SKLKyHGQlWUviOlDY0N7++CMHQRKXYSzizzz7/R9DCIjhsNOkO/Lu+2aT4bE7d21ptzz96INBn0hHgz4mVC3ByxNTYHfNaD6udem0WQ5SW2iz0YYqiEBy+OzVqvr2s1eHG3vqn/rhs7GF1aGz/avX+/Y/cFAyKF/76J1999wx+sHFTCaHahQZIL/r4C6byRinfXXmJt9CaDUz196xzoQL504ezWaKmx7cCqoMmbiERhGT0/Pub//mLNM56+wz4ei6vQ8EJq9l6YLDauioqLt49OTG3XfSND06PIVAhsX5AKBFWtfte/PVvwmJnL+AKhVy55pKlRo3OTy3j19cEsUNm1so34RL5yohCrLoK8Gq2u7tfdcu9GBpKJWLXr78OQLTIlyQlDzLURxVevL+h8rMtrt373vv6gWVUmOlcM1QRsixDr0jGsu+9M4HlqrKTKbEwoigxDSkqsPbtHJ76b+e/9nPfvA/KoLY1Lv+zr07A6sLNbVVP/nSN1Cto7ap6qHH75MRWm2Anvn2QyvJQFldswCKCAxjENjV1rS5t9ti1QUjYRCUIQhCYBSG0Ug4KooiiqIIBFvNNonjAUGUBE6vVatUpN1sQkFAZuld27fDiMyjKCujBKYfvdU3NdAPgsVyi7lQYlCF1oybQsuB3OxqDOEBDV4OKnyj/YpSaUNz0/BEvxLFGxtaAADK5QpbOru1mJBanfeNjdCReLOnRq/WNVU3oQL89ce/fPjl94KFdEqkwnwohgnrH3nmzNHP+/sujU5OPPzwg4kpn29o2q3Tt7fVEGqJpmGjQUtlQ2VW9Y+//b299249dOie0aszZz45E1pauHzpVP/tviuXboT8CUmAoFLp9Q/eddbVrO3doFVC6zpbbHpdOhZemplyGYwtdfVmi5EGGMSoSCeTPCfYcLmtwlZX28AYKiDjTtO2g+1aOKXM+W1C2qCqaChvLqXDohjDlJkfPPk4sBxfPDa1dCy3cff29fv3D8wsrN+9P87RkAJGCNCgU8IC/PmHp+1rmj765L0N3W1v/98fL739Wl/fFa6UjK4uEKSytqmtssWjseIAwuiMeJrybdqxd86XFWABAmStVlNfWd5c5V7X1V4oZnLpiAIDY+EAJEsIAKIIoEBADYbyuYzXaoE4XomiqUScoSlSgbTU1ihked/ObTIoZos5CCEXV6IACibyq2EsdXbg6kgmRjbVX7o1uLaqdQ1iWa9zUdcnjn39Z+u15uOvvm0xWas7GnEDZLSpJgb7clFfIjTTuKsrTiWXx8c6bJ5Tf305kfXtvbP3qcfuY7OJR+66U7owX7OCr7503P/O8T/e+RWzuUxrb/Q2r/vRb17SIy2o6Pr9b/7y+z9/z+zJab04BKetKK3PRXd7HdGE762XX7WpnP03JvcfesJsVZeo1NZt66tr7ThJV6ICm/SnaX+RTN67o0krxdnIXIUW00npqjLTyuLEyvLc2u4eTpRcmNzZvhZjcydf/r2YC8fzPCLrQQBmYZpFC6wCVRncDgSQEAieXV6EKHBucjqLZasq6o7MzOSpLAjA9TX1mJIAYV6AaTbLSJSAiJBSb701N2NnSiY1Hl9aavQ6srmk21lx89r5n/ztbyd/+du6LZ5kOqrUKmAA1iuV529MUwVEkDkFAmEEQSoRDBaqXPbL1/pBgSJgkURBiaaMapVKgcogpIQAI0KYlYpYKGhXllOsQNOs02qZmRg/dOAuh93CCqxZZTMYjOnCqslr3dlQMZ9ZXdO74fOTFzUitRz2IQhQjEUNsQhPi5hZ885HH33nlz+DcY2aL3Bk7F8vv2ZUoJH56V/88AdOewVVuhn2RQRBeOhH/3X6yNuvvfdGubMiGPYFE4HNd979+tHP797akQ8ur9tYH/UtZvLGsfGQJCgOnzrXsK7NaHfUehV/+tOvyso786mgHlZhuKoohlbngl67p92zPpMtvnX8slqR1aotSpUOJ2RcKZj05s2IoeeOTpdTM31uOJsMbNu+RZA4g8U8O7aAYGJHa8uN44eNKo9RYo6c6/daFDgq8HRJAwGIQkIhBixl+UwSJNwuXlyEAM3Q6Fw4iShhg71btbZjjYZnlbqG8MryH1799V1b7hi4cqm6yy204yDFZldjbmPdaCIHiXqWV7Ws21Hx0ONqAho5/X6Z3di8vu3VH36rxe7hZApT4oRCIUgin2XyEV5iVJCCLuXzzkqPzqhBZMasUTVWVZXSEUJQtNdXZotFoFDK5vOyDJEo1tPSFPctkko06PPjBsOnnx53OZ1Ls9MP33eQKRZkEsknInaLZSk1/fbpj9rWdWTylBV22Cq8i2GfisDWtnbGliYIhmLabOq9TZpU6TbIyNHiv37zinPXjoS/WFNW09C+V2co//fv/oChqMdbNRZYeuXIa5EZf7ndmysBDk/jhh17V1H6Gz/6+4f/92OXFwj5ptZX2U9dCWFFlUEPyx65oCy4m6oUorB/22OAL+HP01lGDVsdT77+JcVCdDE1/dEn75VQU7+v8NTuLUePHFdraxPpqY6uRp3RS3w6fuP1E5VV2kVaat+2YyEY5XkWLpTK3YpnvvJ4mcutSWdGLs6KeuXp2UgnZtlW555aWBgPoRA7Kc5MrAQS0QqP3SSKtvRaKO6884FNSSl7ui/U7Fiz9PH8+PtjhVHf+bffdwHy+OBVt8sVvOIjTxYNEGrLIdlXgzP9oU0GgOEmoGw/OnZm9ti/urb2DsWSn5wc296ztbycwJS8WakRAV6kiaEJ7dhCVETTPAflqVKNVaNVakVQBaKYkgR8wSRXTGZCc0oUAiAFJ8mALMMIMR1JRWFVIryaDPn8i4sygsyOTtS47CCfKmb9xUxM4pEShIoyTC2vuAiuWVWWhotKXa6twr7kkzPzMRaDfEBuZXrJW9K0e1vIIm0Sig/ubiSAkoLNUcsrgenl53/wc0E0JUv80PwMJKriw+CTT3xz65btpB5r27z+jRPndKnYwOSnixx35kZJhutvxeDp8PTee2sc9dmmhmqLVoErSEHnBXFFhuFidrP7yQcMW7pPH/3olRc/6L+9CENWsYQYMe1qCiEMRjgaaa2t9+MwyMZtNVpRqbF5G8SJwMjp8zaXftfde/ov96uqupdGZnKrYQFidt7vtdXausqYarf+s/OjFdZGgQLA2I0f5pFkNO23qkw3P7+WnzBlOW7fQ+s7WnevzMkfvf/fFhSy6VQsBE5OTdW6y3OCtBiPuzUWRUDwdtvGfHMUaVx373brRLQvNN/b1JiYXUiBDKIx2mubOF4LUj6XlY2LSgUCsup8qcCcOF5YjaXDlETxrNuiP3THtqbGBp4uxkO+TCqRo2mXShmNpK9PBgb9aYSAERACWN6g1ACy3NvoJnWE2WadmFvBcbSjtancYxYAQESw2tqeb//XzwuB8T/+YH+iGBu+FciqzCKVjc/6JcnuIfgcGPrac0+8eeRzTUWdni5Mjc3kI8k2b/mq2uBQaGPDE1XlnqxQcNtb47kYrJRYmWprab1wazIdDjmsRouz3OWtvXn2A0iF24322eVsOFOUQQAW6DKPpqxC3bphHa7CWJF866Vj46ODd24w3PnYFwWl6ec///kffvb9Cx+fx0G0wltzrv+mpaoi7p8zELhX0lwdm+fLnRLCASnCICJmmFYbtbcnhmp7mtas6QzN+FKqdG/X1tMffdZR35gO+lRKUlRo8iIRC0ZxUZqKp5ESgUg4TkoaFMNydEGi1eu6esOLRd/0J1UV7Vq9vqqs7LWX3l+7pVOn1SIIhqIQpCRRrUZtdpRbdACq7ksvUDPXXJVbKIjp/+yKUqcJyszdXZu0DneqiOBueGnpCqFpBwFRaVOpHFCWu5WmSgqFAQTB5poai8UiSRIIgiAIIgjCUoVQLp9Il2hejCdSAorgMEKieDQRVOCEXoGYzMT45FhHS4vapMFRLp1MoASJq4liPpNIJDSo6vSJ6xNLk+ta1g+OhmW6VOOsiGUZ2KDNRf3Xr/XXVdYXcYX/+vX/+uq3r166GVxchHKlPM1ZKiy4StZl+JXlYQ6CNbiZE9nRkbOiYNjQu15iuIV53/DAuAKRygmgwqCanguSOAGBCrPRlgz5U+l0VUVrnIv6wlmEVz948CE2fXnk9qBCad+3ZtO1jy8CspxKRVR6aNu+NtisZL0sFcznJqKoCLt1zgUoL+Q5k9lCL00q3VYBhXK5wuLENMGjGqeSKeW6O1oWhmeETK6A0aBKZ6qsV5Yb6qqqWwsFaOZ2SMM4nWCdRaz2ajoPPLjr3U9eb2rbqDYaSROD0ULcn/rBd78bC6QtVjsvSAaLldCom7o6FVuMMS6GiLBB1PQqaz6/cTa5uCLQEotrtt/5QDSWHh8dM+jVMS4v2rRFkxBGuKRCG0atercbIkgIBAGOs1mMSqUShmEIgv5D1SNhuFSkBVEGJL7SbdCQCgQEAEDCSVyhIRUag0aj6e3pJAEWhxlApFCckEQoE0/OTI+TWmWiwEiyvq5ifXWVw6QiKxzuqirH9r1dhEG7cfuObKakxki+UGhtb5n3B944cizMyi61LhkNN/Y05uiUw6hsXoM2dtiPnTq/bsOeRJRvqPVMTY8v+fxLK8tNdbVqnZUKJn0LsxRfyiVjaoKR6eRD996dyhRnBwOxxczRN0+GlkIj/YsUo/dPZiJjUcYv5PwAncd0Skc0FCsWUiQuKRhLZp4JBQs1tV4Fk0vPLW7f1nN96uKX//AdZ13tI194emvvJoUMpIMB/xT/8j/e8y0tOh2Ey42SVgOiQdo3Nnbt7JRNqFOlhm6cuDF4cjA4HP/XL97h4pq+/tOPPLGjUExu2boxnQ7fufeOcDA6Oz3/4MFDsUQymy+0ta35ynNfLXe6c1dvT1w5p1EAtZ1rJxACVpOYgrRUV6ykU4l4+tSVq9UNNQUql6KLISpbgrINXc1Zho0li5lcgWVZluYIHJNACQTB//DYIAiCIAiBYAAAnDZra72XkPI2JWpWIkqYNyhhEuZ1JKRXETq1giAwDEVhFENJlQQhCIJMTI3DOAYqCBFGSaU+Eo12djam08vNLVUiKml1ypWlZTpftJoNS/MziE6L6jSNHR24RhOIBO66886QP5JK51eiCX/UR0mFvYe2vH34E7u1ee/Orbv37MwytNZmRpVEOp/VWVywyVXZ2rx5Q09DrU1mU3Qx8dAjD07Nhn3+SGd71Rcevdvl0I+NrdjMHo+jvFAqpQSuzFM9N7uMikRzeStMo8GZUi4g1jb2XBm8DUNid2XN+NDt9Tt6r8+OheOJTz4+Usrmt23qNRj0iKQrZDi3qyybz6SLaVxr1VmdsXgynkijCtXFSzfA4b99o6mh+tWX31xdyTY09uqFw3VdFVev03pdpU6HqJxVOExOj485LCpSiV07e7m6tW0pFgfSNBqlDbWACpI9devA7gookdEXgRyCZQXx2geffe03P8jGg1evD5i6nTPxwchE5itPPH1r4bpBZXr5HxOJWB6WMavbvG13T0t1jSyJMs+Ussl0Ml7K5PLJNCiJvMwplNisv8RxHMtxIAhaLJYKnZbiChqdUqHUGp02XGvQWMqLxWIyEvjn66/7i5AGg++ssyTC0T/89OcvffRhpVsbjETm01iPRxXPROv0BkxDHr9+scbTYLN4AVoKzi5Ohecbq2uz4SiCwZASkxlopRReu29TR1vP4GcDYf8tRGOJ0rBGo5VFrtxp7nJ3LKLgn1/4XQUtPfvsA501jcdPX7w6txKNIqQi0dNu72pfNz43XlnTGlqYN5u0VR1N130z9GgEZllUoHfs34bqyJd//YqZ1+pbmk8O3fCoNfbG5ss3b1utVv/iYkdbY5ndvDQ9bMBRtVITl1CeL5S5rFSBMmht01NzPd3tCAqMT843tXZX1rmg4ZG+3/z2l8lsWkSgvpFhHQpElsZhJm/ByW133GOrKLNVe2cDy50bOsPRqCzLZ0+dmRmf3LVt+6VZP1ZXXRJLy+fPEemMzmrlAUjvdmhtZqvFkmcYCEVsDkeuWDDZbN986jtuq4dPxZPLE3SBknhBFAS326nR6/7jwv8fjChJMAyLAqfCILtR3VJT0VJT0dVc31RbYTdpZa6oxGEAAFCMkEFUkmFWBCAEzeVysURcoVJyAq8zGffs33P4w9O8KC37VpPJgj+QnZuczKdTOIaaTIbvfvfbSoVq6NbA1bMX2FRGYzAiCLauc12+yGqsruV5DsfNZofF5tZPzQ6LPFcqlSqqKstrqjbv3B5Nhcbnl/79/scgpnj4wfuNeuOLL/z7+tWbDAsotfrGphYZ4ACoxPOZq9cuyCANIFT/1DVTjWHD5jXlXrtaRZw79fmFU2d0WtFgUKRy2ar6VrPNuxRJqDU2DWbSyAYcxRQKhdPhkCRJEDgAytXWuHbt3i1IirGxGJcX33/9g8ErfXSy8O6/30pkYkjDtk7FKD46GPr9iy8Nrd648tI/qQVSrTRvvOeuzz47nc+x2w8c0LsqSwozZiapdPqB3juisHT71sCPf3VP1hcOJJmW3lowMgzSTclMNLU04vVWVjcbEZoaHR9SKLETL3z8l7+8kC5w//ebn1QySFQAaI6gREqphpxlNpfZDLAloVSUJEYU8hDEkJDMozLDATyuwPUONVxkWVHieAICJIkXSATCFRCKoSTBIwoVqTSQSDpbkCGEEzUGHpFBcmI5uKaz3mLTNuTJd44v0hAJZafWdO2qbak49dkn5Rk3E0ta9ajz0Lra+jUfvfDh2nZ3R2vr6K0BlMQyC1GfHK6CrPnV5N9O/G1+LlzucQocGJ8cvWPr9uFPT+VL1Bw/2GTGtzxyX7lCPR5YSREazKIwm3Q6LMEKIAOpLl5dWZ7M68ssFhmn/DOd+9YXaX7w0rBULJa77I1rujK8lM2oVF5zhcXwydGLpNHdUKFPwZRRpd7+zD1jk9c2rm9OpUzXbg5F44zXYrVZrO8efrO8oW7PExsREfrwpdcVIqjQa/Y/dZBDaGh64Yy2iTj0nfv+8vrvg77ZyVAE1ZoIpe6Tj4+5He7I6vxb//773Gh//5Xz3Zv2Wsrrp6fmlgbG8qurBpjsamjAYAYnc/nSdCgcqfRWgALDZKJsMuQLBnt77ywUyW2bds5MjkkFNuBLUrBSIPQsSwuSyAsSDCOgJLMsy/Esy7Isy4uizIkCAIIogRMEIUoSShIEqcCVJKZUkFo1QuAQhsA4JsoSDMoIBPM8D4Iwy4uCJNEMVSwWI7FkgeI1asY3eb2zxqbAqa//5EsVjY6B4WGTyQZDdKGwKBDQsSs33jx6rLGh/PaZ2y/9+SVYAA1abSaf0ql0OMLPTV7evLaKBNgqFP/NN77y3CMH6xusFBTfu3VNpVNda1ZUEmBydmTmZv++TetRkMqkfOu2bOZ43r+8NDFww6xFUT5eSgZApgRRjAlWVNY1ijCk0GpfeeuN0YnxEpW/cuPqpVvXlQa1AItD46Nd63qC4cDli+e237H90o2TvsVbTiticGvXtLaxeaSzYWfOVwxMjr720ouLC3PNzY0atZKjKEBEEe9KSK/S+8au6eZpcHz52V2PBYPxuUAwKZZoNbRh3zqNzV5ZUy3LLB/ImY2a6oYGUCEPTvcVMva3Pv4klcSDvNC6frO3zPHam29u6mgJLkzWVpbRUn709sDV05e+9+0ni6UojhKijA0mMzyphWAZAMGSIHG8yBVLPFMSRR6CIJblWIbneZ4VeAiBdXq9CMgiCKAkAXK8UBJlCIQJDMMVvCRjpAKRBAKSZUnSavTZbB5EUYZlVQQBE/jJiwNrq2QvqfGnaBwEj5w4oszSZY7u2GquthwBxMLk+LTNXMZkmMH+ExXWtlg83Hf5Gkqg23atf/P8osmNb9/iDS4FHn78iYHLN5dDYQos+pan2hpr+sfGEBCuMVSceO1dTOQO7LtvfOTWAwe2jS7PpQvUlm3brTqjAkKWpmbfP/e5vqkKIRyz8/njJ0+0d/aCmJIBwIY1a6yVleOx6zAJjy3NlXsaS5mYt7ySETgER3QKzefnLlkVUpFObNp38Np75y6VbptNLcc+PHfPoS0KRbHM6dqxvrfvyvWautqZqSl2KACpSScAaG5eH0tEcmadY+TYBSRD1dZ5733qgXuee7B151p7k1fUoSWMkxrJA//9mKPJykT8zWazqUFlb3OZ2+q33P/Mjvu/wUrQzj13qXQGGCdDkQQilvpunf3N3355+JO36GKiKJU27d3u6a5/8vmnQUjkeb5YoiiKYUtFUeL/005AIAJDGErgMIqQSiWEIqIoYhiGYRgoyRAECRxPEARJklqtFoIgieMK2QwoyaViEcMIGMdEiQcASQKRHAPMLqSKoipLgeXuhvaKdpoSYrFC/+CSSlMlgpZipIRk2eJKEBPR5aVFlRJHMaihsXZufnpNZ4c/lAzHC7jGshAKFiyGv3zwUSRdAjg8H6eLAB4ToBKPIpgxzSFnTn6ey6QWl+bb2zpu9/ctLy8X8vn+/v6rt24gOkce0q/d/aAvDW7Z/QiGq0xmhyTDTS2tRYq2uswZurB3/75YJHxg765cLMFznFKpyGdTLdVtVB40W5pu3pyvq2nPMqWB2Ul/LnXiykVEo5ZB1Ftdt23v/is3+zhWkpQEeOJ/943NT9pMjb4Zf3hpqgzXVTU2HvrGY6xB5hWyzIEASiI4JrP5DJ5ieHDhrVv4ZAIkiIA1s3//fQCsyqQLHM9YcUPIv9rRWPPvv//58Uce/OjUmSd/8DVAS0olNh6IUhrSrTatUimMF5/7wl8DiXyWhdoqHY/v3wATgkatxhCUKlAMRUs8RdE0qVYhGAqCoMjwOIpRpZLAcgiC4KQimcrIAKTUaHEExRVKe2UtgCjPXLr6tw+PqBAEk2STyWS0WpxK4OF9GxIpupjK6Itxb1tZnla+/OLHqWS8usI9Pz/bXu8pd9lhTFuk02s6WqMxH4qiDM2PLYbb2utLbMZd5tZqTEMLsVgoWEjEKjyuTDrpTwugXqPO0FqBgszKXWt7QEicnFu6PjgZL4TtZoNBodXrDbBCcXM2vKe96/zlC4TDvKVz8+EP3rJqyZ6OekCJiwRm0wO43kzg6tsnr1XaPKlEUVSIxaIESHk1BBit5dGCuBqJUUxq85o60lE5urgKopKJ5PUqTyQSURBEa0PTyy++2LmpA7Ho3WKyL5VabCwrMykS3XvudTnceaEglTgcxiBQC4AwX2JIDPEuFG6v+q/fHO1p6t3zrS8PHjnGFg0T01O/+fU/Tn32QiEt+IOx+fn5ex97Zmxu5t6nvh5lSiWoILFKvau+UJzJiRkapZh8ShR5AABgFOF5Pp2MG50aCIJkWUZRFCJhkZNFScIwDIShfKnIZooKghBoFkdRWAYkXlDgBC9KsiDKEAjKcjGX11m1FEXhCkLmeDWp5DihSPMBmnrhow+0epMLVGil0tJ8euOOe3bften61eGFlaDBWe5xWUpUdmA2KOQCVU2eskrn6tLq9NTs1q6GXDbaUFHd0t19/NN3lq/7YBTSGXSYBi/lRQ2GPvLMFw7/8Z/VleWQVTW5MC9L4oo/tmXLPgYMRgJhPaHJlwSbu7xVUvddvf7sU1+YCixPDNx0Wp1aBYxAiASAQyMjXg+5botnqG+sraFp5PINqijLepiXcLVKgoBcPqcMZhBfLN5QriQYcWlsIFPKyyCgMBiuXjnV1NS0sDIXi6e61m5Ac2nwg0d6dWJBJeV4OqUzKEakNmeD07XRixQyRLqgbaxEaPLDNz4pt3lsVY6F8GpgcWV2bG7jwYMkiZsUuAFH4slCMFXkA9nppelv/M/39C4TK/Mcn6PxhIgQdJ6X+IKEoTybxCBWTBl+8t8nFkNxFlJUWXX3bm0vsxsxjQKEZalYkPLFLEMXqJLd4YAQOJFOyYyMoqgsQZIEoCgKoVKpIGGokiAIRhJwAtYZ9QqN6fKNkVcv3pKLeZdBL4IQIwN2ndqqBVQAZQBlt0ZfX+9+6bUTbZvXn7nQV13do+QDBYazlZddudXX0tiUSsfXtdWPX7rQYLbmSW2KSu/YXGV3q7Ud+4S++Vzi1kiATMtaXhj/8Xd++LMf/cprq5wZnpE4scbutZXleIDJFnA9gMo1lX1L4V5LDagROXXj4O0rIptsrnOZ9Ejf+MS+jRuyABXJ5BaHZzd21hobasobO77+4P/sXbcvKfmrXSiTi6RSqRbeXqyyzMcixEg0QcAAw2SUKkqjQxVKuMjUN6kO3vnEy/98Oxibc7gVRtwNuaoqMY/F0FYnGlSUDO1s19mhrJrl4/MxIQlGR7IfvHpieSV+bmgILGZsCkQPyRvbW9PBoKm2pn9+3lFZy1EMn8r4xqbXNbfbDDoYkSBC4mkBkVCRFSAAoEo5NuUzoDLOcrEVnyzLIAjCMIwgyH9KeVmWGZrmOS6XKxTSebbIZBLpQqYAS5AsywzD/AeDAYKgwMuSJDMMw/EUDEksyyTzuQLHR3N5g0aNQWAxnwVBkBX4fKpQShWhklBusPKZwvBgH+hsePf8aJlF7+LCEIwsLi5bTNZ77jowsxxnQc3rh8+g9tpVHi2U5HAo1VjbJuf5wnIgi7CiWk1z8uUzl8v05VdvX+vqaKWLBUaSqjvaSwSJKmwWV4O1tnUuUcI01nAocfnKxXQkxCQDC+MD+WRUq1EZTNaH7j80MzWGAlJLTVWl1TY5PHzi8AefH/3g0Qe3Dw+fBLK55MIikisZJJQGc+HYCqlUSriO4VUCYEynubHhkYHbF7Vqutxe/sJLr8ZKpda2ToRDYRRFcKVmITevMXuQQpkUzi9dPUWjJKBRZ3xJ/8rsUojhULCuq+305U8zUyigwExMUaUmOZFhWbCspmkmElu7fTPI8ePu6rae1nwpiWLowvK0jjBiIMXSNKoAjHpOyAlQgSEkxclPTkKQDYIgEAQlSSqVSoLIwAzMFgq5aIyjGUCUMBQRKAbgRQkEREESRVGhUIEACAMgw0GiICOIjGIAAvMCjIYL9I/+8BNCY7NYLAarmaPpHEUxoiwqVWoVqUG5VCJVTKaWxeLtVaqxoVrFx2GmWIAVPWs3zE7PxhOp5rq224MDibywmOZyuaIWk7MUfGts0aMUmYVFo9eepzTLCZ/G6rl8bWab3ajmsNVZf6wgzlwb0hOySVVRoKX+6Iq3pfdvrx7b3LsOC6/oECgXnTjQ2yrCoALBbvWNzvgW13grUUSnVtpoSvYv1NOkdOPW9O5ei9bQvrA60VSmFYscJCG+qK9oUGE62WzSs8mMjGIP3vfIVGDevzJb5/GM9Y/TAKHzOFGULDdUrGQz0OpsgCsJHA0Y9R6GIRMFXaFEqjR6EWLK6+wczhjt6kefuv8bD98DcWwmHDaSGJVNP/6lp8fOXJ4fm55cmJ/LhGNyoWbf+jhCqyy6y2fOLPQPry6PohKlJ0ACpktFPwiTpRLqD5YyjIJhGJ1OVygUSJKUZblQyAs8x+SLgATKEggBMCiBgAgKnAhKoCgICAxLgggCgMDzoiALgiSKcjabLeULpRKdzlMNrR0Gg1GDo2atToEgHMeBMJQT6RRTrGxrizJsWceagGRsLLMQ6VkRIa4HRRHGU/kSqdRiGAYWog5S3r2+s6bSXVHllfS6pAymZdhVV++trsLzpVywOO8LpkAmT5KyoI3HKV7ACKUJxfR1FWYqm/ngrctcKff+52e83qpLp87nqaLICG6jstyuL3NYLGZzOJRAVG6Tu2k1yf3llY8SFG5r1AqqvLNBdXb4nQKx4Fq7/szo9GJeuL0UB1A3k8chmXA22iuaDI1r3ReufzY2NiYJivNnxgEZwlA0FoqcPPZ5Mc1q1TroxsgCUsLVrPrff/1wMYn4ZQ+jLNOarGt6GgA4/T8/f+bAoY1nP3pVLfAAYWxeswFR6Uib/vPrn2dDs06nvijRrCyqVQpQohUoLBbYO/bf/9CjXzWQypunrik5kpSUSlgDSwqrxnvl3HCOAhmGKRQKWq3WYrFotVpRYguplFCgRJoDRFAQJRmEOEEQZZnnBZHjQUmGZIBnWEgGYASUZTkeS6USxWyGSiSLDzz41E//+2cmtcqpVRuUimImjeM4J0gAxEqSOLvkuzox9/LnlzhJva+n9aG96x7/6lf64/Sa7dszgnB7fGw1GLIpqE2tZWqhUIr4lxdmF2anSix77totBkIYEDCpVIGljACAoELACeLykfNqk3bPw3tkIHvHpg4Fn69sbHr6K/ew6YLForKT6IbqCndlVS4vDvffGuq7NTs1vTC7YDZYBApdnI2MjK0o9K6bEwtTizMlSijmZYpHItnSremRI+fPR/IljdWDKDVOg6POU54FCi0dNaZyU7qYTWfpaIJLs+rlWMhtNnhgbFtHdySamJ+YQzidPhrLXj53C9PaLs+vKpRMr6Uhk4ymAiuFSOLyx4dhkxPECFllynOJ/GoUkfna7nahpbwoyQmmdODgIckXmvrscmhy5Z777hWVivmFgNNbpiFs0eVbR9++tPXQVlpS6UBqdOCKCpQ2d7cOzMYyy4EiVVSpVCRJwnBeEjkCRgVZAEFABGRRAgAIhEBYBOT/94lJFCUJ4HlehmFRFAVBomkWkHGlxQyCSJ23TIsiBq2Go0pGnTYUTcmkWgdBSglIBqJue2Xdms5sLJIpicvhmLT8fk+j9bf/91dQFDZ2dUICpzOrqZKQTKTrejaNBhJ6gf/xb37zwet/GOsb1tmcWLkpVKAlQdRLQoveanSitBTfvr19285fhBdDwzdzn1y+rdGZa+p7dq1tqERUYq5w7NYVDQUKogTyIgpC6VQ2mUxreUVqeQ62KDmAqXRb17Y0wwrtp6fObO3YNDR4u7JV96NnH93eWpsJlzxVpN1kJfSGlSKuVbhv3LqVz0MUwxNKWQR5XKfQEZjFaqcYTjAaqaSALI9NSBrEokZ0amTLHetzkaWanvrZuZiSL0lItJA0XxhOqaqgB2yspsLMZks6hAzPh/W8XMxBjYB54fcn3zt3PqNXtBrxNz/4UIMCK4FgWW39vV969Kv/86uRgYEPX/m4ua5BdKH1tUgwFVlOQlQ4z/KsqFASgASIVA4mICatlkUIxYosRoAsJgkQDPGIXIRhs4gDAsBxFAzDkiRIPIRQrISxOaZkM1g3bd/hKPciOPL0N58ePnZmKZMtyDDN8GoFhGSNcUAy2ZSZUh6EGJ2t6revv4EpbYhC29Wzfr0uAJBVIwsldmm6q3bLnC8PQuXJqcjDZRvcd3Lc/ECF1cOTZtIqFSBh813N1n59Ps5zES5iShhw7Nb564vjkXySGSuqmhxEPhixNzlnPv8A7d40Gy70LRWzaX53FbSld3MsXbxyfeiBh5+4+v4bot5Fal3hhVtfunfL6NytYoH+8hfqJaWyua2Dy4sq2fPm2+dWssj+FXrfnm0QWORL+I/++t5EMGZQEpgsGjAklk0rgybbBg4RmMkol+NyOYpFlBat1qAQxFJH71pXbWVNrV3nNBLKYmvbpk/e8CsE+NC+7snUYlIsUDRDKnC3xS7KEqFWtyjkNz860rN5B6HXbHJ4dz9RqVdgmCyaXGVT07NjI1MOjwuDsdrKyp7O9rNXTmf1xo62/R1Gl1wY4KPRmWQhn8/CZU6eZRAJEkCoIEB5XmJkAcQgJYzAAAgJAs/zAPCfIx9ZFEUZkEVRBGHYbLEodTpvdQ2mIEVZ2LRtx+qNof6ZaU7gURxDMFSEWUCklQCaTSXwWAx0svUuYe+OimgwwGaOP//FbzvqOz69fKPNtAuITxRDmQgEjU350hbSdx0xOD0Ol0Ov18OSHAsJkUBBZzKCQNGoN7Z2b4ZxLhha3X9g39zkqo0Rd/b0Tg8E0pm4W7eBCfHF6ds/vLtBBulyPc4C8wJbbG4SUHLZXlHfvxzJ5ufUCPzqx596G3pwXLTaWmwW883Y7dX8SnNLW2WVNzmbADXGuUhBSXGTCWHJH+NhECSUwUCgJEJFhq/UwCc+O+fBdDzoCMVC9Zu6kG/+6GsqkDl2+H21x6Jx20rZ5PzCBFMiOKQ7pWlRpJb1wSs4Y5O3VMz7hjrrusIlaG1T9+9+9esqveruO7Z/fOYiginjydif/hlxmi06pQaBc7kcW+PhTx49V+m1qQDm+unTmM7pm1X4V2OCatypNFtQsaDDGurrCDWEcGQskc1SdN9KfDaRlznq7nVrHJCECywhSzwnwzAsSYAkigAAAAAkSZI/Hq1pae3eshPTm0GFSmapbCaFqQhJEkSBRwmsxNMoyao4phjO7W+sbTPpwlrNE5vbGtTxik0qKl1Mz55LUf6DXd2f/OsPHmW61mzad9fumrUNt4YnfLf8FFBIFoKZlOLs8SmtuipbSJpdKr1VeeTqx2rl3Q3NVQ6Tq3pdz1Ig1q4NljnWvjN8ZuOarqfffun+bfb9G9xg0L8SpD6PZ+95+LEro323p/Kvnz/Z7fKkWI5wmGGlYv3mfRqno7bM8v+wcJ9vch2EwfZP7+dM72XLbG+SVr3akuXeC7YxYNNrEkIgT8iTkITkCQkJhBZKaAGCMbjb2LIlW71LK62299mdmZ3eT+/n/ZD3b7g/3tf140AT4IXbxsfHrMGl6Y3HHn/gyj9+d16MzE1WQEDuG9/T289c37ghqypBuFstE6XZiD+stEsSju7cM04Wglu39SKm0JhZnR0d7DMU+dqFSwM9A81C9fqlldTQwXvve+6XX/1TRi42kJ3h+wd6u1Oqab34+1evh6YO7zvSPR5665cv/eVjT11a2xy++7CjLVy+eGG4P9ZqaJfO3bTUfUJTqZONntHudrWYSiRXqusApDgGBbpZf4ugEn6vh02kYkqzWcsVRFUt8XJRkiiCyDUEl49GEACBANUw/3foO44DAABoOyAIcS7Prv2Hoj19Dk7opkUQJI16WBeDIPDOrVtfP3deAUACwSAbICOhiqqvNCrtJhJgO/Ye2HP81d+EAt2yttjt7pXbRrPs6zvc39+x9zcvHueur2UKpU89+XixtfbE9gdWljY3F6VGtYyhIIJiiglFu0YunJ24fnVSNfTMv/5Ss6EDSdzAeg/cdefEuZPMQGqmJh/xpGaWZy/lzKH9n/jst163HQOCmA99+Gl++rw34rk4d+PeB+7AcGigj3SM6lvvnRnq3uJmvVdOniQRb6Gi3H5w1/yaZFng1uER0DFgsR5hdA8GGgA2tm/b+auXQVvBcW+kOyHows2JG06rCr7zV08QODQ7PwcjRLkmXJlc/8s//WDEm/rxf/+G8hFBlA0z9tm0qKT0T9yx+9fP/xEnO/vDHVCrdmgkGtw2xA2kWjW+nt6U6jpJEwvzSw/c/Ygtg1OT5zr7O3/xm19E/B7LMFgEp6j2I4/c+R/ffLEhg+Ed23r3H4oHYiABwbaxcmN2fmp+07QurCxkqsoADty7ZcCLgCgIQBj+v7YlAAAAAICGpTtwdN/eI48+gbEsSnEw6UEs3WgV3/jFz6dvzXkD0eePn8hLIgfSCIpTKIAD7a4I/bE7b6u2GgjDNESRpKna5LW7H7i7aRHT585v+8j+2rpWmNqA9Ppgqtfd2cF6CAgB2xXxjd++O9DHzi1vxPp3Xplck3Sgj4RH+wdXVtNTmfVgRxJqteptvnfYV6uXE+HdKzMXto2En/qTP//g//l3uVzti3s/+sjh/ghh1TaaeB8MAySDtESB9boRMDq9uHzq0q3Nqt0/tJ2pvwPjXgCjIl1JDHGVitlSPn1o3/7lhbQvRdx924Pf+n8/SCaTmcLaUP+oA1AEY2IolF4ozzVKCIUDA6N9g1uHWg3lu9/7Cc5F3ptYm59488+/8Fxpcyrk6f3F879yOtx37tg+c3HWhfkElJxYXfqrzzybrJSff/cdayN8+7bx2VsXeJ7P1/JPP/N0unBObWl+D1Gr5SiWkSyUoFzFWqW4VomPVb/66//8/CN/plsQxTAejwcgIUlsETTldnG57Nru/nihNIcAiCrJFksDEIDagG0DIAj9b0IcgWTFHBgaIlkOQEEHdCDQBkxNE1vzM9NuipXq9cFUb3t5UVMNXQE4km2VG3c+c58Bt/pGE7JhpVydsqpw8tFCie/bnpwGm1aLD9LuTL0Q9Vkc1jQgL4SzgAlmNtJdncz+7WOPf/ozP/vuzzsDbLEu9Iwkjh7eD9javrv2lYTmwZ27Jo79UTE3tgzt2bj6rhsEPvsXn7k6WYWari1R8F/+7q9r2WWLFzi6A/T7UVuFTWVxbe30e5mpebRY3mQ87OjW3ZQtAjZRKTdVu1WqVuq18lNPfwB2+Jdfen73+B43TZx4400vSSjNypEDW3LrGzML/L6jO2rlUjLUMV8rIgRHLm2uahYwM7MytnvH4vsbx6dWIv7w2ubSnft6zr23nNgxfuijw3GDp0MP/vSlt5o2UJAa//qbH24LhHriUahppNPz6KHknuaBqlCpC0h9s3jt9I3nHuip1aS9B/ceO3kjwrkuL03xYmyvlghXb+3Yf0SkUFW3YRgGMATAILfX5ePIuAsvSdVkwHv37m3ixpoDgZpjO7ruOA4E/f8JbcDp6uru7R+QDBNHABKFLVNFASO/sQpattziLRPyUFR3MrFYTIOSTtj6Hfv2UrUa3TumNSzS1pGmKBfz7jhOwzaHcogYv/TDCaFi7RkbrmdmZ5ob24dSLb6t8cCenbv+uPGjd9+oSS++E+7uRCGrPxXzxugzF18PBt0I3BwZ8n/z3//kycEhGGkZDnZ8c/zgPUc++uXfl/RNHqx+5usfLbOL7U4DRHybDrb03o2kh6qtLbZaasjX4erh//zvvmjLGcZpzt58RwK3SnqjVa+CsE3Q6NDY8Oj4SN/A8NytWRx3QSgcipEOoASigS19oT17opdmLy0vzUdpeFwGkHypnAgmQbUQZrW9B/ftP7wfcWoX3pmor28seahQEmAcdy/etXj17NqNX9y2fe/BYGwzG9kx0F2av+Cl8cXMZiTGUSA4nT2O8zWqBvd0dw0/2X9jck7mjUBOtKvFh//ic71jXb/+0fNv/M/PH7jrG3ccxn/6298NDMdtvBd1EAxnMYpGKMKGQBglCu1WPt3sIoKOIeuYgupEG4EYHUIh2MAAGYYHt4/ogI3qGkm4HNNyEAuwVXE9S4OsHYBsS0/C9PTGIqRYFkQrBCeQYTQyMF+9sJNFNpsMipj7t/uyVUutKCev/GF5o3TSYUcC5qh2Pe6mMyJ8+fitA4d3OqRYawheqh9s1iJIRUN8OITRpZW15dyxiewjz97lLuQXTy0l0FRTshg2LLcbfT1uf7A8Mgwh6Y51oTHUcV8dNyMgCGxWhUolcGjMUJ2Ll6dHewalZusvP3h/Q1FG9z/eLFeS6Bjrou0L6+3L03cd2PfC8R9CsNXm1cHhAUVuLontoeFtLpu7eOZNHLNzJmOgpYlLcz4mXG7O2HoQgThaRjEFYHY/9KSFRBlO9bZQpukYPLx+fala13fccbCyIezYeYA/Xm1dLleRAoCZMk7TDSqzWfDGYnG0e/r0zQHImTh7GfJ2s2ODq7V1l0Xjflhpi7t7I698++ucTh70YdvGtzdPTaku11f+7M+mMhlVbKMuHAZhkmJYjxcnKVCTWIQ4OTc3EAuk/HQCpzXAgmHYlG3FsWGShQE9GAmjBG4aoG1ajqoruiCU8tPXL8qKbCMYgiBr6TWCYcGqgENgs7AmcMo7y+/99Uc+TBPO9dUNv9+fq9F941tf/M0LZVESCLBLa5O6TQS7BVHGEevW6YUDWw+BNnTjxq38XJZ0MW6LfunHr43dtj3Iatt3jl8rovOrvAcshfwsaQQKSh0x1Y6B3kOdAcmpfOD+g9HYFhgUc6dOU8NJAXZCHHfu0o1OjRBt+I7bD+MMJaliI4KjqGtifro/lEqGu0lW/vAnHmtV0gwnfe7BJzjYFFxyul7fvvOQOXm2snYTCSW9Me9MRu0PM4Te/sRjR2bTrfkSFB7noFQy3BEP7do9LmuyDYGtanllYsqNcoYFtg1dMgo3pt8PdbEXpi+8kV14e21q/N7dW+8YrxotWdIRiuAN+cLZy8XFgiI37r3nMEfhmqqMDI3aDhLt6yHDzIH9Y3EXcnZm2U4wVsL70oXLc5NT9UKBQWBdEkxTBx0IxlCUJHCSbNUbcqPNo9BEqbhcqTsmqtqOqqoEClIM3ZAET9DfFnjDMP7XI7V1TarVNxZnt430Gbqk65qmGQhBZfN5TbUsXSNx6Iuffe6f/+7P6zXxpeMXTp67+ttfvbyRlr/+la85ksHXal4Wo8UKizg3lzK5ptxsCAwe+PGPfvfGW5fOX5pHCbeFOCoAf+XzHyEBBWbwUqtebbcnp9cMGHcYsyaLXLyzbSNFQTp9/TTl9VQazanJCxdOnzh38ozSlGzBePnHz7ttZmluTpbFzMa6i2X9NOdjWQJGWZd7YnbOgNE6L+XzG0999ClPMkir9ut/eAFnISbA3ZicFZfXmyvzc1dP4iC4mZN8wc5CoYgg0Lmb03XAPZpIIKtnT3jdibpcDnR2sAFTLm0uXrimtDyTlSyawPviI2uF6he/9Juwr6fvkR133baP4Muo5qyk1+lQomc85e8O4hZBW1xZm9uYnFIp6sbE/O3xff23HXT1Bbv64vXpG/Gk58EHU4987hP/56//obCQ1crVSiEPsuTBJ56xNA2lOJBkGK83EIz0puTFwspUS2Q9vppiKCZU0yxTrHb4QsNbt15cW+4dHGhLoiTLBAxYDoxiMGwoLGZDlBWJceem5l2uGM6GVNOxIdACHNbFxTuS//3Nv14Q0anZtY8cOTQS7S7l6ikHt/P1LtbdcvSOHVs7e7qXFlcWZueHkj3rpWLLgRZX65AOJWHgyGj/tWuz5c35Pp+jI/bI3p1fHt77z//6s/vuvre8eSXSNYYjdLoqPPmRj2YbWZc77DgOpAlimT99YlG/MLOls3/t0iaUhoY+djuv2UOE//e/+tXnnvpQ/fJCeKCPiEU4hkVx3FTCJghTHMegaOnUJRaCT7/27hMf+4LgkUkbbugOTtJqXfzDr45fuzFxaGfi2KVTeQWeOHU1zA0hpEPzhZaqtnKClC1M0zhZrzYcmGJ87MFDO1Gx3jOSWuHlwdRgKogppRLYqFYqSm65CeJ+M5NHNhf27zliEkhbMPccOfrW8nuXJicPPHGPZgC1fK02PylkViRbGaSj9+z64O17Ro4cOkLQepOvb9k5Dpq6KksQzkIIjBAkhMAMw6GIQ8IwoNomDEiGVhdVHwjgplhYne4KeyAMJShS0zSMIFRTJwDYMjXTkFFA6+vp+O1b7++M9C8upzXLBhFAs6B0vnzu2gzp69gsrARCsQiiNYtT02u5mIG3ecEkMZOEq5WNbKOxfairUXZPLq4RkTBmo5oJ6rIIGmqr3NrkDVErRTgHtL0Iibpg/Qf//n/ff/m3Q70U7XeVCwrgIN/8l3+9/eEDkoQ0G+Ly7KV3XjwV5+jM+StmU1d08NKNmZvB5b/5539plKWRgzvP3bwi1qpP79gqNqumJjdLgssbhVE0n8mMDG0pEACoQLOn5/tSk+sb60Ec9sS6A9HOdLV59O5t+44eTvV4brvX9bV/+M/dvaEzs7PIzVtVxEIHB2O6qUQY5o4PP/jim68KZWgryU397vX+wT0I0nzgznGf167lZbUl8iD2i6nJ93JCf2PtQMG3LU7/5vKv8VDn0ZHgu29dXZhtfvDzf/HKlclPPvDA5OmTytx6wEsDtjO/ceoTn3pwJZNxmBoF+WUQvHz6ZHi70rkjCNgOjOI4RREUY+gmQTlE0UB0g/IRLV2pyWrcjcRZRNYqvd29UMCvUOT/ckEt2wAB2wGMvv6us29ddPkG9u3bZlpQUxBV03QA3QJotyv0rf96yapthlhue2c/uHH9/s8+Yg0w7/4uu9FQ2o7BhLyIijAhlMLVgYEOHZQrzYJukqYGhTAyCkGzi7WrNXD71qiwubhrfL9umxheIG3n9rGxK2dfuW/HbetLK+FAaGryIsjnwr6+V15+E0Oajx19WJ2/rHcFp+eufeiTT3/ju//593d++N3jx4eOHBl7+j5Iko1a+8LqJG5bUZoAa/VWNcf4g92+5Oq50y1Agm1iX+K26eM3rLCyoQjrN5cgZ3V835Yd9w5GsSZFUrTLfXDAd2Rb1+oqj0iy6nYl2gbdkYxEDITP3eoh3VlHrJfb/tiABvO2jyoqaqVe+tUfTloOBxGdU4uah9BnqUA34TdXM9mmLAtCj983vVh3KPCXr/yqBGOXj08f3nP/co44EFQtc5P2DJuoUS+X65FdOi/JDhjt788UK0y2BbgojvLSXi+KEygI4q6YRqyCOKQ6lm4hkCAf7OjRhCKvmVZnn6FA0UDEgmEFsSMagRBO2wUBFgTppC5O3zPc9+bs+jBqpXFMb/kwOO3Wh2Pe0oc+e8e9Rz+K1cq//OHquYncnr3bXlQustFdxY35YadcR10zS2sdva5Tt85nm84gMGBLpQjrEJCTM2jW5Y5ZzYvpW6/8+zebFy8vHXslMLJjur40ffby0d23//mn/nH74V3LK+s7hnf94OU0Llx5bGef3+ctOZLi1gIs/fQdH4gM+v7+t4/OTd0Y3X2X7jgwiYIoCUfC/hRHKlL76qpU1BiOICPuSqtp404VjubS88Me2Kq3ZtfK3/7p3/71v/2ynjO8EMcp8FKB7/ek3v/298YjwfdvTTK4Bn793j2ZpVJfJxl06RSEt1WDInx8WyFIOBoLgTDCA5bkAOM7dvLz8y++eTIrIroqHd43MlvNEYoW84bmWsa1bKXDq3fQTAfFajaM+QNtfj27VOmNdj94eJubAy0L0ClWtaCX//DKk4fvVKQaTtpXMoWB2x7p2D7gD0Qtwy6sri7cvHZ2Ond8YsoC4KiLTtBoN449Ntbp8wKjh+6ac3gM6/RHYiaKgQTVxglWEmZ++7M7nnkQcKSXfvitwcH7/+aFF7ei4bfrpUxGAOgqXAt+7G7swTEvEpQ9mt0qZJiYvyQ1Rnf95TOf/g8TZw3JHov4PX73bQcPffsb3x4f2FLiq3t2bc3lVuS2xDflzqHkbHHjOz/+t2vHXhFWF3Q9+vhnPrpe2Fi48N5jdx3eUFQVNsLhqCUBL7/y/vhoL2TUG3z7/qeelZ22o1m5lYX8xiRFtQcOPdjSEdidpFwuxzJBEzEx0dAlI89n5jJh3YyPDGYrNdu20WhwIJ4q3Fj83Y9+4wsE07V1uispVnk5mx/cOtA1OPLbV1890jkE2kp4/2BgPAlV+Brnp3XQcEV8LVMvlZSWIJIc7A1RilnDSMjr9f7++WPtmllfS/d2RIb6o0d2DYUk/nP7+vanYl6vX1XVncPdZVGNdPdvFktjw/2ffubJz3/6mUce2osirStXZ8plNFOqe1yc3K6RiK1qPGabRqmSCvh5vmSqimUaKIoiGEpzLh9JMCjmOI5hmTCBHdk2vOvgTivA/P4XP23U6gTDgjAEOBAEwoiXA2Fk5sL1b332z2RFcrOJTLZR121eleMUhwOqbROc1+WiJbeTqxcWJD5DYDZqaQGSvHjy9e/+/Rfam4WKol7PzF3PZb/121dhNgCY1q7h8Pr8VcI2xwYGUh3dn/jSZ557+vGzL79EAqY/5ot3DufWS0GXN+5znXr7zWY1Pdjlb5fXlGbWyq/kV6d01OrZvnV1eVUCLrW1S9XqjF5D4ubDp/9wau70jcULl4F6C9dMsCVjquPGGc4bwmh3rVIWGy3ccUIuT6mwvrq5hCZcTZ33U4wXCMml8u6x2KP37msViiffPeHGSdrv0gjQRh2L18Hf3Z8MBIdvLE4VZN6hOm7r69GtSjRBICho26bb47dJr9vfCdjsb777rSvruVUd6KDg+7p7N4rrCuLnARIEBD9lCDbVFY4FA16LAn2docbMykAqUMwsZ3PNRGd/Jr3uc+NjoyPp1TQJIS4QUKsVOBHfwInxw/cEop0Y43YMc/L61ekLk29cm6qoBo2CIQb7aIyGXLZ3S1cXFuF2bYHIboJxaRYAIriHDWpqo5m5yRli5tZkRbN//ePj7zn8czv3ZwuN67nlpkNyFvrtzwM7oFqbCipNp74pIyDiDfhnbzV7UwOJsZ6P/tvPYVfMACBJbD+6f6yfdiKOAUBorSZTtK/RlH9y+eLTdx+wqtVdB8bCvUEU8TWE9vzktF1s0Q6KhXCh1agVKz5vRJJK9z/7YcFNcaEYJOnF1Q3UK9pE2+PybMxWzv9uevuesf7tvZiLwyjWRClNrv/Pf/08hkZBBe2KkqfOnbvtyB3XJ2/ddfueYE9XAwBgE5M3ahMnl/VQHUSKo5Hu2aX62N6DxXyJC3GID5lavDno60ZgviVI6b5wWC5BNROrt4q+kKPbTRiiVNXSLYMmoWo9F/Iln/jcp/ap2pnlldzMMhSMc57OZqmG2Pb+wdThbZ3zc+vZfKVSK0MhNwoALBeWBN3l8gwE3Dv27/j231755HOfrZaKgUAgn14HcILxehwU8RA4BoG2aYC2A2JoMBr1eVZJHEU1g8KI0cGBA9tCqdHeBouK6boGQjgMOhCIAAgAo7gCogS9gtjJQPjN7145Wczs3nbHySvvtXS1KggG6ACqbal1xhUjsM6a1ZAxSEIcsVF1hz1GC6tnWwC2+K2/+uSV45uy0vZ6Yt1upLg8LSc6ABNAcMwwVQRRRnvcEb+v2lbmFnO9O3eWK8vReBR1hv944812SfDEuKjb5SWjhbUGEINNnIzGe5ty2zQasUDq/NKxzu3e+fqK4wMMwM0LRnZtxReJuINxMEByFH3/oTuXTy5lFnKb67KXiU5eW4zGUxdeO0eFF8hkpNRsZ5fTcbRrY21j7/7epqgObt1qm9ZYTy8a49LNtYfuPFyTHWRed3tMHRMLvSHm/i1DiMvR7ZwgtRDc1S4LCIK1VZ7kGFVqeDgGhO1d4eCZF15as+ZCwcTCTPpLn3nYbFZ/+ovfHzwYSfX6dx9+ZmGz9MKbrw/H8dxqmyJIJIQgG+t3HT5Y2Uzrpl1rtkia8XXGi3zNNDSgom2m0+ORJAiCDgj7IpFEV9w7vdyUDdi0w6yPDnLplTQYiyqS4yAUhRMOAKE4BjhoHTVgVY4Z2LV3z5gEdtcH77v+3Qspt6+qSIvNqoKCHhjds7UPQIxbdSYxEAkO9K43rqJwaDEvGx5quiZBrYovXbj7zgdXZq54cB1zhSaQ7obl5xuCz+1rVDf37x1+NNUBY+yKXU3PFV959m///Auf8rl9PT3JD30qCFrwy+ff+8AHn7FV85/++d8+8ddfJVmfYcGtyjJOt1rczfE7o4KMeuR+cbM5U9q8vnzjuWf2EDRG0R6AIhzACXR3/dv3/2CbBINijAzU6g0+XYwFgu25PLaY11WJc1FQEMquSU/07k0FgyW+yRrwhdeODd6/czE9M/depo0zSM4iU12dcdobi+EYLizX233DHqDM0wQNODyK+artOoIDzWYb1XlHs0+9+Ob23v7kwNCusZGl6Wu4xb915tIXv/glwznfblmXzp2dWSoEES414Ilu22/p6EJ1zRdKJim7VVkTBKHRbvXEknWBN1C02azRKgwCtiRJXndItQGKZMLRSCDg2yjWVUkuZjfrI0B1o9Qq1kb7t9dNM0aSEIg5AOw4QEYXQ4ZhpMvT568kh3vMoIfGcQICWqKgwYBpQxxFio363Hzh2ae+rmp11fIfPjqmV2s05Jw49XZ3R2ojPZdeXJU/ZFXx+tD4ln/92TEtdJAoy7n1fNAteWioLKpxB8BJJt4zwFtYuS7/4r+OBSPvo5got2tjg6Mf+b9f+uqX/7JRrH7z379L9Q8KpbYbJliSRDhZ1hPNNthuChjfTDAizLj/5FNfrmVPSYqM1Os+t0cyFUm1ttxzZHWjIuQKLrc35A0Nx+PHzp8a6etzmaZczmMkuri+tH3XPsoVVQxAcexb5y/J7dbvf/dC145OW5bdKor8zce3zd26BVJsw8YK62mbRaotl0FwMxtNAO0V+apaKYm66B7svz55rVmThpN9ggUUVxdPLUw9cd/951enOrZ3GJlFf4Srikpse//7szO9nYmVa6sZtDi+feeeLUOaKWfFNgtDnItSTc0mIQ5xqYU6ZrsaoO6xMNUwTUOlYQqwoWBPaufW1GpuU4K0zqhumIAr5A/6o4aXgmoKGEMtCDNNm0LsqCAhpna9kD0xu7EVDi1fa1VIGNHVkKczvd4WLTESB3ft3rG+vv7PX/kVzoKYbaX6kdyGee5M9Z77Ou46hN991z1N0Cit6orojY3e8aWvbHnxD2devHA9EompAPD4Bx5JMPrVK7cO7xzpZSjqDcUtV3jSI1bzHIU/9MzjvVv6vvzsnyYSO6azJ3TcwjJrhA3DFIdyRKHWDnkiQTaF0NyPv/WtHf2ej+xBnew0KdrlmYWMdjU2HwZdwWDHAJFe/tzOvevDkeFd+wRFX55beu6OB69eff3Q/Udmp+mF1bS/J/yBO/eQLnW11Djz8mVlpQgEcDIQHfb3rWVqTKAHWc/Vg/F+viU0qjyIkNu2dDRVqyqiC2XDNJzHd7ji8aADQG8dO+5huI2NSqOUBhAU48jOjuTZt09aFDLaMzi5mN7B+DiamTx7/EsfesSQW6uzcFOQYQAsFTZlXfBaXgOgQRrPtm90goZhObKlmxbkcQcAw4EBWNN0kKYRFEEcuqeja6g7e/nshgcnSqWN7o6UaJoMzuiqZZk6AMKA7ZiGidqErurXZpZRbyA02H/5d8+7XAwVipY1WYXMIIj0RqNn3z9xx9HbFLuM+QJqVSjnqkOpUQ9mJAYJ3UUtC41oLPHz13/94H13v/TCsYibHguaF+Kxzdy6LZO//Nl/fOrxOw9t7V06fzKS7OmKh1vd1UI6H+2Jbh3vc2BTVfRnP/joO6emP/u5J91uDsBJQ3dk1fJ7k8XNNT0YUXSQkgRgs6zJxqapuWiCQCDcgDjUx2CYYhmV4ubufbshmPCpxJm33z515XIsEZ98Z+HQ7YMIZL9z4tRnv/RcfLhHNXShpb/8x9O3Liz1BTmPjfS4Qo1yQwWJDduP3JwrIig+Mjwo1JWYj6vrbRRwtZezLgnheX3uYoOkgpWKeNuufb87dszFeOOJoC4KbgZVbd3jZmHL3jq8rT066oMwo1Y3cxOba0vpuZt8hVQAZ2J6OpzkPvfZj+dLzYA/dfPWDI7go/t2rcwve0FQaDqmjcG2hQIQgiC6bZog4ACwn2H3bxmrL83H3F6vV6+1mjbH4CAO4ojMN1HKtiynXa+Rfi/GgPVqYTgalBemnr1zx2Q6T3V1vfiblxCavLd/wOeYu8cGXSwhwQbswtyQf/rkDaPRpmnw3HtdEy9cwThO2iiNHRlIV+RrJ2c7QhxH6ePj40Jj4+lHD9023g2LjZXiBGZh115+VdQsyu+ppBfaZbivN7ytZ/DqiYuVTMV2jNEtXe+9+8a2h57EcRqnyEwhMzhyu6Z6La2Ryy14wsFMji8RWizVg9tGOZ02Uag6vXb7ww9UFN0CoY1C4ezlG/GI+/GDB3o7U+aSIlQrJ9579/a7RkNxim9nJs5fb8smINl7dowLYMWHk1hbbumwu7M/K5CIrNmADc6vZveMDVtCRYNsfrPhkdt3bN929dKiA1LlbEVVodnLk6muThTFt/aPtMpFk28M3rlX5gVHVEkcFmnYcoIURO09EmgVNySI6h0Z9sSjAAGaVjOfLRXsdqvmjO7c9epLr+eylVgs3oarE9fO9w/u1lVV5BuYi4Ed0AFhywQxxAZ0hcBIlvMRjE0BkAASiiLhLr9taqaqwDBaKub8bssWlTsP7hIXlp1KUQDweDR8ZmaBo4lQNOQjELVd/Zdv/hvgpv/ja/+vo8sXxGgjl9izq5NzaTK8v3niXcGwdh7Yk5eKJ0+fRVDf9ZwIYZa3fMsUjbGBOImYimPrJNQV6546PYfakFOt3Xv7fjrku//++//hr/+GBMC+4cEjj96utPN6uxHr7hZabc0yLt6cuP/QbU6xrjnSJ77wD8fe/NVP/uMHkUjSm+p4/803gxwD4jiBhmp13hOLSAYOIiAQ8VWalSTnvf72WRQExreNL+cXujp7bl6e6BnpCJLUcGf0VibfKLW9yZDXMFgLMGgK9vjZUhWCIMgTCAZjkUJxg0RUvi7UM01KwzNzi0EW22woLZuAPEEq6AeM8n137zp7/q3Ll95zMahRXhX0AkQqrdU5M59FEBMCNJJEvfHEbQ99wAoQC/WCSpMLS7mh8UNv/vfrP/75m3/yte+0UPfV4xML15datfrTH3yc4OCAn2o3S2K9aLerVqPK8yVNqEtiq7Ov//k33//pb09tVp35uWVdbAF6S2w3ZKmNwE6jUgFbYnE1+86777VUyYB023Fw1uPANAuiPRxNEVY0xP36Fz9qFLIEBhqFfGn17MH9I4FIEKKRYDD/91+451/+9PEAUbpwZanKS001v15aJWifWq/+0//5eCrqEdqNKq8Rbfi/f/0ymupyj/T6UhEy4LrrIx8QGPLLf/+NfF3fe+je1Y11jka296W++dFPsqriA/S+YLCxll+fev973/g3RQR++8q7Q4e333XX0SvXLn/0s5/yJjtmN3PLRfPs5VnddMrVYmoghZNUMBxdy5fqJrpr767VjczYlv3NkpGdK66u8RNXV86evNKdSnzuS08PxrzhIB7sD4R74xBGZIp5KBQKzs3PNJv1ZqMK2KrJt9u1dqFhrdTMsuNqg6DBMFO53LHLZxFAikfcMGo++Oi9Xh9rl/KaVG83ioQoyCsrkFRxoSoOKD4PTdH0r1/5PRPx/uqFF+ot8at/+uWYE84stWTQv9zUM8ubPsY/0NPnctOJzhiIOo6jteolqdVQG7V2q6wqvMvjElQt1t2n6OSpM9dLpcriwgxgSKamK5JoqAqKQFKmLRQkNhCnO1ORfbsdDNss1wwbtBRtrKtry/ioBVib+VylUkJRtLqy6aMQHENK5bYNMu2SDjWI//n3F6w20zt6AMDwVDf37CMHagsTt+3ezdcrKGCRJGlBeEAmPv2Rzz77l1859MzjdF/s4c99vArom7oi4cS3f/HLC1cmnv/d79fXVsRaZZBxf+fPvvjKT/6rtry6cXO60lxLJmKP3nOvXJZ++R8/nb12Pe4P6aLs5rihoSHJwBuCtrS8murp4lxUbyhuGybEsvP1+qWrVzTDePud95cXsjrv3FyoQlQEIvy/f/2Pp29cHkzGQ0G3Cqq0jxME4Uq2jBRaPIESmOHpigZ49ermmvnaItioFbs9hNeFHekLojr/1AcPn8rXBgnn+Fvv3//A0WajzAbp/C1IbvIqCfb0D7dnVqSGDEIiRal8Swj5Q//vbz968/pyHEVgEcehKNjB3unqafjbM+vVq6zXtZZ+Nj7G8A0GRPLNBkkyqmitVUwLYTS5AAAWz4s0bKznpV4/BmpqwpuYX8zS3kSQQHTcluSGYsETp09lqk3bJnzuIMBvBIL9C2uLwUhALCfKG0spfzLa21VvtJduLj78yIPXr586eP+jM2+c7uHcm+sFzx432REY39G/ls3d7THu+sInbRdYa/Cm2hrtpyK+8K2JxbHxvkZdX/XIHXKhsXghtXtPwNkvKYALhry4DZAgCCM3Fi93D/aASFjVRZRs+zA4f2aBjaZAL9OxtSsqrIa9OhIIdXY8HQmy708J+HolO3k9HotYXquWJt55dbNpIvvvG03fmoNacjQUNlqF3nvv7ekNOnaNb6iFnDedaRFJF0KBz9z3bMwXBnwqRXZSNgTB6FBv7FP37Icq9ZYBOnWh/f65MyaKlNuSTdCdgyOerp5g/9jlhWu+blK1syP9eLVYalZqa0vLzWrN0W3CTblcHo7wXr+1SMU7DUzpHEiUagXT0rOZdcZGx3o7P/XRh1KD6N7DUV5YA3EDhKlAoGdDwF4/P1dQiZZJFJoyieGKIGhiQ29nxfyk3CpubhYrFck07GTCBWNgsbKpWypLE/VyUdI1vt2u5vPtwmax0FBlZW7q/He+/cN6rUEQSCIWVhSFoGheUmOxmM/nGRoYWFtdfvH3L3hcgYsXL6M49saxNy9ev+ih4roEQjDuQOBiqZ0a3OYjyRQJ/sn9+xenJt9984+ObpcLtfR6ATf78lmgXW1fP/8uRTQLmbwgyYVqVW3y773yKmf6A4R7Y3FWV2sS5nDdPiCGsMNkx/7wu9deg/zMzXThDycuNEzzOz/42eNPPnz3E/dCCJ7blEcw2iTMabP9/ecvnjhWFxRDkJUzF8+PbhkpFfM3rl8TGq2Bnh7H0hbSK5KmN1rtd48dP3vy/MxEmsRDEOzyBjprDXUgFQP/6vG94UhAbWtSY/XgbqatD37xP97ZuXtweXYyldq5J4Teub3flmu5Qs5uCgZg0y4ScAzYcRCWw0H29PuXo4NDTUcZHMR2jI0QAFTNFCmcgmFycXkhNTJokbikGQ5EvH96Y06SpxaLhUrdC9v9fvrgob3/+fyr3QzwzW/+IwRoU1dPSs2yiaHpsqvOQygs7xgNLt+Y9LvZwdGxhmLqEMwFYjSDC9WKzYu3JuodPb5owgQkLe7uuDU/A0eDFcv7yovvfu9f/rw6976mAumVzOjo6JaxAY8rPJdLZ69ejwRYd8TFevsZr/t7//avX//nv1OJQLW40UnbZ175HaEK/i23Vyt8o1lE3dRqFooH9Gu3JvtT2ygycvbaTF+Cee7LHwdR88yvX29vlGsNy53kGEfi/IgSdCmqeu8HHqwCdZsFEL2cvwK88cbKHY89tT5/edBDssmEC1ELU5krlyu9YLka9b40tegYHSEqngg127n0Yw/f05RqBgC3K9mOKLe+uj68bf/ZpXyrXU1GQ33xrs3ZLMoglWb9zPVbz3z4ga1bxyaOv4zcdedR1WgjDr65avBKlvZ4U93J9bUZ3dAgFLo+vSJVKx0unAUt2LEwFDI0HQRswHR4vTo6NNA9tPPS/Exda+4f2FJb27x6/obX7W/XBZtBNVnJVeS2RZ6+cPMDH3hwdnlxQzcyq8U7e9iH773nnWPH/+flt3XKL0D65/76Xz/zyQ/vP3K/UF7X1PaJn18RLbYjRAwO9PQlYrFoKL227sWp+eW1WksfHOzLZvIhkqC8fs3QhnpTNy5du7Q6kUwlkVAg4On9g/X617/xjw9t70zGej7yzLPVUunG1YnuxOC2vdvtcq0j7vv6t3/01b/409/98jef/sKHW1IxADkEBb3z0muOCLoDnQuzC9UK3zfYfX16siGHPvPsvfvuP/C77/+RlyHC9PpM7fgvXzh0+8HGfCbpid737N5X3n0jX2ngdF97U7nj3juklgiyptqQQpQWcYVgFWAcanNuGYr4hiPRyQtnRsJDgqqmEZBtSvfEoteybQAnBdUMxBNLmSwAaYKsHNi+xYXYckv2+T3P7t4vii0CQX/z4/9O0nESg/wB5m//7tPRaEgRW24CA9/658/EOtyb2ULYi9XKF7LZ7irgqxYvPP34B/yhMaV9WWpW3Y4zefwEgSR5WQJQGAEhn8utqO3VJrwpYRJfv+/wdo+W3ijwMuDN1Hle00NDXU/de8/ijal8yZhZ2OAYIDAQff7Yie/945fO/9ePEYywcdeJxfKiYG3t7ZpbXoMA+7HDW7/4sSeNVuUL3/nDRlNPhd0P7x0Y7o/98Eff//BTzwhNdX0tW1MhC8V4URzfMjC3UitvzD9517aujlg6V25pBup1R7u3z9yY6UpAoz7/zM2F7PIm36gH/G5VkTq2bzP41o7dYyuljQSGjAz0FxwNhbkX/vMn1UI96e+uVusuH2uR1m0HjpZKaUHnl9edQ1t2Ro8MktXM0pmz61oDyOskRFgaJJiAAUEFLfuxz3zs7edfiXb1dCSCq/nV+z90t0MYAADA6uZ/f+tESw4P7Tk4f/a9GoIcvOv+V37+/b/90sd//fKx1aYzipFeCCozpkBBtx18YubmVRICJb5mglCH3yvlMnv27azqSt9wL0ZgIAgtTa4tXVtxSGVg+0gs5Yd1qbS63MxLCKLrGl+LB92V/BJLIICq+Tj7gx9+yJRbYD1dLWSSiU4PSuFIUDN0x3FAENYtayOb98AAzsYmpueObh3W8ptlUJJt8uRidqHaIIN+43JmdvFnRmVjz669Dlb3hRMwYnOYa/rcTSS6JZfJKrX2tqE+cXpKrGUGu+PNthjxxy6dvrR/1x5vNLSmZhuSXKs7mml/4U++WC9XGrWm1BJx0pNviDLgXF9eHxoaVvjSzevLkqiXhFq+rW4L7PJ4PGPDfaCdqVVaF85eBXXARTMkQu0+uMX0eWK+cQPQDQBPL69NXZycEfgb18ruAItoMAHammh0dzJQIlRqCaFoDBextY3S7OLF7ieHrx+/uLO7q1UCDVjRNgQPFy4Z5vnFGcSBvvfzX/7ph59sGUIpk3YFIV4uYjYqNyVH1yEEfvojj8Ccd2fS+y+/ffUnP3l+R1eq1io/8PjeH/76+rlsMeD19cRiLGpfun5xfWXZTZI0hEqOiVkQwOs3JmeJmC9SzvkiIYb1qbIAYzDFhDZW84NDPbeu3XADtosNIR1uTEb8GqDrgMyZWkc0ePzEm0Qp6ceIsHsjqzXPvbYsy+LBDlxVVA+C8eUmhLt4g8I1L83jj/btGeyPLM+clYG8BEQnGjUIAuLNygLkUukoiccJLuBPImwUMxFSIrhjFy4e2jb4drbS9PVzN3ODZKCjw3Xy1nwew7PHTu7Fvdeu38w2TMQhYRQXDPXSpczIyNDyqlAtNHleIRGqTWI3VrNdetfk6+cHoq62UFAbXIRxez0ObENNp23r4LUXl4Lg5vbObr7W8iIQVi6nLzaikWTFXxrcPUbHOhsAEb6/izhzllFhivCYikw5QrInhhBKQTUkG16Zy3zqyfvnpl9DS0vTZy4NHnrwF9/9cU1uBDtG4gnf7NIijDj7O7w1u/XpP/1AMOYr3Fg/tH+8XJPdCOPxiG0xstquj+w7oBk1ytSolOvuTsSLexcaUPPNqW9+6cP/+LHe7/zkZ6jfPZVuHTp8l9vIODV3xGvcdmBcAQhBkN754/pTj37+5PvnfvDyG4dcvbfdff/lqbkd/pjkguUWcer0BA3AvE6ApoUAsIhCLq/Htz6p+TwsKNf3DKcw1DEsPScUEB0a7OnAfS6hOA+CeFNSNQcBAIBX1WXfukJw2RafCrM7urYAjVFepErW8sjokJ3JFadnvCzMkGQhuxyMh4/u3/ffL7/L0WjY7d21pefVy3PFzEpfkNm+ZWBp8eZwosNtQ4amQ5bDtyVZtjUHI90cgiDvvX9qcW2lVMj3dnUqFshXay3b6fJ7VudvsKAV6xnfN7iFQmzDAqkAd+b6+WjcZzWVrQNRAKCuXp90URwIWBwBAw6yWao4rebNlQWYRLt6YqVFvm/LgNcTmLg4EYz5OQR0B11tsbrZ2FhauxZj4NkC2bMLWbvsvv2RhwFe97EsidiNXMlJxu9+6MFX3nv7i1/9y4W5q7Fkd76QScb7Ydr/6v88v1nJ/MVfPW60iCtnrt5+6IjPH9ZNi8Rc9z365DaT/Ztv/6xZq/73b3//2Ifv/+JXP/T2qYtgzZmffue27bsqppPqSI4MDyMKni0UJ2jmhz/+/uj2nULTBP3EG2+/7fYFQYKwbVuT1ZYhcgECsCwAAMB3/mZ7ILTl8tmbXgwPUYg3iBdW1nXTFDGHt5Rwy00mgt4dW7/9vV/hJkCiRCKcsB1Q0tR9O/xLawVJtAMEK9eqBRDv4bwgZse6u4sruXcLywPRCAs4iWSou7+b4Xw/fe39papyYDT5mTu7//WHr2lQjLSUvFBDHbyDiwIkc2ltYWvvIIGKN8pKw4JQQ3nk9j3TM8v1WgNGEUUzSJJMxf16rZqMhxY3l46kBiy55sMkj5uwUVTVTAKnJFEHHLyQr6xbBAjjIb9PbJVb1XyAcDmaSmC4DYEIQT73V88tbSx5gl6G8dMgDFq21OBnZhfffv99X+wxyhu6eurlh+7sfvSzT6swXQUMr+r4y813fvfb6+eXUb8nMtavhKjb7r3LLVdmp6cHegcrxcb3fvKbWGxLuSY8/MSuy+dOffL+Bw0b3yy1YZLEKOT48eM7tm2zDLNaK6+trWUbmScef8QxkDOnLrcabR+K+SiWdamsl/U3MMUx2XikClkKDBQ3m+31GsyyuJ/xwOCB23caMjZ380TCC+EGLNkC4gmMzN9a1tsCl2Bs29iQbUECaIdEdYNDYJDEDFv+45uvhoM9MIZomnliYo6iKG+AzRZT88t53ULPVcqRSBRipC0ut6UUccSKd8XujLohRQt6WNvRq7nyjFGby9bLovb8m6tdWPGOw0cvnl1stFuxgYHl5dWYbWTmZtkwd3nx1nDCb5ioqmiWLfcP9axtlhttscZLgqbLjdbenSMsBmF6++j2frCssARp27IDo4qugxjCYARgaaSbnV6cI+iU2x1oNZos5x7ZNlzLL9uK7KWoRksIR8I3L14FIb0rElIVCQr4WZJy+9wmgdUtYPrafKO5HvTCOAyADmQ7cIhzB2IM4G/5+pL4Qt6djNYEQTP553/8472jyYA3psrgd//jZw4I8bWGJkDP//y1vh76wsTNq1Np0SYRirZstVGrEyT5t3/+6VffevfctcZTH/qT//rez7cObuvwjBBaoS8O0giN0RIX8nUPdUzcvGnYxt0HDrx1/J2uSM+FdB0wTLDSANzUyZPvf/5jX1qfPdNuVwkIcyAU/P5zH+oLU7BRn1+85gm51q2A1TQLlyf3ppI+CtkkZZbC6zaymbE3pVpd0CQDGRgebDWLlib29CXSxcxsveJwvuf6x5gGn4h6sICbImi5pbMMZWiSpqkAaF/Mt96dLVsqb1taP9p44NGPv/KHt/bsHn5nfnGjWbknNaJJ4o1yLhRLDoU88wWp3lb9bvSTH3k4nylWCvU33jmt4oSJ4X9y1w4zPdvhpRXIhC2XpssoZnJeGkIdHMcDjBc1wZXcpj8eWZ3O6hpMsJ7NZvmL//fLwYR56u1XGQxDUdfJ0xdZiVYaRYRCevfvDo3tCHkZzFJMzfAG4pmZ16eWau1qMx7kjn7kY5Li5hhXDTdxErj2xpu3Ls0w/tDVy9fuHR/qCngUrzM7u3nu3ER3V/9QRwyjiHdPXO5NjezY4Q33Dbx84sbNdGN2Lbt79xjUaBzZvYUDhJ3bd9RbfNMoQibRrrXFZrnZKiX8yZ7kgD+Csz6v7fagIHTilT8K2Vo9W6gBgYypaJrW7XbTHNxoZg0e6+/ydvV4ZdWaur6OnLl8xX/HjolL56Jd0VuZFoB5aqru3jq8yVcJjCFgUuYt1O/xdUDj0cFSU7m6WNBMk2TZIGLd3ZP0be9ogUZyeNu1Y2cqm4IGxBwbcoSmLPMAzJA02eZrOIolgmwipFeWNnr6Bnya//q1aQuD09m1/mSHhJMXbt76wOMPTdXLpIUSDFur5iCcjkQilmX0dQYbuWxvZ3y53vzopz6aO/GHDhfcknnTABPJWD7fpDgGRTHbVCxLk1CpLUqcj1X4Vnenv1pWZNMAYLzclGzUPHrPo6+9/FJnd1epZSgNocsXBTFAkqyf/uDl5z788Pr0mZCX49vn0vO5TMVQxfbOz90lim6SRSEQ4ghGkJtxX+yafiPWkXyqM44XVyG53D04tHN0f2/XwDsnT9559ycu3XhvbGcMAzmK9iT8rnq1ePXqHMwwHs6lSzzr9W8sbRpXLltyq2s0gJLIwYcO6U7LtCWhieEmxbpB2bA0U1JlbfzQgeMvH1sXRJE39LgXRwjCdjDQESWFI3xLG6WlSu6JD32sfnED/PRdo4M+byGdK7aNmk0c7ek7Vli548nDKViGS5vSRB4k/Mho76Xc1N3h5GsnLmZl0sLxZEeooJo+s7YzRh3cscUVjF/93c8oLFUmwhoiB1HNFQW9kSDrcVuWwbda6ZUamtwXhYW33j7RTIuGy9011oMZJX908L3VhlnKV2q5eEcKbdpXM5MA7sEo7pmn7x/o9i5dOuVoaKamvHTm2s47D93nsgyzAZt6EI8jIA+jiKzJMGi6KAS2LNDNwi4aUW3GgtCg+8KZOcEgWxB6Y33lybuOPvLg7VNTk++fuQ5jnK9tUJrkDnFwT+z4ezlAr3ztTx5x4db6cjovAxrGtFobLndz2yNHgtHbibJWMwESR1sXJjXEqoBmR1+yPnfaaWyWakrfttsEE4QotFa0Tl56/oHHHnj99wsexkGby0z3/vPLzUylxdFgwodlSw3YMZ+5a3evH745XX/7nYujO7Z/5AuPQbhJuhFUI2q1jD8Q9nNuXlYAiPz9a8dX0rn65Y1ikIBV/amRcROVZzczQhWSTUFFNQUmOQuA+j1uu1Kt1PW6hnpoyNLSh9zcwqmps9eqV1dRsbfrGqAuZ/NdPPGbV9/ccfu+slDo7Aya7XZxZeXKaubYdPrWwlqVz0ns4KoFTJRq64UGZgh+0ENRFKnnGiu53Aa9/8CuqFnILa5TOiFjaJQDImK2jybB4sr9g9rdezuDtCtTqmdYW/BFDQbxh3GPG1FV1YRDlbUCicM93R2FmXyp1nQZtCyCLRtUNcuxQZaiaJp2UMx2sSgMkprpALDCeQHIhaKe9HLeRfqTwZQtV3/+6/9Z36yQoPXsg4cxQgE4sKxUDhwZ+9LXPxTroQq5udnrbyn8FUhc6LJubGeLlKx5rC67LDmOk3Csideez4nzx84dP7h3Z6tSgbg4HB2TmoIFVGtta/b8mnj23dvvf7ia7HBZfETBQfouTBOd0lQYx/f1dphNWHLIJq+5SJrxMB07Ug/9/eexsPv9l38bDjlwQ4EgJxjuKJVK67kWidFyLd8f8OMSum409lHQV3anBnyl7mDhyRHP0/v9d+wcwSAfBPoEFQb/8d49pCkuV7TFcj3sJ3Z6GUmBliynLckxzhsiYJnAhsdHVLF67NzNrlQ3R6JAvTjkd8lk4j/fOCYb8J6eLhsVRRu8dm15x6FdQUS9r58c7IxQuL0oUz/7zetf/+KnFED67jdf8nJxj4uldBMDDZYCTQzbFHQPRlWVRqC386WJmbWGAmrGaH9qoCtxx6E9Xo5euHy1cmuqaKoVFbIM7Mn7DgprSzYo622RoUCKJkAQxDAURVEH0UgYcgwdIxgAJSsNUVfQQp3/4Kc/adPIldPHUBRv5assgDmyZhq6bIkYCXk9DEYEBnu6Zy+cDPooFAMamqG2ixyDa5QP6x7/5N/9xE1zUpX/4uef3bV95Orp92O97ninv57nN9MVl1Tq2zZ46exaHGOFcnHwqfv+683X+nmG8QZkB/YlAdDjvzpZrFY2eiOs40ITDAVLfKQnfmW2sf2Bo2KhcGhk6PL0jf1btkmawTGk0qqasurY0He//7NgpBPFyWc++viFF18ixTaH2yqmQLDpgLQABtJ1TUPphlSHNNXiRZVXBIImHFt3HAAFobDX7WUYU9XbJgzDaDa9Bljm0SMHZaFGIyaHgS6SCIPNP/vk0/3Dw8vl9o2V4tW1zYHdQ7laudwoowQKkSDqGOemamhsRBIKNgwCMFNrKIIi0xhAohCM4BDry/HK7GrdgRHHkTp97GAwmvR7uiLhgd6Uz+PFUUKolSkM9jN4d9g1EOXmFtMOiOA4zlEghiO2baMoapqWZQKKZgiyYpqmLIrVYknTbc02m2LNtNtnTr0GoGBpcyMVCc9dmZi5cktotW3ARhHQbrSF4polN3QQrCrO5ZmMpBqMJ0x5IwjBHTpyz3PPflTQDG9n7N9+8JtiXXB5AiyDFIpLtm1zXDA+MEQFo12JoFgpqKZ97fi5YSyY8IUlTTXk8o4D+2mOjQYIkkIO7h7dO9hhlDK6KCsWWqu2gyx26PZxACM7YkOLS6skQlw6dZbPl+tri8defjUR6YRsx9HqZ995BbIkmW8ADujokAUTkmpgjuPGET+BfOiZxxBd1bwsU17LUsE4gyMtC0VAoNZu1iUF0gDei++JRGldDpgAQlYG9/c1FbMKQ0XYtc1Vp3zyYNQCZdgy2FQ0RZgyDaEdLEzjLoP1nD977d3LPC8LyU8eWc6Xd41vBWxo184hqbzSrDfXNoq5VqtiypGhoVtrVw5EiWGXz8PLrZhvy2Cqr7vL4/GxLIthGMoyIGLVGnVT0PIyjPjcIKINxryyonEMA4A2BMEmYCIYmgiHpTafL7ZrTZVkiaYshTtis/NTfhfFy46qSKqqki6/gQEqAFOgAxoarAMlu1aUCuP3307QbuPyTURtmDDY1EHesD778U/9zdf+8ZNP3Xtteoo17VtnTiA2UFjJPPDwwbWV5mjPjrZZzltOV280OzHhQD5UsIIMI6kyBAJuhvq77/wMxqGdyfhQb+fF09ezpc3BUAfDuqamcqCtJCjMNloQ4cUcZGx0JL2yITeljRbfyud2bN2tkr5Ll88ZrYZZVxiUNhlWAohy0yzlVcBGCEIrtgTSA/3g+89Dmi6FEyGYIEAIKRaq07l8UZQ2apW8IGYazaX5WxTq+BlicHCwO55slMoumkz193hicdGC1Wbpvu2dMUrftW2YcCQcVDEEMBywLtvT6ca7c+Wenu4DoyPf+o//aW3yDCoZ4np6/opitiga7umK7hjqS4VcTaUcSSQ3801FlHDM7O4IJ2IBt4fx+LyGY5sgKhugNxjp6OhgKTzhZQDLbqlmRVAxlG3UJdsCVFWmaDTg9+IkwSvm9EpBRzx8W7EhHME5WTI5wlPYLHd1pcptYb5YXmmLAog4hk0CqGQ5vK7URL7cqs0uzvT2JBESxVkGQHFBlj/32U9vTl9B9GbQg0vNfIeXZm3D7+CXXjllVSonX31hKNlJ4ExlMwvBAEziLE2RJCGDGmyqlQpfaIGlitQVCuqt1mMf+PBnvvxPV5drsZ7hbVsH7rtn/+rEzYgv5HFTK3NXCvmMKIqqZhGkxwa9rnCHTYOcj4EtOObxabLWlK2FQjsrQusVe72sz2brLQufz5Z0i0AYGm4JbZJlJMUMssEiCKiC1EKhvCx1JXqf7vcxmhTt7VwxWnzZ0eBwECcL+WWa5c7PCmG30kUXnty7/XhRQaIYCaKZJmhg9ESxXpqRy64hq5TGZQ2NjaxMpPuGMA9uoZCEag6oQyGQJRVhv99zNp/pig1VqlJGreFh5ND4SF9/CmM4EwJAkhBMOLNe2hLxQxbo9nhYGJINotWGVutK2DaHhvsVreIJuAkKwlEol8tbMDWfbYTAaAdpIzhRKPOGDkgN2UP7FNWQYKgAOJJpRHCyG8dyywt0d8fTDz3TEgUURWDAYOXW6JbhSq0xd3UCJjgYBvlyydDkkS1DF9bTpWrNr2oc6m3zNoo2Q4j22re+v+O5Ty7NLgZQVnSTAABk2sWyysdxt4gHUG8U4DNGow3J6pf/+u+XFaC7Y1CnAJZuDvYM5SdWxYo4n1149MEDyxu5VKqrVeUvXZ1YXxEq5PX4jghEgkO941JtAYAIFUVydUEAcQ0FLMhGaXKpWjQRsJ/xQyRBk4gvgtApn89y+X0Az3HIbclt46D12T1+xCx2j3XyNt9auukOGP19/tLGJkFFiip1vgXdFPxzBXez0OaUIr6hGRl7AA64y6a2jrJlxZ2fGoqCUa81HjG6u23IgiHLb2qMbRAGgNcMSQEUDLNtV+r9MzcQw25li2O9W12xXtbjJmAWQ1CCreNurGxrumZitBMe8EW7fD0jrsM7A/cdSNSo8Km1rB3x10zQgiOUjFpw7LXr1YHtD7oQ74JjFQubSFtKr1cLULggKq2yvXl9bWcy6bF5LDxQtRUDtznM17F1n6PrfgwOUiQa8yAed2dPd0+qC1Kci3+8ePcdD8itQrtYSsX6SBzVQaQpiQiJayaIYCzmYyZ/85JtcBYBZDV/C2Mtww5rPg51l/s5ryrcNbr77bnsxUoz1Ne1LRo73BmyxEpHIqxUpQbWkDAZhxBDaiSHt0GQOj7of+r+HTV3/NJme2W9FWW45dpMwR23Xb5SNt0sbhabrQYgNA1NlAGWdd11z8EcaCAkBHGEuCVF5ap8zJvQMZ8BOqgjD8QDPgqWMVyWVceCeruHOV9q9trVZjpDkDUbhOuLy1VLrHHgZ596pNNCCmq6JYqV9BoOkTRCeDvZMOrxR0K4q+JxwZpDggAMQrZlWSCEohAEwogDQoAD4SRBEISkSrcfONDflQyFQpLIw6YFQLBsN7pDNLK9j7VErw26NbBRzo9sPbC4lGtI1m2uMunCCS0D4iCuWN84kak1K8l4RMyfcUPggS2pJBlbXtgwTHj+2tkwZodS8cGRkCBLbjJqrLyVq0I413Vl8qbrJy0iyPL1PAWTkUBINyHO5+nqG11ZOXP06F1vvHuMihPbwymcoNu1RghnEAR2uWhB523LhCxT8YYIb8TQeFcmmwj404Asc4GJ9fX1+QLphMubToCAUnQ0WyoePLBtY3W2WvQ2yl4MtCADZCEcTIQXVqbMpaWegd0OGW0CPIan5+Zn+OoK3pnYsuWgi5VXF7P+eHx4Twpk3c//8ZJgObypEBgk1OVDgRAiiRrLsjAC1OuSo4g+jAIIEMc5WCd7Up1dg6PXJ27oqgFqIOfWc8t5UlJcGAHK/IfuOBgeTbpIC1UlcS0zPhK3UWRtI0fj7N5tO2VbPnZ6Sm9pMQ8nCiWc88IwbFgKSkAwDNu2YxiW4VgOAOVzxc5UJyDygGOFA34EQtu1MuG4VcVx+ynINkM+ymXauK2BksFSnmKuCYNctV5WIIGAAQdm26IxcfXSut25c3R8/4C32+VYqpyvV4Iu3812CePC1cL6I4cPr1eWv/gXH8NM4+Tb7+Ijz/7sP341HsPuGndDEMhQuIsNIBaKgDhIeyZmlnycv290y43JictXzj349F3eUPhf/vYrURoxNBWBQVHkLVtnOBq0wbfmlttA7rZt23y2mUsvYyx5+tZNlcIevG333HzFF8Ri3hjasLtGRwvZ+cEuD0hQHqaj3MiLdRnkbYAAmZAbhtsra8slnnz7/anJqWtju3r7k6EAgk3enN7Wh3OBcM1S2hZAt/Ihxttol1Tc4VxMNZ/XRBX82l13cFxlZLjDsr1z8wKiNgrFdZ+/Y2CsK5okgsFgpVB5591ziwtl1B3cOpgixGItl/axbLGurUF8NBXrY7mB/h7OT7r9AQsAQRs0ZFVsrs7MS6dPTNyzvz/shySTQTGQpklZFg3BcUC4LcmKZbl8vjen1nVRdlOUPxi46767w33DG4ung2x8fqbk8rkX0jdcmNNKr+7fuquwUdiotXjVnl2YfuLxw02dvTS1cHWjodlI0BvsUEqU3RpN+UgaCXZ2GYYUDnZ6Aslf//6V2++6n7h1rf9IH+E31GK9tl6Y3bR9qSDn5TjA4yclyEU3qnWlpQcHR30jW1m3K7O60SxULr978rGn7ltP38Itl1KWTLlayeVxDHI0hSNxHIVVA/h50U7LAKXrD4Yj2/Z19Y4mNAcV1AqJUwDmByCttDZdnSzDJmTY5a7+eKEJ3piqfO4vP3blrTcg1vfAJx8yjaKqqoBFTVydL2TqRx64A6TwcjpbmpgBXURvvOuL//pzjQ5zGDzmgxyQrXPGnicOQW0ld2nm2PUsAmJAttCyAVzSG++fmemLMm7GCfrZRCxQqq4glu7YAAzDOkwIinhm4trd+7d4KLxSKA0ORx46esAd9MOtBoJBiu00Rd0bDCi8DECgqpsjQ70u0mdLRQiBCBymKEoURcsBMJRoijyMIpZtt2TZaBaj0Xi+UHb5g4VKC4JWIL3dqBhCSy6Waw6IorTTVpozK/NKW19eL+oOEoj61wvzmEZt3Ep7XCSI4FsjSD/gEwQMI0M8DK8t1gBLBlbF1cU3bd24/27AAe3ixgpnkDpvTcxv9PdsqdYWhRaSkQf3bvO5KPfwli6dt0y3x7SsjcwmTjGhEBAKcLcmrvd2Bc4fu8Igrj37xwxDE8Q2SdKWqjoO0JY0S4dJgsRRreY4Fk2JjuYmIAaxq7bqqA0M1vv6kkJZEzPF7lQXyzFWta1p2ul3TmbW8ivlhQZoPfuBwzrCoqZKO9qB4WgpPSfoOgagye6Y7ccqDa6lYwAOCa1WgglHgoTY2uiPMCbo8AhQUhXwJ09u1xScoDyZRq1360B3AILkkloRCRIu1lYSveMWCDtU9GvffTVMQrqpDwwPnD17oTPe98SRZKbWCrEhFwJmlVLCFQVxmPN6HEOvF8uoCwuHw6ANZhdXGIJCCNW2IRyjVMUENNgBAM1xqqpiODYBagZC2oTvxbfOHz76oE/Nb9lOkkzo5788R7gTnFRV9eWDB3vq5TZokxKv1BooQXgjIWLXrp71snTs/Bwgi05jbezA0YvzlU2V1ExhOOXPruRwFAsx6IHemLix4PO7VbnYPTq0UlLnM9UdW0fcsqZUsjhntrBOCdLbrcrRQ0eWq5Xttx+GcNI07Y3pyfrsZFdv/8qtS4hCqxbChrFoMLCwvLB9y6iYzdTzRRWhv3N8vmgCv/jl34Yactsq+jv9oONDAbsu5IGc0sqt7X/48IkbG6QqkBhFkZ6NfFXUrGa23ALAubpuVAqDLLj34ftnJ2/0JeIK32LdLsLrBQG0Ui103jH6vb9/F8LsWrPE0gygATBN3nnHCOZURjpHFm5tTGxWkO3DiWzaqDZMwgE8DII4LdhpMxRomWLUDZuqQro8q6W8ahpJf0Kz9dnZ+VC0U1CBjcJmk9fEbJNEQN9wrLaZQwgMhxwUBAMcq1HE1MwtjsIRCFd0E0dVDKU13TRMh8Fx07IAFAly7GalIjRKoa4hAYQUw3r73RN/dt84jjgC3xgdG5xcLI/53N7wkC5k/W4mlynQINg2mVa+WluT3zh/ivF3io6LMJ3H7nzg1MrK8cnlrM6EKUeXM3Fvj22o3fEYbqo+D2GwNI37lLY+vbDx9Ke/HCy/e+mtAuJOHlu+NhRw0REPilH5Qml4xzZZ4JuVGgiCG+trPUGv2GxDDmAZOkYS1WaDJPFQLJrOrdu1us/tEkXjqYcf7N4+6nfjlZvnEQ8wN73RPXiv0JIQXTj54utbYuGLr/7RveUgooO2Cnu8oZtzazpgww700OOPSudmFrLFHbt3FubWhjtH3G63TKqgyudXyzBC8boy/94ZxwJp0CE5HARtXoVg1IU6ZDtTm6vMkFhkW8BEBDQwOFJfudS2WTfNz0PYAEyzqA9AbI2GbAhHQVMe8CL3pcKcB2RU0kd2Hl+ai+AcXwp5/EED13PLacfA4v3BYn490RVsSoI/HBMa1UQ4Xi7WLQ2wbCtgsyRFmZriQLbEC4Kp+Tpik5M3hweHXH2HpWZVaVUcpebu3urf1lNrzaKqTcpyJ9pqOxSpyRCItlpQg3edzvFF3RQc0FSVR7bviEWC4yPd0xMXogmsJ+v8z5/e8/aFqUDPuF7dcB/Y0liri3Xh9NLMhx48omptriNw/cbEYIQzV64dL9gFyDQry6OhXoKjQUns74g1xPbE2audO0YpULF4A247VUBWai0McqG0aVoqJMGb69L49uFMc8WAYBl1kUFnJDX0xhuv7c10R+IdqA30RgImawFLuUzNyQhBqQDu7YoMgqQMOXiIef7V37txBrOhTVVEuqMfSrn/6Gz+4dbs1z73mKWq1WqNdjNAwxSgtiW3OUmLjiTifx8dRuO/+toPRhJJPSJzgAjnFkkV0tS67tRpzguVNxYkxXr3+IVKVa0L1NmZ7GZTyZR4DQsB/jEQgBHQXyubq6vLm+VqsdrQm9JwZ687Fs8q8CvvXbm1kI3FUu2WfHlxkY0lJm/Nu0lvLV9NdPYvrefd/lixXqfdnKxCpKF6MUSS7Bdv5PIGoRp6X1ck0ZWASSMU41J9gb/5ynPdAeNb//jDfNHaKFuLRUkifTPFxkJFyNf0Fm+6PcFkMrFtOLWzJzoaYgitZbZKrWI26vcXs5tDGIbkCk8dPJyZXHDall4Bb86VXrtwY67eUEnJpj1tAeB5wBXr/X8/fenaehZyu3GORAhQbFdVSVBF5Y7b7pmZWvcyXtgBK/miKkksRa9vFFlXxARJXrIdhJLFVnp1MR4Nud1MuVw0KOfE+TMWgM/P5DJ1FQskcVcYsWlFAlZulaJB+uCRDtylvvrW1UK1Lchmd0/KQQDdUWXa9dbp8zBJd3d2uWiqNrkuN+RIZxLy4rIuBDwujqFR1lWtCXhDvP7e+7fv2YHjAOdxESzVlkTSxSIUZSJwq10F/2YsKaFAsHt8fmG6p8t0J3rv2DHI4Wi0d2tbB3JXT5x++5amQCO7B+q6ppUaQrmR1fUz6XQa8dAw0OVlo7AZYultQV+rWvR4OdTDvXfp8lzF3LFjp+OAxY201G6l+kb2BICWrF6p2tdKAKNkv/rUrp1jyRZMOY6JOrqtyBaIUqxvbU29MXdRNimUDmRqy9FwL2rUbtvSz282MJBcKKQpkrFFcfdgl1DPYhgmy7LP56NpuiVkcIpeUdlfX1yL+Tl5YS1ruT3BqB9u7+mkRkd3L16ebPPKaqtRs/WgN5QgEEZXwgFvpV2Nx3wURVZazvlrG3/+tc8DelFptS6du3Hg8HhmYoWAANA2KNZdrDYYN2UZMgqBomoiKJnYtvU3Z5Yv3loCLT0Vgn0BL0Xit42NVecW5Xp+65adFsJTIaxteFcuzw4PDxIEZJtqtZh/Y0mYr5TjHPiJw0fOnrzOmI6GO3c+cjQQY81KhTdNmvRWqtJba/Nmbf2Tjz+TnVrCYARkCAxwao26ZpgOCDkgDElNRLO9NctJ37zxoccPjGwlXWywVS1ZNplZumGYwNzsaqMujgxv8foYQMfoqMeo+alCfb5d0SSCBR2y3u7vTVAIUFpc9HlcLMMVTSC+Yw9URc/cmApHoyND45fPnTp5c9qzu/f67NIUjzDhXtghbAAGAAAEARCgdRUwDRNxQJgEejrdlHf7i2+ehTRl/66e9KpIkFSx0u4Mx65duAaSZtTPoG4UAzUEBRzAoBkcgWxdFW3bsm07ny9SFMu3pTtvGz89s2k7ajldmKqisUjfjelFgvYy/qDtGCCvgDpCMVi5JkiAY2NE71BP/twUgYBf+9t/GhnyHNq1Y+fu3enMaoiFVaHldjEmqHhcMOZmQB3VFdUfDZKcZ2Wh9PbJy0Sy2xfy7ujikoOprSODbL11MZ3pHEFrlao70OH1ePwBZ+o9KbOyRiLA4GC/O9U/qjchDP+Ljz/+86//Awq7VwHEUK33z1z9wL0HcL8Xrjdzm1kTcUkNwRQcB8A4L6crimPqFgS43e58uYrTtGnZFoSCz+0YPrleHvBR//Spew0wrwlKxfQKAtBYvAmLNd5g3RS9ddsQHaBYN80TuqEIHp1zPInrp2bFUkFtVuIRNwCbGbcMq4CtERoXaoKU1ySXssV8sTDS5XZhNixbLppZztcvLGdgHDy4dWgszu3a2iXaMk76AACSBRG0LccyTLVCB0In35vuTHaQaKktIA5OOQ52/eKVv/zin1+9emLb2Ei1lCUxTBRFAkctRUEAh0RRuVb1uAMFwzPXYNamb0oW//1vfPX8u29WsiUIJCdnp0K9Y/OZEoGgkG3Rthpy06LhLKlgZm3lox8+2p/Axga3FrLai2emujshR+eHhneev3IKqdTjYV8w5ANx0oJxDGEx02g3m3gobmHEL37xouztsEkys3rribFB208FfUyw2NRtJZoEawWmKeqdo9GZzXQ02GnLqiMZaxvrimV5g+HpXMEWi3/ykWem5rKnl+sbm1UWAZ57+I6e7UkXCKst/rVT51bSZTI+UF659ZefetpplQ2+rRiQrBuky6tbkKTpuqxA/QeSdUhyeT1Xz01Us9qxty5/4/uv/+uPjzcFRhdQryec6knQLOj2sIijcUGKiJA0CxVW53zDnuv5iV1PHGB3xPgkih3qYnZ3KQzsIHirKUn5ZViqgUIpxthbEq4hSBJXV3pd3Edv37snFaQBDYGJJq/AIGBbgmGKlBtXDAmAHcC0KrkShzKoaCAtMUoBo11xEoPGt2+p1Mp9PT0OYIAoLNg6wnGRVMpGEBuwNU0RPeyGJmZl0aSx+Wxa4LkLb7xRmTrZQfNhVrvv0KHzl65AJEbCcIRkvB4KobGyqSyrugwCOoz3DqYWlm4WCyuLSyt33nvPx/7vXzFu5sEnnrjvg892bd9NJ7pMtw+PJm0INm2HdfkAlLgxu/Clr33REEuduP6pA1vv2r+7uLHiZfEAgyZj3tVlPRjxDG1xlWsrh3Y/bXiw3j3b8hpPxaPDtx3YvW/r1/7pr77942/Bfjq+ra9RrOoOrBF03rC+/u/fFlRDN41Wu7l3fBzxRNoOdPrK5Ww+q4ptHMNs3TBUE8MICqdUEwZ//Bf3vHB+U8i1HtkZf/qxgT+8ej2TMSaF9p6wbxsIVBzn4DjLRhEKj0ocJUQJI0R4qhBVgmUDRGybc5Fz7axIATVIgBzgzV/fwHVvvbwRZmM7AjDZKlNYEKX9TXVF4z0wTrWd8pHbkrXsBuuJZxV/0u/zhAFVpHVLRt32eqYexYUaD5ycqc4uLj11qJ/Co45c3L19wMYZmOAIuK1oGgAAqq5xVKRUKbCcI9UrjiQTQVKogT99aaYKxilY2Ok2dnZzJKBYMOzQHr0plFB2Sg2ggoiWcwoJV2o5V+/w9OJaF+n5p796qnBzei5vvzx75tVXfoqglCzoliSSjoxBdFsQrkxOIASJ4XhX2EdQdL3NQygRCAWvX5l58fhEvIM7sKX/zdfOJVg6hjkAaDguFt6sdR8Y1xW9vlTc2Gwe/LNHOyLBRrUUTSZNEIEsRVV5pV2x2zyNEZ/4+uuBZCyA+6HGuhHuRCEjwOGp7qjhANcupPOVEgTZgNHujnLbPShi2hTrlUmXSnGEYiAOb8S8eLVp7BofQSCckiqd4Y5ztUbRJDKL6YOH+kifvwUJGUuEFB3QWEoFABNVQRvykkZbVUWjm/ZJgAlkhNX1NWm14koEfT4v3FQB2uMYjAE5hWwaJGHKq8mAeWOyaJj2gf17XN2961cnObANWPTS8ipiAThqSC1bDKGYbrE098TTH6Mh0ZbtsJ+laBevqrrE4x4YwTBN0wiSajfaOIrXqmU3xVoGsLgAX7kxY7AR1XBsqT46NE4CLTeJKobZUmQL90WCwdPnZ3oSPXybxDBmaFvPjUxp59AYLTdu3rhlC/rU/PLdB3aoouWACsd5Fc0sZTc5rLWWyQa83pogRmJx1uuqVCp9Q0PNZrNSqUQYhYb1WCwmGORCKfPBp/9s4o2XgySM2nioL1opZw3R5nklK8ocwzYaDZomTdMgWapervo9DO4Ys4uriANDcr2w2NCYcAeHjKZCPhfTLGXnrk9gjCvVkWrUBcOBQIhdT/NVqrazLxWUbQYx0XZDgDFELaqktPnI4Z6wCzp1+gakWEyYIACAN50ainUPhhVLEnF4g7ZhVUZFnaxv2oCbYMKRBMclInMXbwI1SFL0ffEhnww5o1S+3kr0hYB1EeQVVbLbWDE11omDFJ7k2jZas6l2vvL26cnyxbXVdgWzPd1I12qpbegIDjuwRfEWNAI1oxCycH1ycT0z3JeK4FrcTyGII4mNhkOyLEtTFM/zF85dQDC0ozsh1uoBjp69ugkSgbVKTXXAIRIxtbZD2IpqOBCIw6CkI0ol//HbujZbxiyP1osNJxi1cDqCa9uGOjcrrYvXN/p6uj/x0L3V5XVvwJ9eXpRaDaFclOXi7XfcA7I+DcLXs/mqTKoQKig6BEEoBJqt0t2j/aZq4Ib41x/7GNhs+gmiI8g4mG0TvA+nfaHEmwsTJYp+5613jh7Z7414URJv8023h8tvpjkM6+wee/63Lz64vacsybcdevTG1XNBpx6n0I6EP0wQgg4N7nT1DI9itLsz1V0pZN4+uzS5NDdEI1ilEA+HQp0pJJnoqYKlsVTCUOTZ2eWQK+kg6GjM43YjHpukIQkDLQJDKQpBYNzlYRMEalaUTKUwMN7RqrZNN5HN12THDCICGiH2ckMvvfDKwZGxy6vnJFkjUWLLnl7Sj2GqspglM9WKj5K339NfqPGzTXi1qLlgl5+gBEEpK4AAyCBE9+O+zhBZKVX7Pd7iqphZW+re0mdopiDynM8l6QbgOK1G8/yZs5ANOhbcbEh9qQ4C1AY6USIe4KToxM3MoI8BIQtAUABGDEW1LQvQRK+PSsKtQDzAeXtv3lx0CHl1eeIj43t6B7s1sAwiBZ6vXDtzhm+2QAxCCSAWDnpQTYMsCNKnpyZQ1osSrItjk5GQpaqVar1Rq9UyktpQba2JO4gEEe5QoJtw4QgAe0gEMxyMhkyIYEkGZicmJo4c3I0jsKJIMAIqipSMRhanZxmqo1RR42H44PhIJbMq883uyNDS/BSB000JIrjQ977zw0AiuvPQrlFPhGDA5yIHAXl8+er1zHK2AgGuYh78+Wc/4g7BftBCDPvU9LRsRwrN9APDPTSJwV4WLGVVx1qzJcTN1LOlj33lU44jeCH69OUpk9F1w3JAjHMHl1bSBA56CaQL6wjBXKM451jU3Mz0yOiARSD5armYz568ToT8ruceTcrttaDbe3Umd3MDGk0kto35imr8V++cnFi7GQzEOjTt0RTt49xNA4QgXQAJCgAG+1NtS4r1dDTq5VqxLLf4/lSPDYE2iL3+9klDE/fvGUbsyo7xnT964SQV2tnBUISVh2yLJQnANDVJFDSLjKTi0owGIiU8sX3n+Ikrl0WM6XMDOsSKLeLGhSuf/+RDN89fBUBD1BudfdFQ0ItYDuhmJVFxILItKSOj2zQDWFlZqxRqHcnuy5evulQWFmU32RRLBZcn2ag2dccK9oQEUGINbeTeOwhP+G//5tt11PXVr3yhlFs5dGBbqV5GKEISRBa0GJSdXhBfeOm9vREglAzUG0BbkYb7wqFQqNWWCoL565feevzhzzJe9+vvvk5RxpOPH9221Vtv1hXD8vhjloW2puahi7OTG5vN3AYvCTbtZrIr024W8pF4pVCeWlxdWW5Op8XVrJnEB5mGreXakqjn8uVWqY54/QjjQiGUX9sMqSCqYKRFwzbTFmwLdm1WVH9HQkGstWyTZvqOT8l2xHth4WpLMJnAULnUitHoYKeHdOOleu70yXc50Nnh9Qw7diwcFExQhghdVwm1yWklmC/XinkEw8uNltSoA4bGYEhxPb0wf/PmxNXOzo7OriSKIwrJ3pqe6YtHPve5DwIehZeVYKwzW2k5KClrtgxBpxbKDZt1ECYQ7qjnNm8fHQjhKMVFEW/ohZdeO7J3/PSxVwReXa2KoYExtqPL8nhNV8CBEZJjdF0MuSmplt+4da2yutQsFdwUN9w3RMAWymI1x6JGhqeVXMMD9OzbWWvKhI0HUb8DoKvlzXsfvvOZ++6oVaodHR21WoUkcVPXSJLUNc2x7PRaHqc8sg5lN0sYQc4vLRNsoFBtt3TzP//7VSYSbpurN+fP9vZ1IQD36v+cvXit6AoO+mOduqkSqOUaSoAHu8i+RG+Udjut6l37dzApz+piJuhoZdGs2YxRyRRVMpbsVSsZ0tfwudwsTmIcmecbkcEtlOlszq/YkK2ijjccdtn4sVOXvKHErfM3WZT1+/2yDVxdnLURKIS75oySKNr/9uiO4aF+GHYASJNlkW/L66vQlcmpSEdi++6+SJRuV6Xly6s+xAMYumkphL/BMhwMEqIgj41tWSrl6wW52czCBBSKecS2mIh26o4GETbhQM2yIMnA7Y89hPqYG2+e5+ttSxJIxHaxsIH6/6uu/UOgF4PWFxJqEN6fIM3ODubSUu3GtRW+le1KulQNzuSUrSP00QfuVAEdRhy52TD4KuFy0+5gbr2IgliltGCUrJm18lrdPHrgqEHzzUopGAyObNmGUWHVqJaL2czNZb28JlFw5/CgaDsHb78z4AmClA+AbR2QNUs1AR3M5YqLMmMxr7zyXygqj3jutKSijgI5VRvepQeQgZkN7fm5yyk8PBKmBNjV0EBNEV2g/N7k1J9/4UO7t6csEwAR1kDaSCI2KItani9u6w1ZmIzbgWqhwvow0u1qlfneZGj26mIgFsmX1ocjiWZDdCiTAMxoMKBJkljnfW5X25BsBOBIjFSRdr2xslGgYEKzFVOT/C5mOBXcf8ftSKM1ILcWMiUV4QxVsWCbYXHZgjrinYZa2wv3WzA2ee3q+Cc/bMrpUNhdz9Zg2w6EPShp6aopSTUSpzIb6+V6WxXBrq6uRGdkeW3W5/PhOFrOb4bigabQsmHI7XOV8hkfGosnA+/PzoR8/rYsUZz32tRMw8DMWHepUMmIrS1HH3HaudX1pUbDKtfK/T09ptVqtBski23fOQYgjqaoJIKzbrcE6IKsyE4DJQkCQju7BkpKbmTcg5bqW7cneUuOHtotCEK1Xu4NdLCol2HRrkCXUl3v3DJA+ry8AxAUZ2iWCSimplMsoQoCgWJkIO4n6R9/6+eLFfGxZx61KxlU1VttSbNAX8c+BIq9/YefjQ5E+10hf8BNqA5jwZsZAUPJh+67a2RwkG+VXb5Ao912EB0R647YbIQ8UOdIz+TStebVbKFU5nZ16rCabzfGugdlvZ3NzcU7w42SVS7V7rlznwWKkK5iNhb0edr1tmrZgY4ECjgkgreaigwSkgLgmOpqVjpQbWBL1MPxfGFqN5cqq/ZqTfGANRAEAgGf3xdrVrVmcdWN0pIobokn6qtZyxJAQC61MjhBNcqtCOuxDC0c8HYkwhgK52s6Q1OJjtjiwk1/0Gta4Gah6PMFGqUaF/M6OoxD+OzkZWAWGO5JfuSTT7zw/JswRCio+/DTe2+3qOlb7zMMuSM00KyWXKBRbdRXV8oGYi+kM7oofezTT0CM7HYTKAVyFNtstk3FcHFhmrVM0HGjqKUbkMT2bwnYDA6uzPmjGNgEUZSU5TpLM0sTF0JJzsFAiuteXOIb8yvjB/arpmMYgGMjENikSEZrCBEqWMgVIAY5dfwNERAXbPd3zuWfHtFSnfHizfWmhn3jO++XWZdBcl8aHJ5fn2rjEchu93kYyvFMLmbu3DWsiHXbkQGh7cCoi3ZBqpRLROijdxyZXczmGtDzE/OXso1C03YsxpSRbEGgcaa3s1fTwZkbSwhATtyaJWi3bkKQaaMguprJ6ACYzmzemMu8e+qaYlG8SVQ0iKT8hg5RMAlImlprCLZp1VsJHGdBZdvocDIa0mUpvbTy9utvped4vqC7YNqFgZZcMwTAMpxtW3fiNFsXdZz0OQBRrjSWllaKxaLEy+uZzGt/fAtB8Wy+nt4s6SBebyleT0hUDd2yWqKEAEAqFqk2C9l8OtXfJxvWlRszZy9d5hQ12Bu1GLq6VqFQxrII2yRlETRsrS1IMEpsP7jP5UNkTSyUc4qmECTp9vgMAHFgFMUIywERBMFJzLTAxbXStSsbP/nBG8vzmcxGA0W8mbVKEEWvn3h3+tw5oyUGPNHVW6utzZaP8EAyQAMUYJCmCLqR0JnXz3/rq//x8q9+3hGi/uRzT2uGPreS+8WPrr/71pImUICCddFUrZrbsXcLqNmYL7xRLbm9bhAyE8kor6iAo/DNRq1S51tt3VDr1U3wt1+5I+pNvvjSewrou5Uup2nEB+OHOCAVTxZ429SbIQajMTibr7E2EOtOnJ26DOLQ1m1jnSEOwnB3MHz62rWqKGCIi+GBG3PrPEEjOOlzTA/k9IY9IR/Gepg2pEsLOc4X2H8oBTmyLEskSQq8CjjkqRNVxGxHvIArDNuE0xI4HARxnAQQ+sS5y8lkMuRzic3NeNAtifxiurJl/x3lVhqx9InFjD8cqbUFCobCDIHiJs26gn5v0E3YmkB4kWrJaDYdoW3CMCqqTdxy19kGIoopKOTuGuQocj03ferSDO5FHnvw8bDX7Q2hFs67CMpCIIRkTNPWJRWCccO2HMsgYRQ27LXFZS8bU4nQH9+4zNp0sXmNC3dVq9XHH7xTWLxOMCqMIdPzij+WLKQz/mQHzLKs23fs7eOMz9Of6p65fJkEoc54rLvfPnT77o1y419/ciJfs7/25AfffvsHA32BYNDNKFgzkiAjHdbKupVM1dutQCCwvr7xh5dev/+BB/uSeKNU7I7Hvf5guV5NdHjBi//+IaWlZvLtSwulhbKw2a65CXaMNjCaboNMh88VwY2gi5mYW4sznGhbBVPnLccfjPZGwEg8WRWkN4697wkEORTw8oBuwWXHqNbbDEkZqNXXn+J0vTMQ3sikCc1u6drRQz0+F2SYqu3oIIDKkoF7Bzbnp+qZdcLFRnt6Vc22VVmTNRhlQJR75+oNn4vpiQWblYKHZSKdnSsVycH1mMf7m7fPaw7YUtXucMhuNvr8HOfzyIYU9RFeDpVBo1pUwp6kKmmGroZZok4miBB0/Z1XP3DnPWu5+sjQIOuFZJvMbuQSkSBHghiJaYDNuQiIwi3YgSDIVjXABiiG1WRTb8sLkzOyovT1DMPByFt/fH8w2Hng7rEf/fY1RVFu2zEc9XMin5FalWKBmF5M4wClQnCh1So32j5PELYs25D6O32pjgBLIQMjXZCHypZqS9c3xbJiS4Vtu4LJDsYy9NJqjfV326QnOdj17qUZQwFNdyLTVi9fPv8PX/k0X1sMu7x+nAVtp9ZsiKoCnv6rZ2FAy9XKp+bmF9rSHVwn6XGzrPT65VtYZ3x3OOHWKkOp5PW5jNvEFwt5I9otAtTk1MrBLTTt8RVqjUKh8fnP/unyuReZokiRpMYSbq9HYl2XimmDwLCC6DeRbR5vriGUbAiHGo8c6IYgR1ablmVxrKeAZ702qZfM+QU10jkeiMi21EIcGLAJzcR/efoWAUHd4SCgqrFIWIWlkoLlKlkOJOp4RLashfVMmKGTLL0/ErJx5OLNCwM9QS8N2wQdDXTcOH/N0bXRwV6sWf5dFfroU48Meg1/kK6WS7puKnYDIbxeuAsCRMhp2DahmW7eqIY6ojfnb8Xj4bDXDdrW3OxiV6J/7urM0tRC79DWg7fvlhjNshu1pRWboETE43K5QLmBxfo8tNbKrWkt78zcGt9yFjYyLd3AWBdgglHH9Pnw/fu7eD7N0E6w48jEZnb/bUdu/eY1cTnjcCThsV1utt1Q6bCEFKzhvsFNj2g3obVN6J20lAPcHR0+pHT9zju2rt5a3Brvz6ysESR2bTaH+DqCc9Mz/oD3ubsPTExcuHx9eQzorjXBpDtp6mRYA4kmqW4qkaHI1ZLr1mI+bpZ7t+54T7+ZXg2P3dlVLNb8CCFPnIooCOz3gziJIyhgYV0SzwZ6zq9tqCisuoAZCPGzRKBhaRBXVgEWxWDdTUJwq23byC7TqblQiXU2NxfmtSbsC/lUAhYcrS5XtkQojkycLmWGI5y4uSSyXW0UzRp4UBQ7ybxk62NDYakmulSrBVWNljg+2LWYq9YCsRAM5wtVuV3fMZBkzdomRNw1gEV9gk25eB1xCA5WW5TtpVxx29JUxXIc1rEsXatS3YM4Sm1ef+fGy5e379xhk+Dq6uocmDZ1vaO/x+W3aoZgCiiBu8lQTz69Ets6IMuyLsgUqMuKI1iUKBSHemKTM7NdPsI2aQTSIaTVGYrCDGlgAB3poQhScMr+WALE/Fyi2xAV1txckfwACjAk4FQ9klOeL9zwOp2i5i3DzXgE7nF5V1fXKhWeSZf9LXMxPWXpjo4iG20AUTVBMVUN8SGkq3v8vmCkfH3m+ic+84n33zuDoySYq8uQrQmKuG6fPH3RixMcG5ufn6cRjJdWE0xq6MAeK1/HwRZIUwRBQBhi2rZpayUHXirXbE/IRIGNZjXBaAxlWbLc0+02LRBEYYLAYdCp1gVGrrAcLkmKjnlX80KuLn4w2WtrdQaGvYEOzI/ml/KoYb45sdnbMUjqFRuh6mK97XBEsZGIRZ16i8YsJAgrclSxMvc93ie9Z7/99uqd29y2jd5zxz25hTkIAwhIj0cTBADDACxLmmlojqGZphlmqWZLclAUtB0MhxGCtMX0Zqu1a3+yNUB5goQBOvGeMRLFANtp1hsuLmlbqCgaCgzrKol7xo26bojq5K3G0c4WRVMWCQMsRlPkzu3bVhZyZ06ef/IDDxGkBmGIgYDh7g6e50EQ1CRo9+6ditgszJ+gtWbVieWLpTjK0E6rpZkMQQBtRABEB7d3dEb90R4LIumjw83qBq2ZoqxqSguGHRC07nEjkOMYO/ftvnT9xg9++cKtlRqMmE9+/AkyiBw8sIWDZFiVYBwWDVOpakfH+m4b64/7GLm8+dEH77r37t1eRPeZCgfZEGAQFA6jEOBoKGRQqKPbSr1RsExZ4tsIhgu6LTkQhBMsSZim5YAAhICaYamG43YFDAOFMdbtYtwcvCgRixVJtJDVbG0l1zp/4QoOSg+O9wdZrK6riIe2QdOWVIwL1tzejO6gpJcgGAh1tg70Pv7go52xrvuPHurvdA93d4U9nvnZJUWzecl0czRHYKCu64oKOI6jm6Zj0xwtSjxG0ThJwxhuQ7ADwhwMbqZXZKXlibgNSIdJ0IR0CzJkU8RoGCJsWW7YhqyrRiaT/9aPfqULDcI21teLHEVamkrCkG3pmfyaY+uK2h4c6rl0+QKK4hjH0R4PiOIU54YggqKoaiazcPWSH8NYGIFsx0XSEq9U2wrhcWsApZjeXEFdz+e7kx0cDrtRW27kdKmsWiKKQxiNuYNuAHFMzoZUUWw1S0fuOohg8NziqjdCBiKMZYheCot7vQyHIiTMcRxiwAMw3wm0KaW8u8NTunxs73A3aalhrwfFGdYft3ASxHFBElDUpjCrJ4Q/srd/dxDc6rIHcc1qSJOTK7WGhTiuoD9imrao6wblXquZr88Ji5pXZ5LhCLG9D5lD4H9469zrGyIf6F/lnUj3IEEAkfrip/aFH9iOkzi5upj5/AMfqszeugSYb5ZKtwRwrWphts8U5t749Xvf+avjMYfbGa3rzXqlsNluNymvG3VxrN/tWIYl85bUUsQ6aEowAjggIAtqvd4QBBFwQNt2AABMz+c7O8ciyWFXqJP1d/ijA7HkKO1KuLxdwfiQCjayhRuSlPb67L6B8N9/4/90JVlDLvT3hq9cX242Db6pIigU70miNNEz1M368GItLyoaSOEGDLn9oUZDtmyU4ADIkKfPXm2VwEaJQuQqjCJVwJXG+v8wXTidM04s8ifnipHRXbY7mq1LdUm2EJQKRAAUCsbCG7kNC7Q5H+tOdkC6rDqGChniaH9y60Ai1h3DbNuuSmpbNy0U5Qg3Q3EkjmIgohsYjBiGBQBAyO2W8nVFM+fyxaaDlZu6ieCKA2AUCYKOrquYYzOO1usmO3Dnyf07hkJkPODCMKJWbjWqleXlZcWwWhZ6daVcMcBrq4U/nL60XKt4u0M7toQwv+e9mws///XbqYBPl6WmajimYysiSRqZfEkFqQvvnf3Kc/dpzaLXx86VczyI5EvNizenbYRtNO2LJy+FSAIE7K6ujkDUy+ttNsJSwQCAwI6h6UrLUluOKaEoqBmm9f8VBGexcZwFAID/f+b/5z529t71er2248Rx4qhJmqQlCNEigRBSqyAhXlrEewU8RAiBkOClD0i8c0gIpCh9aEMEhBKFNpRchDqpHcUHOezs+ojXu7PXzOwc/8z8M3xfjAQWswDGJIx9ksbUI4mgGoTFIcAIyz5JCIUsJ3OiJqlZUdUkSRAF6LkjIyvLOKIwlVVZF+EHf7kVszkjN2lkCohjscJXpytfeuP1t77z1p2lpRQCw8gdtM1iviLxqm7Urv7544Sylhe7ALlIfGmHq3vDD/+93IP5EadPnVycWzzih8R0PUbgMM8hLCZA6pg9iLGoqM3tHUXPTMl5xFIUOkNeQUfrcqk4CSQ26tvL/7gfQkXUsrl6MR74xPGNkkyDxsiL24QBAHARXbn5QDxWuLu9EdvKpMiVC4Iuc+cWG8P9JodZCnQydnRFyCUQW86FM4VPkD/ohHvt7hRnTE7UAgou//XTXU8r670QiUp9ZmlsMWr1V+8av7uKNp/2zp3K1DvbRIMjKpugvAPS52Paj+lAyPf6zrFpcPvH7230hu9fvqLMzk0Y2q27QrEEldkg5VE6mvbCLq+yWlHLlDS9IAeJiEmIIjeioagqKfXDOBHkqu+CMPSZFECEMYN8xxPyEsGRFXkIAonBKcPHURT7JE0Sn/qK1NBEF0NAgmTsRhz2Yz7jkiEiQx/Vfv7+73/0vbdZ0Jk8UuNVEcBEkKRXymdOnD7rEqdjmgAI1Zyy8uCLD649eu3oXBTslSalNPV+e6Ot1g5leWVm/vCjnb03Xm9ImTAvxidmioSPpnL5f127PjMzEyEkyJokqosnT68sLYdxuov7TAgGIIXEgxIWVQmAyF1fexZ4TNC1+0+aW//rmEMvoEQFhC1xz3u9AydqjYYv3OiAwEEzPCVP5pMBx3s7A7NlmZ0oOhgDBtfsoXT7s+0b9zfDyLeerIQEnj1eO3/eqM1nikWPwIUvhoW1oSJq5VbHnsrVEfD6vZfrN5qfXn12piF//1vHfbK3C3rAD9kwfRoFL3o+Z3KZGBcpHE8ffrwDbcs8Ved+8I2TPBB+c2/9odW8uXdw38QjJktB6uIiB8YsjPyQ5QM+wwMmoZ4Xj93A9YgfKjTNewGiqSuEkDJJlLhs4MmyzGt6lEDEcAqvEy8a9yCynDiO5Xyp39mDIdkcdmBW16t1V9bzGT7xPGKNg6H9NbXjWqN3f/23z1sgx+QZJGCWS5LEiYKxiFlJqtVq3riz2Xyw118rqR3obumyU5w7ce85M39oUkI+zCgEsvGwtPokuXRtg+MyT9sPi6nODGWVy1hOx7FCv0+ZuFfKF+yYbZGtk6cXEMuyDMMkAGCMEULOwGs22ygVgzQWVUHRNZjGJHDzpYLt9Au6quXyJHVpzBosTJLYHjvlbL4xXW91u1MzlWebzzWW/8/KQwyZcj1fPTIVjbY4QWm320atVKlUKsXpz/552Sb1K7dv6vVpSEcLc9OaxA9G41HXFhtptpBX5MTuOo1CRaWDJOZIDLsjy/RTjZUwA4/VM2utvT981PzFOxfoQb+cL1y/t5xBDGSw5wW7tnWtt/uVRpkIKqdxKcaQYRzHySoGIUSXZRTDJE0ppQLLJgBwHIcpJkwah7HvRzu7L43ZgqqqTjCOoohSurb++OxCdX9gmTY9Xp93x31FxobIQZr4sb+1vbvXekGDeGJmKu3zZwQ6L5RebKz+9NGdH/7kosACFiQ8QnEcsSybULqwsDC2ral6/c0vhy+Wn+YN4aNPbja70dxMxbKHXEpOL8y+uhgsrW2IGSH0VbvHmaa5ubHTbD2fms/zSq5rjTMl/emTJrHDVxfOSTLPUEohhBBChmEopVY/glDmFFkqZFKNl3QVSYJLgoBGEmJQErJJrIl8VpE4XQGYTdO0Xp0IhnaGl2BIeZ63fbcyXT99fvHwsUa2klWNrEsiSZIQQoIgCILw2lffbO2/fPvCN2cbJUOmc42J8dB85diRd7779awqiqoSkTCn6owfGUhwSGT7YcoIuWLFcgNNkYRwOJmVoF7945+uJlAYdgdHp2oliTcEWeUEVZKrjXrKI1mWIYRBELTbbZ7nCSEQQo7jJEkihGiaRghJkiQIAt/3CSFRFJmmuby8PBqNXNdVFAVjzPP85OSEbdut5v6VD68v/Xd99fFyGpPOdvPOx38nprm5ugGStFgpU8SkvNSoVY6UFBp4VCi9d/GX9z5fpRQnUYJjmqYpwzCO48iyjBDKZ9VqrRwzYK9vCYVKtVY/NDtz8uhhTJ1G2frZxW83JtS7t1b299GlS5c2NzdlWdZ1HSE0CkgQpd12r2iUVh+uD4YH/wftObgz5doaAwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<PIL.Image.Image image mode=RGB size=150x150 at 0x7FD255E6BA58>"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Image.open(PATH + fn).resize((150, 150))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "19"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Method 1.\n",
+    "trn_tfms, val_tfms = tfms_from_model(arch, sz)\n",
+    "ds = FilesIndexArrayDataset([fn], np.array([0]), val_tfms, PATH)\n",
+    "dl = DataLoader(ds)\n",
+    "preds = learn.predict_dl(dl)\n",
+    "np.argmax(preds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'boston_bull'"
+      ]
+     },
+     "execution_count": 63,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "learn.data.classes[np.argmax(preds)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "19"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Method 2.\n",
+    "trn_tfms, val_tfms = tfms_from_model(arch, sz)\n",
+    "im = val_tfms(open_image(PATH + fn)) # open_image() returns numpy.ndarray\n",
+    "preds = learn.predict_array(im[None])\n",
+    "np.argmax(preds)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  },
+  "toc": {
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {
+    "height": "calc(100% - 180px)",
+    "left": "10px",
+    "top": "150px",
+    "width": "180.188px"
+   },
+   "toc_section_display": true,
+   "toc_window_display": true
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "0147ea39a83144aa99e7877a908ca502": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "02af08793c9a4c5ba0cbd7462a715f89": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "03c7476e32ce48c2b38a7023c2dcc0a1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "075434e4b0234c5fa61c8d63fec51679": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "08ba1e10c1a641f7876680a632f6821d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_b0edcf9ef0754ca4bb7fe6e8790c464b",
+       "max": 6,
+       "style": "IPY_MODEL_c13bdace91114d639b408aa120c97f79",
+       "value": 6
+      }
+     },
+     "0b49f5119c6d4a25bb575a20e33fe219": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "12cc98b1fc954667bd49c08972278f1d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "13cbbf3a554a40f09d40df39c2cacf47": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "148c1abd5f1747a2a787c09cef3071bc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_902c060a37b4491788462dce6be1798b",
+       "style": "IPY_MODEL_88db019106ca4893816ea780e567a175",
+       "value": "100% 3/3 [16:30&lt;00:00, 330.17s/it]"
+      }
+     },
+     "16993380d0fa42b888a52dbf1bb42f20": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_c74dedf09f57490a9f1ac9af54e14bf3",
+       "max": 6,
+       "style": "IPY_MODEL_557d35c901f54575b5963e3b7ce932a3",
+       "value": 6
+      }
+     },
+     "19c5557812814cb28bc7e0cc80c65c5f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1c241c0e5b5844508c1c50e2a7c09b1b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1c509f99160e41d5af6e565b1541e571": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9352e3fd2af54e09ad67afb4ac446b27",
+       "style": "IPY_MODEL_62e7ecfbbea7427385deb25ed2f4232f",
+       "value": "100% 6/6 [00:00&lt;00:00, 380.26it/s]"
+      }
+     },
+     "1e2f1c40607144eb9cb7b9e257d06f35": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1fc90792a2b74c38aaf73659c3756831": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "201ae86e437e4b5390782e9df272326d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_c8871c57d7bd4b61a99633668fb44621",
+        "IPY_MODEL_38eb37d7293d4273a6ae06b5a451617d"
+       ],
+       "layout": "IPY_MODEL_1c241c0e5b5844508c1c50e2a7c09b1b"
+      }
+     },
+     "20bfce64bf354e2398353b6a2a31d0e5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "21e75994f5e749748dd5693819e51d93": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "22952b3bfa674aff898e452b30bd319e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "26e2b0e7abb24e3fad1b5c0c166aa44d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "description": "Epoch",
+       "layout": "IPY_MODEL_363595af2f5f4ad3a3f5a9e46069d58e",
+       "max": 5,
+       "style": "IPY_MODEL_02af08793c9a4c5ba0cbd7462a715f89",
+       "value": 5
+      }
+     },
+     "288366a4c5ba435286c34d6d5ad69201": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_33f7abed940a4b24b01110da8ec67ddc",
+        "IPY_MODEL_93f4380114fe48b88db18d0c97736fd4"
+       ],
+       "layout": "IPY_MODEL_5b17418f64954c14843a914942f8ce3d"
+      }
+     },
+     "292be092bc964dd7a48bc62c906f5814": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2d1dfcb285154a7bac2db184a87f3c4e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2ff92f760a2b46a99576ab77daccac1d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "33ce7c9b732e4715ae12b71669addfdf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_20bfce64bf354e2398353b6a2a31d0e5",
+       "max": 6,
+       "style": "IPY_MODEL_830aa543858f4a54a14aad440bcbde34",
+       "value": 6
+      }
+     },
+     "33f7abed940a4b24b01110da8ec67ddc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_7ba0d94e2ef544fe9126eacee6588468",
+       "max": 6,
+       "style": "IPY_MODEL_8c8cb52ff5e54c55a297af7571a105ea",
+       "value": 6
+      }
+     },
+     "363595af2f5f4ad3a3f5a9e46069d58e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "37f00a662a3c4b5f9f29db6903cfc5ba": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "37faed3c96f343e895d8f29ab07137c0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "38eb37d7293d4273a6ae06b5a451617d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_42c23fec7e814a9aaf39ffa59c0ffe20",
+       "style": "IPY_MODEL_7163788d004d4c15b0b0137a654079a0",
+       "value": "100% 7/7 [35:35&lt;00:00, 305.08s/it]"
+      }
+     },
+     "39cf7d6b5e98460e9a621f1d74e32fad": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_cb554ddf38bb4597b282655ee74ca321",
+       "style": "IPY_MODEL_c45beabad9d34af5b39ce603b5308ef9",
+       "value": "100% 5/5 [27:26&lt;00:00, 329.38s/it]"
+      }
+     },
+     "39d7df82d70b40df9f1171dad9ce2b4c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3a1160614abc4724b73cc9bc2e0d0d46": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_19c5557812814cb28bc7e0cc80c65c5f",
+       "style": "IPY_MODEL_87707de469bc4c4bb2ba2a2ed7322de1",
+       "value": "100% 5/5 [00:28&lt;00:00,  5.70s/it]"
+      }
+     },
+     "3b2e29458fdc49d0864a7fc9a1faafb6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3ed035ff92d947ad9059d4bc03f2576c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_16993380d0fa42b888a52dbf1bb42f20",
+        "IPY_MODEL_a52bd3eee7aa4e9093ee525fc42ff232"
+       ],
+       "layout": "IPY_MODEL_66e271ee790148eb89ae51b9b22216aa"
+      }
+     },
+     "40060908ceee46fb859195274eca3da8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_4b3362ffeac948e490ce91f1e0786f2e",
+        "IPY_MODEL_c09f764cc1c74e3aa75fea864a8d21f3"
+       ],
+       "layout": "IPY_MODEL_e6926f2efb5340528a00c5045376c380"
+      }
+     },
+     "405077ae66ac44afbd35d90a6afd6cab": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "41a9d48c29ef4752bcd2ddc7076dac3c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "42c23fec7e814a9aaf39ffa59c0ffe20": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "43f1cb9394c5422798a91c1b6b0a5907": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "45a9f25bf3964af68dfce8bbb2091917": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4654ebf91a484cb8b153920fb89bb522": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4b3362ffeac948e490ce91f1e0786f2e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_67e1b7b183484f03b2f63c22c44e8713",
+       "max": 6,
+       "style": "IPY_MODEL_12cc98b1fc954667bd49c08972278f1d",
+       "value": 6
+      }
+     },
+     "4c5e108b0b9145cb9987a673dda89bb6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4d7cbd1c9b0b45359d4d31ad4e50e441": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "54f04d9c381446649b742e1242de6953": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "description": "Epoch",
+       "layout": "IPY_MODEL_f6539e378c294a6c955da278da4ade4e",
+       "max": 2,
+       "style": "IPY_MODEL_b1cddc992f864976b0f4132e0c4819f4",
+       "value": 2
+      }
+     },
+     "557d35c901f54575b5963e3b7ce932a3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "5791e4167111408ca3f1be2e16334803": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5b0ec0306b6440c1a068951bf0d4a50c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "5b17418f64954c14843a914942f8ce3d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5b494db622384a7fabd7ed86d7f0575c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_26e2b0e7abb24e3fad1b5c0c166aa44d",
+        "IPY_MODEL_c05cfeeac9a04c68a7387dc65bf48227"
+       ],
+       "layout": "IPY_MODEL_4654ebf91a484cb8b153920fb89bb522"
+      }
+     },
+     "5c13867f02614d49bc038af563f5a5a2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_7234b227a46b404598576e19a230a94e",
+       "max": 6,
+       "style": "IPY_MODEL_7ae2ea4a6e144242ad504c2032fbb9b9",
+       "value": 6
+      }
+     },
+     "5d3aa8de854a491485458bcaf88b9de4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_c6a3a9d502b94ffba6cb6708c9762bd0",
+        "IPY_MODEL_8d9389e09e1d44d88ffffdb83ac6f407"
+       ],
+       "layout": "IPY_MODEL_03c7476e32ce48c2b38a7023c2dcc0a1"
+      }
+     },
+     "5f4033806f5144f28e0999110bf34612": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "description": "Epoch",
+       "layout": "IPY_MODEL_e59a2233ae454d81ada1b8494763e7bc",
+       "max": 2,
+       "style": "IPY_MODEL_292be092bc964dd7a48bc62c906f5814",
+       "value": 2
+      }
+     },
+     "61defccfe9dc4330931ce420b9976dcd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_4d7cbd1c9b0b45359d4d31ad4e50e441",
+       "style": "IPY_MODEL_45a9f25bf3964af68dfce8bbb2091917",
+       "value": "100% 2/2 [10:08&lt;00:00, 304.26s/it]"
+      }
+     },
+     "62e7ecfbbea7427385deb25ed2f4232f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "62e8fbf1622b4a36a186e7f319552990": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "description": "Epoch",
+       "layout": "IPY_MODEL_41a9d48c29ef4752bcd2ddc7076dac3c",
+       "max": 2,
+       "style": "IPY_MODEL_5b0ec0306b6440c1a068951bf0d4a50c",
+       "value": 2
+      }
+     },
+     "65d9210f3d3345019a1fcf4ad82f1ae9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "66179fdeb4534eb281f2690ded33950e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "66e271ee790148eb89ae51b9b22216aa": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "67e1b7b183484f03b2f63c22c44e8713": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7163788d004d4c15b0b0137a654079a0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7234b227a46b404598576e19a230a94e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "77132b06e4ad40fdabdc0dd93922af21": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "784cd320488247aa87d575558f81d06b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7998921f656343ffadf133220692f859": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "description": "Epoch",
+       "layout": "IPY_MODEL_0b49f5119c6d4a25bb575a20e33fe219",
+       "max": 5,
+       "style": "IPY_MODEL_cfeaf84bdbe34c7898e1ea8fc61b539c",
+       "value": 5
+      }
+     },
+     "7ad08fc0082a41bc882cedf6004206dd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_33ce7c9b732e4715ae12b71669addfdf",
+        "IPY_MODEL_bc6e6b33b84344f094704454a0cf6f6b"
+       ],
+       "layout": "IPY_MODEL_2ff92f760a2b46a99576ab77daccac1d"
+      }
+     },
+     "7adf432cd98f46df927bf9da9d94b182": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7ae2ea4a6e144242ad504c2032fbb9b9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7b215de0d6b64c3897c22bd817bbcb8d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "description": "Epoch",
+       "layout": "IPY_MODEL_1e2f1c40607144eb9cb7b9e257d06f35",
+       "max": 3,
+       "style": "IPY_MODEL_f38f8ae81eca43f9b1828369ebffd849",
+       "value": 3
+      }
+     },
+     "7ba0d94e2ef544fe9126eacee6588468": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8228413e70844312b5aa3128e3bea3ad": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_890f789420e4416697cafbf732f38b95",
+       "style": "IPY_MODEL_b52cba9c0daf49aab716b75c91137766",
+       "value": "100% 2/2 [00:06&lt;00:00,  3.12s/it]"
+      }
+     },
+     "830aa543858f4a54a14aad440bcbde34": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "868f105f38aa47b2b0223680dc202859": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "87707de469bc4c4bb2ba2a2ed7322de1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "879f0f26c06041698336e79b9b92b0c8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_c19f1e5cf61444b5926c89b67c374dc8",
+        "IPY_MODEL_148c1abd5f1747a2a787c09cef3071bc"
+       ],
+       "layout": "IPY_MODEL_b4a9636246544cd7a3ebcff56595bea2"
+      }
+     },
+     "88db019106ca4893816ea780e567a175": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "890f789420e4416697cafbf732f38b95": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8c8cb52ff5e54c55a297af7571a105ea": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8d9389e09e1d44d88ffffdb83ac6f407": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_1fc90792a2b74c38aaf73659c3756831",
+       "style": "IPY_MODEL_66179fdeb4534eb281f2690ded33950e",
+       "value": "100% 2/2 [00:06&lt;00:00,  3.17s/it]"
+      }
+     },
+     "902c060a37b4491788462dce6be1798b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "91b150ff417c44d1bc68e66d1b3c5925": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9352e3fd2af54e09ad67afb4ac446b27": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "93f4380114fe48b88db18d0c97736fd4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_b7e6303bb38542c9a8282079c33beca7",
+       "style": "IPY_MODEL_21e75994f5e749748dd5693819e51d93",
+       "value": "100% 6/6 [00:00&lt;00:00, 343.35it/s]"
+      }
+     },
+     "956dbbddf33a476db031c3d1b8ad5b4e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_7998921f656343ffadf133220692f859",
+        "IPY_MODEL_39cf7d6b5e98460e9a621f1d74e32fad"
+       ],
+       "layout": "IPY_MODEL_65d9210f3d3345019a1fcf4ad82f1ae9"
+      }
+     },
+     "a19c0f9c5cb34e9e8cdfe5c356084b80": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a52bd3eee7aa4e9093ee525fc42ff232": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_405077ae66ac44afbd35d90a6afd6cab",
+       "style": "IPY_MODEL_fa7fbd7aa5ab41a5aaabfca1db46058e",
+       "value": "100% 6/6 [00:00&lt;00:00, 377.47it/s]"
+      }
+     },
+     "a6ba13af33984f1b96ed120d3798b035": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a6cf535c8f30471e947503cae6bdb611": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "description": "Epoch",
+       "layout": "IPY_MODEL_e77a75b0e9b446318ef399e225003e65",
+       "max": 7,
+       "style": "IPY_MODEL_c8469a077e5449b69821e6b27b8e74e5",
+       "value": 7
+      }
+     },
+     "a7afeac8de60479e8c92248312fde8fc": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "aad1581c410d48feb48e6b943c14bdb8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b0edcf9ef0754ca4bb7fe6e8790c464b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b1258a718296423d9f4d9c0535aae63b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_3b2e29458fdc49d0864a7fc9a1faafb6",
+       "style": "IPY_MODEL_37f00a662a3c4b5f9f29db6903cfc5ba",
+       "value": "100% 3/3 [15:16&lt;00:00, 305.39s/it]"
+      }
+     },
+     "b1cddc992f864976b0f4132e0c4819f4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b3ae58ce0bce4cd1b678a043b8ce4415": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_54f04d9c381446649b742e1242de6953",
+        "IPY_MODEL_e10c6be126a045d9809b90c0880e7362"
+       ],
+       "layout": "IPY_MODEL_77132b06e4ad40fdabdc0dd93922af21"
+      }
+     },
+     "b4a9636246544cd7a3ebcff56595bea2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b4c9fe6ac6f649dc9ed8a077a5eaeb20": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b52cba9c0daf49aab716b75c91137766": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b7e6303bb38542c9a8282079c33beca7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ba26964d72134b3aa6095e3102f1531b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bc6e6b33b84344f094704454a0cf6f6b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_e6337586212341de8a4de0ce6bd25649",
+       "style": "IPY_MODEL_7adf432cd98f46df927bf9da9d94b182",
+       "value": "100% 6/6 [00:00&lt;00:00, 270.73it/s]"
+      }
+     },
+     "bd8469f87f2d4e789610110acd07571d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_ed2e720acb7a467c85bd7db465281523",
+        "IPY_MODEL_3a1160614abc4724b73cc9bc2e0d0d46"
+       ],
+       "layout": "IPY_MODEL_37faed3c96f343e895d8f29ab07137c0"
+      }
+     },
+     "c01a6ed0806a4aaaaf580bf56e78398f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c05cfeeac9a04c68a7387dc65bf48227": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a7afeac8de60479e8c92248312fde8fc",
+       "style": "IPY_MODEL_22952b3bfa674aff898e452b30bd319e",
+       "value": "100% 5/5 [00:16&lt;00:00,  3.28s/it]"
+      }
+     },
+     "c09f764cc1c74e3aa75fea864a8d21f3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_c80d11f161704ab3bda86e7d1dfaff03",
+       "style": "IPY_MODEL_e1df5ccb47594688afaee7c51d9cfeed",
+       "value": "100% 6/6 [00:00&lt;00:00, 377.26it/s]"
+      }
+     },
+     "c13bdace91114d639b408aa120c97f79": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c19f1e5cf61444b5926c89b67c374dc8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "description": "Epoch",
+       "layout": "IPY_MODEL_43f1cb9394c5422798a91c1b6b0a5907",
+       "max": 3,
+       "style": "IPY_MODEL_aad1581c410d48feb48e6b943c14bdb8",
+       "value": 3
+      }
+     },
+     "c28408357da544cd8c8bbd5c7469e541": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_5c13867f02614d49bc038af563f5a5a2",
+        "IPY_MODEL_1c509f99160e41d5af6e565b1541e571"
+       ],
+       "layout": "IPY_MODEL_e41e9dc77ce44f3fad0aee4db429cd7d"
+      }
+     },
+     "c30905e882964682bbe231e445b57833": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_08ba1e10c1a641f7876680a632f6821d",
+        "IPY_MODEL_e6f6231f671e4871b9e496cce50bf2b9"
+       ],
+       "layout": "IPY_MODEL_db256ef0046f46d085353ffba880c8fa"
+      }
+     },
+     "c438be876cfc49e8920f2704c6cddbdc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_de9c288444e74ea38dbac2ef1b1078e4",
+        "IPY_MODEL_fe3c562acb4e432280f6432df0710577"
+       ],
+       "layout": "IPY_MODEL_ba26964d72134b3aa6095e3102f1531b"
+      }
+     },
+     "c45beabad9d34af5b39ce603b5308ef9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c522ca216e5a49e4a7624f94b7215c52": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_62e8fbf1622b4a36a186e7f319552990",
+        "IPY_MODEL_8228413e70844312b5aa3128e3bea3ad"
+       ],
+       "layout": "IPY_MODEL_cb6af7a441964132bb58e75ef7b4bd19"
+      }
+     },
+     "c6a3a9d502b94ffba6cb6708c9762bd0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "description": "Epoch",
+       "layout": "IPY_MODEL_868f105f38aa47b2b0223680dc202859",
+       "max": 2,
+       "style": "IPY_MODEL_f4c78df23c774bb290250936916d962e",
+       "value": 2
+      }
+     },
+     "c74dedf09f57490a9f1ac9af54e14bf3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c80d11f161704ab3bda86e7d1dfaff03": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c8469a077e5449b69821e6b27b8e74e5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c8871c57d7bd4b61a99633668fb44621": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "description": "Epoch",
+       "layout": "IPY_MODEL_2d1dfcb285154a7bac2db184a87f3c4e",
+       "max": 7,
+       "style": "IPY_MODEL_ce4922cb72aa4e5c8b5713e47e49029e",
+       "value": 7
+      }
+     },
+     "c8ef187b9a1249018de7378cee824894": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_7b215de0d6b64c3897c22bd817bbcb8d",
+        "IPY_MODEL_b1258a718296423d9f4d9c0535aae63b"
+       ],
+       "layout": "IPY_MODEL_784cd320488247aa87d575558f81d06b"
+      }
+     },
+     "cac9427c464f4db9b71c36da9245c066": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "cb554ddf38bb4597b282655ee74ca321": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cb6af7a441964132bb58e75ef7b4bd19": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ce4922cb72aa4e5c8b5713e47e49029e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "cfeaf84bdbe34c7898e1ea8fc61b539c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "d2b4db8ba2cb4c859ba3e0041c243193": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_13cbbf3a554a40f09d40df39c2cacf47",
+       "style": "IPY_MODEL_91b150ff417c44d1bc68e66d1b3c5925",
+       "value": "100% 7/7 [38:27&lt;00:00, 329.65s/it]"
+      }
+     },
+     "db256ef0046f46d085353ffba880c8fa": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "de9c288444e74ea38dbac2ef1b1078e4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "description": "Epoch",
+       "layout": "IPY_MODEL_0147ea39a83144aa99e7877a908ca502",
+       "max": 5,
+       "style": "IPY_MODEL_075434e4b0234c5fa61c8d63fec51679",
+       "value": 5
+      }
+     },
+     "def3b0d0275c454e95c5c2952fc9d017": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_5f4033806f5144f28e0999110bf34612",
+        "IPY_MODEL_61defccfe9dc4330931ce420b9976dcd"
+       ],
+       "layout": "IPY_MODEL_e22e48eeda32478cbb6bf53babd9e700"
+      }
+     },
+     "e10c6be126a045d9809b90c0880e7362": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5791e4167111408ca3f1be2e16334803",
+       "style": "IPY_MODEL_c01a6ed0806a4aaaaf580bf56e78398f",
+       "value": "100% 2/2 [10:59&lt;00:00, 329.53s/it]"
+      }
+     },
+     "e1df5ccb47594688afaee7c51d9cfeed": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e22e48eeda32478cbb6bf53babd9e700": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e41e9dc77ce44f3fad0aee4db429cd7d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e59a2233ae454d81ada1b8494763e7bc": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e6337586212341de8a4de0ce6bd25649": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e6926f2efb5340528a00c5045376c380": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e6f6231f671e4871b9e496cce50bf2b9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_4c5e108b0b9145cb9987a673dda89bb6",
+       "style": "IPY_MODEL_a19c0f9c5cb34e9e8cdfe5c356084b80",
+       "value": "100% 6/6 [00:00&lt;00:00, 42.32it/s]"
+      }
+     },
+     "e77a75b0e9b446318ef399e225003e65": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ed2e720acb7a467c85bd7db465281523": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "IntProgressModel",
+      "state": {
+       "bar_style": "success",
+       "description": "Epoch",
+       "layout": "IPY_MODEL_f9852feeb51543e4a0d21c5cd6326380",
+       "max": 5,
+       "style": "IPY_MODEL_cac9427c464f4db9b71c36da9245c066",
+       "value": 5
+      }
+     },
+     "f2cf6963cc204b18921e63e1933ad18b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_a6cf535c8f30471e947503cae6bdb611",
+        "IPY_MODEL_d2b4db8ba2cb4c859ba3e0041c243193"
+       ],
+       "layout": "IPY_MODEL_b4c9fe6ac6f649dc9ed8a077a5eaeb20"
+      }
+     },
+     "f38f8ae81eca43f9b1828369ebffd849": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f4c78df23c774bb290250936916d962e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f6539e378c294a6c955da278da4ade4e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f9852feeb51543e4a0d21c5cd6326380": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "fa7fbd7aa5ab41a5aaabfca1db46058e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "fe3c562acb4e432280f6432df0710577": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.1.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a6ba13af33984f1b96ed120d3798b035",
+       "style": "IPY_MODEL_39d7df82d70b40df9f1171dad9ce2b4c",
+       "value": "100% 5/5 [25:26&lt;00:00, 305.38s/it]"
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
In the first few DL lessons Jeremy often works with dog breeds notebook (lesson1-breeds.ipynb), but says he can't give it us since the competition is unfinished and he doesn't want us to cheat.

The competition has been finished, so let's make this notebook available to all so it's easier to follow the video lessons.

I found a copy of it in this repo https://github.com/tanakatsu/fastai-course1-v2. I can't tell whether it is identical to Jeremy's copy and how it was acquired. But it's probably better to have it in any form than none.

I tested it that it runs to a successful completion as is.

Here are the changes I have applied to lesson1-breeds.ipynb found under the github repo mentioned above:

- cleaned up the corrections that were made due to the API changes made since the video lessons.
- added a few notes where to find data needed for that notebook to run.
- edited the last section to remove the non-working code and clarify that there are 2 methods.
- removed the hardcoded section numbers (jupyter generates those automatically).