### PR TITLE
Correct return type for create_cnn

### DIFF
--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -55,7 +55,7 @@ class ClassificationLearner(Learner):
 def create_cnn(data:DataBunch, arch:Callable, cut:Union[int,Callable]=None, pretrained:bool=True,
                 lin_ftrs:Optional[Collection[int]]=None, ps:Floats=0.5,
                 custom_head:Optional[nn.Module]=None, split_on:Optional[SplitFuncOrIdxList]=None,
-                classification:bool=True, **kwargs:Any)->None:
+                classification:bool=True, **kwargs:Any)->ClassificationLearner:
     "Build convnet style learners."
     assert classification, 'Regression CNN not implemented yet, bug us on the forums if you want this!'
     meta = cnn_config(arch)


### PR DESCRIPTION
Sorry new PR because the previous one didn't pass a the signature check and I couldn't find a way to re-check.
______________________________
Most because I was working in PyCharm and the linter kept complaining that the return type of `create_cnn` is `None` which shouldn't be correct. 

Solves this issue that I opened earlier
https://github.com/fastai/fastai/issues/1032