### PR TITLE
Fix charts in ML lesson 2 notebook

### DIFF
--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -40,7 +40,7 @@ dependencies:
 - libsodium
 - libxml2
 - markupsafe
-- matplotlib
+- matplotlib <= 2.2.3
 - mistune
 - mkl
 - nbconvert
@@ -104,3 +104,5 @@ dependencies:
   - plotnine
   - kaggle-cli
   - ipywidgets
+  - pdpbox<=0.1.0
+  - treeinterpreter


### PR DESCRIPTION
The latest version of pdpbox has a signature change which doesn't
work with the notebooks. You can fix most of them by passing `x.columns` as the extra parameter. But it was still failing on the call to `plot_pdp(['Enclosure_EROPS w AC', 'Enclosure_EROPS', 'Enclosure_OROPS'], 5, 'Enclosure')` So I ended up going back to 0.1.0 to get things working again.

The treeinterpreter library was also missing.

Furthermore, matplotlib 3.0 has a new api that doesn't work with ANY version of pdpbox, so that needed to be pinned to 2.2.3. https://github.com/SauceCat/PDPbox/issues/37