### PR TITLE
Typo in get_rnn_classifier module

### DIFF
--- a/fastai/lm_rnn.py
+++ b/fastai/lm_rnn.py
@@ -244,4 +244,3 @@ def get_rnn_classifier(bptt, max_seq, n_class, n_tok, emb_sz, n_hid, n_layers, p
                       dropouth=dropouth, dropouti=dropouti, dropoute=dropoute, wdrop=wdrop, qrnn=qrnn)
     return SequentialRNN(rnn_enc, PoolingLinearClassifier(layers, drops))
 
-get_rnn_classifer=get_rnn_classifier


### PR DESCRIPTION
When **'get_rnn_classifier'** was called, it would initialize it as **'get_rnn_classifer'**. Notice the **'i'** missing in **classifier**.

Referring to issue #774 