### PR TITLE
Enable skipping validation for n-epoch (training speedup)

### DIFF
--- a/fastai/sgdr.py
+++ b/fastai/sgdr.py
@@ -3,6 +3,7 @@ from .layer_optimizer import *
 from enum import IntEnum
 from timeit import default_timer as timer
 import copy
+import math
 
 
 class Callback:
@@ -363,12 +364,14 @@ class SaveBestModel(LossRecorder):
         
     def save_when_only_loss(self, metrics):
         loss = metrics[0]
+        if math.isnan(loss): return
         if self.best_loss == None or loss < self.best_loss:
             self.best_loss = loss
             self.model.save(f'{self.name}')
     
     def save_when_acc(self, metrics):
         loss, acc = metrics[0], metrics[1]
+        if math.isnan(acc) or math.isnan(loss): return
         if self.best_acc == None or acc > self.best_acc:
             self.best_acc = acc
             self.best_loss = loss

--- a/fastai/sgdr.py
+++ b/fastai/sgdr.py
@@ -80,7 +80,7 @@ class LossRecorder(Callback):
         self.epoch += 1
         self.epochs.append(self.iteration)
         self.times.append(timer() - self.start_at)
-        if not math.isnan(metrics[0]): self.save_metrics(metrics)
+        self.save_metrics(metrics)
 
     def on_batch_end(self, loss):
         self.iteration += 1

--- a/fastai/sgdr.py
+++ b/fastai/sgdr.py
@@ -80,7 +80,7 @@ class LossRecorder(Callback):
         self.epoch += 1
         self.epochs.append(self.iteration)
         self.times.append(timer() - self.start_at)
-        self.save_metrics(metrics)
+        if not math.isnan(metrics[0]): self.save_metrics(metrics)
 
     def on_batch_end(self, loss):
         self.iteration += 1
@@ -364,14 +364,12 @@ class SaveBestModel(LossRecorder):
         
     def save_when_only_loss(self, metrics):
         loss = metrics[0]
-        if math.isnan(loss): return
         if self.best_loss == None or loss < self.best_loss:
             self.best_loss = loss
             self.model.save(f'{self.name}')
     
     def save_when_acc(self, metrics):
         loss, acc = metrics[0], metrics[1]
-        if math.isnan(acc) or math.isnan(loss): return
         if self.best_acc == None or acc > self.best_acc:
             self.best_acc = acc
             self.best_loss = loss
@@ -382,6 +380,7 @@ class SaveBestModel(LossRecorder):
         
     def on_epoch_end(self, metrics):
         super().on_epoch_end(metrics)
+        if math.isnan(metrics[0]): return
         self.save_method(metrics)
 
 


### PR DESCRIPTION
This simple change enables training speedup when validation computation can take quite some (or same) time comparing to the training time (e.g. for sampling-based fully convoluted semantic segmentation) and you don't really care about the validation metrics up until a given number of epochs, when you know they will start being high enough for you to care, and therefore track.