### PR TITLE
Image2image

### DIFF
--- a/docs/vision.data.html
+++ b/docs/vision.data.html
@@ -1507,7 +1507,7 @@ For example:</p>
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p>Create <a href="/vision.data.html#normalize"><code>normalize</code></a> and <a href="/vision.data.html#denormalize"><code>denormalize</code></a> functions using <code>mean</code> and <code>std</code>. <code>device</code> will store them on the device specified. <code>do_y</code> determines if the target should also be normaized or not.</p>
+<p>Create <a href="/vision.data.html#normalize"><code>normalize</code></a> and <a href="/vision.data.html#denormalize"><code>denormalize</code></a> functions using <code>mean</code> and <code>std</code>. <code>device</code> will store them on the device specified. <code>tfm_y</code> determines if the target should also be normaized or not.</p>
 
 </div>
 </div>

--- a/docs_src/vision.data.ipynb
+++ b/docs_src/vision.data.ipynb
@@ -1466,7 +1466,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create [`normalize`](/vision.data.html#normalize) and [`denormalize`](/vision.data.html#denormalize) functions using `mean` and `std`. `device` will store them on the device specified. `do_y` determines if the target should also be normaized or not."
+    "Create [`normalize`](/vision.data.html#normalize) and [`denormalize`](/vision.data.html#denormalize) functions using `mean` and `std`. `device` will store them on the device specified. `tfm_y` determines if the target should also be normaized or not."
    ]
   },
   {

--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -152,6 +152,18 @@ class ImageMultiDataset(ImageClassificationBase):
         train_ds = cls(*train, classes=classes)
         return [train_ds,cls(*valid, classes=train_ds.classes)]
 
+class ImageToImageDataset(ImageDatasetBase):
+    "A dataset for segmentation task."
+    def __init__(self, x:FilePathList, y:FilePathList, **kwargs):
+        assert len(x)==len(y)
+        super().__init__(x=x, y=y, **kwargs)
+        self.loss_func = F.mse_loss
+
+    def _get_y(self,i,x):  return self.image_opener(self.y[i])
+
+    def reconstruct_output(self, out, x): 
+        return Image(out)
+
 class SegmentationDataset(ImageClassificationBase):
     "A dataset for segmentation task."
     def __init__(self, x:FilePathList, y:FilePathList, classes:Collection[Any], div:bool=False):

--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -55,6 +55,8 @@ class ImageLearner(Learner):
             x,y = dl.dataset[i]
             x.show(ax=axs[i,1], y=y) #Doing that first will update x before we pass it to reconstruct_output
             pred = dl.reconstruct_output(preds[i], x)
+            if self.data.denorm and self.data.tfm_y and isinstance(pred, Image):
+                pred = Image(self.data.denorm(pred.data))
             x.show(ax=axs[i,0], y=pred)
         plt.tight_layout()
 


### PR DESCRIPTION
Add support for image to image training:

- normalization of y variable can be turned on w/ tfm_y in normalize call
- standardize do_y to tfm_y
- support optional y_kwargs (to override y sz for example)
- support optional separate y_tfms, if none use same tfms as x assuming y_tfm is true
- for show_results, denormalize y if it is an image
