### PR TITLE
added ability to specify text and label columns by column name

### DIFF
--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -21,9 +21,8 @@ class TextDataset():
                  create_mtd:TextMtd=TextMtd.CSV, classes:Classes=None):
         self.tokenizer = ifnone(tokenizer, Tokenizer())
         self.path,self.max_vocab,self.min_freq = Path(path)/'tmp',max_vocab,min_freq
-        self.txt_cols, self.label_cols, self.pd_header = txt_cols, label_cols, None if (txt_cols is None) else 'infer'
-        self.n_labels = n_labels if (label_cols is None) else len(label_cols)
-        self.chunksize,self.name,self.df,self.create_mtd = chunksize,name,df,create_mtd
+        self.label_cols = ifnone(label_cols, list(range(n_labels)))
+        self.txt_cols,self.chunksize,self.name,self.df,self.create_mtd = txt_cols,chunksize,name,df,create_mtd
         self.vocab=vocab
         os.makedirs(self.path, exist_ok=True)
         if not self.check_toks(): self.tokenize()
@@ -73,25 +72,15 @@ class TextDataset():
         "Tokenize the texts in the csv file."
         print(f'Tokenizing {self.name}.')
         curr_len = get_chunk_length(self.df) if (self.create_mtd == TextMtd.DF) else get_chunk_length(self.csv_file, self.chunksize)
-        dfs = self.df if (self.create_mtd == TextMtd.DF) else pd.read_csv(self.csv_file, header=self.pd_header, chunksize=self.chunksize)
+        if (self.create_mtd == TextMtd.DF): dfs = self.df
+        else: dfs = pd.read_csv(self.csv_file, header='infer' if self.txt_cols is not None else None, chunksize=self.chunksize)
         tokens,labels = [],[]
         for _ in progress_bar(range(curr_len), leave=False):
             df = next(dfs) if (type(dfs) == pd.io.parsers.TextFileReader) else self.df
-
-            if (self.label_cols):
-                lbls = df[self.label_cols].values.astype(np.int64) if (self.n_labels > 0) else []
-            else:  
-                lbls = df.iloc[:,range(self.n_labels)].values.astype(np.int64)
-            
-            texts = f'\n{BOS} {FLD} 1 ' + (df[self.n_labels].astype(str) if (not self.txt_cols) else df[self.txt_cols[0]].astype(str))
-
-            if(self.txt_cols): 
-                for i, col in enumerate(self.txt_cols[1:]):
-                    texts += f' {FLD} {i+2} ' + df[col].astype(str)
-            else:
-                for i in range(self.n_labels+1, len(df.columns)):
-                    texts += f' {FLD} {i-self.n_labels+1} ' + df[i].astype(str)
-            
+            lbls = df[self.label_cols].values.astype(np.int64) if (len(self.label_cols) > 0) else []
+            self.txt_cols = ifnone(self.txt_cols, list(range(len(self.label_cols),len(df.columns))))
+            texts = f'{FLD} {1} ' + df[self.txt_cols[0]].astype(str)
+            for i, col in enumerate(self.txt_cols[1:]):  texts += f' {FLD} {i+2} ' + df[col].astype(str)
             toks = self.tokenizer.process_all(texts)
             tokens += toks
             labels += list(np.squeeze(lbls))


### PR DESCRIPTION
Added the ability for users to specify the text and label column(s) instead of having to rely on the n_labels argument to delineate between text and label columns.

Why is this useful?

First, it makes running ablations and experiments with various configurations much easier.  Instead of having to create multiple .csv files or DataFrames for each experiment you want to run, you can instead use a *single* file and use it to develop datasets/dataloaders using different combinations of text and/or label columns.  For example, I have a .csv file with roughly a dozen candidate text columns and label columns, some of which I want to use for multi-label problems and others for multi-class problems.  Using the "txt_cols" and "label_cols" arguments, I can load my data into a *single* DataFrame and use that one object to create any number of datasets/dataloaders I need.

Second, this approach is more intuitive and less error-prone.  Instead of having to make sure your .csv file/DataFrame is structured with labels first and then text columns second and then that your n_labels split is correct, users can explicitly and clearly define what text/label columns they want to use.

Notes:
1.  Tested against /examples/text.ipynb
2. Presupposes that DataFrames/CSV files will have a header row