### PR TITLE
Load model using a specific device

### DIFF
--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -167,9 +167,10 @@ class Learner():
         "Save model with `name` to `self.model_dir`."
         torch.save(self.model.state_dict(), self.path/self.model_dir/f'{name}.pth')
 
-    def load(self, name:PathOrStr):
-        "Load model `name` from `self.model_dir`."
-        self.model.load_state_dict(torch.load(self.path/self.model_dir/f'{name}.pth'))
+    def load(self, name:PathOrStr, device:torch.device=None):
+        "Load model `name` from `self.model_dir` using `device`."
+        if device is None: device = self.data.device
+        self.model.load_state_dict(torch.load(self.path/self.model_dir/f'{name}.pth', map_location=device))
 
     def get_preds(self, is_test:bool=False) -> List[Tensor]:
         "Return predictions and targets on the valid or test set, depending on `is_test`."

--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -168,7 +168,7 @@ class Learner():
         torch.save(self.model.state_dict(), self.path/self.model_dir/f'{name}.pth')
 
     def load(self, name:PathOrStr, device:torch.device=None):
-        "Load model `name` from `self.model_dir` using `device`."
+        "Load model `name` from `self.model_dir` using `device`, defaulting to `self.data.device`."
         if device is None: device = self.data.device
         self.model.load_state_dict(torch.load(self.path/self.model_dir/f'{name}.pth', map_location=device))
 


### PR DESCRIPTION
When loading a model, `torch.load` fails if you're using the CPU version of fastai.

Now you can choose your device manually when loading a model or use the same one that your data is loaded with (which is the CPU when using the CPU fastai version)