### PR TITLE
Issue #641 - Use PackedSequence in RNNcore to improve pooling accuracy (and RNN speed)

### DIFF
--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -268,11 +268,10 @@ class SortishSampler(Sampler):
 
 def pad_collate(samples:BatchSamples, pad_idx:int=1, pad_first:bool=True) -> Tuple[LongTensor, LongTensor]:
     "Function that collect samples and adds padding."
-    ys = torch.tensor([s[1] for s in samples]).squeeze()
-    padded_xs, lengths = pad_packed_sequence(pack_sequence([torch.tensor(s[0]) for s in samples]), batch_first=True,
-                                             padding_value=pad_idx)
+    ys = torch.tensor(np.array([s[1] for s in samples])).squeeze()
+    padded_xs = pad_packed_sequence(pack_sequence([torch.tensor(s[0]) for s in samples]), padding_value=pad_idx)
 
-    return (padded_xs, lengths), ys
+    return (padded_xs,), ys
 
 DataFunc = Callable[[Collection[DatasetBase], PathOrStr, KWArgs], DataBunch]
 fastai_types[DataFunc] = 'DataFunc'

--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -1,4 +1,6 @@
 "NLP data loading pipeline. Supports csv, folders, and preprocessed data."
+from torch.nn.utils.rnn import pad_packed_sequence, pack_sequence
+
 from ..torch_core import *
 from .transform import *
 from ..data import *
@@ -266,10 +268,11 @@ class SortishSampler(Sampler):
 
 def pad_collate(samples:BatchSamples, pad_idx:int=1, pad_first:bool=True) -> Tuple[LongTensor, LongTensor]:
     "Function that collect samples and adds padding."
-    max_len = max([len(s[0]) for s in samples])
-    res = torch.zeros(max_len, len(samples)).long() + pad_idx
-    for i,s in enumerate(samples): res[-len(s[0]):,i] = LongTensor(s[0])
-    return res, torch.tensor([s[1] for s in samples]).squeeze()
+    ys = torch.tensor([s[1] for s in samples]).squeeze()
+    padded_xs, lengths = pad_packed_sequence(pack_sequence([torch.tensor(s[0]) for s in samples]), batch_first=True,
+                                             padding_value=pad_idx)
+
+    return (padded_xs, lengths), ys
 
 DataFunc = Callable[[Collection[DatasetBase], PathOrStr, KWArgs], DataBunch]
 fastai_types[DataFunc] = 'DataFunc'

--- a/fastai/text/models.py
+++ b/fastai/text/models.py
@@ -1,3 +1,5 @@
+from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
+
 from ..torch_core import *
 from ..layers import *
 
@@ -83,7 +85,7 @@ class RNNCore(nn.Module):
 
         super().__init__()
         self.bs,self.qrnn,self.ndir = 1, qrnn,(2 if bidir else 1)
-        self.emb_sz,self.n_hid,self.n_layers = emb_sz,n_hid,n_layers
+        self.emb_sz,self.n_hid,self.n_layers,self.pad_token = emb_sz,n_hid,n_layers,pad_token
         self.encoder = nn.Embedding(vocab_sz, emb_sz, padding_idx=pad_token)
         self.encoder_dp = EmbeddingDropout(self.encoder, embed_p)
         if self.qrnn:
@@ -104,15 +106,25 @@ class RNNCore(nn.Module):
         self.input_dp = RNNDropout(input_p)
         self.hidden_dps = nn.ModuleList([RNNDropout(hidden_p) for l in range(n_layers)])
 
-    def forward(self, input:LongTensor) -> Tuple[Tensor,Tensor]:
+    def forward(self, input:Tuple[LongTensor, LongTensor]) -> Tuple[Tensor,Tensor]:
+        input, lengths = input
+
+        # pack_padded can not handle zero lengths texts
+        empty_inputs = np.argwhere(lengths <= 0)
+        lengths[empty_inputs] = 1
+
         sl,bs = input.size()
         if bs!=self.bs:
             self.bs=bs
             self.reset()
+
         raw_output = self.input_dp(self.encoder_dp(input))
         new_hidden,raw_outputs,outputs = [],[],[]
         for l, (rnn,hid_dp) in enumerate(zip(self.rnns, self.hidden_dps)):
