### PR TITLE
Fixed typos on comments. Under examples, changed 'accesss' to 'access'

### DIFF
--- a/examples/collab.ipynb
+++ b/examples/collab.ipynb
@@ -6,8 +6,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fastai import *          # Quick accesss to most common functionality\n",
-    "from fastai.collab import *   # Quick accesss to collab filtering functionality\n",
+    "from fastai import *          # Quick access to most common functionality\n",
+    "from fastai.collab import *   # Quick access to collab filtering functionality\n",
     "from fastai.docs import *     # Access to example data provided with fastai"
    ]
   },

--- a/examples/tabular.ipynb
+++ b/examples/tabular.ipynb
@@ -6,8 +6,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fastai import *          # Quick accesss to most common functionality\n",
-    "from fastai.tabular import *  # Quick accesss to tabular functionality\n",
+    "from fastai import *          # Quick access to most common functionality\n",
+    "from fastai.tabular import *  # Quick access to tabular functionality\n",
     "from fastai.docs import *     # Access to example data provided with fastai"
    ]
   },

--- a/examples/text.ipynb
+++ b/examples/text.ipynb
@@ -6,8 +6,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fastai import *        # Quick accesss to most common functionality\n",
-    "from fastai.text import *   # Quick accesss to NLP functionality\n",
+    "from fastai import *        # Quick access to most common functionality\n",
+    "from fastai.text import *   # Quick access to NLP functionality\n",
     "from fastai.docs import *   # Access to example data provided with fastai"
    ]
   },

--- a/examples/vision.ipynb
+++ b/examples/vision.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "from fastai import *          # Quick accesss to most common functionality\n",
-    "from fastai.vision import *   # Quick accesss to computer vision functionality\n",
+    "from fastai import *          # Quick access to most common functionality\n",
+    "from fastai.vision import *   # Quick access to computer vision functionality\n",
     "from fastai.docs import *     # Access to example data provided with fastai"
    ]
   },


### PR DESCRIPTION
Fixed small typo on comments when importing fastai libraries in the following files:

./examples/text.ipynb:9:    "from fastai import *        # Quick accesss to most common functionality\n",
./examples/text.ipynb:10:    "from fastai.text import *   # Quick accesss to NLP functionality\n",
./examples/collab.ipynb:9:    "from fastai import *          # Quick accesss to most common functionality\n",
./examples/collab.ipynb:10:    "from fastai.collab import *   # Quick accesss to collab filtering functionality\n",
./examples/vision.ipynb:11:    "from fastai import *          # Quick accesss to most common functionality\n",
./examples/vision.ipynb:12:    "from fastai.vision import *   # Quick accesss to computer vision functionality\n",
./examples/tabular.ipynb:9:    "from fastai import *          # Quick accesss to most common functionality\n",
./examples/tabular.ipynb:10:    "from fastai.tabular import *  # Quick accesss to tabular functionality\n",

Changed "Quick accesss to" to "Quick access to"
