### PR TITLE
create x in cuda for model_sizes()

### DIFF
--- a/fastai/callbacks/hooks.py
+++ b/fastai/callbacks/hooks.py
@@ -76,7 +76,7 @@ def model_sizes(m:Model, size:tuple=(256,256), full:bool=True) -> Tuple[Sizes,Te
     "Pass a dummy input through the model to get the various sizes."
     hooks = hook_outputs(m)
     ch_in = in_channels(m)
-    x = torch.zeros(1,ch_in,*size).cuda()
+    x = torch.zeros(1,ch_in,*size).cuda() if next(m.parameters()).is_cuda else torch.zeros(1,ch_in,*size).cpu()
     x = m.eval()(x)
     res = [o.stored.shape for o in hooks]
     if not full: hooks.remove()

--- a/fastai/callbacks/hooks.py
+++ b/fastai/callbacks/hooks.py
@@ -76,7 +76,7 @@ def model_sizes(m:Model, size:tuple=(256,256), full:bool=True) -> Tuple[Sizes,Te
     "Pass a dummy input through the model to get the various sizes."
     hooks = hook_outputs(m)
     ch_in = in_channels(m)
-    x = torch.zeros(1,ch_in,*size).cuda() if next(m.parameters()).is_cuda else torch.zeros(1,ch_in,*size).cpu()
+    x = next(m.parameters()).new(1,ch_in,*size)
     x = m.eval()(x)
     res = [o.stored.shape for o in hooks]
     if not full: hooks.remove()

--- a/fastai/callbacks/hooks.py
+++ b/fastai/callbacks/hooks.py
@@ -76,7 +76,7 @@ def model_sizes(m:Model, size:tuple=(256,256), full:bool=True) -> Tuple[Sizes,Te
     "Pass a dummy input through the model to get the various sizes."
     hooks = hook_outputs(m)
     ch_in = in_channels(m)
-    x = torch.zeros(1,ch_in,*size)
+    x = torch.zeros(1,ch_in,*size).cuda()
     x = m.eval()(x)
     res = [o.stored.shape for o in hooks]
     if not full: hooks.remove()


### PR DESCRIPTION
In my case, as default, tensor x in model_sizes() is created in cpu rather than cuda. It leads to error at `x = m.eval()(x)`.

Link in forum: [error x in model_sizes](https://forums.fast.ai/t/developer-chat/22363/335)