### PR TITLE
Observational Weights

### DIFF
--- a/fastai/dataset.py
+++ b/fastai/dataset.py
@@ -328,6 +328,10 @@ class ModelData():
     def trn_y(self): return self.trn_ds.y
     @property
     def val_y(self): return self.val_ds.y
+    @property
+    def trn_w(self): return self.trn_ds.w
+    @property
+    def val_w(self): return self.val_ds.w
 
 
 class ImageData(ModelData):

--- a/tutorials/observational_wgts.ipynb
+++ b/tutorials/observational_wgts.ipynb
@@ -1,0 +1,493 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "IPython.notebook.set_autosave_interval(0)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Autosave disabled\n"
+     ]
+    }
+   ],
+   "source": [
+    "%reload_ext autoreload\n",
+    "%autoreload 2\n",
+    "%matplotlib inline\n",
+    "%autosave 0\n",
+    "from fastai.column_data import *\n",
+    "import seaborn as sns\n",
+    "warnings.filterwarnings('ignore')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Generate Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create input features - x1, x2, and x3 - and their effect on the reponse variable through the `scale` object. We'll later pass `scale` to numpy's `random.gamma()` method to generate a gamma-distributed response variable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.axes._subplots.AxesSubplot at 0x1fc1d851748>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX8AAAD8CAYAAACfF6SlAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzt3Xd8VOed7/HPb2ZUUS80dZDoYIoQBlwSSFz3Bjs2MThOSOJdJ3fjLdcp17m765v4pqy3xDe7cYo3duI4cbANdkwSYuIYgwOYIqrpCIGQBKhXQHV+9w+Nc2VZghFIOlN+79eLFzNnntF8Dwf99Og5z3mOqCrGGGPCi8vpAMYYY0aeFX9jjAlDVvyNMSYMWfE3xpgwZMXfGGPCkBV/Y4wJQ1b8jTEmDFnxN8aYMGTF3xhjwpDH6QB9paWlaW5urtMxjDEmqOzevbtWVdP9bR9wxT83N5fi4mKnYxhjTFARkbLBtLdhH2OMCUNW/I0xJgxZ8TfGmDBkxd8YY8KQFX9jjAlDfhV/EblNRI6JSImIPNrP61Ei8qLv9R0ikuvb/kkR2dfrj1dEZg/tLhhjjBmsKxZ/EXEDTwG3A9OAlSIyrU+zB4EGVc0HngSeAFDVX6rqbFWdDXwKOK2q+4ZyB4wxxgyePz3/IqBEVUtVtQNYDSzr02YZ8Jzv8RpgqYhInzYrgV9dS1hjjDFDw5/inwGU93pe4dvWbxtV7QKagNQ+be7Dir8xxgQEf67w7duDB+h71/fLthGRBcBFVT3Y7weIPAQ8BJCdne1HJGPCzws7zvS7/f4F9j1jBs+fnn8FkNXreSZwdqA2IuIBEoH6Xq+v4DK9flV9WlULVbUwPd3vpSmMMcZcJX96/ruAAhHJAyrpKeT392mzDlgFvAPcC2xUVQUQERewHLhpqEIbE+jK6i6w50wD+840UlZ/kermdpoudeJxCxc7ukmMiSB1VCRjE6PJT48jNS7K6cgmzFyx+Ktql4g8DGwA3MCzqnpIRB4HilV1HfAM8LyIlNDT41/R60vcBFSoaunQxzfGOX2HYaqb29hf0cjBymZqWtsBiHS7SIuPJCE6gtHxUSgQF+Wl6VIn+ysa2XHKC0DKqEjm5yRTmJvCqKiAW2/RhCC//pep6npgfZ9tj/V63EZP776/924Crr/6iMYELq8qh842s720jlO1FxAgL20UCyakMCEtjtEJUbg+MPGth6pS19rBieoWDp1tZsPhKt48Ws31E1JZOnU0UR73yO6MCSvWxTDmKnR0eSk+Xc/m4zXUXeggOTaCW6ePZW52EvHREX59DREhLT6KtPgoFk5M43xzG1tP1LKlpJaDZ5u4a3YGk8bED/OemHBlxd+Yy+g7tNPZ3VP03z5RS9OlTsYnRnN/UTbTxicM2MP319iEaO6Zl8m8nGRe3VvJz7ad5s6Z41icn3ZNX9eY/ljxN8YPbZ3d7DxVz5aSWlrbu8hJifX1zOP44PWM1yY3bRQPL8nnxV3l/O7dc7S2d3HLtDFD/jkmvFnxN+YyLrZ3sfVkHe+U1tLW6aVgdBw3T05nQlrcsH5uhNvF/QuyeW1fJZuP1yACt0wbO6yfacKLFX8TUga6EAr8vxhKVTlQ0cTLu8t5aVcFHd1epo9P4OZJ6WQmxw5V1CtyiXDX7AxUYdOxGsYlxjAzI3HEPt+ENiv+xvhUN7fx6t5K1uyu4ER1K1EeF9PHJ3DTpHTGJEQ7kklE+Nh146lqbmPN7nLS4iIZlxjjSBYTWqz4m7DR328Fnd1e0uKiWLO7nM3Ha/AqzMtJ5jsfn8mds8bx2/3nHEj6fh63i08uyOGpTSX8aucZ/mZJARFuuxWHuTZW/E1Yqmi4yO6yBg5UNHGps5txidH89w9N5J65mUxIH97x/KuREBPBvfMy+enW02w+XsNHpo5xOpIJclb8TdhQVU5Ut7LpWA2n6y7gcQnTxyfw5Vsns2hiGm5XYM+mKRgdz3WZiWw+VsOszERGxzszFGVCgxV/ExbqWtt5ZW8lp2ovkBgTwZ0zxzE3O5mYSDc3FgTPYoJ3zBzHsaoWXtt3lr+8Ic+mf5qrZsXfhDRVZXtpHa8fOo/Ld/K0MDcZjys4x8zjoyO4bfo4fr2vkoNnm232j7lqVvxNyPKq8tsD59heWsekMXHcPSeTxBj/ll4IZIW5yWw7Wcsfj1QxfXyC03FMkArO7o8xV9Dl9fJScTnbS+u4IT+NTy/MDYnCDz3z/5dOHUNNSzsHKhqdjmOClPX8TchRVV7dU8mBiiZumz6WmyYFz5i+v6aPT2BsQjRvHqmmq9uLx6Z+mkGy4m9CzubjNewtb+QjU0f7Vfgvd1VwoHKJ8JGpY/jFjjJe2VvJJwqzrvwmY3qx7oIJKQcrm/jD4Squy0zkw5NHOx1nWE0dF8/4pGh+vPkkXm/f22obc3lW/E3IKK+/yNo9FWQlx/DxuZkhPw1SRLghP52TNRfYfLzG6TgmyFjxNyGh26t86eX9AKyYnx02yx/MzEhkbEI0P9lid0k1gxMe3yEm5D2zpZSdp+r5i1njSR4V6XScEeN2CZ9ZnMvWkjoOn212Oo4JIlb8TdArqW7h3zYc55ZpY5ibneR0nBG3cn42sZFuntlyyukoJohY8TdBTVX5x18fJCbSzbc/PjPkx/n7kxgbwfJ5mazbX0lta7vTcUyQ8Kv4i8htInJMREpE5NF+Xo8SkRd9r+8Qkdxer80SkXdE5JCIvCsithqVGTKv7TvL9tJ6vnrbZNLiopyO45hPLcyhs1tZu7vC6SgmSFyx+IuIG3gKuB2YBqwUkWl9mj0INKhqPvAk8ITvvR7gF8AXVHU68CGgc8jSm7DWdKmTb/7uCNdlJbFyvn936QpV+aPjmZ+bzOpd5ajatE9zZf70/IuAElUtVdUOYDWwrE+bZcBzvsdrgKXS8/v3LcABVd0PoKp1qto9NNFNuHvyjePUX2jnW3fNwBXgyzGPhJVF2ZyqvcD20nqno5gg4E/xzwDKez2v8G3rt42qdgFNQCowCVAR2SAie0Tkq/19gIg8JCLFIlJcU2Pzlc2VlVS38vz2MlYWZTPDVrYEepZ7Toj28KudwXfFshl5/hT//rpUfX+vHKiNB7gB+KTv77tFZOkHGqo+raqFqlqYnh5667CYofft9UeIjXDzyEcnOR0lYERHuPn43ExeP3ie+gsdTscxAc6f4l8B9F44JBM4O1Ab3zh/IlDv275ZVWtV9SKwHph7raFNeHv7eA0bj1bz8JJ8UsP4JG9/VhZl09Ht5ZU9duLXXJ4/C7vtAgpEJA+oBFYA9/dpsw5YBbwD3AtsVFUVkQ3AV0UkFugAbqbnhLAxV6Xbq3xlzX5SRkUSE+EOykXZhtPksfHMzU7ihZ1neNDu9GUu44rFX1W7RORhYAPgBp5V1UMi8jhQrKrrgGeA50WkhJ4e/wrfextE5Lv0/ABRYL2q/m6Y9sWEgVf2VFDV3M7Komxbxtin7w/AvLQ41u6p4Nvrj/IPd051KJUJdH4t6ayq6+kZsum97bFej9uA5QO89xf0TPc05pq0dXbz5BvHyUiKYYbdwWpAMzMS+d27Z9l12mb9mIFZ18kEjV9sL+NsUxu3Th9rwxmXEelxcV1mEgcrm2i8aCd+Tf+s+Jug0NzWyVNvlXBjQRr5o+OcjhPwivJS6PIqr+ypdDqKCVB2Jy8TkPqOY79x+DwNFzuZlRl+C7ddjXGJMWQmx7B61xk+uzjXflMyH2A9fxPwWto62VJSy8yMRDKSYpyOEzTm5SRzvKqVAxVNTkcxAciKvwl4bx2rpturfHTaGKejBJXrMpOI8rh4eXf5lRubsGPF3wS0+gsd7DxVT2FuSliv2nk1oiPc3D5jLOv2naWt05bUMu9nxd8EtD8eqcLtEpZMCe2bsQ+X5YVZNLd18YfDVU5HMQHGir8JWNUtbewvb2ThhDQSoiOcjhOUFk5IJSMphpeLbejHvJ8VfxOw3jpaTYTbxQ0FaU5HCVoul3DPvEy2lNRytvGS03FMALHibwJSTUs7ByqauH5CCnFRNiP5Wiyfl4kqttibeR8r/iYgvXWsGo9buKHAlvi+VlkpsVw/IYWXd1fYXb7Mn1nxNwGntKaV/eWNXD8h1Xr9Q2T5vCzK6i6y85St92N6WPE3Aef7G0vwuIUbrdc/ZG6fOZa4KA8v2w3ejY8VfxNQSmta+fW+ShbkWa9/KMVGerhz5jjWv3uOC+1dTscxAcC+u0xA+f5bJUR6XNxoM3yGRO81kpJiI7jY0c1jrx1kXk4K9y/IdjCZcZr1/E3AOF17gdf2neWBBTnE27z+IZedEktaXCS7yxqcjmICgBV/EzD+c2MJHpfw0M0TnI4SkkSEudnJnK67SF1ru9NxjMNs2Mc4pveQRF1rO6/urWDhhFT+eLjawVShbU52Mm8crmL3Gev9hzvr+ZuAsOlYDS4RbpxkM3yGU2JMBAVj4th7ppFur835D2dW/I3j6lrb2VveQFFeiq3hMwLmZifTdKmTrSW1TkcxDvKr+IvIbSJyTERKROTRfl6PEpEXfa/vEJFc3/ZcEbkkIvt8f340tPFNKNh0vKfXf5PN6x8RU8clEBPhtjn/Ye6KY/4i4gaeAj4KVAC7RGSdqh7u1exBoEFV80VkBfAEcJ/vtZOqOnuIc5sQUX+hg71nGlgwIZWEGOv1j4QIt4vrshLZcOg8TRc7SYy1f/dw5E/PvwgoUdVSVe0AVgPL+rRZBjzne7wGWCp201Djh03HqnGJcLP1+kfUvOwUOrq8rDtw1ukoxiH+FP8MoPdi4BW+bf22UdUuoAlI9b2WJyJ7RWSziNx4jXlNCKm/0MGeMw0U5qZYr3+EjU+KZsrYeNbYOv9hy5/i318Pvu80gYHanAOyVXUO8AjwgogkfOADRB4SkWIRKa6pqfEjkgkFm45VIyLcbDN8RpyIcO+8TPZXNHG8qsXpOMYB/hT/CiCr1/NMoO/vin9uIyIeIBGoV9V2Va0DUNXdwElgUt8PUNWnVbVQVQvT060QhIPy+ovsOdPA/NxkEq3X74i752TgcYnd5StM+VP8dwEFIpInIpHACmBdnzbrgFW+x/cCG1VVRSTdd8IYEZkAFAClQxPdBLP/3HjC1+u3e/M6JTUuiiVTRvPq3ko6u71OxzEj7IrF3zeG/zCwATgCvKSqh0TkcRH5mK/ZM0CqiJTQM7zz3nTQm4ADIrKfnhPBX1BVW1A8zJXWtLJ2TyUL8lKs1++w5YVZ1LZ28NZRu6o63Pi1vIOqrgfW99n2WK/HbcDyft63Flh7jRlNiPnemyeIdLtsrD8AfGhyOmlxkazdU8Et08c6HceMILvC14yoY+dbWLf/LJ9ZnGsrdwaACLeLZbMz2Hi0moYLHU7HMSPIir8ZUd994xhxkR4+f5Ot3Bko7pmbSWe3sm6/zfkPJ7aqpxkxByoa2XCoiv/xkUkkxUY6HSfs9V5VdVxiNE+/XUqEu6c/aDd6CX3W8zcj5t//cJzk2Ag+d0Ou01FMH3Oyk6lsvERVc5vTUcwIseJvRsSu0/VsPl7DF26eaGP9Aei6zERcAnttnf+wYcXfDDtV5V83HCM9PopPL8x1Oo7pR3x0BJPGxLOvvBGv2jr/4cCKvxl2m47VsPNUPQ9/OJ+YSLfTccwA5mQn09zWRUl1q9NRzAiw4m+GVWe3l2/+7jAT0kaxsshOIgayqWPjiYlws8eGfsKCFX8zrH65vYyTNRf4X3dMJdJj/90CmcftYlZmIofPNtPc1ul0HDPM7LvRDJvGix383zdPsDg/laVTbQ2fYDA3O5kur7L+wDmno5hhZsXfDJsn3zhO86VO/vHOadi9fYJDZnIMaXFRrN1jt3gMdXaRlxkWByoaeX57GUV5Kew908jeM41ORzJ+EBHmZifxh8NVlNVdICd1lNORzDCx4m+uWe8rRQG8qvxw00lGRXq4ZZotFhZs5mQn88aRKtbuqeSRj37g9hsmRNiwjxlyO0rrqGy8xB2zxhEdYVM7g01iTASLJ6bxyp4KvF6b8x+qrPibIdV4sYM/HK4if3QcszISnY5jrtI98zKoaLjErtN2+41QZcXfDBlV5ZU9lShw1+wMO8kbxG6dPpZRkW478RvCrPibIbPjVD0lNa3cPmMsKaNs1c5gFhvp4Y6Z41j/7nkudXQ7HccMAyv+ZkjUtbbz+sHzFIyOoyg3xek4ZgjcMy+T1vYuNhw673QUMwys+Jtr1tXtZfWuclwuuHuODfeEiqLcFDKTY2zoJ0TZVE9zzV4/dJ7Kxks8sCDbbtISIt6bvjtpTDxvHa3mh5tOkhjTsxS33eglNFjP31yTDYfOs+1kHQsnpjJtvM3uCTVzspJQYJ8t9hZy/Cr+InKbiBwTkRIRebSf16NE5EXf6ztEJLfP69ki0ioiXx6a2CYQnKhq4Usv7ScjKYbbp9vFXKEoNS6KnNRY9pxpRG2d/5ByxeIvIm7gKeB2YBqwUkSm9Wn2INCgqvnAk8ATfV5/Evj9tcc1gaLhQgd/+fNioiPcfHJBNh63/RIZquZmJ1PT2k5FwyWno5gh5M93bBFQoqqlqtoBrAaW9WmzDHjO93gNsFR8Z/1E5C6gFDg0NJGN0zq7vXzxhT2ca2zj6U/Ps3H+EDczIxGPS2yd/xDjT/HPAMp7Pa/wbeu3jap2AU1AqoiMAv4n8I1rj2oCgderfHXNAbadrOM7H5/J3OxkpyOZYRYd4Wba+AQOVDTR1e11Oo4ZIv4U//7m7fUd/BuozTeAJ1X1sveFE5GHRKRYRIpramr8iGScoKp8e/0RXt1byVduncw98zKdjmRGyNzsZC51dnP0fIvTUcwQ8WeqZwWQ1et5JnB2gDYVIuIBEoF6YAFwr4j8C5AEeEWkTVW/3/vNqvo08DRAYWGhnVUKUD/YdJKfbDnFZxbl8tcfmuh0HDOC8kfHkRDtsaGfEOJPz38XUCAieSISCawA1vVpsw5Y5Xt8L7BRe9yoqrmqmgv8X+DbfQu/CQ7PbDnFv244xrLZ43nsL+zmLOHGJcLsrCSOV7VQ29rudBwzBK5Y/H1j+A8DG4AjwEuqekhEHheRj/maPUPPGH8J8AjwgemgJnj9YnsZ/+e3h7l9xlj+ffl1uFxW+MPRnOxkvAqv7ev7i78JRn5d4auq64H1fbY91utxG7D8Cl/j61eRzzhsze4K/vHXB1k6ZTTfWzHHpnSGsTEJ0WQkxbB2dwUP3pDndBxzjWx5B/M+ve/KdaCikRd3lZM/Oo6bJqUT6bHCH+7mZCfx2wPnOHKumanjEpyOY66BfTebfh0+28xLxeXkpI7igQU5RFiP3wDXZSYR4RbW7rbF3oKd9fzNBxyvauFXu84wPimGVQtz/tzj73uvXhN+RkV5+PDk0fx631kevX2KDQMGMTty5n1Ka1v5xfYyRsdH8dlFeUTZPXhNH/fMy6S2tZ23T9g1OcHMir/5s5LqFn6xvYzkUZF8dnEeMZFW+M0HfXjyaJJjI1i7u9LpKOYaWPE3ANS2tvPZn+3C43LxmUW5xEXZiKDpX6THxbLZGbxxuIqmi51OxzFXyYq/ob2rm88/v5vq5nY+dX0OybZQm7mCe+Zm0tHt5TcHbM5/sLLib/jO+qPsLmvgu5+YTVZKrNNxTBCYkZHA5DHxvGyzfoKWFf8w9/rBc/xs22k+tziPO2eNczqOCRIiwn3zs9hf3sihs01OxzFXwQZ2w1h5/UW+suYA12Um8ujtU5yOY4LEe1N+VcHjEr7xm8PcNbtnlXe7v2/wsJ5/mPJ6lS+/vB8Uvn//XLt61wxaTKSbWZmJ7CtvpL2z2+k4ZpCs5x+GXthxhp2n6tlxqp6752TwpxO1TkcyQaooL5U9ZxrZX9FEUV6K03HMIFh3Lww1Xerk9wfPMSFtFIU5dicuc/WykmMYmxDNzlN1doP3IGM9/xB1uaUYfrP/LF5V7p6TYevym2siIhTlpbBu/1m7wXuQsZ5/mDlR3cLhc80smTKG1Lgop+OYEDA7K4lIt4udp+udjmIGwYp/GPGq8vt3z5McG8GiialOxzEhIjrCzXVZiRyoaKTpkl3xGyys+IeRPWUNnG9u47YZ42yJZjOkinJT6exWXt1jF30FC6sAYaK9q5s3DleRnRLLjPF2Ew4ztDKSY8hMjuGFnWfsxG+QsOIfJt45WUdLexd3zBxnJ3nNsCjKTeF4VSvFZQ1ORzF+sOIfBto7u/nTiVomj4kn29buMcNkVmYS8dEefv5OmdNRjB/8Kv4icpuIHBOREhF5tJ/Xo0TkRd/rO0Qk17e9SET2+f7sF5G7hza+8cf20joudXazZMpop6OYEBbpcXFfYRa/f/cc55ps2megu2LxFxE38BRwOzANWCki0/o0exBoUNV84EngCd/2g0Chqs4GbgN+LCJ2bcEIau/q5k8ltUwaE2crdppht2pRLl5V6/0HAX96/kVAiaqWqmoHsBpY1qfNMuA53+M1wFIREVW9qKpdvu3RgJ0JGmE7Suu52NHNkiljnI5iwkBWSiy3Th/LCzvOcLGj68pvMI7xpxeeAZT3el4BLBiojap2iUgTkArUisgC4FkgB/hUrx8GZph1dXvZWlJLfnqcjfWbEfHCjjNkp8Ty+4Pn+dor77Ig7/9fT2IrfgYWf3r+/U0N6duDH7CNqu5Q1enAfOBrIhL9gQ8QeUhEikWkuKbGbgo9VPZXNNLS3sWNBWlORzFhJDslloykGLaW1OG1aZ8By5/iXwFk9XqeCfS9d9uf2/jG9BOB913rrapHgAvAjL4foKpPq2qhqhamp6f7n94MSFXZUlLL2IRo8kfHOR3HhBERYXF+GrWt7ZyoanU6jhmAP8V/F1AgInkiEgmsANb1abMOWOV7fC+wUVXV9x4PgIjkAJOB00OS3FzWiepWqprbWZyfZvP6zYibkZFAQrSHrSdtufBAdcXi7xujfxjYABwBXlLVQyLyuIh8zNfsGSBVREqAR4D3poPeAOwXkX3Aq8Bfq6r9bxgBW0pqiY/ycF1motNRTBjyuFxcPyGVkupWqprbnI5j+uHXtEtVXQ+s77PtsV6P24Dl/bzveeD5a8xoBul4VQsl1a3cMm0MHlvDxzikKDeFt45Vs7Wklo/PzXQ6junDKkMIev6dMjwuYX6u3VnJOCc2ysOcrGT2lTfS2m6T/AKNFf8Q09LWySt7KpiZkcioKLuezjhrUX4qXV5le2md01FMH1b8Q8yreyu50NHN9RNsvX7jvNHx0Uwbl8C2k7W0tNla/4HEin8IUd9l9TMzEslMjnE6jjEAfHjyaNo6vfxi+8C3FjUjz4p/CNleWk9JdSufWphj0ztNwMhIjqFgdBw/+VMplzq6nY5jfKz4h5Dnt58mKTaCj1033ukoxrzPhyaPpu5CB6t3We8/UFjxDxHnm9rYcKiKTxRmER3hdjqOMe+TlzaKorwUnn67lPYu6/0HAiv+IeKFnWfwqvJJWzzLBKiHP5zPuaY2XtlT6XQUgxX/kNDZ7eVXO89w86R0clJHOR3HmH7dWJDGrMxEfrjpJF3dXqfjhD0r/iFgw6Hz1LS08+mFOU5HMWZAIsIXP5zPmfqL/PbAOafjhD0r/iHg5++UkZUSw82T7DaNJrB9dOoYJo+J56m3SvB6bblnJ1nxD3JHzjWz81Q9DyzIwe2y6Z0msLlcwl9/eCInqlt5/dB5p+OENbv+P4i9sOMMr+6txOMS3C7hhR02jc4Evr+YNZ7vvXmC/3jzBLdNH4vLOi2OsJ5/ELvU0c2+8gZmZyURG2k/x01wcLuEv1mSz9HzLfzhcJXTccKWFf8gtrusns5utXV8TND5b7PGk5say3+8eQK1Wz06wop/kPJ6le2n6slJjWV8kq3jY4KLx+3i4SUFHD7XzBvW+3eEFf8gtel4NfUXOlhovX4TpO6aPZ6c1Fj+Y6P1/p1gA8VB6rltZcRHe5g+3m7TaIJDfxMSCnOSWbunko1Hq1k6dYwDqcKX9fyDUGlNK5uP11CUl2LTO01Qm52VTFZKDN+zsf8RZz3/IPT89jIi3EKR3abRBDm3SyjMSeHVvZV8fd1hJo+Nf9/r99taVcPGev5B5kJ7F2uKK7hj5jjioyOcjmPMNZuTnURSbAQbj1ZZ738E+VX8ReQ2ETkmIiUi8mg/r0eJyIu+13eISK5v+0dFZLeIvOv7e8nQxg8/r+ytpKW9i1WLcp2OYsyQ8Lhc3DwpnfKGS5TWXnA6Tti4YvEXETfwFHA7MA1YKSLT+jR7EGhQ1XzgSeAJ3/Za4L+p6kxgFfD8UAUPR16v8tOtp5iZkcicrCSn4xgzZOZmJxMf5WHzsRqno4QNf3r+RUCJqpaqagewGljWp80y4Dnf4zXAUhERVd2rqmd92w8B0SISNRTBw9EbR6oorbnAQzdNsNs0mpAS4XaxOD+NkppWKhouOh0nLPhT/DOA8l7PK3zb+m2jql1AE9B3Avo9wF5Vbb+6qOFNVfnR5pNkpcRw+4yxTscxZsgV5aUQHeFi83Hr/Y8Ef4p/f13MvmdlLttGRKbTMxT0+X4/QOQhESkWkeKaGjvw/Skua2DvmUb+6sYJeNx2nt6EnugIN9dPSOXw2WZqWqyPONz8qSIVQFav55nA2YHaiIgHSATqfc8zgVeBT6vqyf4+QFWfVtVCVS1MT08f3B6EiR9vPklybATL52VdubExQWrRxDTcLmFrSa3TUUKeP8V/F1AgInkiEgmsANb1abOOnhO6APcCG1VVRSQJ+B3wNVXdOlShw82Jqhb+eKSaVYtyiYm0m7Ob0BUX5WF2VhJ7yxu42N7ldJyQdsWLvFS1S0QeBjYAbuBZVT0kIo8Dxaq6DngGeF5ESujp8a/wvf1hIB/4JxH5J9+2W1S1eqh3JFS9sOMMa3dXEOEWRkV6bM1+E/IW5adRXNbArtP1/OVNE5yOE7L8usJXVdcD6/tse6zX4zZgeT/v+ybwzWvMGNaaLnWyr7yR+XkpjIqyC7JN6BubEE1+ehzvlNbR2e0lws5xDQv7Vw1w207W4lXlhvw0p6MYM2IW56fS3NbF+nftRu/DxYp/AGtu62TnqXpmZiaSMirS6TjGjJiCMfGkxUXy7JZTtuTDMLHiH8DL5q6EAAAPDUlEQVRe2HGG9i4vNxbYDCgTXlwiLJqYxv6KJvacaXA6Tkiy4h+g2ru6eXbLKfLT48iwO3WZMDQ3O5mEaA/PbDnldJSQZMU/QL229yzVLe3cOMnG+k14ivS4WLkgm9cPnrclH4aBFf8A5PUqP377JNPGJZCfHud0HGMcs2phLiLCc9tOOx0l5FjxD0BvHq3mZM0FPn+zLeBmwtv4pJ61rFbvLKfVLvoaUlb8A9CPN58kIymGO2eOczqKMY777OI8Wtq7eHVPhdNRQooV/wBTfLqe4rIG/urGPFvAzRhgbnYSszIT+dm20zbtcwjZJaMBoPeSDc9vLyMmwg2ILeVgDCAifGZRLo+8tJ8tJbU29XmIWNcygFS3tHHkXDMLJ6YS6bFDY8x77pw1jrS4SH629bTTUUKG9fwDyJYTtXhcwvUT+t4Hx5jw1Pu335kZSWw8Ws1/vnmC1Lgo7l+Q7WCy4GfdywDRfKmTveWNzMtJJs4WcDPmAxbkpSAC20vrnI4SEqz4B4htJ+vwem0BN2MGkhATwYyMRHafaaC9q9vpOEHPin8AaOvsZsepOmZkJJIaZ/e3N2Ygiyak0tbpZe+ZRqejBD0r/gFg1+l63wJu1us35nKyUmLJSIrhndI6m/Z5jaz4O6yjy8vWklompI8iMznW6TjGBDQRYeHEVGpa2tlaYmP/18KKv8Ne21dJc1sXN9ncZWP8MisjkVGRbn62zVb7vBZW/B3k9SpPv13K2IRoCkbbAm7G+MPjdlGUl8qbR6sprWl1Ok7QsuLvoDePVnOiupWbJqXbAm7GDML1E1KIcLv4ia31f9Ws+DtEVfnhphIyk2OYmZHodBxjgkp8dAT3zM1g7e4KalvbnY4TlPwq/iJym4gcE5ESEXm0n9ejRORF3+s7RCTXtz1VRN4SkVYR+f7QRg9uu043sOdMI3914wTcLuv1GzNYf3njBNq7vPz8nTKnowSlKxZ/EXEDTwG3A9OAlSIyrU+zB4EGVc0HngSe8G1vA/4J+PKQJQ4RP9p8kpRRkXyiMMvpKMYEpYnpcXxk6hief+c0lzrsoq/B8qfnXwSUqGqpqnYAq4FlfdosA57zPV4DLBURUdULqrqFnh8Cxufo+WY2Hq3mM4tyiYl0Ox3HmKD1+Zsn0HCxk9W7bAXcwfJnEZkMoLzX8wpgwUBtVLVLRJqAVKDWnxAi8hDwEEB2dugu1vTeIlUvFZcT6XYRG+m2ZZuNuQbzc1NYkJfCjzafZGVRNtER1pnylz89//4GpPteWudPmwGp6tOqWqiqhenpoT3fveFiBwcqGpmfm0xspC3gZsy1+rulBVQ1t/NycfmVG5s/86f4VwC9B6YzgbMDtRERD5AI1A9FwFCz5UTPL0OLbQE3Y4bEwompFOYk84NNJ23Bt0Hwp/jvAgpEJE9EIoEVwLo+bdYBq3yP7wU2qi288QEX2rsoLqtndlYSSbGRTscxJiSICH+7tIBzTW2s2W33+fXXFYu/qnYBDwMbgCPAS6p6SEQeF5GP+Zo9A6SKSAnwCPDn6aAichr4LvAZEanoZ6ZQ2Nh2spbObrXb0BkzxG4sSGNOdhLf31hCW6f1/v3h16Czqq4H1vfZ9livx23A8gHem3sN+UJG48UOtp2sY/r4BMYkRDsdx5iQIiJ89dYprPyv7fx062n++4cmOh0p4NkZxxHyzJZTtHd5WTpljNNRjAkJ/c2UmzI2nu+9eZwV87NIHmVDq5djyzuMgMaLHfx062lmjE9gbKL1+o0ZLrdOH0t7p5fvv1XidJSAZ8V/BPzkT6e40NHFkqnW6zdmOI1JiGZeTjI/f+c0p2ovOB0noFnxH2bVLW08u/UUd8wcx1gb6zdm2H1k2hiiPW4ee+2g3e3rMqz4D7Mn3zhOR5eXr9wy2ekoxoSFhOgIvnTLJP50opbfvXvO6TgBy4r/MDp2voUXd5XzqYU55KaNcjqOMWHjgetzmD4+gcd/c5iWtk6n4wQkK/7D6NvrjxAX5eFvlxQ4HcWYsOJxu/jmXTOoaW3nX14/5nScgGTFf5hsPFrF5uM1/M2SAptyZowD5mQn87nFeTy/vYzNx2ucjhNwrPgPg9b2Lv7x1YPkj47j04tynI5jTNj6yq2TKRgdx1de3k/DhQ6n4wQUK/7D4F9fP8q55jaeuGcWUR5bYtYYp0RHuHnyvtk0XOzgH379rs3+6cWu8B1iu8vq+fn2MlYtzGVeTrLTcYwJS32v/l0yZQzr3z3PF3+5hx88MM+hVIHFev5DqOliJ3//4j7GJ8bw5VttaqcxgeKmgjSmj0/g9wfPs63Er3tMhTwr/kPE61UeeWkf55va+M/75xAXZb9UGRMoRIR752aSHh/FF1/YQ1mdXf1rxX+I/GBTCW8ereaf/mIac7NtuMeYQBMV4eaB63NQ4IFndnC+KbxvLS6BdgKksLBQi4uLnY4xKK/sqeBLL+/nY9eNpyg3BZH+7mppjAkE08cncP9/bWd8Ugwvfn4hKSEyFVtEdqtqob/tred/jX6z/yxffnk/Cyek8sQ9s6zwGxPgrstK4ier5lNWf5H7/2s755ouOR3JEVb8r8Ha3RX8/Yv7KMxJ4SerComOsGmdxgSDhRNTeXbVfCoaLvHxH2zj2PkWpyONOCv+V6Gz28s3fnOIL728n/m5yTz72fnERtoJXmOCyQ0Fabz0+YV4Vbn3h9t4bV+l05FGlFWsQTp6vpl/ePUgu8sa+NziPL52xxQi3PYz1Jhg0fcagFULc1m9q5y/W72PTcdq+PrHppMYE+FQupFjxd9Pta3t/OCtkzz3zmkSoj18b8Vsls3OcDqWMeYaJcVG8lc3TmDTsWrW7T/LW8eq+ZslBTxwfXZIX6Hv12wfEbkN+B7gBn6iqv/c5/Uo4OfAPKAOuE9VT/te+xrwINAN/K2qbrjcZwXSbB9V5WBlM7/cUcYreyvp7PaysiibCamjiLV5/MaEnNlZSXzn90f404laxiVGc39RNvcVZTE6PvBvxDTY2T5XLP4i4gaOAx8FKoBdwEpVPdyrzV8Ds1T1CyKyArhbVe8TkWnAr4AiYDzwR2CSqnYP9HlOF/+61naKyxrYUVrPHw6fp6LhEtERLu6Zm8nnbshjYnpcvzeONsYEv/sXZAPw9vEann67lC0ltXhcwvzcFJZMGc2i/FQmjYkPyKHewRZ/f7qvRUCJqpb6PmA1sAw43KvNMuDrvsdrgO9Lz5zHZcBqVW0HTolIie/rveNvwKuhqngVur1Kt1fp8nrp6lYudHTR0vben06a2zo539TOuaZLnKq9wImqVs4391z4EelxsXhiKn+7tIBbp40lMTb0xwCNMT1umpTOTZPSKa1pZc3uCjYereZb648AEOVxMWVcArmpseSkxJIeH0VibCTJsREkxUSSGBNBpMeFxy1EuF1EuAWPq+fvQJoK7k/xzwDKez2vABYM1EZVu0SkCUj1bd/e573DMlB+oKKR5T96x1fsB3fhWkK0h5zUUSzKT2XymHgKc5OZkZEY0uN9xpgP6u+3+szkWD69MJebJqWxu6yBdyuaOHyumeLTDfxm/1kGU248LsH13g+A9/+FCNwxYxzfvW/2te2Ev1n8aNPfj6q+uztQG3/ei4g8BDzke9oqIiN+6513B9c8DQj21aFsHwJDsO9DsOeHANqHY8CTK67qrWnAoG4e4k/xrwCyej3PBM4O0KZCRDxAIlDv53tR1aeBp/2P7SwRKR7M2Fogsn0IDMG+D8GeH0JqH3IH8x5/zlrsAgpEJE9EIoEVwLo+bdYBq3yP7wU2as+Z5HXAChGJEpE8oADYOZiAxhhjht4Ve/6+MfyHgQ30TPV8VlUPicjjQLGqrgOeAZ73ndCtp+cHBL52L9FzcrgL+OLlZvoYY4wZGX5NVlfV9cD6Ptse6/W4DVg+wHu/BXzrGjIGoqAZoroM24fAEOz7EOz5IUz3IeCWdDbGGDP8Au9KBWOMMcPOiv8gichpEXlXRPaJSGCsQ3EFIvKsiFSLyMFe21JE5A0ROeH7O2BvPzZA/q+LSKXvOOwTkTuczHglIpIlIm+JyBEROSQif+fbHkzHYaB9CJpjISLRIrJTRPb79uEbvu15IrLDdxxe9E1uCUiX2YeficipXsfhshcM2LDPIInIaaBQVQNiXrA/ROQmoBX4uarO8G37F6BeVf9ZRB4FklX1fzqZcyAD5P860Kqq/+ZkNn+JyDhgnKruEZF4YDdwF/AZguc4DLQPnyBIjoVv5YFRqtoqIhHAFuDvgEeAV1R1tYj8CNivqj90MutALrMPXwB+q6pr/Pk61vMPA6r6Nj2zsHpbBjzne/wcPd/EAWmA/EFFVc+p6h7f4xbgCD1XuwfTcRhoH4KG9mj1PY3w/VFgCT1L00DgH4eB9mFQrPgPngJ/EJHdviuTg9UYVT0HPd/UwGiH81yNh0XkgG9YKGCHS/oSkVxgDrCDID0OffYBguhYiIhbRPYB1cAbwEmgUVW7fE2GbRmaodJ3H1T1vePwLd9xeNK32vKArPgP3mJVnQvcDnzRNyRhRt4PgYnAbOAc8O/OxvGPiMQBa4G/V9Vmp/NcjX72IaiOhap2q+pselYcKAKm9tdsZFMNTt99EJEZwNeAKcB8IAW47PChFf9BUtWzvr+rgVfp+c8TjKp8Y7jvjeVWO5xnUFS1yvcN4AX+iyA4Dr7x2bXAL1X1Fd/moDoO/e1DMB4LAFVtBDYB1wNJvqVpYIBlaAJRr324zTcsp75VlH/KFY6DFf9BEJFRvhNdiMgo4Bbg4OXfFbB6L8mxCnjNwSyD9l7B9LmbAD8OvpN0zwBHVPW7vV4KmuMw0D4E07EQkXQRSfI9jgE+Qs+5i7foWZoGAv849LcPR3t1IoSecxaXPQ4222cQRGQCPb196Lk6+gXfFcwBTUR+BXyInpX/qoD/DfwaeAnIBs4Ay1U1IE+qDpD/Q/QMMyhwGvj8e2PngUhEbgD+RM8Csl7f5v9Fz5h5sByHgfZhJUFyLERkFj0ndN30dH5fUtXHfd/bq+kZLtkLPODrQQecy+zDRiCdntWU9wFf6HVi+INfx4q/McaEHxv2McaYMGTF3xhjwpAVf2OMCUNW/I0xJgxZ8TfGmDBkxd8YY8KQFX9jjAlDVvyNMSYM/T/EsguJX8p0YAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "n = 10000\n",
+    "np.random.seed(90210)\n",
+    "x1 = np.random.uniform(0, 5, n)\n",
+    "x2 = np.random.normal(100, 20, n)\n",
+    "x3 = np.random.choice((1,2,3,4,5), n, p = (0.35, 0.2, 0.05, 0.25, 0.15))\n",
+    "scale = np.clip(3.2 * x1 + 0.05 * x2 + 2.15 * x3 - 0.12*x1*x3, a_min = 5, a_max = 1e15)\n",
+    "sns.distplot(scale)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Observation weights, `w`, will also be randomly generated. Each record in the dataset will be observed between 0.5 and 1.5 time units. This type of data often appears in modeling problems where observation periods vary between records in the dataset or when new records are created when something about the observational unit changes throughout the observation period. It is very common in insurance modeling, for instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w = np.random.uniform(0.5, 1.5, n)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Standardize the numerical features for the neural network. We'll assume that `x3` is categorical and so this only needs to be done for `x1` and `x2`. Note tha we standardize with the weighted mean and weighted standard deviation. It woud likely be fine to not standardize with weights."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def standardize(x, w):\n",
+    "    wgtd_avg = np.average(x, weights = w)\n",
+    "    wgtd_avg_2 = np.average(x**2, weights = w)\n",
+    "    return (x - wgtd_avg) / np.sqrt(wgtd_avg_2 - wgtd_avg**2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x1 = standardize(x1, w)\n",
+    "x2 = standardize(x2, w)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Bundle the input features into both a numpy array and then a pandas dataframe. For our model, we'll need to select an embedding size for feature `x3`. We'll use the formula: \\begin{equation*} embeddings = floor(\\frac{cardinality\\ of\\ feature + 1}{2}) \\end{equation*}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = np.stack((x1, x2, x3), axis = 1)\n",
+    "df = pd.DataFrame(x, columns = ['x1', 'x2', 'x3'])\n",
+    "df['x3'] = df.x3.astype('category').cat.codes\n",
+    "x3_uniques = df.x3.nunique()\n",
+    "emb_sz = [(x3_uniques, (x3_uniques + 1)//2)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, create a gamma-distributed response variable, `y`, which is assumed to have a scale parameter defined by the linear combination of the input features encoded into `scale` with a constant shape parameter of `1.2`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.axes._subplots.AxesSubplot at 0x1fc1d95c5c0>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYQAAAD8CAYAAAB3u9PLAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzt3XuQXOV55/Hv093Tc9eMNDNCmpGEJEs2iItlEGCvjVO+xAavjZw1TgQum2TJynHMJrsu7xZOyqyLdVImW2uSlIltYshiEgIY35RCNraDDb4KJBAIAYKRBNJoJDS6jC5z69uzf/RpqWn3zPTMdE9Pd/8+VV19+vR7Tr/vtHSefi/nfc3dERERCZU7AyIiMjcoIIiICKCAICIiAQUEEREBFBBERCSggCAiIoACgoiIBBQQREQEUEAQEZFApNwZmIrOzk5fvnx5ubMhIlJRtm3bdsTduyZLV1EBYfny5WzdurXc2RARqShm9moh6dRkJCIigAKCiIgEFBBERARQQBARkYACgoiIAAoIIiISUEAQERFAAUFERAIKCCIiAlTYncqz4b4t+/Luv/6KZbOcExGR2aUagoiIAAoIIiISUEAQERFAfQgFy9e3oH4FEakmqiEUaCSWxN3LnQ0RkZIpKCCY2VVmtsvMes3s5jzv15vZA8H7W8xsebD/cjPbHjyeMbPfyzrmFTPbEbw3pxc5GI0nue2RF/n5y0fKnRURkZKZNCCYWRi4A7gaWANcZ2ZrcpLdCBx391XA7cBtwf7ngHXuvha4Cvi6mWU3U73L3de6+7oZlqOk+gdHiCVSPP7yAGOJZLmzIyJSEoXUEC4Het19j7vHgPuB9Tlp1gP3BNsPAe8xM3P3YXdPBPsbgIpsc+k/MQrAcCzJE3uPlTk3IiKlUUhA6AH2Z73uC/blTRMEgBNAB4CZXWFmO4EdwJ9kBQgHfmRm28xs4/SLUHr9gyPMa4jwhq5mfvHyEeLJVLmzJCJSdIUEBMuzL/eX/rhp3H2Lu18AXAZ8zswagvff7u6XkG6K+rSZvTPvh5ttNLOtZrZ1YGCggOwWX//gCN3tjbzrTQs5NZZg66vHy5IPEZFSKiQg9AFLs14vAfrHSxP0EbQBr2tbcfcXgCHgwuB1f/B8GPgu6aap3+Lud7r7Ondf19XVVUB2iyuWSDFwaozu9kZWdDazbEETW/YcnfV8iIiUWiEB4UlgtZmtMLMosAHYlJNmE3BDsH0t8Ki7e3BMBMDMzgXeBLxiZs1m1hrsbwbeR7oDes45dHIUB7rbGjAzVi9sYeDUGLGEmo1EpLpMemOauyfM7CbgESAM3O3uO83sVmCru28C7gLuNbNe0jWDDcHh7wBuNrM4kAL+1N2PmNlK4LtmlsnDfe7+w2IXrhj6B0cA6G5vBGBxWyNOOlCIiFSTgu5UdvfNwOacfbdkbY8CH81z3L3AvXn27wHePNXMlkP/4AhN0TBtjXUALG5Pd4EcPDFSzmyJiBSd7lSeRP+JEbrbGglqM7Q31tFQF+LgoGoIIlJdFBAmkEileO3kGN3tDWf2mRmL2xpVQxCRqqOAMIHDJ8dIpvxM/0FGd1sDh06OkkxV5H12IiJ5KSBMIFML6G57fUBY3NZIPOnsPTJUjmyJiJSEAsIETozEAZjfHH3d/kzH8vMHT856nkRESkUBYQKj8RTRSIhw6PU3Yne11hM24/l+BQQRqR4KCBMYiSdpiPz2nygSCrFwXr1qCCJSVRQQJjAaT9JQF8773uK2RtUQRKSqKCBMYCSepHHcgNDAkdNjHD6l+xFEpDooIExgLJ4at4awqC3dsfziwVOzmSURkZJRQJjASDxJYzR/QOhqrQdgz8Dp2cySiEjJKCBMIN2HkP9P1FofoaU+onsRRKRqKCCMw90n7FQ2M1Z2NbNHAUFEqoQCwjhiyRQpZ9xOZYCVnc3sGVBAEJHqoIAwjtF4egGc8WoIACs6WzgwOMJILDlb2RIRKRkFhHGMxNMX+YkCwsquZgD1I4hIVVBAGMdoLBMQxv8TZQLCniMaaSQilU8BYRyjQQ1hoj6EFZ1BQFA/gohUAQWEcRTSZNQUjdDd1qB7EUSkKiggjGM0MXmnMsDKrhb1IYhIVSgoIJjZVWa2y8x6zezmPO/Xm9kDwftbzGx5sP9yM9sePJ4xs98r9JzlNhqfvA8B0v0IewaGcNfqaSJS2SYNCGYWBu4ArgbWANeZ2ZqcZDcCx919FXA7cFuw/zlgnbuvBa4Cvm5mkQLPWVajsSR1YSMSmvhPtKKzmVNjCQZOj81SzkRESqOQGsLlQK+773H3GHA/sD4nzXrgnmD7IeA9ZmbuPuzuiWB/A5D5GV3IOctqoplOs63sagHUsSwila+QgNAD7M963Rfsy5smCAAngA4AM7vCzHYCO4A/Cd4v5JwEx280s61mtnVgYKCA7BbHRNNWZFupkUYiUiUKCQiWZ19ug/m4adx9i7tfAFwGfM7MGgo8J8Hxd7r7Ondf19XVVUB2i2N0gqmvs/W0N1IfCWmkkYhUvEICQh+wNOv1EqB/vDRmFgHagGPZCdz9BWAIuLDAc5ZVoU1GoZCxolOT3IlI5YsUkOZJYLWZrQAOABuA63PSbAJuAH4NXAs86u4eHLPf3RNmdi7wJuAVYLCAc5bVaDxJR0t0wjT3bdkHQCRkPLN/8Mzr669YVvL8iYgU26QBIbiY3wQ8AoSBu919p5ndCmx1903AXcC9ZtZLumawITj8HcDNZhYHUsCfuvsRgHznLHLZZqTQGgJAZ2s9zx88SSKVmnRUkojIXFVIDQF33wxsztl3S9b2KPDRPMfdC9xb6DnnisnWQsjV1VJPyuHYUIyFrQ0lzp2ISGno52we8aRPuhZCts6W9HKaR07FSpktEZGSUkDIY7SAeYyynQkIujlNRCqYAkIeIwVOW5HRGA3TXB/R3coiUtEUEPIoZOrrXF0tUY6cUkAQkcqlgJDHVJuMIN1spCYjEalkCgh5jATrKU+phtBaz1AsqfWVRaRiKSDkcaaGEJ1aDQFQP4KIVCwFhDzOBIRI4X+es0NPFRBEpDIpIOQxEk8SCRmRcOF/ngXNUUKmGoKIVC4FhDxGpzBtRUY4ZCxojqpjWUQqlgJCHoVOfZ2rs6WeATUZiUiFUkDIIz2P0dT/NF0t9RwbipFMaX1lEak8Cgh5jMSTNE5hhFFGZ2s9iZTTPzhSglyJiJSWAkIeo/Ek9ZHpNRkB7NbqaSJSgRQQ8oglUtRPYchpRldrOiBofWURqUQKCHnEkinqpjDkNKM5GqahLsSeI6ohiEjlUUDII55wotOoIZgZnS31qiGISEVSQMiRTDlJ92nVECA90kgBQUQqkQJCjngyPbFdNGzTOr6ztZ5DJ0cZGksUM1siIiVXUEAws6vMbJeZ9ZrZzXnerzezB4L3t5jZ8mD/75rZNjPbETy/O+uYnwXn3B48FharUDMRS6QDQt00mozg7EijvUdUSxCRyjLpVc/MwsAdwNXAGuA6M1uTk+xG4Li7rwJuB24L9h8BPuTuFwE3APfmHPcxd18bPA7PoBxFc7aGMP0mI4A9CggiUmEKuepdDvS6+x53jwH3A+tz0qwH7gm2HwLeY2bm7k+7e3+wfyfQYGb1xch4qcSCgDDdPoSOlihmsEf3IohIhSnkqtcD7M963Rfsy5vG3RPACaAjJ81HgKfdPXuyn38Kmos+b2Z5G+3NbKOZbTWzrQMDAwVkd2YyTUbTGWUE6UDS3daojmURqTiFXPXyXahzJ+uZMI2ZXUC6GemTWe9/LGhKujJ4fDzfh7v7ne6+zt3XdXV1FZDdmYkn09mebpMRwMquZt2LICIVp5CrXh+wNOv1EqB/vDRmFgHagGPB6yXAd4FPuPvuzAHufiB4PgXcR7ppquxm2qkM8IauFvYODOGuSe5EpHIUctV7ElhtZivMLApsADblpNlEutMY4FrgUXd3M2sHHgY+5+6/zCQ2s4iZdQbbdcAHgedmVpTiiM2wUxnSNYShWJLDmgpbRCrIpFe9oE/gJuAR4AXgQXffaWa3mtk1QbK7gA4z6wU+A2SGpt4ErAI+nzO8tB54xMyeBbYDB4B/LGbBpuvMKKMZ1BBWdrYAmuRORCpLpJBE7r4Z2Jyz75as7VHgo3mO+yLwxXFOe2nh2Zw9Z5qMpnljGqRrCAC7B4b4D2/oLEq+RERKTXcq55jpfQgAi9saaK2P8NKhU8XKlohIySkg5IglUxjpNZKny8x446JWdikgiEgFUUDIEU+kiEZCjHNbRMHetKiVFw+d1EgjEakYCgg5YsnUjJqLMs5b1MrJ0QSHTo4WIVciIqWngJAjnvQZ3YOQ8aZzWgF4Uc1GIlIhFBByxBLFqiHMA1A/gohUDAWEHOnlM2fWfwDQ1lTHonkNvHjwZBFyJSJSegoIOeKJVFGajCDTsawagohUBgWEHMXqVIZ0x/LugdNn7m0QEZnLCrpTuZbEgmGnM3Hfln0AHBuKEU86X3m0l3PmNXD9FcuKkUURkZJQDSFHPJma9uI4uc6Z1wCgoaciUhEUEHIUs8loYWs9IYPXTiggiMjcp4CQI57wGTcZZUTCITpb6lVDEJGKoICQJZ5MkXQvyrDTjEVtDRxUDUFEKoACQpaReBKY2UynuXraGzkxEuf0WKJo5xQRKQUFhCwjsXRAKNZ9CADd7Y0A9A+OFO2cIiKloICQJRMQil1DAOg7roAgInObAkKW4UwNoYgBoaEuTGdLVDUEEZnzFBCyjMTT7fzFGmWU0d3eyAEFBBGZ4wq68pnZVWa2y8x6zezmPO/Xm9kDwftbzGx5sP93zWybme0Int+ddcylwf5eM/t7m+mKNEUwEsusp1zcgLAk6FgeODVW1POKiBTTpFc+MwsDdwBXA2uA68xsTU6yG4Hj7r4KuB24Ldh/BPiQu18E3ADcm3XMV4GNwOrgcdUMylEUw7ES1RDmp/sRnjtwoqjnFREppkKufJcDve6+x91jwP3A+pw064F7gu2HgPeYmbn70+7eH+zfCTQEtYnFwDx3/7Wn15j8JvDhGZdmhjLDTot5HwJAd1sjBuxQQBCROayQgNAD7M963Rfsy5vG3RPACaAjJ81HgKfdfSxI3zfJOQEws41mttXMtg4MDBSQ3ekrxSgjSHcsd7TU82yfAoKIzF2FXPny/VzOXTl+wjRmdgHpZqRPTuGc6Z3ud7r7Ondf19XVVUB2py8zyqjYTUYAS+Y3qslIROa0Qq58fcDSrNdLgP7x0phZBGgDjgWvlwDfBT7h7ruz0i+Z5Jyz7myTUfEDQk97I4dOjnL4lKaxEJG5qZAr35PAajNbYWZRYAOwKSfNJtKdxgDXAo+6u5tZO/Aw8Dl3/2UmsbsfBE6Z2VuD0UWfAL4/w7LM2EgsiQGRUPEHPGVuUHtmv2oJIjI3TRoQgj6Bm4BHgBeAB919p5ndambXBMnuAjrMrBf4DJAZmnoTsAr4vJltDx4Lg/c+BXwD6AV2Az8oVqGmaziWJBoJUYoRsD3zG4mEjKf2HS/6uUVEiqGgFdPcfTOwOWffLVnbo8BH8xz3ReCL45xzK3DhVDJbaiPxZEmaiyDdDLWmex5PKyCIyBylO5WzjMQSJelQzrhk2Xye2X+ChNZYFpE5SAEhy3AsWfQhp9nesqydkXiSXa+dKtlniIhMlwJClnSTUelm0Lhk2XwAnto3WLLPEBGZLgWELCOxZFHXQsi1ZH4jnS31PP2q+hFEZO5RQMhS6iYjM+OSZe08vV81BBGZexQQsoyWcJRRxluWzWfvkSGODcVK+jkiIlOlgJAlcx9Cqdy3Zd+ZQPC3P36J+7bsK9lniYhMlQJCluFYoqRNRpC+YzlksO/YcEk/R0RkqhQQsozGUyVvMopGQnS3N7L3yFBJP0dEZKoUEAKJZIpYMkU0UvqF297Q1cL+48OMBZPpiYjMBQoIgeF4adZCyGfVwhZSDnuPqpYgInOHAkJgNFgLoZT3IWQsW9BEJGTsPny65J8lIlIoBYTAcIlWS8unLhxieUczuwdUQxCRuUMBIZAJCKXuVM54w8IWDp0cZeDU2Kx8nojIZBQQApnV0kp5H0K2N3Q1A/Cr3Udm5fNERCajgBAYmeUaQnd7I411YX7Zq4AgInODAkJgKJYAoH6WagghM1Z2NfPL3qO4+6x8pojIRBQQAsNBQJitJiOAN57TyoHBEXb2n5y1zxQRGY8CQmBobHb7EAAu6J5HXdjY9Ez/rH2miMh4Crr6mdlVZrbLzHrN7OY879eb2QPB+1vMbHmwv8PMfmpmp83sKznH/Cw45/bgsbAYBZquTA2hfpb6EACaohF+541d/Nsz/aRSajYSkfKa9OpnZmHgDuBqYA1wnZmtyUl2I3Dc3VcBtwO3BftHgc8Dnx3n9B9z97XB4/B0ClAsmRrCbNyYlu2atT0cPDHKk68cm9XPFRHJVcjV73Kg1933uHsMuB9Yn5NmPXBPsP0Q8B4zM3cfcvdfkA4Mc9pwLEFjXZiQlX4uo2zvPX8hjXVhvq9mIxEps0ICQg+wP+t1X7Avbxp3TwAngI4Czv1PQXPR583yX4nNbKOZbTWzrQMDAwWccnqGYkma68MlO/94mqIR3nfBOWzecZBYIjXrny8iklFIQMh3oc5t8C4kTa6PuftFwJXB4+P5Ern7ne6+zt3XdXV1TZrZ6RoeS9AUjZTs/BNZv7abweE4P3+5dAFPRGQyhQSEPmBp1uslQG77xpk0ZhYB2oAJG8Xd/UDwfAq4j3TTVNkMxZI0RWe/hgBw5eouOpqjfGtrX1k+X0QEoJCfxE8Cq81sBXAA2ABcn5NmE3AD8GvgWuBRn+BuqyBotLv7ETOrAz4I/GQa+S+a4ViC5vrZryFkltFcs3geP3r+EF9/bDetDXVcf8WyWc+LiNS2SWsIQZ/ATcAjwAvAg+6+08xuNbNrgmR3AR1m1gt8BjgzNNXMXgG+DPyhmfUFI5TqgUfM7FlgO+lA84/FK9bUDY2Vr4YAcOny+aQcnt43WLY8iEhtK+gnsbtvBjbn7Lsla3sU+Og4xy4f57SXFpbF2TEcS7BoXkPZPn9hawPnLmhi66vHuXJ1Z9nyISK1S3cqB4bGkjSVYZRRtnXLF3Dk9BivHh0uaz5EpDYpIASGYwmayzTKKOOinjbqIyG2vqqb1ERk9ikgBIZi5a8hRCMhLupp47n+k4wG6zOIiMwWBQQgnkwRS6TKXkMAuGhJG7FEisde0j0JIjK7FBA4u3xmOUcZZazsbKEpGmbzjoPlzoqI1BgFBM7OdFqO+xByhUPGmsXz+Mnzr6nZSERmlQICZ2c6nQs1BEg3Gw3Fkmo2EpFZpYDA2fWU50IfAqSbjeY31fHws2o2EpHZo4DA2fWUyz3KKCMcMt5/wSL+/QU1G4nI7FFAIKsPYY7UEAA+cNFihmJJHlezkYjMEgUEzvYhlGM9hPG8dWUHrQ0Rfvz8a+XOiojUCAUEztYQyrUeQj7RSIh3n7eQn7zwGomkFs4RkdJTQCCrhjCHAgLA+9Ys4vhwnG2vHi93VkSkBiggcLaG0DhHhp1m/M6buoiGQ/xIzUYiMgsUEEjPYxQNh4hG5tafo6U+wttXdfCj5w8xwXpDIiJFMbfaSMpkeCwxZ4acZmRWUmtvjLL/2Ahf/vFLLG5r1EpqIlIyc+sncZkMxZJzrv8g47zFrRjwfP/JcmdFRKqcAgLpPoS5Mm1FrtaGOs7taOLZvhNqNhKRklJAILNa2tysIQC8eWk7A6fHOHhitNxZEZEqVlBAMLOrzGyXmfWa2c153q83sweC97eY2fJgf4eZ/dTMTpvZV3KOudTMdgTH/L2ZWTEKNB3DsQRNdXOzhgBwUXcbIYPt+wfLnRURqWKTBgQzCwN3AFcDa4DrzGxNTrIbgePuvgq4Hbgt2D8KfB74bJ5TfxXYCKwOHldNpwDFMDSWnFN3Kedqqo/wxnNaebZvkGRKzUYiUhqF1BAuB3rdfY+7x4D7gfU5adYD9wTbDwHvMTNz9yF3/wXpwHCGmS0G5rn7rz3dMP5N4MMzKchMpPsQ5m6TEcDape2cHE2wZe/RcmdFRKpUIQGhB9if9bov2Jc3jbsngBNAxyTn7JvknLNmKDa3awgA5y2aRzQSYtP2/nJnRUSqVCEBIV/bfm67RSFpppXezDaa2VYz2zowUJqZP4fH5n4NIRoJccHieTy84+CZO6tFRIqpkIDQByzNer0EyP2ZeiaNmUWANuDYJOdcMsk5AXD3O919nbuv6+rqKiC7U5NKOcPxJM1zdNhptstXLODUaIIHn9w/eWIRkSkqJCA8Caw2sxVmFgU2AJty0mwCbgi2rwUe9QkGzbv7QeCUmb01GF30CeD7U859EYwmkrgzp4edZpzb0cyl587nG7/YqxlQRaToJg0IQZ/ATcAjwAvAg+6+08xuNbNrgmR3AR1m1gt8BjgzNNXMXgG+DPyhmfVljVD6FPANoBfYDfygOEWamrMznc79GgLAJ9+5kr7jI2x+7lC5syIiVaagn8XuvhnYnLPvlqztUeCj4xy7fJz9W4ELC81oqczFtRAm8t7zz2FlVzNff2w3H7p4MWW8fUNEqkzN36k8F1dLm0goZGy8ciU7+0/y+MtHyp0dEakiNR8QKq2GcN+WfYwlUixojvKZB7Zzz69eKXeWRKRKKCDEKquGAFAXDrF+bTdHh2L8bNfhcmdHRKqEAkKF1RAyVi9s5S1L23nspQF2HTpV7uyISBWo+YAwV9dTLsQHLlpMQ12Y//ntZ4lrGKqIzFDNB4QzNYQKajLKaK6PsH5tD8/sH+T2H79U7uyISIWr+YAwFKvcGgLART1tbLhsKV99bDe/7NWoIxGZvpoPCMNjCcygoa5y/xS3fGgNKzub+e8PbOf4UKzc2RGRClW5V8EiyaynXMk3eH3v6X6uvnAxR06P8cf3bOW+Lfu4b8u+cmdLRCpMzQeEubye8lR0tzdy5eoutu07zu6B0+XOjohUoJoPCKdGE7RUwMR2hXj3eQtZ0Bzle08f0KgjEZmymg8Ix4ZiLGiOljsbRVEXDvHhtT0cHYrx0xd1w5qITE3NB4Sjp6snIACsWtjCJcvaefzlAV48dLLc2RGRCqKAMDRGR0t9ubNRVFdfmL5h7eZv7yCZmmjhOhGRs2o6IKRSzrGhGJ0t1VNDgPQNax+8eDHb9w/yz795tdzZEZEKUdMBYXAkTsqho4qajDLevKSdK1d38jc/fJFXjw6VOzsiUgFqOiAcPT0GwIIqazICMDO+9JGLCYeMP7t/u0YdicikajsgBHf1dlZhDQGgp72RL33kYp7ZP8jf/kRzHYnIxKpjAP40HT2dDgjV1qmckblbed258/mHn+5mJJZi1cIWrr9iWZlzJiJzUUE1BDO7ysx2mVmvmd2c5/16M3sgeH+LmS3Peu9zwf5dZvb+rP2vmNkOM9tuZluLUZipOjoUNBlVaQ0h44MXd9PZWs8DT+7jxEi83NkRkTlq0oBgZmHgDuBqYA1wnZmtyUl2I3Dc3VcBtwO3BceuATYAFwBXAf8QnC/jXe6+1t3Xzbgk03DkdAwzmN9UV46PnzXRSIiPXb6MeMq5b8urxBLqTxCR31ZIDeFyoNfd97h7DLgfWJ+TZj1wT7D9EPAeS88Wtx64393H3H0v0Bucb044NjTG/KYokXD1d6UsnNfARy5Zwv7jI3zx4efLnR0RmYMKuRL2APuzXvcF+/KmcfcEcALomORYB35kZtvMbOPUsz5zR0/HqnLI6Xgu6mnjHas6+eavX+V7Tx8od3ZEZI4ppFM537zQube/jpdmomPf7u79ZrYQ+LGZvejuj//Wh6eDxUaAZcuK2xlabdNWFOL9Fywilkxx83ee5U2LWjl/8bxyZ0lE5ohCagh9wNKs10uA/vHSmFkEaAOOTXSsu2eeDwPfZZymJHe/093Xufu6rq6uArJbuKNDY3RW6Qij8YRDxleufwvzGur41D9vUyeziJxRSEB4ElhtZivMLEq6k3hTTppNwA3B9rXAo+7uwf4NwSikFcBq4AkzazazVgAzawbeBzw38+JMzdGhGB1VNm1FIRa2NnDHxy6h7/gIn/3WM6Q035GIUEBACPoEbgIeAV4AHnT3nWZ2q5ldEyS7C+gws17gM8DNwbE7gQeB54EfAp929yRwDvALM3sGeAJ42N1/WNyiTSyeTDE4HK+5JqOMy5Yv4C8+cD4/fv41vvb47nJnR0TmgIJuTHP3zcDmnH23ZG2PAh8d59i/Av4qZ98e4M1TzWwxZdYertab0iaSuWGtPhLiop42/s8Pd3FhdxvvfGNxm+REpLJU/3jLcVT7tBWFMDP+0yU9nDOvgU/eu40n9h4rd5ZEpIxqNyBU+bQVhaqPhPmjty+nu72BP/qnJ9j2qoKCSK2q3YBQI9NWFKK1oY5//S9vZeG8Bj5+1xNs3nGw3FkSkTKo3YAQ1BCqbXGc6Vo4r4EHNr6V8xa18qf/8hRf+sGLWm1NpMbU7GynR4fGiISMeQ3VPY9RoTIdzR9e20MkFOJrj+3mBzsOcu+NV7Cso6nMuROR2VDTNYT5zVFCoXw3U9euSDjEh9/Sw++vW8Jrp0a5+u8e51tb909+oIhUvBquIdTWPEZTtXbpfJZ3NPP4ywP8j4ee5Td7jvG/P3wBTdGa/ScjUvVq9n/30dO1N23FVLU3Rfngxd00RSN856k+fv7yANddvoxz5jVokR2RKlS7TUY1Om3FVIXMeO/55/BHb1/BUCzJP/ysl6f2HS93tkSkBGo3INTgTKczsWphC//13atYMr+Jh7b18Ym7n+DnLw+QnrJKRKpBTTYZDY0lOD2WUJPRFM1rqOPGd6zgl71H2PrqcT5+1xMsbmvg3I4mutsbWbWwhfMWtXLpsgW0VfkqdCLVqCYDwtP7BgFY0621AKYqZMaVq7v42w1r+bdnDvLYSwMcHBzhV71H+c5T6UV3opEQb1vZwZWrOmmqj6i/QaRC1GRA2LL3KCGDdefOL3dWKta3t6Uv/m9b2XFm30gsycGTI2zZc4zHXxrgN3uO8t7zz+H31y2piWVKRSpdbQaEPce4qKeNVt2UVlSN0TArO1tY2dnCoZOj/PC5gzykFjAOAAAIRElEQVS84yC7B07zFx84nytXd5JealtE5qKa+9k2Gk+yff8gV2T9spXiWzSvgRvetpzrL1/GyZE4n7j7Ca75yi/5/vYDDMcS5c6eiORRczWEp/cNEkumuGLFgnJnpeqZGRf2tPG/rlnDd586wNce282f37+dxrow7zqvi3XnLuDCnjZWdDazoDlKWHeNi5RVzQWELXuPYgbrlisgzJZMf8MfX7mSV44MsePACX7x8hE27zh0Jk3IYEFzPV2t6cfqhS28eWk7686dT3d7Y7myLlJTai8g7DnGmsXzaGtU/8FsC5mxsquFlV0trF/bw8nROAcHRzg2HOf0aILTY3FOjSbYffg0v+o9QiKYbXXRvAY+cmkP7z7vHNYubVdNQqREaiogjCWSPLXvOB+74txyZ0VI39cwb1H+wJxMOYdOjrJn4DQvHjrF1x7bwx0/3c2C5ijrzp3PqoUtnNvRRGtDHU3RMM31kfRzNP3cVB+hqS6syQtFpqCggGBmVwF/B4SBb7j7l3Lerwe+CVwKHAX+wN1fCd77HHAjkAT+zN0fKeScpfBs3wnGEimuWKnmorkuHDJ62hvpaW/kytVd/MeLFvP4ywM8+uJhnu0b5NEXD5+pQUyksS5MNBIiEjKikRALmqN0tKSbpC5e0sbFS9pZ3tGk0U8iFBAQzCwM3AH8LtAHPGlmm9z9+axkNwLH3X2VmW0AbgP+wMzWABuAC4Bu4Cdm9sbgmMnOWVT9gyN8/nvPEY2E1KFcgR4OVnG7bPkCLlu+gGTKOTESJ5ZIEUum0s+JJGNZr8cS6edEykm5k0g6Q2MJeg+fel2T1LyGCBd0t9Ezv5Gu1nraGutoiISorwvTUBeiIRKmq7We7vZGFrbW654KqVqF1BAuB3rdfQ+Amd0PrAeyL97rgS8E2w8BX7H0T671wP3uPgbsNbPe4HwUcM6i2dl/gv/8/55keCzJ3TdcRnuT5jCqdOGQzWguqmTKee3kKAcGR+g7PsL+48Ps7D/B6bEEE1U8wiFj0bwGFrc10NoQoak+QnM0TFPQVBUJh6gLGXVBraQuHCISNsJmxJIpRmJJRuJJRuMpRuPJM4/6SLrZq6U+aP6qjxAJpY8zS39uOGSELPPM2e0gXciMUIj0dpA2FBw7kZAZ9ZEQdeEQdZEQdWEjGg5eh9OvzQx3J5504skUiaSnA28yxVg8eSYIu6c/LxK2dP5DoeDZsp5DhMP2uv2qoc0NhQSEHiB7hZQ+4Irx0rh7wsxOAB3B/t/kHNsTbE92zqKIJVJs/OY2QmZ861Nv47xFmq5C0het7vZGutsbuWz52f2ZmkQ8ma5ZxJMp4skUp0YTDA7HGRyJcWI4zrGhGAdPjJ6poYwlksQTTrLAyf4iwUUzGg4RCYdIJM/WaObidIHhkJV0SdWQkQ4UoXQAnEyhcyp6gX/Nws9XoCLnD2DHF95PQ1244PTTUUhAyPf15JZivDTj7c9X5877lzGzjcDG4OVpM9s1Tj4ndf5fFJSsEzgy3c+oQCpv9au1MldleRv/ety3CilvQSNpCgkIfcDSrNdLgP5x0vSZWQRoA45Ncuxk5wTA3e8E7iwgn0VhZlvdfd1sfV65qbzVr9bKrPJOXyG9Y08Cq81shZlFSXcSb8pJswm4Idi+FnjU0xPlbwI2mFm9ma0AVgNPFHhOERGZRZPWEII+gZuAR0gPEb3b3Xea2a3AVnffBNwF3Bt0Gh8jfYEnSPcg6c7iBPBpd08C5Dtn8YsnIiKFMq149XpmtjFopqoJKm/1q7Uyq7wzOJcCgoiIQA1Ofy0iIvkpIATM7Coz22VmvWZ2c7nzUypm9oqZ7TCz7Wa2Ndi3wMx+bGYvB88Vu5Scmd1tZofN7LmsfXnLZ2l/H3znz5rZJeXL+fSMU94vmNmB4DvebmYfyHrvc0F5d5nZ+8uT6+kzs6Vm9lMze8HMdprZnwf7q/k7Hq/Mxf+e3b3mH6Q7tncDK4Eo8Aywptz5KlFZXwE6c/b9DXBzsH0zcFu58zmD8r0TuAR4brLyAR8AfkD6fpm3AlvKnf8ilfcLwGfzpF0T/NuuB1YE/+bD5S7DFMu7GLgk2G4FXgrKVc3f8XhlLvr3rBpC2pnpOdw9BmSm0qgV64F7gu17gA+XMS8z4u6Pkx7plm288q0HvulpvwHazWzx7OS0OMYp73jOTCXj7nuB7KlkKoK7H3T3p4LtU8ALpGc/qObveLwyj2fa37MCQlq+6Tkm+oNXMgd+ZGbbgrvAAc5x94OQ/scHLCxb7kpjvPJV8/d+U9BEcndWE2BVldfMlgNvAbZQI99xTpmhyN+zAkJaIdNzVIu3u/slwNXAp83sneXOUBlV6/f+VeANwFrgIPB/g/1VU14zawG+Dfw3dz85UdI8+6qlzEX/nhUQ0gqZnqMquHt/8HwY+C7pquRrmWp08Hy4fDksifHKV5Xfu7u/5u5Jd08B/8jZ5oKqKK+Z1ZG+MP6Lu38n2F3V33G+Mpfie1ZASKuJqTTMrNnMWjPbwPuA53j91CM3AN8vTw5LZrzybQI+EYxEeStwItPsUMly2sh/j/R3DONPJVMxzMxIz4zwgrt/Oeutqv2OxytzSb7ncvegz5UH6dEIL5Hukf/LcuenRGVcSXr0wTPAzkw5SU9V/u/Ay8HzgnLndQZl/FfS1ec46V9KN45XPtJV6zuC73wHsK7c+S9See8NyvNscHFYnJX+L4Py7gKuLnf+p1Hed5Bu/ngW2B48PlDl3/F4ZS7696w7lUVEBFCTkYiIBBQQREQEUEAQEZGAAoKIiAAKCCIiElBAEBERQAFBREQCCggiIgLA/weujsYY+OVo/AAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "y = np.random.gamma(shape = 1.2, scale = scale, size = n)\n",
+    "y_range = [0., y.max()]\n",
+    "sns.distplot(y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Model Data Object"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll make model data object from the pandas dataframe, `x` that we created above. Notice the new method `from_data_frame_wgts` and the argument `w` for observation weights. Every method that has been updated to account for observation weights will have a `_wgts` suffix and will take a `w` argument"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "val_idxs = np.random.permutation(len(y))[:3000]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "md_frame = ColumnarModelData.from_data_frame_wgts(path = '.', val_idxs = val_idxs, df = df, y = y, w = w, cat_flds = ['x3'], bs = 64)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's make sure that we can find the observation weights in the training dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((7000, 1), array([[1.27281],\n",
+       "        [0.60026],\n",
+       "        [1.17155],\n",
+       "        [0.8497 ],\n",
+       "        [0.52879],\n",
+       "        [0.50638],\n",
+       "        [1.25269],\n",
+       "        [1.40499],\n",
+       "        [0.96872],\n",
+       "        [1.38995]]))"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "md_frame.trn_w.shape, md_frame.trn_w[0:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Custom Loss and Evaluation Metric"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we have observational weights in our datasets and data loaders, we need to make sure our model's loss function and our evaluation metric that we'll be using to monitor learning can accept observational weights. Not doing so will cause an error. PyTorch doesn't not supply weighted loss functions, so we'll need to create our own. Deviance, which is a general distance measure between prediction and response that accounts for non-nomal response distributions, is a good choice for our loss function. It is proportional to negative loglikelihood. See https://en.wikipedia.org/wiki/Deviance_(statistics). To monitor training we'll use weighted Mean Absolute Error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def wgtd_dev(prds, resp, wgts):\n",
+    "    prds.data.clamp_(min = 1e-5) # predictions must be positive\n",
+    "    dev = -2.0 * wgts * (torch.log(resp/prds) - (resp - prds) / prds)\n",
+    "    return dev.sum() / wgts.sum()\n",
+    "\n",
+    "def wgtd_mae(prds, resp, wgts):\n",
+    "    ae = torch.abs(prds - resp)\n",
+    "    return ae.sum() / wgts.sum()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Train model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "On the first pass, we'll not use a fastai `learner`. Instead, we'll pass the model data and model itself to the `fit` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7a5370acfad146c5928a7a1246423191",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=3), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch      trn_loss   val_loss   wgtd_mae                                                                              \n",
+      "    0      2.551857   2.260304   62.414538 \n",
+      "    1      1.4651     1.075139   18.005387                                                                             \n",
+      "    2      1.083785   0.984699   15.648591                                                                             \n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[array([0.9847]), 15.64859113387261]"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "m = MixedInputModel(emb_szs = emb_sz, n_cont = len(df.columns)-1, emb_drop = 0., out_sz = 1, szs = [10],\n",
+    "                    drops = [0.1], y_range = y_range, use_bn = True)\n",
+    "opt = optim.Adam(m.parameters(), 1e-3)\n",
+    "fit(model = m, data = md_frame, n_epochs = 3, opt = opt, crit = wgtd_dev, metrics = [wgtd_mae])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we'll use a `learner` object so that we can find a good learning rate. Notice that we need to pass our user-defined loss function to `crit=`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learner = md_frame.get_learner(emb_szs = emb_sz, n_cont = len(df.columns)-1, emb_drop = 0., out_sz = 1,\n",
+    "                               szs = [10], drops = [0.1], y_range = y_range, use_bn = True, \n",
+    "                               crit = wgtd_dev, metrics = [wgtd_mae])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dd426df2dc0546d8934d25e02a15f659",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=1), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 44%|██████████████████████████████                                       | 48/110 [00:00<00:00, 479.98it/s, loss=2.64]\n",
+      "                                                                                                                       \r"
+     ]
+    }
+   ],
+   "source": [
+    "learner.lr_find()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEOCAYAAABmVAtTAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzt3Xd8FHX+x/HXJwVCIIQWeiB0CF0CCFhAOWwoduWsWJDTU2x33tnL3U+9s2NBsKAnng0V7B4IAtJBWgglUiTSawghQJLv749dc7mQssHsTsr7+XjMI7uz35157xD2k5nvzHfMOYeIiAhAmNcBRESk/FBREBGRPCoKIiKSR0VBRETyqCiIiEgeFQUREcmjoiAiInlUFEREJI+KgoiI5FFREBGRPBFeByitBg0auISEBK9jiIhUKIsXL97lnIsrqV2FKwoJCQksWrTI6xgiIhWKmW0KpJ0OH4mISB4VBRERyaOiICIieVQUREQkj4qCiIjkUVEQEZE8KgoBSN1xgNxc3bZURCo/FYUSzFq3k8HPzOSpb9d4HUVEJOhUFEowbuZ6AMZ+/xOLN+0ttu3GXQeZvPQXcjzeq0jdkcFfJi2n+yPfctcHy9i6/5CneUSk4lBRKMbqbenMWreLPwxsQ5PYGtz94TIyj2QX2vZA1lGueXMBo99byvkv/cCyzftCmtU5x7z1u7nhrYUMfuZ7PvnxF3on1OOzZVsY9NQMnv52Dfszj+KcDoOJSNEq3DAXofT6rA3UiAznplNac3K7Bvx+/Hye/Go1jwzr8j/tnHM88OlKNu/J5I7B7Zk4fxPnv/wDV/RtwZ/O6Ehsjcgyy/T0t2tYtz2Dfm3q079NfeLrRTNl6RbenLORlK3p1I2OZPTp7bi6X0vq16rO5j2Z/OObNYz5LpUx36VSLTyMmKgIYmtE0iO+Dqe0j+Pkdg2oX6t6mWUUkYrLKtpfjklJSS4UYx/tOJDFSU9M5/I+8TzqLwKPfJbMmz9sZOINfRnQtkFe248Wp3H3h8u4Y3B7Rg9ux4Gsozzzn7W8NWcjTWJr8NzlPeidUO83Z5q6ajs3vL2IOtGR7Ms8CkB4mJGT6+jQKIYRAxIY1qMZNaqFH/PeZZv3MTt1FweysknPOsrujMMs2LCHvZlHMYOe8XW4dkArzu7SmIhw7UCKVDZmttg5l1RiOxWFwj31zRpempHK9LsGktCgJgBZR3M454VZpO09xLAeTbm6XwLR1cIZOmY2XZvF8u6NJxIeZnnL+PHnvYx+bylpezP542ntuO20toV+4Y79/iden72BkSe35pr+CVSLOLbN/syj/O7Z76lXsxpT/ngS29OzmPPTLtZsy2BwYkP6ta6PmR3zvuLk5DpW/rKf79fu5JMff2HDroM0q1ODa/sncFmfeGpHld0ejoh4S0XhNzh0JId+T0yjT0I9xl39v9swbW8mr8z4iY+X/MKhoznUrBZOtYgwvhp9Co1jo45ZVsbhbB6anMykJWn0bFGHJy/qRvtGMYDvsNNzU9fx/LR1xNerweY9h0ioH829Z3fid4mN/udL/s4PljJ56RYm3zKALs1iy/wz5+Y6vlu9g9dmr2fe+j3UrBbOJUnxXDegFS3qR5f5+kQktFQUfoN/zdvEA5+u5IOb+tGnVeGHffYfOsqkxWl8tnwLtw9uz6ntix+mfMqyLTw0eSUHsrK56dTW3HpaO56fto5XZvzEJb2a88RF3Zi1bid/+yKF1B0Z9Iivw7X9Ezira2Nmr9vF9W8t4tbT2nLXkA7B+Mj/Y+Uv+3l99gY+W7aFHOcY2D6OAW0bkJRQj85NaxOpw0siFY6KwnHanXGYM56bRfO6Nfjk5v6lPiRT0rL/78vVTFqSltcvcEXfFjw2rAth/sNOR3NyeX/hZl6fvYENuw7SoFY1ch00jKnOlD+eVOihpWDZnp7F23M3MmXZFjbv8Z3WGhUZxqnt47johOYM6thQBUKkglBROA7OOUb+azHfr9nJlFsH0LFx7aCsZ07qLv72RQont2/AX87sWGjhyc11zErdxdtzNrJg4x7eveFEujYv+8NGgdqRnsWiTXuZv343X6zYxq6Mw9SvWY2LejVn9OntqFldJ7KJlGcqCsfh/YU/c8+kFdx/TiduOLl1UNZRGWTn5DJz3U4+XJTGN8nbaB1Xi7FXnkDbhjGe5Fm3/QCTl25h2uodJDapzahTW9OukTdZRMorFYVS2rT7IGc9P4se8XV45/q+eYdzpHg/pO7itn//yKGjOfzj4m4M7da01MvIOppDmFmpD419uWIrL0xbx+ptBwgz6NmiLqu2pHPoaA5DEhtxy6C2dI+vU+o8IpWRikIpHMnO5fJxc0ndkcHXt59C0zo1ynT5ld22/Vnc8u4SFm/ay+kdGzKkcyMGdWxIw5hjz8b6tf3kpb+wcks6KVvT2bDrIDWrhXNZ73iu7pdAfL3iz3Y6eDibRz5L5oNFaXRsHMNlveM5p1sTGsZEsefgESbM2chbczaSnnWUB4cmMmJAq2B8bJEKRUUhQIs37eWvHy9n7fYMXhjek/O6l/4vXfF1kI+Zto6PFqexZX8WAN2bx9KvTQP6tq5HUsu6bNyVyeuz1/P58q1k5zqa1alBpya16dQkho27M/lqxVZynOP0jg05o3NjBrRt8D8FOjfXsTRtH3d9sIyNuw9yy8C2jB7crtDO7ozD2dz5/lK+XbWda/sn8MDQxP+5hkSkqlFRKEHG4Wz++fVq3p63iSa1o/jbBV04rWOjMkhYtTnnSNl6gGkp25m+ZgfL0/aTnesIM8h1UKt6BJcmxXNt/4Rjrn/Ytj+LifM38e8Fm9mVcRiA1g1qEl8vms17M0nbe4gj2bk0iY3i2ct6cGLr+sVmycl1/N+XKbw+ewODOzXiheE9iK6mDnGpmlQUiuGc44KX57AsbR/X9Evg7jM6UEtnzwRF5pFslmzax4KNe6gbHcnFvZoTU8KV0rm5jjXbD/BD6i5mp+5i54HDxNeNpkX9aFrUi2ZotybUia4WcIa3527k4SnJNImtwZ/P7MC53Zqqz0iqHBWFYny9chuj3lnMExd25fI+LcoomZRnCzbs4ZHPkknekk735rHcPzSxTMajEqkoAi0KVe7Ko9xcx3NT19K6QU0u7tXc6zgSIn1a1eOzP57E05d0Z3v6YS4ZO5e/f7GKI9m5XkcTKVeqXFH4auU2Vm87wOjB7TQaaBUTFmZc1Ks53919Kled2JLxszZw8dg5bNx10OtoIuVGlfpWzMl1PDt1Le0a1jqu8+mlcoiuFsFj53dh7JW92LjrIOe8MIvxM9ez5+ARr6OJeK5KFYXPl28hdUcGtw9ur9MThTO7NOar20+he3wd/v5lCn3/byo3T1zM9DU7yM7RYSWpmqrMKTfZObk8N3UdHRvHcFaXxl7HkXKiWZ0avHvjiazels4HC9P45Mc0vlyxjbrRkZzRuTFnd21Cvzb1NfCfVBlB+003s3gzm25mKWaWbGaji2g30MyW+tt8H6w8k5duYcOug9zxu/Y6HVGO0bFxbR48N5F5957Oq1f14pT2cXy2bAtXv7GAoS/MZv3ODK8jioRE0E5JNbMmQBPn3BIziwEWA+c751bla1MHmAOc6Zz72cwaOud2FLfc4z0l9UDWUT798ReuPLFlmQ6HLZVX1tEcvl21nYcmryQ7x/HUpd05o7P2MqVi8vyUVOfcVufcEv/jA0AK0KxAs98DHzvnfva3K7Yg/BYxUZFc1S9BBUECFhUZznndm/L5bSfTKq4mN/1rMU9+vZqc3Ip1bY9IaYTkQKmZJQA9gfkFXmoP1DWzGWa22MyuDkUekdJoVqcGH9zUj+F94nllxk88P3Wt15FEgiboHc1mVguYBNzunEsvZP29gNOBGsBcM5vnnFtbYBkjgZEALVroCmQJvajIcB6/sBvZOY4XvkvlhJZ1GdihodexRMpcUPcUzCwSX0GY6Jz7uJAmacDXzrmDzrldwEyge8FGzrlxzrkk51xSXFzx90IWCaZHh3WhY+MY7nh/Kb/sO+R1HJEyF8yzjwx4HUhxzj1TRLPJwMlmFmFm0UBffH0PIuVSjWrhvHJlL47mOG6ZuETDZEilE8w9hQHAVcBp/lNOl5rZ2WY2ysxGATjnUoCvgeXAAuA159zKIGYS+c1aNajJPy/uxtLN+7jt3z+yPG0fFW1gSZGiVMlRUkXKwphp6xgzPZUj2bm0bViLi05ozogBCURFhnsdTeQYnp+SKlLZ3Xp6OxbeN5jHL+xK3ehInvx6NY9/qaOfUrGpKIj8BrE1IhnepwUfjurPtf0TeHveJhZv2uN1LJHjpqIgUkb+dEYHmsbW4J5JKzicneN1HJHjoqIgUkZqVo/gbxd0IXVHBi9P/8nrOCLHRUVBpAwN6tCQ83s05eUZqazdfsDrOCKlpqIgUsYeGJpIreoRjPrXYj798RddyyAVioqCSBmrX6s6Y4afAMDt7y9lwJPf8dzUtRw8nO1xMpGSqSiIBMFJ7Row9c5Teeu6PnRpWpvnpq7j3k9WeB1LpEQqCiJBEhZmnNo+jjdH9OGOwe2ZvHQL3yRv8zqWSLFUFERC4OZBbUhsUpv7PlnJ3oNHvI4jUiQVBZEQiAwP46lLurMv8wiPfJbsdRyRIqkoiIRIYtPa/PG0tny6dAvf6jCSlFMqCiIhdMugtiQ2qc09k5Yzb/1ur+OIHENFQSSEIsPDePmKE6hbsxpXvDaf12at17DbUq6oKIiEWEKDmky+ZQCDOzXkb1+kcNt7S8k8omsYpHxQURDxQExUJGOv7MWfzujA58u38NBkdT5L+aCiIOIRM+OWQW0ZeUprPlycxtLN+7yOJKKiIOK1W09rR1xMdR6akkxurvoXxFsqCiIeq1U9gr+e1ZFlm/cxaUma13GkilNRECkHzu/RjBNa1OHJr9eQnnXU6zhShakoiJQDYWHGw+d1ZvfBw4yZts7rOFKFqSiIlBPdmtfhsqR4Xp+9gTdmb9D1C+KJCK8DiMh/PTA0kT0Hj/Do56tYs+0Aj57fmeoR4V7HkipEewoi5UjN6hGMvbIXt53WlvcXbeaK8fPZlXHY61hShagoiJQzYWHGnUM68OLve7Jyy35Gv/ejDiVJyKgoiJRTQ7s15d6zO/FD6m6+XKFRVSU0VBREyrEr+rYksUlt/vbFKo2PJCGhoiBSjoWHGY8O68zW/Vm8+F2q13GkClBRECnnkhLqceEJzRg/az3rd2Z4HUcqORUFkQrgL2d1JCoinIemJHMkO9frOFKJqSiIVAANY6K4a0h7Zq3bxan/nM4bszeoj0GCImhFwczizWy6maWYWbKZjS6mbW8zyzGzi4OVR6Siu6Z/AhNG9Ca+XjSPfr6Kk56czpRlW7yOJZVMMK9ozgbucs4tMbMYYLGZ/cc5typ/IzMLB54EvgliFpEKz8wY2KEhAzs0ZNHGPTz2RQp//mgZ3ZrFktCgptfxpJIocU/BzGqaWZj/cXszO8/MIkt6n3Nuq3Nuif/xASAFaFZI01uBScCOUiUXqcKSEurx6pW9iAwP48+Tlus+DFJmAjl8NBOIMrNmwDRgBDChNCsxswSgJzC/wPxmwAXA2NIsT0SgcWwUD5yTyIINe3hn/iav40glEUhRMOdcJnAhMMY5dwGQGOgKzKwWvj2B251z6QVefg64xzmXU8IyRprZIjNbtHPnzkBXLVLpXZLUnFPax/HEV6vZvCfT6zhSCQRUFMysH3AF8IV/XkB9Ef7DTJOAic65jwtpkgS8Z2YbgYuBl83s/IKNnHPjnHNJzrmkuLi4QFYtUiWYGU9c2JUwM/78kQ4jyW8XSFG4Hfgr8IlzLtnMWgPTS3qTmRnwOpDinHumsDbOuVbOuQTnXALwEXCzc+7TgNOLCE3r1OC+czoxd/1ubn9/KYezi93xFilWiX/xO+e+B74H8Hc473LO3RbAsgcAVwErzGypf969QAv/ctWPIFJGLu8dz97MI/zj6zXsyjjM2Kt6UTuqxPNBRI5hJQ3Ja2bvAqOAHGAxEAs845z7Z/DjHSspKcktWrTIi1WLlHsfL0njzx8tp23DWrw5ojdNYmt4HUnKCTNb7JxLKqldIIePEv0dxOcDX+L7S/+q35hPRILgwhOa88a1vdm8J5PTnvqeh6ck8/NudUBL4AIpCpH+DuPzgcnOuaOAerNEyqlT2scx5daTOLtrEybO38TAp6Zzy7tL2Jd5xOtoUgEEUhReBTYCNYGZZtYSKHhqqYiUI23iavH0pd2Z9efTGHlKG75N3sY9k5brDm5SohKLgnPuBedcM+fc2c5nEzAoBNlE5DdqHBvFX87qyJ/O6MA3ydv5YNFmryNJORfIMBexZvbMrxePmdnT+PYaRKSCuOGk1vRvU5+Hp6xiw66DXseRciyQw0dvAAeAS/1TOvBmMEOJSNkKCzOevrQ71SLCuP29Hzmao3sySOECKQptnHMPOefW+6dHgNbBDiYiZatJbA2euLAry9L28/zUdV7HkXIqkKJwyMxO+vWJmQ0ADgUvkogEy1ldm3BJr+a8PCOVhRv3eB1HyqFAisIfgJfMbKOZbQJexHcxm4hUQA+d15n4etHc/t5S0rOOeh1HyplAzj5a6pzrDnQDujrnejrnlgU/mogEQ63qETx7WQ+2pWfx0ORkr+NIOVPk2EdmdmcR8wEoapA7ESn/TmhRl1tPa8tzU9cxsEMcw3oUdv8rqYqK21OIKWESkQrsj4PackKLOtz/6Up+2aduQvEpcUC88kYD4omUnZ93Z3LGczMZ1DGOl6/o5XUcCaKyHBBPRCqpFvWjuXlgG75csY05qbu8jiPlgIqCSBV34ymtia9Xg4c/SyZbF7VVeSoKIlVcVGQ495+TyNrtGbwzb5PXccRjJd55zcyqAxcBCfnbO+ceDV4sEQmlIYmNOLldA575z1rO7d6U+rWqex1JPBLInsJkYBiQDRzMN4lIJWFmPHRuIplHcnjq2zVexxEPlbinADR3zp0Z9CQi4qm2DWMYMSCB8bM2MKRzYwZ1aOh1JPFAIHsKc8ysa9CTiIjn7hrSgY6NY7j7g2XsOJDldRzxQCBF4SRgsZmtMbPlZrbCzJYHO5iIhF5UZDhjhvfk4JFs7vpgGbm5Fes6JvntAjl8dFbQU4hIudGuUQwPDE3kvk9WMn7Wem46tY3XkSSEAhkQbxNQBzjXP9XxzxORSur3fVpwZufG/PObNaxI2+91HAmhQG7HORqYCDT0T++Y2a3BDiYi3jEznrioK/VrVeOeSct1UVsVEkifwvVAX+fcg865B4ETgRuDG0tEvFYnuhoPn9uZVVvTefOHjV7HkRAJpCgYkJPveY5/nohUcmd2aczpHRvyzH/WkrY30+s4EgKBFIU3gflm9rCZPQzMA14PaioRKRfMjEeGdQbgwcnJVLRRlaX0AulofgYYAewB9gIjnHPPBTuYiJQPzetGc+fv2vPd6h18vXKb13EkyIosCmZW2/+zHrAReAf4F7DJP09EqogRAxLo1KQ2D01J5oDu61ypFben8K7/52JgUb7p1+ciUkVEhIfx+IVd2ZlxmKe/Xet1HAmiIi9ec84N9f9sFbo4IlJe9Yivw1UntuStuRu5oGczusfX8TqSBEEg1ylMC2ReIW3izWy6maWYWbL/eoeCba7wD52x3MzmmFn3wKOLSKjdfUYH4mpV595PVujahUqquD6FKH/fQQMzq2tm9fxTAtA0gGVnA3c55zrhu7bhFjNLLNBmA3Cqc64b8Bgw7ng+hIiERu2oSB48N5HkLem8NVcDG1RGxe0p3ISv/6Cj/+ev02TgpZIW7Jzb6pxb4n98AEgBmhVoM8c5t9f/dB7QvLQfQERC65yuTRjYIY5nvl3Dln2HvI4jZazIouCce97fn3C3c661c66Vf+runHuxNCvx7130BOYX0+x64KvSLFdEQs/MeGxYF3Kc47oJCzXEdiUTyHUKY8ysi5ldamZX/zoFugIzqwVMAm53zqUX0WYQvqJwTxGvjzSzRWa2aOfOnYGuWkSCJL5eNK9d3ZtNuzO5dOxcXe1ciQTS0fwQMMY/DQL+AZwXyMLNLBJfQZjonPu4iDbdgNeAYc653YW1cc6Nc84lOeeS4uLiAlm1iATZSe0a8M4Nfdlz8AiXjp3LTzszvI4kZSCQYS4uBk4HtjnnRgDdgRLv6m1mhm84jBT/VdGFtWkBfAxc5ZzTyc8iFUyvlnV5b2Q/juTkctmr89ifqQvbKrpAisIh51wukO2/ynkH0DqA9w0ArgJOM7Ol/ulsMxtlZqP8bR4E6gMv+1/XRXEiFUxi09pMGNGH3QcP8+rMn7yOI79RIHdeW2RmdYDx+M4+ygAWlPQm59xsShhN1Tl3A3BDABlEpBzr0iyWc7s15c0fNnLtgAQaxkR5HUmOUyAdzTc75/Y558YCvwOu8R9GEhHJc8fv2nMkJ5eXp2tvoSIr7uK1EwpOQD0gwv9YRCRPqwY1uTSpORPnb9LZSBVYcXsKT/unl/BdXzAO3yGk+cALwY8mIhXNrae1w8x4fuo6r6PIcSru4rVBzrlBwCbgBP8pob3wXYSWGqqAIlJxNK1Tg6tObMmkJWmk7tApqhVRIGcfdXTOrfj1iXNuJdAjeJFEpCK7eWAbakSG88RXq72OIschkKKQYmavmdlAMzvVzMbjG8dIROQY9WtV59bT2zE1ZTvfrd7udRwppUCKwgggGRgN3A6s8s8TESnUdQNa0SauJg9PWUXW0Ryv40gpBHJKapZz7lnn3AX+6VnnnEbAEpEiVYsI49FhXfh5TyZjv9cpqhVJcaekfuD/uSLfjXDyptBFFJGKaEDbBgzt1oSXZ/zEz7t1impFUdwVzb/eKW1oKIKISOVz/zmJTF+9g0c+S+b1a3t7HUcCUNwpqVv9PzcVNoUuoohUVI1jo7h9cHumrd7B9DU7vI4jASju8NEBM0svZDpgZoXeF0FEpKBr+ifQsn40j3+Zovs6VwDF7SnEOOdqFzLFOOdqhzKkiFRc1SLC+MuZHVm7PYMPF6d5HUdKEMgpqQCYWUMza/HrFMxQIlK5nNmlMUkt6/L0t2vJOJztdRwpRiB3XjvPzNYBG4DvgY3oXsoiUgpmxn3ndGJXxmFe1Smq5VogewqPAScCa51zrfDdhe2HoKYSkUqnZ4u6nNu9KeNnrWfr/kNex5EiBFIUjvrvnRxmZmHOuelo7CMROQ5/PqMDublw/ycr1elcTgVSFPaZWS1gJjDRzJ4HdFBQREotvl40953TiWmrd3DPpBXk5jqvI0kBgdyOcxhwCLgDuAKIBR4NZigRqbyu6Z/AvsyjPDt1LTFRETx0biJmxd65V0IokKIwEvjQOZcGvBXkPCJSBdx2elvSs47y+uwNxERFcNeQDl5HEr9AikJt4Bsz2wO8B3zknNN4uCJy3MyM+8/pREZWNmO+S6V1XE0u6Nnc61hCYKOkPuKc6wzcAjQFvjezqUFPJiKVmpnx9wu60DuhLg98mqxB88qJgC9eA3YA24DdQMPgxBGRqiQiPIxnL+uBGdz23o8c1RlJngvk4rU/mNkMYBrQALjROdct2MFEpGpoXjeaxy/sytLN+3h+6jqv41R5gfQptARud84tDXYYEamahnZrysy1O3lpRioD2jagX5v6XkeqsgLpU/iLCoKIBNvD53WmVf2a3PLuEn7ameF1nCqrNH0KIiJBE10tgtev7U2YwdWvL9BQGB5RURCRcqNVg5pMGNGH9ENHuer1Bew9eMTrSFWOioKIlCtdmsUy/pokft6TyYgJC8k8olF1QklFQUTKnRNb1+fF4T1ZlraP+z9d6XWcKkVFQUTKpSGdG3Pbae34eMkvfLhos9dxqoygFQUzizez6WaWYmbJZja6kDZmZi+YWaqZLTezE4KVR0QqnttOb0e/1vV5cHIy67Yf8DpOlRDMPYVs4C7nXCd8N+m5xcwSC7Q5C2jnn0YCrwQxj4hUMOFhxvOX9yC6Wji3vLuEQ0dyvI5U6QWtKDjntjrnlvgfHwBSgGYFmg0D3nY+84A6ZtYkWJlEpOJpWDuKZy/rwbodGdz90TIVhiALSZ+CmSUAPYH5BV5qBuQ/WJjGsYVDRKq4U9rHcc+ZHfli+VbOfXE2yVv2ex2p0gp6UfDftW0SvqEy0gu+XMhbjrkVk5mNNLNFZrZo586dwYgpIuXcqFPb8M71fUk/dJQLXprD+Jnrdee2IAhqUTCzSHwFYaJz7uNCmqQB8fmeNwe2FGzknBvnnEtyziXFxcUFJ6yIlHsntWvA17efwqkd4vj7lym8PCPV60iVTjDPPjLgdSDFOfdMEc2mAFf7z0I6EdjvnNsarEwiUvHVq1mNcVf1Ymi3Jjw/bR2rthQ8ACG/RTD3FAYAVwGnmdlS/3S2mY0ys1H+Nl8C64FUYDxwcxDziEglYWY8NqwLsTWqcfeHyziSrfswlJVAhs4+Ls652RTeZ5C/jcN3RzcRkVKpW7Ma/3dBF0b+azEvTk/lzt+19zpSpaArmkWkwhrSuTEX9mzGS9NTWfmLzkgqCyoKIlKhPXRuZxrUqsZt//6RbfuzvI5T4akoiEiFFhsdyZjhJ7A9PYuLXpnDet2g5zdRURCRCq9Pq3q8N7IfWUdzuHjsXJan7fM6UoWloiAilULX5rF8OKofNSLDGT5uHos37fE6UoWkoiAilUbruFp8fHN/4mKqc9O/lrA9XX0MpaWiICKVSqPaUYy7OonMI9ncPHGJrmEoJRUFEal02jeK4R8Xd2Pxpr38/YtVXsepUFQURKRSGtqtKTec1Iq35m7i4yVpXsepMFQURKTS+stZHTmxdT3u/WQFa7bpzm2BUFEQkUorIjyMF4b3pFb1SG55dwmZR7K9jlTuqSiISKXWMCaK5y/vwU87M3hwcrLXcco9FQURqfQGtG3ArYPa8tHiNCYtVv9CcVQURKRKGD24PX1b1eP+T1eydrv6F4qioiAiVUJ4mPHC8J7UrB7O78fP06iqRVBREJEqo1HtKN4b2Y9q4WEMHzePeet3ex2p3FFREJEqpW3DWnz0h/40io3i6jcW8E3yNq8jlSsqCiJS5TStU4MPb+pHpya1uXniEqav2eF1pHK1ImyPAAANpklEQVRDRUFEqqS6Nasx8Ya+tG8Uwx8nLiF5i/oYQEVBRKqwWtUjePPa3tSuEcl1ExayZd8hryN5TkVBRKq0xrFRvDmiN5mHcxjx5kLSs456HclTKgoiUuV1bFybV67sxU87MzhvzGy+W73d60ieUVEQEQFOateAt6/vQ3iYcd2ERVw3YSEbdx30OlbIqSiIiPj1b9OAr0afwr1nd2T++t0MeW4mc37a5XWskFJREBHJp1pEGCNPacP0uwfSsl40N729mFVb0r2OFTIqCiIihWhYO4q3rutDzeoRXPvmAtL2ZnodKSRUFEREitC0Tg3euq4PWUdzuOaNBew9eMTrSEGnoiAiUowOjWMYf3USm/ce4uo3FrDHo8Jw/YSFvL/w56CvR0VBRKQEfVvX59Ure7F2+wEufXUu2/ZnhXT9ew8eYdrqHezLDP41FCoKIiIBGNSxIW9d14dt+7O45NU5/Lw7dH0MKVt9Hd2JTWsHfV0qCiIiATqxdX3evbEvB7KyuXjsHFJ3ZIRkvav8RaFTkwpcFMzsDTPbYWYri3g91sw+M7NlZpZsZiOClUVEpKx0a16HD27qR66D34+fx/qdwS8Mq7amExdTnQa1qgd9XcHcU5gAnFnM67cAq5xz3YGBwNNmVi2IeUREykT7RjG8e2NfcnIdw8fPC/qVzylbD5AYgr0ECGJRcM7NBPYU1wSIMTMDavnbZgcrj4hIWWrfKIaJN/blSHYuw8fPC1ofw5HsXFJ3HAjJoSPwtk/hRaATsAVYAYx2zuV6mEdEpFQ6Nq7NxBtO5NDRHK5+Y35QRlhN3ZHB0RwXkk5m8LYonAEsBZoCPYAXzazQT21mI81skZkt2rlzZygziogUK7FpbcZd5buO4e4PluGcK9Pl/9rJnNgkpkyXWxQvi8II4GPnkwpsADoW1tA5N845l+ScS4qLiwtpSBGRkvRpVY+/ntWRb1dtZ9zM9WW67JSt6URFhtGqQa0yXW5RvCwKPwOnA5hZI6ADULZbU0QkRK4/qRVnd23Mk1+vZu5Pu8tsuau2pNOhUQzhYVZmyyxOME9J/TcwF+hgZmlmdr2ZjTKzUf4mjwH9zWwFMA24xzlXtcaoFZFKw8z4x8XdSWhQk1v/XTb3fHbOkbItPWT9CQARwVqwc254Ca9vAYYEa/0iIqFWq3oEr17Zi+Hj53HumNlc0z+BO3/XnpioSNL2ZvLvBT/z1cpt3Hhya4b3aVHi8rbuz2Jf5tGQnXkEQSwKIiJVUbtGMUy7cyD//HY1E+Zs5IvlW+nctDbfr/WdJNOiXjR//XgFP+/J5E9DOhBWzGGhvOEtVBRERCqu2OhI/nZ+Vy7pFc+DU5JZtTWdmwe2ZXjfFjSKqc6DU5J5ZcZPpO09xFOXdKN6RHihy/n15j4dVRRERCq+7vF1mHzLgGPm//38LrSoF80TX63m590HeWBoIkkJ9Y5pl7ItnZb1o6lVPXRf1RoQT0QkxMyMUae24eUrTmDL/iwuHjuX6ycszDtc9KuUrQfo1Dh0ewmgoiAi4pmzuzbh+z8N5M9ndmDhxj2c/cIs7vtkBRmHszl4OJuNuw+G9Mwj0OEjERFPRVeL4OaBbbmiT0uen7aON+dsYMaanVzeOx7nQjNcdn7aUxARKQdioyN58NxEPhrVn6jIMJ7+z1oAOoVoeItfaU9BRKQc6dWyLl/cdjJjvlvHxt2ZNKtTI6TrV1EQESlnoiLD+dMZhQ4FF3Q6fCQiInlUFEREJI+KgoiI5FFREBGRPCoKIiKSR0VBRETyqCiIiEgeFQUREcljzjmvM5SKme0ENgXYPBYo7p54Rb0e6Pzinud/3AAoq1uNlvSZStu+NNsgkHlVfRsUtz20DSrvNvDi/0FR2YrSzjkXW2Ir51ylnYBxx/N6oPOLe17g8aJQfaZgboNA5lX1bVDC9tA2qKTbwIv/B6XdBoG2reyHjz47ztcDnV/c85LWfbxKu9yy3AaBzKvq26Ck35Gyom1QvraBF/8PSrvsgNpWuMNHFZGZLXLOJXmdw0vaBtoGoG1QET5/Zd9TKC/GeR2gHNA20DYAbYNy//m1pyAiInm0pyAiInlUFEREJI+KgoiI5FFRKAfMrKaZLTazoV5nCTUz62RmY83sIzP7g9d5vGBm55vZeDObbGZDvM7jBTNrbWavm9lHXmcJJf///bf8//5XeJ0HVBR+EzN7w8x2mNnKAvPPNLM1ZpZqZn8JYFH3AB8EJ2XwlMXnd86lOOdGAZcC5fpUvcKU0Tb41Dl3I3AtcFkQ4wZFGW2D9c6564ObNDRKuT0uBD7y//ufF/KwhVBR+G0mAGfmn2Fm4cBLwFlAIjDczBLNrKuZfV5gamhmg4FVwPZQhy8DE/iNn9//nvOA2cC00MYvExMog23gd7//fRXNBMpuG1QGEwhwewDNgc3+ZjkhzFikCK8DVGTOuZlmllBgdh8g1Tm3HsDM3gOGOeceB445PGRmg4Ca+H5RDpnZl8653KAGLyNl8fn9y5kCTDGzL4B3g5e47JXR74ABTwBfOeeWBDdx2Sur34PKojTbA0jDVxiWUk7+SFdRKHvN+G/lB98/et+iGjvn7gMws2uBXRWlIBSjVJ/fzAbi24WuDnwZ1GShU6ptANwKDAZizaytc25sMMOFSGl/D+oDfwd6mtlf/cWjMilqe7wAvGhm5xDc4TACpqJQ9qyQeSVeIeicm1D2UTxRqs/vnJsBzAhWGI+Udhu8gO/LoTIp7TbYDYwKXhzPFbo9nHMHgRGhDlOccrG7UsmkAfH5njcHtniUxQtV/fODtgFoGxRUYbaHikLZWwi0M7NWZlYNuByY4nGmUKrqnx+0DUDboKAKsz1UFH4DM/s3MBfoYGZpZna9cy4b+CPwDZACfOCcS/YyZ7BU9c8P2gagbVBQRd8eGhBPRETyaE9BRETyqCiIiEgeFQUREcmjoiAiInlUFEREJI+KgoiI5FFRkKAzs4wQrOO8AIcpL8t1DjSz/sfxvp5m9pr/8bVm9mLZpys9M0soONxzIW3izOzrUGWS0FNRkArDP/xwoZxzU5xzTwRhncWNDzYQKHVRAO4FxhxXII8553YCW81sgNdZJDhUFCSkzOxPZrbQzJab2SP55n9qvrvPJZvZyHzzM8zsUTObD/Qzs41m9oiZLTGzFWbW0d8u7y9uM5tgZi+Y2RwzW29mF/vnh5nZy/51fG5mX/76WoGMM8zs/8zse2C0mZ1rZvPN7Eczm2pmjfxDI48C7jCzpWZ2sv+v6En+z7ewsC9OM4sBujnnlhXyWkszm+bfNtPMrIV/fhszm+df5qOF7XmZ7w5eX5jZMjNbaWaX+ef39m+HZWa2wMxi/HsEs/zbcElheztmFm5m/8z3b3VTvpc/BcrFXcIkCJxzmjQFdQIy/D+HAOPwjRgZBnwOnOJ/rZ7/Zw1gJVDf/9wBl+Zb1kbgVv/jm4HX/I+vBV70P54AfOhfRyK+cewBLsY3PHcY0BjYC1xcSN4ZwMv5ntflv1f/3wA87X/8MHB3vnbvAif5H7cAUgpZ9iBgUr7n+XN/Blzjf3wd8Kn/8efAcP/jUb9uzwLLvQgYn+95LFANWA/09s+rjW9k5Gggyj+vHbDI/zgBWOl/PBK43/+4OrAIaOV/3gxY4fXvlabgTBo6W0JpiH/60f+8Fr4vpZnAbWZ2gX9+vH/+bnx3o5pUYDkf+38uxncvhsJ86nz3plhlZo38804CPvTP32Zm04vJ+n6+x82B982sCb4v2g1FvGcwkGiWN0pybTOLcc4dyNemCbCziPf3y/d5/gX8I9/88/2P3wWeKuS9K4CnzOxJ4HPn3Cwz6wpsdc4tBHDOpYNvrwLfGP498G3f9oUsbwjQLd+eVCy+f5MNwA6gaRGfQSo4FQUJJQMed869+j8zfTfaGQz0c85lmtkMIMr/cpZzruBtCg/7f+ZQ9O/w4XyPrcDPQBzM93gM8Ixzboo/68NFvCcM32c4VMxyD/Hfz1aSgAcmc86tNbNewNnA42b2Lb7DPIUt4w58t3/t7s+cVUgbw7dH9k0hr0Xh+xxSCalPQULpG+A6M6sFYGbNzHd/3lhgr78gdARODNL6ZwMX+fsWGuHrKA5ELPCL//E1+eYfAGLyPf8W30iYAPj/Ei8oBWhbxHrm4BtSGXzH7Gf7H8/Dd3iIfK//DzNrCmQ6597BtydxArAaaGpmvf1tYvwd57H49iBygauAwjrwvwH+YGaR/ve29+9hgG/PotizlKTiUlGQkHHOfYvv8MdcM1sBfITvS/VrIMLMlgOP4fsSDIZJ+G52shJ4FZgP7A/gfQ8DH5rZLGBXvvmfARf82tEM3AYk+TtmV1HIncScc6vx3XYzpuBr/veP8G+Hq4DR/vm3A3ea2QJ8h58Ky9wVWGBmS4H7gL85544AlwFjzGwZ8B98f+W/DFxjZvPwfcEfLGR5rwGrgCX+01Rf5b97ZYOALwp5j1QCGjpbqhQzq+WcyzDfPYEXAAOcc9tCnOEO4IBz7rUA20cDh5xzzswux9fpPCyoIYvPMxMY5pzb61UGCR71KUhV87mZ1cHXYfxYqAuC3yvAJaVo3wtfx7AB+/CdmeQJM4vD17+iglBJaU9BRETyqE9BRETyqCiIiEgeFQUREcmjoiAiInlUFEREJI+KgoiI5Pl/PdGt7JRsNWUAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "learner.sched.plot(n_skip_end = 0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Looks like we can select a large learning rate. Let's select `0.2`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "139614a9605a4419a39f7441183ed061",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, description='Epoch', max=3), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch      trn_loss   val_loss   wgtd_mae                                                                              \n",
+      "    0      1.060752   0.948967   14.140661 \n",
+      "    1      1.001423   1.033588   13.873948                                                                             \n",
+      "    2      0.980037   0.986358   15.62873                                                                              \n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[array([0.98636]), 15.6287303577572]"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "learner.fit(lrs = 0.2, n_cycle = 3)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Updates to model.py, dataset.py, and column_data.py to incorporate observational weights (i.e. each record has a different influence/weight on the loss function) for structured data. I don't believe observational weights are needed that much outside of structured data. In addition to observation weights being useful in its own right, this bring fastai more in-line with Keras which supports observation weights.

The one aspect that I didn't feel was worthwhile to tackle is that observation weights impact the size of the gradients in a slightly nuanced way. Essentially, the larger the observation weights the larger will be the weighted sum of the gradients for a particular batch. But PyTorch divides the sum of the gradients by the total number of records in the batch. What we'd really want to to do is divide the weighted sum of the gradients by the sum of the observation weights in the batch and not the number of records. This difference will only matter if the observation weights are much larger or smaller than 1.0 on average. If so, the user should reduce the learning rate commensurately.  In this case, using other fastai tools like `lr_find` become even more important. 

There is also an observational_wgts.ipynb in the tutorials section to show why and how to use the new observation weight functionality. 