### PR TITLE
Propagate the batch size

### DIFF
--- a/courses/dl1/lesson1-vgg.ipynb
+++ b/courses/dl1/lesson1-vgg.ipynb
@@ -74,7 +74,7 @@
    },
    "outputs": [],
    "source": [
-    "data = ImageClassifierData.from_paths(PATH, tfms=tfms_from_model(arch, sz))"
+    "data = ImageClassifierData.from_paths(PATH, bs=bs, tfms=tfms_from_model(arch, sz))"
    ]
   },
   {


### PR DESCRIPTION
The batch size was not propagated to `ImageClassifierData.from_paths`.