### PR TITLE
make the Model section of the lesson7-CAM work

### DIFF
--- a/courses/dl1/lesson7-CAM.ipynb
+++ b/courses/dl1/lesson7-CAM.ipynb
@@ -603,7 +603,8 @@
    },
    "outputs": [],
    "source": [
-    "lr=np.array([1e-6,1e-4,1e-2])"
+    "# 12 layer groups call for 12 lrs\n",
+    "lr=np.array([[1e-6]*4,[1e-4]*4,[1e-2]*4]).flatten()"
    ]
   },
   {
@@ -661,7 +662,9 @@
     }
    ],
    "source": [
-    "accuracy_np(*learn.TTA())"
+    "log_preds,y = learn.TTA()\n",
+    "preds = np.mean(np.exp(log_preds),0)\n",
+    "accuracy_np(preds,y)"
    ]
   },
   {
@@ -719,7 +722,9 @@
     }
    ],
    "source": [
-    "accuracy_np(*learn.TTA())"
+    "log_preds,y = learn.TTA()\n",
+    "preds = np.mean(np.exp(log_preds),0)\n",
+    "accuracy_np(preds,y)"
    ]
   },
   {


### PR DESCRIPTION
- fix the mismatch of 12 layer groups and lrs
- fix the accuracy_np code which expected non-log input

for discussion see:
http://forums.fast.ai/t/lesson7-cam-mismatch-between-of-lrs-and-of-layer-groups/19425