### PR TITLE
Update Utils.py : Remove unwanted imports

### DIFF
--- a/fastai/utils.py
+++ b/fastai/utils.py
@@ -19,13 +19,9 @@ from sklearn.manifold import TSNE
 import bcolz
 
 from IPython.lib.display import FileLink
-
-
-np.set_printoptions(precision=4, linewidth=100)
-
-
 from keras.layers import deserialize as layer_from_config 
 
+np.set_printoptions(precision=4, linewidth=100)
 
 to_bw = np.array([0.299, 0.587, 0.114])
 

--- a/fastai/utils.py
+++ b/fastai/utils.py
@@ -20,24 +20,7 @@ import bcolz
 
 from IPython.lib.display import FileLink
 
-import keras
-from keras import backend as K
-from keras.utils.data_utils import get_file
-from keras.utils import np_utils
-from keras.utils.np_utils import to_categorical
-from keras.models import Sequential, Model
-from keras.layers import Input, Embedding, Reshape, merge, LSTM, Bidirectional
-from keras.layers import TimeDistributed, Activation, SimpleRNN, GRU
-from keras.layers import Flatten, Dense, Dropout, Lambda
-from keras.regularizers import l2, l1
-from keras.layers.normalization import BatchNormalization
-from keras.optimizers import SGD, RMSprop, Adam
-from keras.layers import deserialize as layer_from_config
-from keras.metrics import categorical_crossentropy, categorical_accuracy
-from keras.layers.convolutional import *
-from keras.preprocessing import image, sequence
-from keras.preprocessing.text import Tokenizer
-from vgg16 import Vgg16
+
 np.set_printoptions(precision=4, linewidth=100)
 
 
@@ -92,11 +75,6 @@ def get_classes(path):
     return (val_batches.classes, batches.classes, onehot(val_batches.classes), onehot(batches.classes),
         val_batches.filenames, batches.filenames, test_batches.filenames)
 
-def limit_mem():
-    K.get_session().close()
-    cfg = K.tf.ConfigProto()
-    cfg.gpu_options.allow_growth = True
-    K.set_session(K.tf.Session(config=cfg))
 
 class MixIterator(object):
     def __init__(self, iters):

--- a/fastai/utils.py
+++ b/fastai/utils.py
@@ -24,6 +24,9 @@ from IPython.lib.display import FileLink
 np.set_printoptions(precision=4, linewidth=100)
 
 
+from keras.layers import deserialize as layer_from_config 
+
+
 to_bw = np.array([0.299, 0.587, 0.114])
 
 def gray(img): return np.rollaxis(img, 0, 1).dot(to_bw)


### PR DESCRIPTION
I believe We dont use keras in any notebooks So These dependencies/imports can be removed. Further limit_mem() function will be used only when keras is used.