### PR TITLE
Return files from get_files() in sorted order

### DIFF
--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -12,7 +12,7 @@ def _maybe_squeeze(arr): return (arr if is1d(arr) else np.squeeze(arr))
 
 def get_files(c:PathOrStr, extensions:Collection[str]=None, recurse:bool=False)->FilePathList:
     "Return list of files in `c` that have a suffix in `extensions`. `recurse` determines if we search subfolders."
-    return [o for o in Path(c).glob('**/*' if recurse else '*')
+    return [o for o in sorted(Path(c).glob('**/*' if recurse else '*'))
             if not o.name.startswith('.') and not o.is_dir()
             and (extensions is None or (o.suffix.lower() in extensions))]
 


### PR DESCRIPTION
A simple fix to get sorted class names...

If one imports classes from folders with names in the form of:
```
data/subclassA_itemsA 
     subclassA_itemsB 
     subclassB_itemsA 
     subclassB_itemsB 
     subclassB_itemsC 
     ...
```

I would prefer the class numerical representation (data.c) to follow the sorted order of the names (data.classes).

Currently I might get 
```
data.classes = [subclassB_itemsA, subclassB_itemsC, subclassA_itemsA, ...]
```
<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
