### PR TITLE
Add RemoveMinVariance TabularTransform

### DIFF
--- a/fastai/tabular/transform.py
+++ b/fastai/tabular/transform.py
@@ -65,6 +65,7 @@ class FillMissing(TabularTransform):
                     if name+'_na' not in self.cat_names: self.cat_names.append(name+'_na')
                 df[name] = df[name].fillna(self.na_dict[name])
 
+@dataclass
 class RemoveMinVariance(TabularTransform):
     "Remove variables below a certain variance threshold."
     min_variance:float=0.00001

--- a/tests/test_tabular_transform.py
+++ b/tests/test_tabular_transform.py
@@ -69,8 +69,8 @@ def test_remove_min_variance():
     remove_min_variance_transform.apply_train(train_df)
     remove_min_variance_transform.apply_test(valid_df)
     
-    # Make sure column 'A' is dropped for both train and test set.
-    # Also, column 'B' must not be dropped for the test set even though its
-    # variance in the test set is below the threshold.
+    # Make sure column 'B' is dropped for both train and test set
+    # Also, column 'A' must not be dropped for the test set even though its
+    # variance in the test set is below the threshold
     assert train_df.equals(pd.DataFrame({'A': [0., 1.]}))
     assert valid_df.equals(pd.DataFrame({'A': [0., 0.]}))

--- a/tests/test_tabular_transform.py
+++ b/tests/test_tabular_transform.py
@@ -60,3 +60,17 @@ def test_fill_missing_returns_correct_medians():
     # Make sure the train median is used in both cases
     assert train_df.equals(expected_filled_train_df)
     assert valid_df.equals(expected_filled_valid_df)
+
+def test_remove_min_variance():
+    train_df = pd.DataFrame({'A': [0., 1.], 'B': [0., 0.]})
+    valid_df = pd.DataFrame({'A': [0., 0.], 'B': [0., 1.]})
+    
+    remove_min_variance_transform = RemoveMinVariance([], ['A', 'B'])
+    remove_min_variance_transform.apply_train(train_df)
+    remove_min_variance_transform.apply_test(valid_df)
+    
+    # Make sure column 'A' is dropped for both train and test set.
+    # Also, column 'B' must not be dropped for the test set even though its
+    # variance in the test set is below the threshold.
+    assert train_df.equals(pd.DataFrame({'A': [0., 1.]}))
+    assert valid_df.equals(pd.DataFrame({'A': [0., 0.]}))


### PR DESCRIPTION
This PR adds a new TabularTransform class to automatically remove features with a variance below a given threshold (0.00001 by default) as we expect these features to not add any value to the model's predictive power. Like #1039, this PR is also heavily inspired by TransmogrifAI's [SanityChecker](https://github.com/salesforce/TransmogrifAI/blob/master/core/src/main/scala/com/salesforce/op/stages/impl/preparators/SanityChecker.scala) and includes the required unit tests.