### PR TITLE
Improve the flexibility of Dataset.resize

### DIFF
--- a/fastai/dataloader.py
+++ b/fastai/dataloader.py
@@ -22,7 +22,7 @@ def get_tensor(batch, pin, half=False):
 
 
 class DataLoader(object):
-    def __init__(self, dataset, batch_size=1, shuffle=False, sampler=None, batch_sampler=None, pad_idx=0,
+    def __init__(self, dataset: Dataset, batch_size=1, shuffle=False, sampler=None, batch_sampler=None, pad_idx=0,
                  num_workers=None, pin_memory=False, drop_last=False, pre_pad=True, half=False,
                  transpose=False, transpose_y=False):
         self.dataset,self.batch_size,self.num_workers = dataset,batch_size,num_workers

--- a/fastai/dataloader.py
+++ b/fastai/dataloader.py
@@ -22,7 +22,7 @@ def get_tensor(batch, pin, half=False):
 
 
 class DataLoader(object):
-    def __init__(self, dataset: Dataset, batch_size=1, shuffle=False, sampler=None, batch_sampler=None, pad_idx=0,
+    def __init__(self, dataset, batch_size=1, shuffle=False, sampler=None, batch_sampler=None, pad_idx=0,
                  num_workers=None, pin_memory=False, drop_last=False, pre_pad=True, half=False,
                  transpose=False, transpose_y=False):
         self.dataset,self.batch_size,self.num_workers = dataset,batch_size,num_workers

--- a/fastai/dataset.py
+++ b/fastai/dataset.py
@@ -277,7 +277,7 @@ class FilesDataset(BaseDataset):
     def get_x(self, i): return open_image(os.path.join(self.path, self.fnames[i]))
     def get_n(self): return len(self.fnames)
 
-    def resize_imgs(self, targ: int, new_path: str, resume: bool=True, fn=None):
+    def resize_imgs(self, targ, new_path, resume=True, fn=None):
         """
         resize all images in the dataset and save them to `new_path`
         :param targ: The target size
@@ -396,7 +396,7 @@ class ImageData(ModelData):
     @property
     def c(self): return self.trn_ds.c
 
-    def resized(self, dl: DataLoader, targ: int, new_path: str, resume: bool = True,
+    def resized(self, dl, targ, new_path, resume = True,
                 fn: Optional[Callable[[ImageFile], ImageFile]]=None):
         """
         Return a copy of this dataset resized
@@ -410,7 +410,7 @@ class ImageData(ModelData):
         """
         return dl.dataset.resize_imgs(targ, new_path, resume=resume, fn=fn) if dl else None
 
-    def resize(self, targ_sz: int, new_path: str = 'tmp', resume: bool =True, fn=None):
+    def resize(self, targ_sz, new_path='tmp', resume=True, fn=None):
         new_ds = []
         dls = [self.trn_dl,self.val_dl,self.fix_dl,self.aug_dl]
         if self.test_dl: dls += [self.test_dl, self.test_aug_dl]

--- a/fastai/dataset.py
+++ b/fastai/dataset.py
@@ -1,11 +1,6 @@
-import csv
-
-from .imports import *
-from .torch_imports import *
-from .core import *
-from .transforms import *
-from .layer_optimizer import *
 from .dataloader import DataLoader
+from .transforms import *
+
 
 def get_cv_idxs(n, cv_idx=0, val_pct=0.2, seed=42):
     """ Get a list of index values for Validation set from a dataset
@@ -25,30 +20,64 @@ def get_cv_idxs(n, cv_idx=0, val_pct=0.2, seed=42):
     idxs = np.random.permutation(n)
     return idxs[idx_start:idx_start+n_val]
 
-def resize_img(fname, targ, path, new_path):
+def path_for(root_path, new_path, targ):
+    return os.path.join(root_path, new_path, str(targ))
+
+def resize_img(fname, targ, path, new_path, fn=None):
     """
     Enlarge or shrink a single image to scale, such that the smaller of the height or width dimension is equal to targ.
     """
-    dest = os.path.join(path,new_path,str(targ),fname)
+    if fn is None:
+        fn = resize_fn(targ)
+    dest = os.path.join(path_for(path, new_path, targ), fname)
     if os.path.exists(dest): return
     im = Image.open(os.path.join(path, fname)).convert('RGB')
-    r,c = im.size
-    ratio = targ/min(r,c)
-    sz = (scale_to(r, ratio, targ), scale_to(c, ratio, targ))
     os.makedirs(os.path.split(dest)[0], exist_ok=True)
-    im.resize(sz, Image.LINEAR).save(dest)
+    fn(im).save(dest)
 
-def resize_imgs(fnames, targ, path, new_path):
+def resize_fn(targ):
+    def resize(im):
+        r,c = im.size
+        ratio = targ/min(r,c)
+        sz = (scale_to(r, ratio, targ), scale_to(c, ratio, targ))
+        return im.resize(sz, Image.LINEAR)
+    return resize
+
+
+def resize_imgs(fnames, targ, path, new_path, resume=True, fn=None):
     """
     Enlarge or shrink a set of images in the same directory to scale, such that the smaller of the height or width dimension is equal to targ.
     Note: 
     -- This function is multithreaded for efficiency. 
     -- When destination file or folder already exist, function exists without raising an error. 
     """
-    if not os.path.exists(os.path.join(path,new_path,str(targ),fnames[0])):
-        with ThreadPoolExecutor(8) as e:
-            ims = e.map(lambda x: resize_img(x, targ, path, new_path), fnames)
-            for x in tqdm(ims, total=len(fnames), leave=False): pass
+    target_path = path_for(path, new_path, targ)
+    if os.path.exists(target_path):
+        if resume:
+            subdirs = {os.path.dirname(p) for p in fnames}
+            already_resized_fnames = set()
+            for subdir in subdirs:
+                files = [os.path.join(subdir, file) for file in os.listdir(os.path.join(target_path, subdir))]
+                already_resized_fnames.update(set(files))
+            original_fnames = set(fnames)
+            fnames = list(original_fnames - already_resized_fnames)
+        else:
+            fnames = []
+
+    errors = {}
+    def safely_process(fname):
+        try:
+            resize_img(fname, targ, path, new_path, fn=fn)
+        except Exception as ex:
+            errors[fname] = ex
+
+    if len(fnames) > 0:
+        with ThreadPoolExecutor(num_cpus()) as e:
+            ims = e.map(lambda fname: safely_process(fname), fnames)
+            for _ in tqdm(ims, total=len(fnames), leave=False): pass
+    if errors:
+        print('Some images failed to process:')
+        print(json.dump(errors, indent=2))
     return os.path.join(path,new_path,str(targ))
 
 def read_dir(path, folder):
@@ -245,8 +274,16 @@ class FilesDataset(BaseDataset):
     def get_x(self, i): return open_image(os.path.join(self.path, self.fnames[i]))
     def get_n(self): return len(self.fnames)
 
-    def resize_imgs(self, targ, new_path):
-        dest = resize_imgs(self.fnames, targ, self.path, new_path)
+    def resize_imgs(self, targ: int, new_path: str, resume: bool=True, fn=None):
+        """
+        resize all images in the dataset and save them to `new_path`
+        :param targ: The target size
+        :param new_path:
+        :param resume: If true (default), allow resuming a partial resize operation by checking for the existence
+        of individual images rather than the existence of the directory
+        :return:
+        """
+        dest = resize_imgs(self.fnames, targ, self.path, new_path, resume, fn)
         return self.__class__(self.fnames, self.y, self.transform, dest)
 
     def denorm(self,arr):
@@ -299,8 +336,8 @@ class ArraysIndexDataset(ArraysDataset):
 
 class ArraysIndexRegressionDataset(ArraysIndexDataset):
     def is_reg(self): return True
-    
-    
+
+
 class ArraysNhotDataset(ArraysDataset):
     def get_c(self): return self.y.shape[1]
     @property
@@ -355,16 +392,16 @@ class ImageData(ModelData):
     @property
     def c(self): return self.trn_ds.c
 
-    def resized(self, dl, targ, new_path):
-        return dl.dataset.resize_imgs(targ,new_path) if dl else None
+    def resized(self, dl: DataLoader, targ: int, new_path: str, resume: bool = True, fn=None):
+        return dl.dataset.resize_imgs(targ, new_path, resume=resume, fn=fn) if dl else None
 
-    def resize(self, targ_sz, new_path='tmp'):
+    def resize(self, targ_sz: int, new_path: str = 'tmp', resume: bool =True, fn=None):
         new_ds = []
         dls = [self.trn_dl,self.val_dl,self.fix_dl,self.aug_dl]
         if self.test_dl: dls += [self.test_dl, self.test_aug_dl]
         else: dls += [None,None]
         t = tqdm_notebook(dls)
-        for dl in t: new_ds.append(self.resized(dl, targ_sz, new_path))
+        for dl in t: new_ds.append(self.resized(dl, targ_sz, new_path, resume, fn))
         t.close()
         return self.__class__(new_ds[0].path, new_ds, self.bs, self.num_workers, self.classes)
 

--- a/fastai/dataset.py
+++ b/fastai/dataset.py
@@ -1,4 +1,5 @@
 from typing import Optional, Callable
+from PIL.ImageFile import ImageFile
 
 from .dataloader import DataLoader
 from .transforms import *
@@ -396,7 +397,7 @@ class ImageData(ModelData):
     def c(self): return self.trn_ds.c
 
     def resized(self, dl: DataLoader, targ: int, new_path: str, resume: bool = True,
-                fn: Optional[Callable[[Image], Image]]=None):
+                fn: Optional[Callable[[ImageFile], ImageFile]]=None):
         """
         Return a copy of this dataset resized
         :param dl:

--- a/fastai/dataset.py
+++ b/fastai/dataset.py
@@ -1,3 +1,5 @@
+from typing import Optional, Callable
+
 from .dataloader import DataLoader
 from .transforms import *
 
@@ -281,6 +283,7 @@ class FilesDataset(BaseDataset):
         :param new_path:
         :param resume: If true (default), allow resuming a partial resize operation by checking for the existence
         of individual images rather than the existence of the directory
+        :param fn: Custom resizing function Img -> Img
         :return:
         """
         dest = resize_imgs(self.fnames, targ, self.path, new_path, resume, fn)
@@ -392,7 +395,18 @@ class ImageData(ModelData):
     @property
     def c(self): return self.trn_ds.c
 
-    def resized(self, dl: DataLoader, targ: int, new_path: str, resume: bool = True, fn=None):
+    def resized(self, dl: DataLoader, targ: int, new_path: str, resume: bool = True,
+                fn: Optional[Callable[[Image], Image]]=None):
+        """
+        Return a copy of this dataset resized
+        :param dl:
+        :param targ:
+        :param new_path:
+        :param resume: Check for images in the DataSet that haven't been resized yet (useful if a previous resize
+        operation was aborted)
+        :param fn: Optional custom resizing function
+        :return:
+        """
         return dl.dataset.resize_imgs(targ, new_path, resume=resume, fn=fn) if dl else None
 
     def resize(self, targ_sz: int, new_path: str = 'tmp', resume: bool =True, fn=None):

--- a/fastai/dataset.py
+++ b/fastai/dataset.py
@@ -1,6 +1,4 @@
-from typing import Optional, Callable
 from PIL.ImageFile import ImageFile
-
 from .dataloader import DataLoader
 from .transforms import *
 
@@ -64,9 +62,7 @@ def resize_imgs(fnames, targ, path, new_path, resume=True, fn=None):
             already_resized_fnames.update(set(files))
         original_fnames = set(fnames)
         fnames = list(original_fnames - already_resized_fnames)
-    else:
-        fnames = []
-
+    
     errors = {}
     def safely_process(fname):
         try:
@@ -280,12 +276,13 @@ class FilesDataset(BaseDataset):
     def resize_imgs(self, targ, new_path, resume=True, fn=None):
         """
         resize all images in the dataset and save them to `new_path`
-        :param targ: The target size
-        :param new_path:
-        :param resume: If true (default), allow resuming a partial resize operation by checking for the existence
+        
+        Arguments:
+        targ (int): the target size
+        new_path (string): the new folder to save the images
+        resume (bool): if true (default), allow resuming a partial resize operation by checking for the existence
         of individual images rather than the existence of the directory
-        :param fn: Custom resizing function Img -> Img
-        :return:
+        fn (function): custom resizing function Img -> Img
         """
         dest = resize_imgs(self.fnames, targ, self.path, new_path, resume, fn)
         return self.__class__(self.fnames, self.y, self.transform, dest)
@@ -396,21 +393,23 @@ class ImageData(ModelData):
     @property
     def c(self): return self.trn_ds.c
 
-    def resized(self, dl, targ, new_path, resume = True,
-                fn: Optional[Callable[[ImageFile], ImageFile]]=None):
+    def resized(self, dl, targ, new_path, resume = True, fn=None):
         """
         Return a copy of this dataset resized
-        :param dl:
-        :param targ:
-        :param new_path:
-        :param resume: Check for images in the DataSet that haven't been resized yet (useful if a previous resize
-        operation was aborted)
-        :param fn: Optional custom resizing function
-        :return:
         """
         return dl.dataset.resize_imgs(targ, new_path, resume=resume, fn=fn) if dl else None
 
     def resize(self, targ_sz, new_path='tmp', resume=True, fn=None):
+        """
+        Resizes all the images in the train, valid, test folders to a given size.
+
+        Arguments:
+        targ_sz (int): the target size
+        new_path (str): the path to save the resized images (default tmp)
+        resume (bool): if True, check for images in the DataSet that haven't been resized yet (useful if a previous resize
+        operation was aborted)
+        fn (function): optional custom resizing function
+        """
         new_ds = []
         dls = [self.trn_dl,self.val_dl,self.fix_dl,self.aug_dl]
         if self.test_dl: dls += [self.test_dl, self.test_aug_dl]


### PR DESCRIPTION
This PR adds 3 features:
1. Resumable resizing. If a previous resize operation failed or if more images were added to the dataset, `resume=True` (the new default) will find and resize them. The previous behavior would not attempt to perform any resizing if the `targ` directory existed. By checking all files at the beginning of the run, it's comparable in speed to the original (checking if files exist individually is significantly slower).
2. Add support for custom resizing functions via `fn` parameter. (default=None which defaults to im.resize)
3. Add error handling to image resizing -- rather than crashing mid run, any errors are output at the end

~I also added mypy types to the functions that I touched.~ I'm happy to remove if they're bothersome, but they make development easier in IDEs like PyCharm as well as making the code a bit easier to use in the future.
Fixes #678 