### PR TITLE
softmax after relu

### DIFF
--- a/courses/dl1/lesson7-cifar10.ipynb
+++ b/courses/dl1/lesson7-cifar10.ipynb
@@ -209,7 +209,7 @@
     "        for l in self.layers:\n",
     "            l_x = l(x)\n",
     "            x = F.relu(l_x)\n",
-    "        return F.log_softmax(l_x, dim=-1)"
+    "        return F.log_softmax(x, dim=-1)"
    ]
   },
   {


### PR DESCRIPTION
Relu operation at the last layer seems to be ignored. The accuracy score increased by 0.1 after this change. Please let me know if I should submit the whole notebook with updated outputs. Or, should I open a topic in `fastai-dev`.

Thanks.


