### PR TITLE
fix: call slow/memory-intensive make_button and make_img methods only for each batch at time of render, not for the entire list on initial render.

### DIFF
--- a/fastai/widgets/file_picker.py
+++ b/fastai/widgets/file_picker.py
@@ -17,9 +17,7 @@ class FileDeleter():
         self.all_images,self.batch = [],[]
         self.batch_size = batch_size
         for fp in [o for o in map(Path,file_paths) if o.is_file()]:
-            img = self.make_img(fp)
-            delete_btn = self.make_button('Delete', file_path=fp, handler=self.on_delete)
-            self.all_images.append((img, delete_btn, fp))
+            self.all_images.append(fp)
         self.render()
 
     def make_img(self, file_path, height='250px', width='300px', format='jpg'):
@@ -36,7 +34,7 @@ class FileDeleter():
             if (delete_btn.flagged_for_delete == True): self.delete_image(fp)
             to_remove.append((img, delete_btn, fp))
         for img, delete_btn, fp in to_remove:
-            self.all_images.remove((img, delete_btn, fp))
+            self.all_images.remove(fp)
         self.empty_batch()
         self.render()
 
@@ -67,7 +65,9 @@ class FileDeleter():
         clear_output()
         if (len(self.all_images) == 0): return display('No images to show :)')
         widgets_to_render = []
-        for img, delete_btn, fp in self.all_images[:self.batch_size]:
+        for fp in self.all_images[:self.batch_size]:
+            img = self.make_img(fp)
+            delete_btn = self.make_button('Delete', file_path=fp, handler=self.on_delete)
             widgets_to_render.append(self.make_vertical_box([img, delete_btn]))
             self.batch.append((img, delete_btn, fp))
         display(self.make_horizontal_box(widgets_to_render))


### PR DESCRIPTION
If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR.