### PR TITLE
fix for error TypeError: _cuda() got an unexpected keyword argument '…

### DIFF
--- a/old/fastai/core.py
+++ b/old/fastai/core.py
@@ -38,7 +38,7 @@ def T(a, half=False, cuda=True):
         elif a.dtype in (np.float32, np.float64):
             a = to_half(a) if half else torch.FloatTensor(a)
         else: raise NotImplementedError(a.dtype)
-    if cuda: a = to_gpu(a, non_blocking=True)
+    if cuda: a = to_gpu(a)
     return a
 
 def to_half(tensor):


### PR DESCRIPTION
While running courses/dl1/lesson1.ipynb people were getting this error 
  File "/home/***/fastai/courses/dl1/fastai/core.py", line 41, in T
    if cuda: a = to_gpu(a, non_blocking=True)
  File "/home/***/fastai/courses/dl1/fastai/core.py", line 90, in to_gpu
    return x.cuda(*args, **kwargs) if USE_GPU else x
TypeError: _cuda() got an unexpected keyword argument 'non_blocking'

This Pull request solves this issue 