### PR TITLE
fbeta error because of `y_true` dimension

### DIFF
--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -8,7 +8,7 @@ def fbeta(y_pred:Tensor, y_true:Tensor, thresh:float=0.5, beta:float=2, eps:floa
     beta2 = beta**2
     if sigmoid: y_pred = y_pred.sigmoid()
     y_pred = (y_pred>thresh).float()
-    y_true = y_true.float().reshape(-1,1)
+    y_true = y_true.float()[:,None]
     TP = (y_pred*y_true).sum(dim=1)
     prec = TP/(y_pred.sum(dim=1)+eps)
     rec = TP/(y_true.sum(dim=1)+eps)

--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -8,7 +8,7 @@ def fbeta(y_pred:Tensor, y_true:Tensor, thresh:float=0.5, beta:float=2, eps:floa
     beta2 = beta**2
     if sigmoid: y_pred = y_pred.sigmoid()
     y_pred = (y_pred>thresh).float()
-    y_true = y_true.float()
+    y_true = y_true.float().reshape(-1,1)
     TP = (y_pred*y_true).sum(dim=1)
     prec = TP/(y_pred.sum(dim=1)+eps)
     rec = TP/(y_true.sum(dim=1)+eps)


### PR DESCRIPTION
For a multi-label classification problem,

```
> preds,y = learn.get_preds()
> fbeta(preds,y)
```

gets the following error:

```
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-31-97bbcf467e8e> in <module>()
----> 1 fbeta(preds,y)

~/fastai/fastai/metrics.py in fbeta(y_pred, y_true, thresh, beta, eps, sigmoid)
     10     y_pred = (y_pred>thresh).float()
     11     y_true = y_true.float()
---> 12     TP = (y_pred*y_true).sum(dim=1)
     13     prec = TP/(y_pred.sum(dim=1)+eps)
     14     rec = TP/(y_true.sum(dim=1)+eps)

RuntimeError: The size of tensor a (676) must match the size of tensor b (3573) at non-singleton dimension 1
```

I found that it's because `y_pred` has dimension (batch_size, output_size) and `y_true` has dimension (batch_size,). Reshaping `y_true` to be (batch_size,1) seems to solve the problem.