### PR TITLE
Modify `_df_to_fns_labels`

### DIFF
--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -247,7 +247,7 @@ def _df_to_fns_labels(df:pd.DataFrame, fn_col:int=0, label_col:int=1,
     "Get image file names and labels from `df`."
     if label_delim:
         df.iloc[:,label_col] = list(csv.reader(df.iloc[:,label_col], delimiter=label_delim))
-    labels = df.iloc[:,label_col]
+    labels = df.iloc[:,label_col].values
     fnames = df.iloc[:,fn_col]
     if suffix: fnames = fnames.astype(str) + suffix
     return fnames, labels


### PR DESCRIPTION
Currently `ImageDataBunch.from_df` only works with dataframes with consecutive indices starting from `0`, because `np.concatenate` only takes series starting from `0`. This update modifies `_df_to_fns_labels` so that `from_df` accepts dataframes with arbitrary indices.

Details in notebook: https://gist.github.com/yang-zhang/0d74788f82c210a75fd0f549be948b98
Forum thread: https://forums.fast.ai/t/imagedatabunch-from-df-only-works-with-dataframe-with-consecutive-indices-starting-from-0/26685