### PR TITLE
added a unit test for split_bn_bias

### DIFF
--- a/tests/test_torch_core.py
+++ b/tests/test_torch_core.py
@@ -65,6 +65,10 @@ def test_split_model():
     pool = split_model(m,[m[2][0]])[1][0]
     assert pool == m[2][0], "Did not properly split at adaptive pooling layer"
 
+def test_split_bn_bias():
+    bn_group = split_bn_bias(simple_cnn((1, 1, 1), bn=True))[1]
+    assert len(bn_group) > 0 and isinstance(bn_group[0], bn_types)
+
 def test_set_bn_eval():
     m = simple_cnn(b,bn=True)
     requires_grad(m,False)


### PR DESCRIPTION
Added a unit test for split_bn_bias in torch_core.py 

@sgugger I saw this todo sitting on top of the function i was writing test for but didn't quite get the idea here, could you help explain it to me so I can fix it along with the test
`baba12c2 (Ubuntu 2018-10-13 13:40:05 +0000 146) fastai/torch_core.py`
`#TODO: add the test to put bias with bn layers`
`def split_bn_bias(layer_groups:ModuleList)->ModuleList:`