### PR TITLE
Update environment-cpu.yml, missing testfixtures

### DIFF
--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -77,6 +77,7 @@ dependencies:
 - six
 - sqlite
 - statsmodels
+- testfixtures
 - testpath
 - tk
 - tornado<5


### PR DESCRIPTION
A recent edit to environment.yml was made to add in testfixtures.  This edit also needs to be made to environment-cpu.yml.  This solves the problem that calling 'pytest tests' within the fastai environment will fail with an error complaining about missing testfixtures.