### PR TITLE
Changed glob pattern in TextDataset.from_folder()

### DIFF
--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -160,7 +160,7 @@ class TextDataset(BaseTextDataset):
         path = Path(folder)/'tmp'
         os.makedirs(path, exist_ok=True)
         texts = []
-        for fname in (Path(folder)/name).glob('*.*'):
+        for fname in (Path(folder)/name).glob('*'):
             texts.append(fname.open('r', encoding='utf8').read())
         texts,labels = np.array(texts),np.array([classes[0]] * len(texts))
         if shuffle:


### PR DESCRIPTION
Changed TextDataset.from_folder() so it now grabs all files in folder, it used to assume *.* naming. This meant that the clinical notes I was processing, which didn't have a filetype extension, were producing an empty dataframe that was creating errors down the line.