-            raw_output, new_h = rnn(raw_output, self.hidden[l])
+
+            packed_rnn_inp = pack_padded_sequence(raw_output, lengths, batch_first=True)
+            rnn_output, new_h = rnn(packed_rnn_inp, self.hidden[l])
+            raw_output, _ = pad_packed_sequence(rnn_output, batch_first=True, padding_value=self.pad_token)
             new_hidden.append(new_h)
             raw_outputs.append(raw_output)
             if l != self.n_layers - 1: raw_output = hid_dp(raw_output)
@@ -168,16 +180,18 @@ class MultiBatchRNNCore(RNNCore):
         "Concatenate the `arrs` along the batch dimension."
         return [torch.cat([l[si] for l in arrs]) for si in range_of(arrs[0])]
 
-    def forward(self, input:LongTensor) -> Tuple[Tensor,Tensor]:
+    def forward(self, input:Tuple[LongTensor, LongTensor]) -> Tuple[Tensor,Tensor]:
+        input, lengths = input
         sl,bs = input.size()
+
         self.reset()
         raw_outputs, outputs = [],[]
         for i in range(0, sl, self.bptt):
-            r, o = super().forward(input[i: min(i+self.bptt, sl)])
+            r, o = super().forward(input[i: min(i+self.bptt, sl)], np.minimum(lengths - i, self.bptt))
             if i>(sl-self.max_seq):
                 raw_outputs.append(r)
                 outputs.append(o)
-        return self.concat(raw_outputs), self.concat(outputs)
+        return self.concat(raw_outputs), self.concat(outputs), lengths
 
 class PoolingLinearClassifier(nn.Module):
     "Create a linear classifier with pooling."
@@ -190,17 +204,21 @@ class PoolingLinearClassifier(nn.Module):
             mod_layers += bn_drop_lin(n_in, n_out, p=p, actn=actn)
         self.layers = nn.Sequential(*mod_layers)
 
-    def pool(self, x:Tensor, bs:int, is_max:bool):
-        "Pool the tensor along the seq_len dimension."
-        f = F.adaptive_max_pool1d if is_max else F.adaptive_avg_pool1d
-        return f(x.permute(1,2,0), (1,)).view(bs,-1)
+    def avg_pool(self, x:Tensor, lengths:LongTensor):
+        lengths = np.minimum(lengths, x.shape[1]) # in case the text is shorter than max_len
+        lss = to_device(torch.tensor(np.array(lengths).astype(np.float32)))
+        return torch.div(torch.sum(x, dim=1).permute(1,0), lss).permute(1,0)
 
-    def forward(self, input:Tuple[Tensor,Tensor]) -> Tuple[Tensor,Tensor,Tensor]:
-        raw_outputs, outputs = input
+    def max_pool(self, x:Tensor, bs:int):
+        "Pool the tensor along the seq_len dimension."
+        return F.adaptive_max_pool1d(x.permute(1,2,0), (1,)).view(bs,-1)
+
+    def forward(self, input:Tuple[Tensor,Tensor, LongTensor]) -> Tuple[Tensor,Tensor,Tensor]:
+        raw_outputs, outputs, lengths = input
         output = outputs[-1]
         sl,bs,_ = output.size()
-        avgpool = self.pool(output, bs, False)
-        mxpool = self.pool(output, bs, True)
+        avgpool = self.avg_pool(output, lengths)
+        mxpool = self.max_pool(output, bs)
         x = torch.cat([output[-1], mxpool, avgpool], 1)
         x = self.layers(x)
         return x, raw_outputs, outputs


### PR DESCRIPTION
In the current implementation, the RNN output pooling calculates the average of the entire tensor including the padding. This pooling creates inconsistent behavior when predicting batches of texts (due to the change in the amount of padding). 
This PR replaces the previous padding with PyTorch PackedSequence to pack and pad the texts in the RNN core. This change also improves the RNN speed.
We also use the lengths to calculate the average pooling while ignoring the padding; 

Note: In the current implementation of MultiBatchRNN, predicting a batch that contains texts with more than 1*bptt difference in length is not recommended.

p.s.
It's my first PR, so feedback will be appreciated :)