### PR TITLE
fix callback logic

### DIFF
--- a/fastai/callbacks/tracker.py
+++ b/fastai/callbacks/tracker.py
@@ -69,7 +69,7 @@ class EarlyStoppingCallback(TrackerCallback):
             self.best,self.wait = current,0
         else:
             self.wait += 1
-            if self.wait >= self.patience:
+            if self.wait > self.patience:
                 print(f'Epoch {epoch}: early stopping')
                 return True
 
@@ -116,7 +116,7 @@ class ReduceLROnPlateauCallback(TrackerCallback):
         if self.operator(current - self.min_delta, self.best): self.best,self.wait = current,0
         else:
             self.wait += 1
-            if self.wait == self.patience:
+            if self.wait > self.patience:
                 self.opt.lr *= self.factor
-                self.wait == 0
+                self.wait = 0
                 print(f'Epoch {epoch}: reducing lr to {self.opt.lr}')


### PR DESCRIPTION
There were issues with the earlier version of Tracker callbacks. `ReduceLROnPlateauCallback` was never getting the `self.wait` reset and the logic of `patience` was wrong and inconsistent between the callbacks. For instance, with patience=0 `ReduceLROnPlateauCallback` was never triggered and patience 0 and 1 were equivalent on the `EarlyStoppingCallback`.