### PR TITLE
Fix the QRNN performance issue when no split_fn is provided.

### DIFF
--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -119,7 +119,7 @@ class TokenizedDataset(TextBase):
 def _join_texts(texts:Collection[str], mark_fields:bool=True):
     if is1d(texts): texts = texts[:,None]
     df = pd.DataFrame({i:texts[:,i] for i in range(texts.shape[1])})
-    text_col = f'{FLD} {1} ' + df[0] if mark_fields else df[txt_cols[0]]
+    text_col = f'{FLD} {1} ' + df[0] if mark_fields else df[0]
     for i in range(1,len(df.columns)):
         text_col += (f' {FLD} {i+1} ' if mark_fields else ' ') + df[i]
     return text_col.values

--- a/fastai/text/models.py
+++ b/fastai/text/models.py
@@ -30,7 +30,7 @@ class WeightDropout(nn.Module):
             #Makes a copy of the weights of the selected layers.
             w = getattr(self.module, layer)
             self.register_parameter(f'{layer}_raw', nn.Parameter(w.data))
-        self.reset()
+            self.module._parameters[layer] = F.dropout(w, p=self.weight_p, training=False)
 
     def _setweights(self):
         "Apply dropout to the raw weights."

--- a/fastai/text/models.py
+++ b/fastai/text/models.py
@@ -30,6 +30,7 @@ class WeightDropout(nn.Module):
             #Makes a copy of the weights of the selected layers.
             w = getattr(self.module, layer)
             self.register_parameter(f'{layer}_raw', nn.Parameter(w.data))
+        self.reset()
 
     def _setweights(self):
         "Apply dropout to the raw weights."

--- a/fastai/text/qrnn/qrnn.py
+++ b/fastai/text/qrnn/qrnn.py
@@ -46,6 +46,8 @@ class QRNNLayer(nn.Module):
         self.linear = nn.Linear(self.window * self.input_size, 3 * self.hidden_size if self.output_gate else 2 * self.hidden_size)
 
     def reset(self):
+        for c in self.children():
+            if hasattr(c, 'reset'): c.reset()
         # If you are saving the previous value of x, you should call this when starting with a new state
         self.prevX = None
 

--- a/tests/test_mod_independency.py
+++ b/tests/test_mod_independency.py
@@ -93,6 +93,8 @@ def test_setup_parser():
 
 # fastai must not depend on 'extras_require' package requirements from setup.py,
 # which won't be installed by default
+if 'extras_require' not in data:
+    data['extras_require']= {'dev':[]}
 extras_require = [(re.split(r'[>=<]+',x))[0] for x in data['extras_require']['dev']]
 exceptions = ['pytest'] # see the top for the reason for exceptions
 unwanted_deps = [x for x in extras_require if x not in exceptions]

--- a/tests/test_text_train.py
+++ b/tests/test_text_train.py
@@ -37,7 +37,8 @@ def manual_seed(seed=42):
 def test_val_loss(learn):
     assert learn.validate()[1] > 0.5
 
-@pytest.mark.xfail(reason="bug in the WeightDrop reset / initialisation")
+@pytest.mark.skipif(not torch.cuda.is_available(),
+                    reason="QRNN requires cupy that depends on cuda")
 def test_qrnn_works_with_no_split():
     manual_seed()
     path, df_trn, df_val = prep_human_numbers()
@@ -47,6 +48,8 @@ def test_qrnn_works_with_no_split():
     learn.fit_one_cycle(4, 5e-3)
     assert learn.validate()[1] > 0.5
 
+@pytest.mark.skipif(not torch.cuda.is_available(),
+                    reason="QRNN requires cupy that depends on cuda")
 def test_qrnn_works_if_split_fn_provided():
     manual_seed()
     path, df_trn, df_val = prep_human_numbers()


### PR DESCRIPTION
The PR adds two tests but they can be run only if you have a cupy installed to pinpoint the issue.
It also fixes the issue by calling reset() during the init of WeightsDrops:
https://github.com/fastai/fastai/pull/1135/commits/7706e228d938222640faa35b448ca52e282434a1

But It isn't the best idea since it may cause case-cading resets during initialization, so I've changed it to simply execute relevant part of the reset function without propagating the reset call it down the tree.

https://github.com/fastai/fastai/pull/1135/commits/d60adca369f6e548a494109a849ea5ebb1061a61