### PR TITLE
(doc-build) remove code sub-cells with vbox data

### DIFF
--- a/fastai/gen_doc/convert2html.py
+++ b/fastai/gen_doc/convert2html.py
@@ -30,9 +30,10 @@ def read_nb(fname):
 
 def convert_nb(fname, dest_path='.'):
     "Convert a notebook `fname` to html file in `dest_path`."
-    from .gen_notebooks import remove_undoc_cells
+    from .gen_notebooks import remove_undoc_cells, remove_code_cell_jupyter_widget_state_elem
     nb = read_nb(fname)
     nb['cells'] = remove_undoc_cells(nb['cells'])
+    nb['cells'] = remove_code_cell_jupyter_widget_state_elem(nb['cells'])
     fname = Path(fname)
     dest_name = fname.with_suffix('.html').name
     meta = nb['metadata']

--- a/fastai/gen_doc/gen_notebooks.py
+++ b/fastai/gen_doc/gen_notebooks.py
@@ -66,9 +66,9 @@ def get_global_vars(mod):
     return d
 
 def write_nb(nb, nb_path, mode='w'):
-    try: 
+    try:
         with open(nb_path, mode) as f: f.write(nbformat.writes(nb, version=4))
-    except Exception as e: 
+    except Exception as e:
         print(f'Could not output nb format. Dumping json instead.\nPath: {nb_path}\nException: {e}')
         json.dump(nb, open(nb_path, mode), indent=1)
 
@@ -205,7 +205,7 @@ def update_nb_metadata(nb_path=None, title=None, summary=None, keywords='fastai'
     NotebookNotary().sign(nb)
 
 def has_metadata_cell(cells, fn):
-    for c in cells: 
+    for c in cells:
         if re.search(f"update_nb_metadata\('{fn}'", c['source']): return c
 
 def stringify(s): return f'\'{s}\'' if isinstance(s, str) else s
@@ -243,6 +243,14 @@ def parse_sections(cells):
 def remove_undoc_cells(cells):
     old, _, _ = parse_sections(cells)
     return old
+
+# currently code vbox sub-cells mainly
+def remove_code_cell_jupyter_widget_state_elem(cells):
+    for c in cells:
+        if c['cell_type'] == 'code':
+            if 'outputs' in c:
+                c['outputs'] = [l for l in c['outputs'] if not ('data' in l and 'application/vnd.jupyter.widget-view+json' in l.data)]
+    return cells
 
 def update_module_page(mod, dest_path='.'):
     "Update the documentation notebook of a given module."
@@ -319,4 +327,3 @@ def update_notebooks(source_path, dest_path=None, update_html=True, update_nb=Fa
         for f in Path(source_path).glob('*.ipynb'):
             update_notebooks(f, dest_path=dest_path, update_html=update_html, update_nb=update_nb, update_nb_links=update_nb_links, do_execute=do_execute, html_path=html_path)
     else: print('Could not resolve source file:', source_path)
-


### PR DESCRIPTION
This patch removes these sections that are hidden in the output docs:

```
<div class="output_area">
<div id="72d0f10a-5376-4ad2-9d0e-89429d070497"></div>
<div class="output_subarea output_widget_view ">
<script type="text/javascript">
var element = $('#72d0f10a-5376-4ad2-9d0e-89429d070497');
</script>
<script type="application/vnd.jupyter.widget-view+json">
{"model_id": "", "version_major": 2, "version_minor": 0}
</script>
</div>
</div>
```

which removes the constant regeneration of these fields `<div id="72d0f10a-5376-4ad2-9d0e-89429d070497">`

the notebook cell that it surgically removes is:
```

    {
     "data": {
      "application/vnd.jupyter.widget-view+json": {
       "model_id": "",
       "version_major": 2,
       "version_minor": 0
      },
      "text/plain": [
       "VBox(children=(HBox(children=(IntProgress(value=0, max=1), HTML(value='0.00% [0/1 00:00<00:00]'))), HTML(value…"
      ]
     },
     "metadata": {},
     "output_type": "display_data"
    },

```
which is part of the this code cell:

```
 {
   "cell_type": "code",
   "execution_count": null,
   "metadata": {},
   "outputs": [
    {
     "data": {
      "application/vnd.jupyter.widget-view+json": {
       "model_id": "",
       "version_major": 2,
       "version_minor": 0
      },
      "text/plain": [
       "VBox(children=(HBox(children=(IntProgress(value=0, max=1), HTML(value='0.00% [0/1 00:00<00:00]'))), HTML(value…"
      ]
     },
     "metadata": {},
     "output_type": "display_data"
    },
    {
     "name": "stdout",
     "output_type": "stream",
     "text": [
      "Total time: 00:05\n",
      "epoch  train loss  valid loss  accuracy\n",
      "0      0.086652    0.038705    0.986261  (00:05)\n",
      "\n"
     ]
    }
    ],
```

This example is from `docs_src/basic_train.ipynb`

Since I wasn't involved with building the converter I defer to you to decide whether this is a safe removal.

Thanks.