### PR TITLE
Update decimals normalized plot_confusion_matrix

### DIFF
--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -105,7 +105,7 @@ class ClassificationInterpretation():
         cm = ((self.pred_class==x[:,None]) & (self.y_true==x[:,None,None])).sum(2)
         return to_np(cm)
 
-    def plot_confusion_matrix(self, normalize:bool=False, title:str='Confusion matrix', cmap:Any="Blues", **kwargs)->None:
+    def plot_confusion_matrix(self, normalize:bool=False, title:str='Confusion matrix', cmap:Any="Blues", norm_dec:int=2, **kwargs)->None:
         "Plot the confusion matrix, passing `kawrgs` to `plt.figure`."
         # This function is mainly copied from the sklearn docs
         cm = self.confusion_matrix()
@@ -119,7 +119,7 @@ class ClassificationInterpretation():
         if normalize: cm = cm.astype('float') / cm.sum(axis=1)[:, np.newaxis]
         thresh = cm.max() / 2.
         for i, j in itertools.product(range(cm.shape[0]), range(cm.shape[1])):
-            plt.text(j, i, cm[i, j], horizontalalignment="center", color="white" if cm[i, j] > thresh else "black")
+            plt.text(j, i, f'{cm[i, j]:.{norm_dec}f}', horizontalalignment="center", color="white" if cm[i, j] > thresh else "black")
 
         plt.tight_layout()
         plt.ylabel('Actual')


### PR DESCRIPTION
Update plot_confusion_matrix to include "norm_dec" parameter to set decimals for normalized confusion matrix plot.

Notebook: https://github.com/MicPie/fastai_course_v3/blob/master/ClassificationInterpretation_normalized_PR.ipynb

Kind regards
Michael

If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR.
