### PR TITLE
move model output to CPU

### DIFF
--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -18,7 +18,7 @@ def loss_batch(model:nn.Module, xb:Tensor, yb:Tensor, loss_func:OptLossFunc=None
     out = model(*xb)
     out = cb_handler.on_loss_begin(out)
 
-    if not loss_func: return to_detach(out), yb[0].detach()
+    if not loss_func: return to_detach(out.cpu()), yb[0].cpu().detach()
     loss = loss_func(out, *yb)
 
     if opt is not None:


### PR DESCRIPTION
fixes gpu memory leakage when no loss function is defined in `loss_batch`