### PR TITLE
Update imdb.ipynb to explicitly open files with encoding utf-8

### DIFF
--- a/courses/dl2/imdb.ipynb
+++ b/courses/dl2/imdb.ipynb
@@ -89,7 +89,7 @@
     "    texts,labels = [],[]\n",
     "    for idx,label in enumerate(CLASSES):\n",
     "        for fname in (path/label).glob('*.*'):\n",
-    "            texts.append(fname.open('r').read())\n",
+    "            texts.append(fname.open('r', encoding='utf-8').read())\n",
     "            labels.append(idx)\n",
     "    return np.array(texts),np.array(labels)\n",
     "\n",
@@ -183,7 +183,7 @@
     "df_trn[df_trn['labels']!=2].to_csv(CLAS_PATH/'train.csv', header=False, index=False)\n",
     "df_val.to_csv(CLAS_PATH/'test.csv', header=False, index=False)\n",
     "\n",
-    "(CLAS_PATH/'classes.txt').open('w').writelines(f'{o}\\n' for o in CLASSES)"
+    "(CLAS_PATH/'classes.txt').open('w', encoding='utf-8').writelines(f'{o}\\n' for o in CLASSES)"
    ]
   },
   {


### PR DESCRIPTION
Explicitly set open encodings - helps prevent errors where the system locale isn't utf-8 for some reason.

The notebook as it is threw an error in my docker-contained version of Fast.AI that I'm using. Not sure how prevalent this would be in general, but it seems safe to explicitly set to utf-8. 