### PR TITLE
Add n_labels attribute to TextDataSet Class and uses it when calling an RNNLearner.classifier

### DIFF
--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -32,6 +32,7 @@ class TextDataset(BaseTextDataset):
         self.label_cols = ifnone(label_cols, list(range(n_labels)))
         self.txt_cols,self.chunksize,self.name,self.df,self.create_mtd = txt_cols,chunksize,name,df,create_mtd
         self.vocab=vocab
+        self.n_labels = n_labels
         os.makedirs(self.path, exist_ok=True)
         if clear_cache: self.clear()
         if not self.check_toks(): self.tokenize()

--- a/fastai/text/learner.py
+++ b/fastai/text/learner.py
@@ -91,10 +91,8 @@ class RNNLearner(Learner):
         if lin_ftrs is None: lin_ftrs = [50]
         if ps is None:  ps = [0.1]
         ds = data.train_ds
-        vocab_size, lbl = ds.vocab_size, ds.labels[0]
-        n_class = (len(ds.classes) if (not is_listy(lbl) or (len(lbl) == 1))
-                   else len(lbl))
-        layers = [emb_sz*3] + lin_ftrs + [n_class]
+        vocab_size, n_labels = ds.vocab_size, ds.n_labels
+        layers = [emb_sz*3] + lin_ftrs + [n_labels]
         ps = [dps[4]] + ps
         model = get_rnn_classifier(bptt, max_len, n_class, vocab_size, emb_sz, nh, nl, pad_token,
                     layers, ps, input_p=dps[0], weight_p=dps[1], embed_p=dps[2], hidden_p=dps[3], qrnn=qrnn)


### PR DESCRIPTION
When you create a RNNLearner.classifier from a TextClasDataBunch where you didn't specify the classes, if the labels are in an array, and One Hot encoded, the RNNLearner.classifier gets the wrong number of label. 
This pull request adds n_labels attribute to TextDataSet so that if you call TextClasDataBunch(...,n_labels=n_labels,...) , and you call a RNNLearner.classifier on this TextClasDataBunch, you get the right number of labels in your model.
