### PR TITLE
Fix issue while evaluating when label don't start from 0.

### DIFF
--- a/courses/dl2/imdb_scripts/eval_clas.py
+++ b/courses/dl2/imdb_scripts/eval_clas.py
@@ -31,6 +31,8 @@ def eval_clas(dir_path, cuda_id, lm_id='', clas_id=None, bs=64, backwards=False,
     else:
         val_sent = np.load(dir_path / 'tmp' / f'val_{IDS}.npy')
     val_lbls = np.load(dir_path / 'tmp' / 'lbl_val.npy').flatten()
+    val_lbls = val_lbls.flatten()
+    val_lbls -= val_lbls.min()
     c=int(val_lbls.max())+1
 
     val_ds = TextDataset(val_sent, val_lbls)


### PR DESCRIPTION
Currently while training labels are flatten and normalized to start from zero.

i.e : In training script.

    trn_lbls = trn_lbls.flatten()
    val_lbls = val_lbls.flatten()
    trn_lbls -= trn_lbls.min()
    val_lbls -= val_lbls.min()

Whereas label are not normalized in evaluation script.

This leads for model to think there are more labels instead of there actually is and spilts out error complaining about dimensions in 1.layers.1.lin.weight

Both needs training and evaluation script need to flatten and normaize the labels.

Replicated it while working on https://github.com/mhjabreel/CharCNN/tree/master/data/ag_news_csv corpus.