### PR TITLE
Add kwargs for Segmentation Dataset to accept shape argument

### DIFF
--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -147,14 +147,15 @@ class ImageMultiDataset(ImageClassificationBase):
 
 class SegmentationDataset(ImageClassificationBase):
     "A dataset for segmentation task."
-    def __init__(self, x:FilePathList, y:FilePathList, classes:Collection[Any]):
+    def __init__(self, x:FilePathList, y:FilePathList, classes:Collection[Any], **kwargs:Any):
         assert len(x)==len(y)
         super().__init__(x, classes)
         self.y = np.array(y)
         self.loss_func = CrossEntropyFlat()
         self.mask_opener = open_mask
+        self.kwargs = kwargs
 
-    def _get_y(self,i): return self.mask_opener(self.y[i])
+    def _get_y(self,i): return self.mask_opener(self.y[i], **self.kwargs)
 
 class ObjectDetectDataset(ImageClassificationBase):
     "A dataset with annotated images."

--- a/fastai/vision/image.py
+++ b/fastai/vision/image.py
@@ -378,7 +378,7 @@ def open_mask(fn:PathOrStr, div=False, convert_mode='L')->ImageSegment:
 
 def open_mask_rle(mask_rle:str, shape:Tuple[int, int])->ImageSegment:
     "Return `ImageSegment` object create from run-length encoded string in `mask_lre` with size in `shape`."
-    x = FloatTensor(rle_decode(mask_rle, shape).astype(np.uint8))
+    x = FloatTensor(rle_decode(str(mask_rle), shape).astype(np.uint8))
     x = x.view(shape[1], shape[0], -1)
     return ImageSegment(x.permute(2,0,1))
 


### PR DESCRIPTION
The current SegmentationDataset has a np.array type for y, while open_mask_rle accept str only, so I add one step to convert np.array str type to a pure str. I am not sure is this the best way to do, but it works. 

I also have to add a kwargs because there is no way to pass an argument `shape` if I want to use open_mask_rle as the mask_opener.

A expected way to call the function will be:
databunch = (ImageFileList.from_folder(TRAIN)
        .label_from_df(image_df)
 .random_split_by_pct(0.2)
 .datasets(SegmentationRLEDataset, classes=codes, shape=(768,768))
   .transform(get_transforms(), size=size, tfm_y=True)
        .databunch(bs=bs)
        .normalize(imagenet_stats)
)

https://forums.fast.ai/t/segmentation-dataset-for-run-length-encoding/28967/3