### PR TITLE
bugfix: set reduction attribute as none on loss fn if nothing is specified

### DIFF
--- a/fastai/torch_core.py
+++ b/fastai/torch_core.py
@@ -203,8 +203,10 @@ def calc_loss(y_pred:Tensor, y_true:Tensor, loss_func:LossFunction):
         setattr(loss_func, 'reduction', 'none')
         l = loss_func(y_pred, y_true)
         setattr(loss_func, 'reduction', old_red)
-        return l
-    else: return loss_func(y_pred, y_true, reduction='none')
+    else:
+        l = loss_func(y_pred, y_true)
+        setattr(loss_func, 'reduction', 'none')
+    return l
 
 def model_type(dtype):
     return (torch.float32 if np.issubdtype(dtype, np.floating) else


### PR DESCRIPTION
Possible fix for #1136 

Previously it was passed as a kwarg to the loss function, but mixup loss function doesn't have setters for the same.
Pytorch core loss functions seem to import from `nn._Loss` which has the setters for `reduction` parameter, so inheriting `MixupLoss` from that instead of `nn.Module` seems like another way to fix this bug. 

Setting the attribute explicitly when it doesn't exist seemed like a better approach, which is why the changes.
