### PR TITLE
metrics additions

### DIFF
--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -1,13 +1,18 @@
 from .imports import *
 from .torch_imports import *
 
-def accuracy_np(preds, targs):
-    preds = np.argmax(preds, 1)
-    return (preds==targs).mean()
+# There are 2 versions of each metrics function, depending on the type of the prediction tensor:
+# *    torch preds/log_preds
+# *_np numpy preds/log_preds
+#
 
 def accuracy(preds, targs):
     preds = torch.max(preds, dim=1)[1]
     return (preds==targs).float().mean()
+
+def accuracy_np(preds, targs):
+    preds = np.argmax(preds, 1)
+    return (preds==targs).mean()
 
 def accuracy_thresh(thresh):
     return lambda preds,targs: accuracy_multi(preds, targs, thresh)
@@ -18,17 +23,29 @@ def accuracy_multi(preds, targs, thresh):
 def accuracy_multi_np(preds, targs, thresh):
     return ((preds>thresh)==targs).mean()
 
-def recall(preds, targs, thresh=0.5):
+def recall(log_preds, targs, thresh=0.5):
+    preds = torch.exp(log_preds)
+    pred_pos = torch.max(preds > thresh, dim=1)[1]
+    tpos = torch.mul((targs.byte() == pred_pos.byte()), targs.byte())
+    return tpos.sum()/targs.sum()
+
+def recall_np(preds, targs, thresh=0.5):
     pred_pos = preds > thresh
     tpos = torch.mul((targs.byte() == pred_pos), targs.byte())
     return tpos.sum()/targs.sum()
 
-def precision(preds, targs, thresh=0.5):
+def precision(log_preds, targs, thresh=0.5):
+    preds = torch.exp(log_preds)
+    pred_pos = torch.max(preds > thresh, dim=1)[1]
+    tpos = torch.mul((targs.byte() == pred_pos.byte()), targs.byte())
+    return tpos.sum()/pred_pos.sum()
+
+def precision_np(preds, targs, thresh=0.5):
     pred_pos = preds > thresh
     tpos = torch.mul((targs.byte() == pred_pos), targs.byte())
     return tpos.sum()/pred_pos.sum()
 
-def fbeta(preds, targs, beta, thresh=0.5):
+def fbeta(log_preds, targs, beta, thresh=0.5):
     """Calculates the F-beta score (the weighted harmonic mean of precision and recall).
     This is the micro averaged version where the true positives, false negatives and
     false positives are calculated globally (as opposed to on a per label basis).
@@ -38,8 +55,17 @@ def fbeta(preds, targs, beta, thresh=0.5):
     """
     assert beta > 0, 'beta needs to be greater than 0'
     beta2 = beta ** 2
-    rec = recall(preds, targs, thresh)
-    prec = precision(preds, targs, thresh)
+    rec = recall(log_preds, targs, thresh)
+    prec = precision(log_preds, targs, thresh)
     return (1 + beta2) * prec * rec / (beta2 * prec + rec)
 
-def f1(preds, targs, thresh=0.5): return fbeta(preds, targs, 1, thresh)
+def fbeta_np(preds, targs, beta, thresh=0.5):
+    """ see fbeta """
+    assert beta > 0, 'beta needs to be greater than 0'
+    beta2 = beta ** 2
+    rec = recall_np(preds, targs, thresh)
+    prec = precision_np(preds, targs, thresh)
+    return (1 + beta2) * prec * rec / (beta2 * prec + rec)
+
+def f1(log_preds, targs, thresh=0.5): return fbeta(log_preds, targs, 1, thresh)
+def f1_np(preds, targs, thresh=0.5): return fbeta_np(preds, targs, 1, thresh)


### PR DESCRIPTION
as discussed here: https://github.com/fastai/fastai/issues/658
- add torch/log_preds versions of the metrics: f1, fbeta, precision, recall
- rename the previous ones with the same name to have _np suffix

I checked the notebooks and didn't see any notebook that used either of `f1, fbeta, precision, recall`, so it's relatively safe to switch. It'll blow for the users who used it. 