### PR TITLE
Fix bug for backwards=True when creating a LanguageModelLoader

### DIFF
--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -232,7 +232,7 @@ class LanguageModelLoader():
         "Split the corpus `data` in batches."
         nb = data.shape[0] // self.bs
         data = np.array(data[:nb*self.bs]).reshape(self.bs, -1).T
-        if self.backwards: data=data[::-1]
+        if self.backwards: data=data[::-1].copy()
         return LongTensor(data)
 
     def get_batch(self, i:int, seq_len:int) -> Tuple[LongTensor, LongTensor]:

--- a/tests/test_text_data.py
+++ b/tests/test_text_data.py
@@ -1,12 +1,17 @@
-from fastai.text.data import LanguageModelLoader, TextDataset
+from fastai.text.data import LanguageModelLoader, TextDataset, Tokenizer
 import pandas as pd
 import numpy as np
 
 
+class DummyTokenizer(Tokenizer):
+
+    def process_all(self, texts):
+        return [t.split() for t in texts]
+
 def test_should_load_backwards_lm():
     # GIVEN
-    df = pd.DataFrame([{0: 0, "text": " fast ai is a cool project"}, {0: 0, 'text': "hello world"}])
-    text_ds = TextDataset.from_df('/tmp/', df, label_cols=[0], txt_cols=["text"], min_freq=0)
+    df = pd.DataFrame([{0: 0, "text": "fast ai is a cool project"}, {0: 0, 'text': "hello world"}])
+    text_ds = TextDataset.from_df('/tmp/', df, label_cols=[0], txt_cols=["text"], min_freq=0, tokenizer=DummyTokenizer())
     # WHEN
     lml = LanguageModelLoader(text_ds, bs=1, backwards=True)
     # THEN

--- a/tests/test_text_data.py
+++ b/tests/test_text_data.py
@@ -1,0 +1,16 @@
+from fastai.text.data import LanguageModelLoader, TextDataset
+import pandas as pd
+import numpy as np
+
+
+def test_should_load_backwards_lm():
+    # GIVEN
+    df = pd.DataFrame([{0: 0, "text": " fast ai is a cool project"}, {0: 0, 'text': "hello world"}])
+    text_ds = TextDataset.from_df('/tmp/', df, label_cols=[0], txt_cols=["text"], min_freq=0)
+    # WHEN
+    lml = LanguageModelLoader(text_ds, bs=1, backwards=True)
+    # THEN
+    batch = lml.get_batch(0, 70)
+
+    as_text = [text_ds.vocab.itos[x] for x in batch[0]]
+    np.testing.assert_array_equal(as_text[:2], ["world", "hello"])


### PR DESCRIPTION
Currently it fails with the following error:
`ValueError: some of the strides of a given numpy array are negative. This is currently not supported, but will be added in future releases.`
A simple fix is to copy the data so that it is no longer a view.