### PR TITLE
plot_losses of only part of the train/val losses

### DIFF
--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -313,14 +313,22 @@ class Recorder(LearnerCallback):
         ax.set_xscale('log')
         ax.xaxis.set_major_formatter(plt.FormatStrFormatter('%.0e'))
 
-    def plot_losses(self)->None:
+    def plot_losses(self, last:int=None)->None:
         "Plot training and validation losses."
+        if last is None:
+            last=len(self.nb_batches)
+        else:
+            assert last<=len(self.nb_batches), "We can only plot up to the last %d epochs. Please adapt 'last' parameter accordingly."%len(self.nb_batches)
         _, ax = plt.subplots(1,1)
-        iterations = range_of(self.losses)
-        ax.plot(iterations, self.losses)
-        val_iter = self.nb_batches
-        val_iter = np.cumsum(val_iter)
-        ax.plot(val_iter, self.val_losses)
+        l_b=np.sum(self.nb_batches[-last:])
+        iterations = range_of(self.losses)[-l_b:]
+        ax.plot(iterations, self.losses[-l_b:], label='Train')
+        val_iter = self.nb_batches[-last:]
+        val_iter = np.cumsum(val_iter)+np.sum(self.nb_batches[:-last])
+        ax.plot(val_iter, self.val_losses[-last:], label='Validation')
+        ax.set_ylabel('Loss')
+        ax.set_xlabel('Batches processed')
+        ax.legend()
 
     def plot_metrics(self)->None:
         "Plot metrics collected during training."


### PR DESCRIPTION
I implemented in the plot_losses() function the capability of accept an integer as parameters with the number of epochs you want to actually plot.

In the following pictures you see the usecase on a mock training: the full plot in the first (3 epochs), and the plot with only the last 2 epochs losses.

I also added labels.

Since the modification is very basic, I implemented no tests. Instead, I simply added an assertion check on the input.

<img width="386" alt="screen shot 2018-11-09 at 12 02 41" src="https://user-images.githubusercontent.com/8724860/48311557-b725c000-e5a1-11e8-99be-4c28d3e13c59.png">
<img width="422" alt="screen shot 2018-11-09 at 12 02 55" src="https://user-images.githubusercontent.com/8724860/48311558-b725c000-e5a1-11e8-9f5c-f678df72d216.png">

