### PR TITLE
Fix ImageDataBunch.from_folder bug

### DIFF
--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -283,7 +283,7 @@ class ImageDataBunch(DataBunch):
         else: datasets = ImageClassificationDataset.from_folder(path/train, valid_pct=valid_pct)
 
         if test: datasets.append(ImageClassificationDataset.from_single_folder(
-            path/test,classes=train_ds.classes))
+            path/test,classes=datasets[0].classes))
         return cls.create(*datasets, path=path, **kwargs)
 
 


### PR DESCRIPTION
Bug when using ImageDataBunch.from_folder and valid_pct with test.  

train_ds is not created when using valid_pct so instead of using train_ds, the test will use datasets[0].classes which is available if using train and valid folders or just one folder and a valid_pct.

Discussed here: 
https://forums.fast.ai/t/bug-when-using-imagedatabunch-from-folder-and-valid-pct-with-test/28292

This is the code that won't work without this fix: 
```
data = ImageDataBunch.from_folder(PATH, train="train", test="test", ds_tfms=get_transforms(), size=112, bs=64, valid_pct=0.90)
```
