### PR TITLE
Couple of DL1 Lesson 4 changes

### DIFF
--- a/courses/dl1/lesson4-imdb.ipynb
+++ b/courses/dl1/lesson4-imdb.ipynb
@@ -196,6 +196,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*Note:* If you get an error like:\n",
+    "\n",
+    "    Can't find model 'en'. It doesn't seem to be a shortcut link, a Python package or a valid path to a data directory.\n",
+    "    \n",
+    "then you need to install the Spacy language model by running this command on the command-line:\n",
+    "\n",
+    "    $ python -m spacy download en"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {},

--- a/courses/dl1/lesson4-imdb.ipynb
+++ b/courses/dl1/lesson4-imdb.ipynb
@@ -651,17 +651,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "learner.load_cycle('adam3_10',2)"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 23,
    "metadata": {
     "scrolled": true
@@ -706,17 +695,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "learner.save_encoder('adam3_10_enc')"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -731,7 +709,7 @@
    },
    "outputs": [],
    "source": [
-    "learner.save_encoder('adam3_20_enc')"
+    "learner.save_encoder('adam3_10_enc')"
    ]
   },
   {
@@ -740,7 +718,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "learner.load_encoder('adam3_20_enc')"
+    "learner.load_encoder('adam3_10_enc')"
    ]
   },
   {
@@ -1029,7 +1007,7 @@
     "m3 = md2.get_model(opt_fn, 1500, bptt, emb_sz=em_sz, n_hid=nh, n_layers=nl, \n",
     "           dropout=0.1, dropouti=0.4, wdrop=0.5, dropoute=0.05, dropouth=0.3)\n",
     "m3.reg_fn = partial(seq2seq_reg, alpha=2, beta=1)\n",
-    "m3.load_encoder(f'adam3_20_enc')"
+    "m3.load_encoder(f'adam3_10_enc')"
    ]
   },
   {


### PR DESCRIPTION
First change fixes #632 by documenting how to install the Spacy language model if it is not installed.

Second one (I think) fixes some encoder changes that might have been introduced in a48668b850d613664bb487071918f54c830a435e. I think there were some encoders that were not used or were renamed before re-running the notebook.

Please feel free to just take the instructions commit if that is easier to verify.