### PR TITLE
Fix an issue in ImageItemList.from_csv method

### DIFF
--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -291,6 +291,7 @@ class ImageItemList(ItemList):
     @classmethod
     def from_csv(cls, path:PathOrStr, csv_name:str, create_func:Callable=open_image, cols:IntsOrStrs=0, header:str='infer',
                  folder:PathOrStr='.', suffix:str='')->'ItemList':
+        path = Path(path)
         df = pd.read_csv(path/csv_name, header=header)
         return cls.from_df(df, path=path, create_func=create_func, cols=cols, folder=folder, suffix=suffix)
 


### PR DESCRIPTION
There is a bug in ImageItemList.from_csv method. When we pass a string instead of a Path object to the path parameter, this causes an error.

Fix for this bug is to convert string into Path object.

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
