### PR TITLE
Made TextDataBunch call DataBunch.create properly.

### DIFF
--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -352,9 +352,7 @@ class TextDataBunch(DataBunch):
     @classmethod
     def create(cls, datasets:Collection[TextDataset], path:PathOrStr, **kwargs) -> DataBunch:
         "Call's `DataBunch.create` but changes the arguments so it'll work OK"
-        train_ml, valid_ml = datasets[:2]
-        test_ml = None if len(datasets) < 3 else datasets[2]
-        return DataBunch.create(train_ml, valid_ml, test_ml, path=path)
+        return DataBunch.create(*datasets, path=path, **kwargs)
 
 
 class TextLMDataBunch(TextDataBunch):

--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -349,6 +349,14 @@ class TextDataBunch(DataBunch):
                                         shuffle=shuffle, vocab=train_ds.vocab, **txt_kwargs))
         return cls.create(datasets, path, **kwargs)
 
+    @classmethod
+    def create(cls, datasets:Collection[TextDataset], path:PathOrStr, **kwargs) -> DataBunch:
+        "Call's `DataBunch.create` but changes the arguments so it'll work OK"
+        train_ml, valid_ml = datasets[:2]
+        test_ml = None if len(datasets) < 3 else datasets[2]
+        return DataBunch.create(train_ml, valid_ml, test_ml, path=path)
+
+
 class TextLMDataBunch(TextDataBunch):
     "Create a `TextDataBunch` suitable for training a language model."
     @classmethod


### PR DESCRIPTION
DataBunch.create takes three initial args 'train_ds, valid_ds, test_ds',
we were passing it a list of 'datasets', which it was putting all into
train_ds.

Now we break those out before calling DataSet.

Now some of the text examples and documentation are starting to work for
me.

If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR.
