### PR TITLE
Changes to make the learner.predict_array method work when called fro…

### DIFF
--- a/fastai/conv_learner.py
+++ b/fastai/conv_learner.py
@@ -207,3 +207,19 @@ class ConvLearner(Learner):
         """
         self.freeze_to(0)
         self.precompute = False
+
+    def predict_array(self, arr):
+        """
+        This over-ride is necessary because otherwise the learner method accesses the wrong model when it is called
+        with precompute set to true
+
+        Args:
+            arr: a numpy array to be used as input to the model for prediction purposes
+        Returns:
+            a numpy array containing the predictions from the model
+        """
+        precompute = self.precompute
+        self.precompute = False
+        pred = super().predict_array(arr)
+        self.precompute = precompute
+        return pred

--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -386,8 +386,7 @@ class Learner():
         Returns:
             a numpy array containing the predictions from the model
         """
-        if not isinstance(arr, np.ndarray):
-                raise OSError(f'Not valid numpy array')
+        if not isinstance(arr, np.ndarray): raise OSError(f'Not valid numpy array')
         self.model.eval()
         return to_np(self.model(to_gpu(V(T(arr)))))
 

--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -380,6 +380,14 @@ class Learner():
     def predict_dl(self, dl): return predict_with_targs(self.model, dl)[0]
 
     def predict_array(self, arr):
+        """
+        Args:
+            arr: a numpy array to be used as input to the model for prediction purposes
+        Returns:
+            a numpy array containing the predictions from the model
+        """
+        if not isinstance(arr, np.ndarray):
+                raise OSError(f'Not valid numpy array')
         self.model.eval()
         return to_np(self.model(to_gpu(V(T(arr)))))
 
@@ -391,7 +399,7 @@ class Learner():
         is to increase the accuracy of predictions by examining the images using multiple
         perspectives.
 
-        Args:
+
             n_aug: a number of augmentation images to use per original image
             is_test: indicate to use test images; otherwise use validation images
 


### PR DESCRIPTION
…m conv_learner when .precompute = True.  I have had to over ride he predict_array function in Learner since conv_learner over rides the model property and otherwise causes a problem.

I have also added a check in the predict_array method to make sure that it is passed a numpy array.  In some to the fastai notebook examples it looks to get passed an image which caused me confusion.