### PR TITLE
more user-friendly cycle_save_name verification

### DIFF
--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -155,7 +155,8 @@ class Learner():
                 the cycles. For an intuitive explanation, please see
                 https://github.com/fastai/fastai/blob/master/courses/dl1/lesson1.ipynb
 
-            cycle_save_name (str): use to save the weights at end of each cycle
+            cycle_save_name (str): use to save the weights at end of each cycle (requires
+                use_clr, use_clr_beta or cycle_len arg)
 
             best_save_name (str): use to save weights of best model during training.
 
@@ -195,6 +196,9 @@ class Learner():
         Returns:
             None
         """
+
+        if cycle_save_name:
+            assert use_clr or use_clr_beta or cycle_len, "cycle_save_name argument requires either of the following arguments use_clr, use_clr_beta, cycle_len"
 
         if callbacks is None: callbacks=[]
         if metrics is None: metrics=self.metrics

--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -219,12 +219,14 @@ class Learner():
             clr_div,cut_div = use_clr[:2]
             moms = use_clr[2:] if len(use_clr) > 2 else None
             cycle_end = self.get_cycle_end(cycle_save_name)
+            assert cycle_len, "use_clr requires cycle_len arg"
             self.sched = CircularLR(layer_opt, len(data.trn_dl)*cycle_len, on_cycle_end=cycle_end, div=clr_div, cut_div=cut_div,
                                     momentums=moms)
         elif use_clr_beta is not None:
             div,pct = use_clr_beta[:2]
             moms = use_clr_beta[2:] if len(use_clr_beta) > 3 else None
             cycle_end = self.get_cycle_end(cycle_save_name)
+            assert cycle_len, "use_clr_beta requires cycle_len arg"
             self.sched = CircularLR_beta(layer_opt, len(data.trn_dl)*cycle_len, on_cycle_end=cycle_end, div=div,
                                     pct=pct, momentums=moms)
         elif cycle_len:


### PR DESCRIPTION
verify that when `learn.fit()'s cycle_save_name` arg is passed, one of `use_clr, use_clr_beta or cycle_len` args is passed too.

For the initial issue please see: http://forums.fast.ai/t/save-cycle/7779/4, plus by looking at the code I added 2 more arguments that will use cycle_save_name.

I suppose there is no test suite yet here, here is a little something half-baked I crafted:

```
def testme(cycle_save_name=None, use_clr=None, use_clr_beta=None, cycle_len=None):
    if cycle_save_name:
        assert use_clr or use_clr_beta or cycle_len, "cycle_save_name argument requires either of the following arguments use_clr, use_clr_beta, cycle_len"

# ok
testme()
testme(cycle_save_name='cycle-saved', cycle_len=1)
# not ok
testme(cycle_save_name='cycle-saved')
```