### PR TITLE
Remove version constraint from testpath dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -81,7 +81,7 @@ dependencies:
 - sqlite
 - statsmodels
 - testfixtures
-- testpath>=0.4.2
+- testpath
 - tk
 - tornado<5
 - tqdm


### PR DESCRIPTION
Because this constraint breaks `conda env update` in mac and ubuntu18.04
