### PR TITLE
Updated the import statement to resolve NameError: name 'DatasetType' is not defined

### DIFF
--- a/fastai/widgets/file_picker.py
+++ b/fastai/widgets/file_picker.py
@@ -1,4 +1,5 @@
 from ..torch_core import *
+from ..basic_data import *
 from ..basic_train import *
 from ..vision.data import *
 from ..vision.transform import *


### PR DESCRIPTION
When running lesson2-download.ipynb notebook, there was an issue in file_picker.py:

<img width="810" alt="screen shot 2018-11-06 at 6 01 33 pm" src="https://user-images.githubusercontent.com/5401333/48053416-08266480-e1ee-11e8-898b-4c041fc4631d.png">

Updated the import statements to include basic_data.py to resolve the issue.