### PR TITLE
Strip space from file name when CSV has spaces

### DIFF
--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -254,7 +254,7 @@ def _df_to_fns_labels(df:pd.DataFrame, fn_col:int=0, label_col:int=1,
     if label_delim:
         df.iloc[:,label_col] = list(csv.reader(df.iloc[:,label_col], delimiter=label_delim))
     labels = df.iloc[:,label_col].values
-    fnames = df.iloc[:,fn_col]
+    fnames = df.iloc[:,fn_col].map(lambda x: x.lstrip())
     if suffix: fnames = fnames.astype(str) + suffix
     return fnames, labels
 


### PR DESCRIPTION
+ When the CSV has a space between columns, the fname series has a leading space which confuses the code which appends the path and folder with the file name. Example path which has problems (from the food-101 dataset labels.csv)
```
apple_pie, apple_pie/1005649
apple_pie, apple_pie/1014775
apple_pie, apple_pie/1026328
apple_pie, apple_pie/1028787
apple_pie, apple_pie/1043283
apple_pie, apple_pie/1050519
```