### PR TITLE
Fix references to newly renamed _SAMPLE paths

### DIFF
--- a/fastai/datasets.py
+++ b/fastai/datasets.py
@@ -27,7 +27,7 @@ class URLs():
 
     @classmethod
     def get_adult(cls):
-        path = untar_data(cls.ADULT)
+        path = untar_data(cls.ADULT_SAMPLE)
         return pd.read_csv(path/'adult.csv')
 
     @classmethod
@@ -37,18 +37,18 @@ class URLs():
 
     @classmethod
     def get_imdb(cls, classifier=False):
-        path = untar_data(cls.IMDB)
+        path = untar_data(cls.IMDB_SAMPLE)
         data_class = TextClasDataBunch if classifier else TextLMDataBunch
         return data_class.from_csv(path)
 
     @classmethod
     def get_movie_lens(cls):
-        path = untar_data(cls.ML)
+        path = untar_data(cls.ML_SAMPLE)
         return pd.read_csv(path/'ratings.csv')
 
     @classmethod
     def download_wt103_model(cls):
-        path = untar_data(cls.IMDB)
+        path = untar_data(cls.IMDB_SAMPLE)
         model_path = path/'models'
         model_path.mkdir(exist_ok=True)
         url = 'http://files.fast.ai/models/wt103_v1/'

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,12 @@
+import pytest
+from fastai.datasets import URLs
+
+
+@pytest.mark.parametrize("dataset", [
+    'adult', 'mnist', 'movie_lens',
+    # 'imdb',  # imdb fails unless 'en' spacy language is available
+])
+def test_get_samples(dataset, tmpdir):
+    method = f'get_{dataset}'
+    df = getattr(URLs, method)()
+    assert df is not None


### PR DESCRIPTION
The sample attribute names were modified in commit 4524202 but some
classmethods still referred to the old names.

This was affecting the 'quick CLI test' in the README (`jupyter nbconvert --execute --ExecutePreprocessor.timeout=600 --to notebook examples/tabular.ipynb`), which now runs as expected.

This commit also adds some unit tests to check that the methods work. The `get_imdb` method currently fails unless the 'en' spacy language has been downloaded, and I'm not sure whether that's an expected prerequisite for the unit tests, so I've left it commented out for now.
