### PR TITLE
RNNLearner.classifier multilabel issue

### DIFF
--- a/fastai/text/learner.py
+++ b/fastai/text/learner.py
@@ -97,7 +97,7 @@ class RNNLearner(Learner):
         if ps is None:  ps = [0.1]
         ds = data.train_ds
         vocab_size, lbl = ds.vocab_size, ds.labels[0]
-        n_class = (len(ds.classes) if (not is_listy(lbl) or (len(lbl) == 1))
+        n_class = (len(ds.classes) if (not isinstance(lbl, collections.Iterable) or (len(lbl) == 1))
                    else len(lbl))
         layers = [emb_sz*3] + lin_ftrs + [n_class]
         ps = [dps[4]] + ps

--- a/tests/test_text_train.py
+++ b/tests/test_text_train.py
@@ -40,7 +40,7 @@ def text_df(n_labels):
     df = pd.DataFrame(data)
     return df
 
-@pytest.mark.skip(reason="multilabel part of this test will fail without the fix to https://github.com/fastai/fastai/issues/946")
+# @pytest.mark.skip(reason="multilabel part of this test will fail without the fix to https://github.com/fastai/fastai/issues/946")
 def test_classifier():
     for n_labels in [1, 8]:
         path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data', 'tmp')

--- a/tests/test_text_train.py
+++ b/tests/test_text_train.py
@@ -40,7 +40,6 @@ def text_df(n_labels):
     df = pd.DataFrame(data)
     return df
 
-# @pytest.mark.skip(reason="multilabel part of this test will fail without the fix to https://github.com/fastai/fastai/issues/946")
 def test_classifier():
     for n_labels in [1, 8]:
         path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data', 'tmp')

--- a/tests/test_text_train.py
+++ b/tests/test_text_train.py
@@ -28,3 +28,28 @@ def learn():
 
 def test_val_loss(learn):
     assert learn.validate()[1] > 0.3
+
+def text_df(n_labels):
+    data = []
+    texts = ["fast ai is a cool project", "hello world"]
+    for ind, text in enumerate(texts):
+        sample = {}
+        for label in range(n_labels): sample[label] = ind%2
+        sample["text"] = text
+        data.append(sample)
+    df = pd.DataFrame(data)
+    return df
+
+@pytest.mark.skip(reason="multilabel part of this test will fail without the fix to https://github.com/fastai/fastai/issues/946")
+def test_classifier():
+    for n_labels in [1, 8]:
+        path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data', 'tmp')
+        os.makedirs(path)
+        try:
+            df = text_df(n_labels=n_labels)
+            data = TextClasDataBunch.from_df(path, train_df=df, valid_df=df, label_cols=list(range(n_labels)), txt_cols=["text"])
+            classifier = RNNLearner.classifier(data)
+            layers = [l for l in classifier.layer_groups[-1].modules()]
+            assert layers[-1].out_features == n_labels if n_labels > 1 else n_labels+1
+        finally:
+            shutil.rmtree(path)


### PR DESCRIPTION
Issue: https://github.com/fastai/fastai/issues/946
Discussion: https://forums.fast.ai/t/fastai-rnnlearner-classifier-wrong-size-of-head-of-classifier/27960

The added test checks both the singlelabel and multilabel case:
- without fix: singlelabel part of the test will work, multilabel part will fail
- with fix: both parts should work