### PR TITLE
set drop_last=True for batch norm training safe

### DIFF
--- a/fastai/basic_data.py
+++ b/fastai/basic_data.py
@@ -118,7 +118,7 @@ class DataBunch():
         "`DataBunch` factory. `bs` batch size, `tfms` for `Dataset`, `tfms` for `DataLoader`."
         datasets = [train_ds,valid_ds]
         if test_ds is not None: datasets.append(test_ds)
-        dls = [DataLoader(*o, num_workers=num_workers) for o in
+        dls = [DataLoader(*o, num_workers=num_workers, drop_last=True) for o in
                zip(datasets, (bs,bs*2,bs*2), (True,False,False))]
         return cls(*dls, path=path, device=device, tfms=tfms, collate_fn=collate_fn)
 


### PR DESCRIPTION
# Objective
Make training of models with batch normalization safer.

# Details
Current initialization of `DataLoader` causes errors when `len(data_set) % batch_size = 1` and BatchNorm is used.