### PR TITLE
Convert str to make sure it is a str type for open_mask_str

### DIFF
--- a/fastai/vision/image.py
+++ b/fastai/vision/image.py
@@ -380,7 +380,7 @@ def open_mask(fn:PathOrStr, div=False, convert_mode='L')->ImageSegment:
 
 def open_mask_rle(mask_rle:str, shape:Tuple[int, int])->ImageSegment:
     "Return `ImageSegment` object create from run-length encoded string in `mask_lre` with size in `shape`."
-    x = FloatTensor(rle_decode(mask_rle, shape).astype(np.uint8))
+    x = FloatTensor(rle_decode(str(mask_rle), shape).astype(np.uint8))
     x = x.view(shape[1], shape[0], -1)
     return ImageSegment(x.permute(2,0,1))
 


### PR DESCRIPTION
 Currently if a np.array('1') pass to the function, it will fail as it does not have a str.split() method. Add str(mask_rle) to make sure it is a pure string.

Follow up on this pull request.
#1096 