### PR TITLE
Fix ML1 course, lesson4, error on plot_pdp

### DIFF
--- a/courses/ml1/lesson2-rf_interpretation.ipynb
+++ b/courses/ml1/lesson2-rf_interpretation.ipynb
@@ -3063,9 +3063,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def plot_pdp(feat, clusters=None, feat_name=None):\n",
-    "    feat_name = feat_name or feat\n",
-    "    p = pdp.pdp_isolate(m, x, feat)\n",
+    "def plot_pdp(feat_name, clusters=None):\n",
+    "    p = pdp.pdp_isolate(m, x, feature=feat_name, model_features=x.columns)\n",
     "    return pdp.pdp_plot(p, feat_name, plot_lines=True, \n",
     "                        cluster=clusters is not None, n_cluster_centers=clusters)"
    ]


### PR DESCRIPTION
In ML1, lesson 4, the code for the function plot_pdp has an error if it's run as is: TypeError: pdp_isolate() missing 1 required positional argument: ‘feature’
See this discussion on the forums: https://forums.fast.ai/t/error-when-i-try-to-create-plot-in-ml-lesson-4/24697

pdp_isolate takes an additional required positional argument: https://github.com/SauceCat/PDPbox/blob/master/pdpbox/pdp.py#L68