### PR TITLE
Bugfix for tabular/data.py when cat_names default to None

### DIFF
--- a/fastai/tabular/data.py
+++ b/fastai/tabular/data.py
@@ -71,8 +71,7 @@ def tabular_data_from_df(path, train_df:DataFrame, valid_df:DataFrame, dep_var:s
                         tfms:OptTabTfms=None, cat_names:OptStrList=None, cont_names:OptStrList=None,
                         stats:OptStats=None, log_output:bool=False, **kwargs)->DataBunch:
     "Create a `DataBunch` from train/valid/test dataframes."
-    if cat_names is None:
-        cat_names = []
+    cat_names = ifnone(cat_names, [])
     cont_names = ifnone(cont_names, list(set(train_df)-set(cat_names)-{dep_var}))
     train_ds = TabularDataset.from_dataframe(train_df, dep_var, tfms, cat_names, cont_names, stats, log_output)
     valid_ds = TabularDataset.from_dataframe(valid_df, dep_var, train_ds.tfms, train_ds.cat_names,

--- a/fastai/tabular/data.py
+++ b/fastai/tabular/data.py
@@ -71,6 +71,8 @@ def tabular_data_from_df(path, train_df:DataFrame, valid_df:DataFrame, dep_var:s
                         tfms:OptTabTfms=None, cat_names:OptStrList=None, cont_names:OptStrList=None,
                         stats:OptStats=None, log_output:bool=False, **kwargs)->DataBunch:
     "Create a `DataBunch` from train/valid/test dataframes."
+    if cat_names is None:
+        cat_names = []
     cont_names = ifnone(cont_names, list(set(train_df)-set(cat_names)-{dep_var}))
     train_ds = TabularDataset.from_dataframe(train_df, dep_var, tfms, cat_names, cont_names, stats, log_output)
     valid_ds = TabularDataset.from_dataframe(valid_df, dep_var, train_ds.tfms, train_ds.cat_names,


### PR DESCRIPTION
I found that creating a tabular data with `tabular_data_from_df(...)` can cause an exception when `cat_names` is not specified, thus defaulting to `None`.

The quick fix was to check if `cat_names` is `None` and then changing it to the empty list.

You can reproduce the bug with this code:
```python
import pandas as pd
import numpy as np
from fastai.tabular import *
from sklearn.model_selection import train_test_split

df = pd.DataFrame(np.random.randn(6,4), columns=list('ABCD'))

X_train, X_val = train_test_split(df)
tab = tabular_data_from_df(path='./', train_df=X_train, valid_df=X_val, dep_var='D')
```