### PR TITLE
Add RemoveMaxCorrelation TabularTransform

### DIFF
--- a/fastai/tabular/transform.py
+++ b/fastai/tabular/transform.py
@@ -1,7 +1,8 @@
 "Cleaning and feature engineering functions for structured data"
 from ..torch_core import *
 
-__all__ = ['Categorify', 'FillMissing', 'FillStrategy', 'TabularTransform']
+__all__ = ['Categorify', 'FillMissing', 'FillStrategy', 'TabularTransform',
+           'RemoveMaxCorrelation']
 
 @dataclass
 class TabularTransform():
@@ -63,3 +64,40 @@ class FillMissing(TabularTransform):
                     df[name+'_na'] = pd.isnull(df[name])
                     if name+'_na' not in self.cat_names: self.cat_names.append(name+'_na')
                 df[name] = df[name].fillna(self.na_dict[name])
+
+@dataclass
+class RemoveMaxCorrelation(TabularTransform):
+    "Remove variables above a certain correlation with the target variable."
+    target_col:str
+    max_correlation:float=0.95
+    remove_cols:bool=True
+    check_sample:float=1.0
+    verbose:bool=True
+
+    def apply_train(self, df:DataFrame):
+        self.columns_to_drop = []
+        for n in self.cont_names:
+            current_column = df[n]
+            if self.check_sample < 1.0:
+                n_correlation = (current_column
+                              .sample(int(len(current_column) * check_sample))
+                              .corr(df[self.target_col]))
+            else:
+                n_correlation = current_column.corr(df[self.target_col])
+            if n_correlation > self.max_correlation:
+                if self.verbose:
+                    if self.remove_cols:
+                        print(("Dropping column '%s' since its correlation"
+                               + " with the target variable of %0.4f is above"
+                               + " the threshold") % (n, n_correlation))
+                    else:
+                        print(("Attention: The correlation with the target"
+                               + "variable of column '%s' is %0.4f and thus"
+                               + " above the threshold") % (n, n_correlation))
+                if self.remove_cols:
+                    self.columns_to_drop.append(n)
+
+        df.drop(columns=self.columns_to_drop, inplace=True)
+
+    def apply_test(self, df:DataFrame):
+        df.drop(columns=self.columns_to_drop, inplace=True)

--- a/tests/test_tabular_transform.py
+++ b/tests/test_tabular_transform.py
@@ -60,3 +60,18 @@ def test_fill_missing_returns_correct_medians():
     # Make sure the train median is used in both cases
     assert train_df.equals(expected_filled_train_df)
     assert valid_df.equals(expected_filled_valid_df)
+    
+def test_remove_max_correlation():
+    train_df = pd.DataFrame({'A': [0, 0], 'B': [0, 1], 'T': [0, 1]})
+    valid_df = pd.DataFrame({'A': [0, 1], 'B': [1, 1], 'T': [0, 1]})
+    
+    remove_max_correlation_transform = RemoveMaxCorrelation([], ['A', 'B'],
+                                                            target_col='T')
+    remove_max_correlation_transform.apply_train(train_df)
+    remove_max_correlation_transform.apply_test(valid_df)
+    
+    # Make sure column 'B' is dropped for both train and test set
+    # Also, column 'A' must not be dropped for the test set even though its
+    # correlation in the test set is above the threshold
+    assert train_df.equals(pd.DataFrame({'A': [0, 0], 'T': [0, 1]}))
+    assert valid_df.equals(pd.DataFrame({'A': [0, 1], 'T': [0, 1]}))


### PR DESCRIPTION
This PR adds a new TabularTransform class to automatically remove features that correlate with the target variable more than a given threshold (0.95 by default). The PR is heavily inspired by TransmogrifAI's [SanityChecker](https://github.com/salesforce/TransmogrifAI/blob/master/core/src/main/scala/com/salesforce/op/stages/impl/preparators/SanityChecker.scala) and includes the required unit tests.