### PR TITLE
add tqdm progress bar for evaluation of validation set

### DIFF
--- a/fastai/model.py
+++ b/fastai/model.py
@@ -232,7 +232,9 @@ def validate(stepper, dl, metrics, epoch, seq_first=False, validate_skip = 0):
     batch_cnts,loss,res = [],[],[]
     stepper.reset(False)
     with no_grad_context():
-        for (*x,y) in iter(dl):
+        num_batch = len(dl)
+        t = tqdm(iter(dl), leave=False, total=num_batch, miniters=0, desc='Validation')
+        for (*x,y) in t:
             y = VV(y)
             preds, l = stepper.evaluate(VV(x), y)
             batch_cnts.append(batch_sz(x, seq_first=seq_first))
@@ -302,4 +304,3 @@ def model_summary(m, inputs):
 
     for h in hooks: h.remove()
     return summary
-

--- a/fastai/model.py
+++ b/fastai/model.py
@@ -232,8 +232,7 @@ def validate(stepper, dl, metrics, epoch, seq_first=False, validate_skip = 0):
     batch_cnts,loss,res = [],[],[]
     stepper.reset(False)
     with no_grad_context():
-        num_batch = len(dl)
-        t = tqdm(iter(dl), leave=False, total=num_batch, miniters=0, desc='Validation')
+        t = tqdm(iter(dl), leave=False, total=len(dl), miniters=0, desc='Validation')
         for (*x,y) in t:
             y = VV(y)
             preds, l = stepper.evaluate(VV(x), y)


### PR DESCRIPTION
During training of large datasets `learn.fit` often would display nothing for a very long time while working on the validation set. This PR adds the same progress bar to the validation loop that's already present in the fit loop.