### PR TITLE
fix wrong dimension in dice

### DIFF
--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -24,7 +24,7 @@ def accuracy_thresh(y_pred:Tensor, y_true:Tensor, thresh:float=0.5, sigmoid:bool
 def dice(input:Tensor, targs:Tensor, iou:bool=False)->Rank0Tensor:
     "Dice coefficient metric for binary target. If iou=True, returns iou metric, classic for segmentation problems."
     n = targs.shape[0]
-    input = input.argmax(dim=-1).view(n,-1)
+    input = input.argmax(dim=1).view(n,-1)
     targs = targs.view(n,-1)
     intersect = (input*targs).sum().float()
     union = (input+targs).sum().float()


### PR DESCRIPTION
I believe in a Segmentation , the 1st dimension is the batch size, the 2nd dimension is the number of class. Therefore input.argmax() should be taking the 2nd dimension (dim=1) instead of the last dimension.