### PR TITLE
Inconsistent naming of itos.pkl

### DIFF
--- a/courses/dl2/imdb_scripts/finetune_lm.py
+++ b/courses/dl2/imdb_scripts/finetune_lm.py
@@ -107,7 +107,7 @@ def train_lm(dir_path, pretrain_path, cuda_id=0, cl=25, pretrain_id='wt103', lm_
             ew = to_np(wgts['0.encoder.weight'])
             row_m = ew.mean(0)
 
-            itos2 = pickle.load(open(pretrain_path / 'tmp' / f'itos_{pretrain_id}.pkl', 'rb'))
+            itos2 = pickle.load(open(pretrain_path / 'tmp' / f'itos.pkl', 'rb'))
             stoi2 = collections.defaultdict(lambda:-1, {v:k for k,v in enumerate(itos2)})
             nw = np.zeros((vs, em_sz), dtype=np.float32)
             nb = np.zeros((vs,), dtype=np.float32)


### PR DESCRIPTION
`pretrain_lm.py` saves the index file as `itos.pkl` in the appropriate tmp folder. But `finetune_lm.py` currently expects `itos_{pretrain_id}.pkl`, so this breaks. Since the location of the tmp file already unambiguously refers to the pre-trained model (`pretrain_path / tmp / itos.pkl`). Would it be more consistent to just expect `itos.pkl` (as in this PR)? Or was it done this way because current users tend to have `dir_path == pretrain_path`? Given that they are separate parameters, I thought this change was more sensible.