### PR TITLE
Fixed issue when column with file names in labels.csv not a string

### DIFF
--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -276,7 +276,7 @@ def csv_to_fns_labels(csv_path:PathOrStr, fn_col:int=0, label_col:int=1,
         df.iloc[:,label_col] = list(csv.reader(df.iloc[:,label_col], delimiter=label_delim))
     labels = df.iloc[:,label_col]
     fnames = df.iloc[:,fn_col]
-    if suffix: fnames = fnames + suffix
+    if suffix: fnames = fnames.astype(str) + suffix
     return fnames, labels
 
 def image_data_from_csv(path:PathOrStr, folder:PathOrStr='.', sep=None, csv_labels:PathOrStr='labels.csv', valid_pct:float=0.2,


### PR DESCRIPTION
Current code raises an error like this when a column with filenames with not a string type.

``` shell
TypeError                                 Traceback (most recent call last)
<ipython-input-64-a08dd1a682d0> in <module>()
      1 csv_labels='trainLabels.csv'
----> 2 fnames, labels = csv_to_fns_labels(PATH/csv_labels, suffix='.png', label_delim=None)
      3 
      4 valid_pct = 0.2
      5 (train_fns,train_lbls), (valid_fns,valid_lbls) = random_split(valid_pct, f'{folder_path}/' + fnames, labels)

~/python_packages/fastai/fastai/vision/data.py in csv_to_fns_labels(csv_path, fn_col, label_col, label_delim, header, suffix)
    277     labels = df.iloc[:,label_col]
    278     fnames = df.iloc[:,fn_col]
--> 279     if suffix: fnames = fnames + suffix
    280     return fnames, labels
    281 

~/anaconda3/lib/python3.6/site-packages/pandas/core/ops.py in wrapper(left, right)
   1064             rvalues = rvalues.values
   1065 
-> 1066         result = safe_na_op(lvalues, rvalues)
   1067         return construct_result(left, result,
   1068                                 index=left.index, name=res_name, dtype=None)

~/anaconda3/lib/python3.6/site-packages/pandas/core/ops.py in safe_na_op(lvalues, rvalues)
   1028         try:
   1029             with np.errstate(all='ignore'):
-> 1030                 return na_op(lvalues, rvalues)
   1031         except Exception:
   1032             if is_object_dtype(lvalues):

~/anaconda3/lib/python3.6/site-packages/pandas/core/ops.py in na_op(x, y)
   1018                 result = np.empty(len(x), dtype=x.dtype)
   1019                 mask = notna(x)
-> 1020                 result[mask] = op(x[mask], y)
   1021 
   1022             result, changed = maybe_upcast_putmask(result, ~mask, np.nan)

TypeError: ufunc 'add' did not contain a loop with signature matching types dtype('<U21') dtype('<U21') dtype('<U21')
```