### PR TITLE
2 clarifications added to ml1 notebooks

### DIFF
--- a/courses/ml1/lesson1-rf.ipynb
+++ b/courses/ml1/lesson1-rf.ipynb
@@ -2533,6 +2533,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "hidden": true
+   },
+   "source": [
+    "Normally, pandas will continue displaying the text categories, while treating them as numerical data internally. Optionally, we can replace the text categories with numbers, which will make this variable non-categorical, like so:."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/courses/ml1/lesson2-rf_interpretation.ipynb
+++ b/courses/ml1/lesson2-rf_interpretation.ipynb
@@ -2655,6 +2655,39 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "hidden": true
+   },
+   "source": [
+    "proc_df's optional *max_n_cat* argument will turn some categorical variables into new columns.\n",
+    "\n",
+    "For example, the column **ProductSize** which has 6 categories:\n",
+    "\n",
+    "* Large\n",
+    "* Large / Medium\n",
+    "* Medium\n",
+    "* Compact\n",
+    "* Small\n",
+    "* Mini\n",
+    "\n",
+    "gets turned into 6 new columns:\n",
+    "\n",
+    "* ProductSize_Large\n",
+    "* ProductSize_Large / Medium\n",
+    "* ProductSize_Medium\n",
+    "* ProductSize_Compact\n",
+    "* ProductSize_Small\n",
+    "* ProductSize_Mini\n",
+    "\n",
+    "and the column **ProductSize** gets removed.\n",
+    "\n",
+    "It will only happen to columns whose number of categories is no bigger than the value of the *max_n_cat* argument.\n",
+    "\n",
+    "Now some of these new columns may prove to have more important features than in the earlier situation, where all categories were in one column."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 31,
    "metadata": {


### PR DESCRIPTION
- courses/ml1/lesson1-rf.ipynb

Expand on why pandas shows text for categorical data.

- courses/ml1/lesson2-rf_interpretation.ipynb

Add explanation to the "One-hot encoding" section with an example.