### PR TITLE
Order of predictions in RNNLearner.get_preds()

### DIFF
--- a/fastai/text/learner.py
+++ b/fastai/text/learner.py
@@ -7,7 +7,6 @@ from ..datasets import untar_data
 from ..metrics import accuracy
 from ..train import GradientClipping
 from .models import get_language_model, get_rnn_classifier
-from ..basic_train import _loss_func2activ
 
 __all__ = ['RNNLearner', 'convert_weights', 'lm_split', 'rnn_classifier_split']
 
@@ -69,9 +68,7 @@ class RNNLearner(Learner):
 
     def get_preds(self, ds_type:DatasetType=DatasetType.Valid, with_loss:bool=False, n_batch:Optional[int]=None, pbar:Optional[PBar]=None, ordered=True) -> List[Tensor]:
         "Return predictions and targets on the valid, train, or test set, depending on `ds_type`."
-        lf = self.loss_func if with_loss else None
-        preds = get_preds(self.model, self.dl(ds_type), cb_handler=CallbackHandler(self.callbacks),
-                         activ=_loss_func2activ(self.loss_func), loss_func=lf, n_batch=n_batch, pbar=pbar)
+        preds = super().get_preds(ds_type=ds_type, with_loss=with_loss, n_batch=n_batch, pbar=pbar)
         if ordered and hasattr(self.dl(ds_type), 'sampler'):
             sampler = [i for i in self.dl(ds_type).sampler]
             reverse_sampler = np.argsort(sampler)

--- a/tests/test_text_order_preds.py
+++ b/tests/test_text_order_preds.py
@@ -1,0 +1,13 @@
+import pytest
+from fastai import *
+from fastai.text import *
+
+def test_order_preds():
+    path = untar_data(URLs.IMDB_SAMPLE)
+    data_lm = TextLMDataBunch.from_csv(path)
+    data_clas = TextClasDataBunch.from_csv(path, vocab=data_lm.train_ds.vocab)
+    learn = RNNLearner.classifier(data_clas)
+    preds = learn.get_preds()
+    true_value = pd.read_csv(path/'valid.csv', header=None).iloc[:,0]
+    assert np.all(torch.Tensor.numpy(preds[1]) == true_value)
+    


### PR DESCRIPTION
Referencing this issue : https://github.com/fastai/fastai/issues/975
This PR makes RNNLearner input predictions in the original order. This PR also contains a test that checks  if the true value contained in get_preds[1] is equal to the true_value that was specified when creating the TextClasDataBunch.

I also hesitated to add a test that verified that get_preds(ordered=False) and get_preds(ordered=True) had the same loss. The reason for that is that the output might go through a sigmoid/softmax to be probabilities and you can't just take the loss from the learner. I might add a test later, but feel free to do it yourself.