### PR TITLE
update deprecated API: scipy.misc.imresize => skimage.transform.resize

### DIFF
--- a/courses/dl1/lesson7-CAM.ipynb
+++ b/courses/dl1/lesson7-CAM.ipynb
@@ -23,7 +23,8 @@
     "from fastai.conv_learner import *\n",
     "from fastai.model import *\n",
     "from fastai.dataset import *\n",
-    "from fastai.sgdr import *"
+    "from fastai.sgdr import *\n",
+    "import skimage.transform.resize"
    ]
   },
   {
@@ -568,7 +569,7 @@
    ],
    "source": [
     "plt.imshow(dx)\n",
-    "plt.imshow(scipy.misc.imresize(f2, dx.shape), alpha=0.5, cmap='hot');"
+    "plt.imshow(skimage.transform.resize(f2, dx.shape), alpha=0.5, cmap='hot');"
    ]
   },
   {


### PR DESCRIPTION
python3.6/site-packages/ipykernel_launcher.py:2: DeprecationWarning: `imresize` is deprecated!
`imresize` is deprecated in SciPy 1.0.0, and will be removed in 1.2.0.
Use ``skimage.transform.resize`` instead.