### PR TITLE
Add on_loss_end callback in CallbackHandler

### DIFF
--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -20,6 +20,7 @@ def loss_batch(model:Model, xb:Tensor, yb:Tensor, loss_fn:OptLossFunc=None,
     out = cb_handler.on_loss_begin(out)
     if not loss_fn: return out.detach(),yb[0].detach()
     loss = loss_fn(out, *yb)
+    loss = cb_handler.on_loss_end(loss)
     mets = [f(out,*yb).detach().cpu() for f in metrics] if metrics is not None else []
 
     if opt is not None:

--- a/fastai/callback.py
+++ b/fastai/callback.py
@@ -129,6 +129,9 @@ class Callback():
     def on_loss_begin(self, **kwargs:Any)->None:
         "Called after forward pass but before loss has been computed. Returns the output (which can allow us to modify it)."
         pass
+    def on_loss_end(self, **kwargs:Any)->None:
+        "Called after loss has been computed. Returns the final reduced loss"
+        pass
     def on_backward_begin(self, **kwargs:Any)->None:
         """Called after the forward pass and the loss has been computed, but before backprop.
            Returns the loss (which can allow us to modify it, for instance for reg functions)"""
@@ -207,6 +210,13 @@ class CallbackHandler():
             a = cb.on_loss_begin(**self.state_dict)
             if a is not None: self.state_dict['last_output'] = a
         return self.state_dict['last_output']
+
+    def on_loss_end(self, loss:Tensor)->None:
+        self.state_dict['last_loss'] = loss
+        for cb in self.callbacks:
+            a = cb.on_loss_end(**self.state_dict)
+            if a is not None: self.state_dict['last_loss'] = a
+        return self.state_dict['last_loss']
 
     def on_backward_begin(self, loss:Tensor)->None:
         "Handle gradient calculation on `loss`."


### PR DESCRIPTION
This pull request adds another callback method `on_loss_end` which is called after the loss is calculated by the loss function. Extended discussions are [here](http://forums.fast.ai/t/allow-for-more-than-one-output-for-loss-and-metric/21991/29)