### PR TITLE
Fix typo in dl1/lesson3-rossman

### DIFF
--- a/courses/dl1/lesson3-rossman.ipynb
+++ b/courses/dl1/lesson3-rossman.ipynb
@@ -2586,7 +2586,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Google trends data has a special category for the whole of the Germany - we'll pull that out so we can use it explicitly."
+    "The Google trends data has a special category for the whole of Germany - we'll pull that out so we can use it explicitly."
    ]
   },
   {


### PR DESCRIPTION
Removed the word "the": whole of **~the~** Germany