### PR TITLE
Fix style-transfer n_iter String Formatting

### DIFF
--- a/courses/dl2/style-transfer.ipynb
+++ b/courses/dl2/style-transfer.ipynb
@@ -241,7 +241,7 @@
     "    loss = loss_fn(opt_img_v)\n",
     "    loss.backward()\n",
     "    n_iter+=1\n",
-    "    if n_iter%show_iter==0: print(f'Iteration: n_iter, loss: {loss.data[0]}')\n",
+    "    if n_iter%show_iter==0: print(f'Iteration: {n_iter}, loss: {loss.data[0]}')\n",
     "    return loss"
    ]
   },


### PR DESCRIPTION
When printing the loss, the print line currently appears as follows:
`Iteration: n_iter, loss: 0.2112911492586136`

Surrounding `n_iter` with curly brackets fixes the formatting to display the correct integer value for the Iteration.