### PR TITLE
fix if statement in tabular_data_from_df

### DIFF
--- a/fastai/tabular/data.py
+++ b/fastai/tabular/data.py
@@ -76,7 +76,7 @@ def tabular_data_from_df(path, train_df:DataFrame, valid_df:DataFrame, dep_var:s
     valid_ds = TabularDataset.from_dataframe(valid_df, dep_var, train_ds.tfms, train_ds.cat_names,
                                              train_ds.cont_names, train_ds.stats, log_output)
     datasets = [train_ds, valid_ds]
-    if test_df:
+    if test_df is not None:
         datasets.append(TabularDataset.from_dataframe(test_df, dep_var, train_ds.tfms, train_ds.cat_names,
                                                       train_ds.cont_names, train_ds.stats, log_output))
     return DataBunch.create(*datasets, path=path, **kwargs)


### PR DESCRIPTION
Current code raises an error like this:

```shell
In [3]: if df:
   ...:     print('yes')
   ...:
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-3-bce6c5c77019> in <module>()
----> 1 if df:
      2     print('yes')
      3

~/.pyenv/versions/3.5.3/envs/py35/lib/python3.5/site-packages/pandas/core/generic.py in __nonzero__(self)
   1119         raise ValueError("The truth value of a {0} is ambiguous. "
   1120                          "Use a.empty, a.bool(), a.item(), a.any() or a.all()."
-> 1121                          .format(self.__class__.__name__))
   1122
   1123     __bool__ = __nonzero__

ValueError: The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```