### PR TITLE
fix courses/dl2/style-transfer.ipynb

### DIFF
--- a/courses/dl2/style-transfer.ipynb
+++ b/courses/dl2/style-transfer.ipynb
@@ -38,6 +38,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# wget http://files.fast.ai/data/imagenet-sample-train.tar.gz\n",
     "PATH = Path('data/imagenet')\n",
     "PATH_TRN = PATH/'train'"
    ]
@@ -495,6 +496,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# wget https://raw.githubusercontent.com/jeffxtang/fast-style-transfer/master/images/starry_night.jpg\n",
     "style_fn = PATH/'style'/'starry_night.jpg'"
    ]
   },
@@ -780,6 +782,15 @@
    "outputs": [],
    "source": [
     "opt_img_v, optimizer = get_opt()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sfs = [SaveFeatures(children(m_vgg)[idx]) for idx in block_ends]"
    ]
   },
   {


### PR DESCRIPTION
- fix RuntimeError: Trying to backward through the graph a second time, but the buffers have already been freed. Specify retain_graph=True when calling backward the first time.
by reinitializing sfs
- add sources for dataset + style image