### PR TITLE
Fix TabularModel to have a final output layer

### DIFF
--- a/fastai/tabular/data.py
+++ b/fastai/tabular/data.py
@@ -44,7 +44,7 @@ class TabularDataset(DatasetBase):
     def __getitem__(self, idx)->Tuple[Tuple[LongTensor,FloatTensor], Tensor]:
         return ((self.cats[idx], self.conts[idx]), self.y[idx])
     @property
-    def c(self)->int: return 1 if isinstance(self.y, FloatTensor) else self.y.max()+1
+    def c(self)->int: return 1 if isinstance(self.y, FloatTensor) else self.y.max().item()+1
 
     def get_emb_szs(self, sz_dict): return [def_emb_sz(self.df, n, sz_dict) for n in self.cat_names]
 

--- a/fastai/tabular/models.py
+++ b/fastai/tabular/models.py
@@ -16,7 +16,7 @@ class TabularModel(nn.Module):
         n_emb = sum(e.embedding_dim for e in self.embeds)
         self.n_emb,self.n_cont,self.y_range = n_emb,n_cont,y_range
         sizes = [n_emb + n_cont] + layers + [out_sz]
-        actns = [nn.ReLU(inplace=True)] * (len(sizes)-2)
+        actns = [nn.ReLU(inplace=True)] * (len(sizes)-2) + [None]
         layers = []
         for i,(n_in,n_out,dp,act) in enumerate(zip(sizes[:-1],sizes[1:],[0.]+ps,actns)):
             layers += bn_drop_lin(n_in, n_out, bn=use_bn and i!=0, p=dp, actn=act)


### PR DESCRIPTION
Previously, because `len(actns)` is always one less than `len(sizes[:-1])`, etc..
the zip gets cut off early and we never add a layer with an output size
equal to `out_sz`.  By adding a final `None` actn, we avoid adding an
incorrect ReLU to the end of the model without short-circuiting early.

After fixing this, this sufraced a bug in TabularDataset, in which
the property `c` returns a Tensor rather than an int.

`y.max()` returns a rank zero tensor, so we need to call `.item()`
to get the actual int out.