### PR TITLE
fix: courses/dl2/style-transfer-net.ipynb

### DIFF
--- a/courses/dl2/style-transfer-net.ipynb
+++ b/courses/dl2/style-transfer-net.ipynb
@@ -666,7 +666,7 @@
    },
    "outputs": [],
    "source": [
-    "x,y=md.val_ds[201]"
+    "x,y=md.val_ds[len(val_x)-1]"
    ]
   },
   {


### PR DESCRIPTION
fix:  IndexError: index 201 is out of bounds for axis 0 with size 197
by removing the hardcoded index, and replacing it with actual var len