### PR TITLE
Fix tabular example

### DIFF
--- a/examples/tabular.ipynb
+++ b/examples/tabular.ipynb
@@ -179,7 +179,7 @@
    ],
    "source": [
     "path = untar_data(URLs.ADULT_SAMPLE)\n",
-    "df = URLs.get_adult()\n",
+    "df = pd.read_csv(path/'adult.csv')\n",
     "train_df, valid_df = df[:-2000].copy(),df[-2000:].copy()\n",
     "train_df.head()"
    ]


### PR DESCRIPTION
Fix tabular example notebook line from:
`df = URLs.get_adult()`
to:
`df = pd.read_csv(path/'adult.csv')`
