### PR TITLE
Fix `max_vocab` for `TextLMDataBunch`

### DIFF
--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -14,7 +14,7 @@ text_extensions = {'.txt'}
 class LanguageModelLoader():
     "Create a dataloader with bptt slightly changing."
     def __init__(self, dataset:LabelList, bs:int=64, bptt:int=70, backwards:bool=False, shuffle:bool=False,
-                 max_len:int=25):
+                 max_len:int=25, **kwargs):
         self.dataset,self.bs,self.bptt,self.backwards,self.shuffle = dataset,bs,bptt,backwards,shuffle
         self.first,self.i,self.iter = True,0,0
         self.n = len(np.concatenate(dataset.x.items)) // self.bs if len(dataset.x.items) > 0 else 0

--- a/tests/test_text_data.py
+++ b/tests/test_text_data.py
@@ -43,6 +43,7 @@ def test_from_csv_and_from_df():
     df = text_df(['neg','pos'])
     data1 = TextClasDataBunch.from_df(path, train_df=df, valid_df=df, test_df=df, label_cols=0, text_cols=["text"])
     assert len(data1.classes) == 2
+
     df = text_df(['neg','pos','neg pos'])
     data2 = TextClasDataBunch.from_df(path, train_df=df, valid_df=df, test_df=df,
                                   label_cols=0, text_cols=["text"], label_delim=' ')
@@ -52,6 +53,9 @@ def test_from_csv_and_from_df():
     text_csv_file(path/'tmp.csv', ['neg','pos'])
     data3 = TextLMDataBunch.from_csv(path, 'tmp.csv', test='tmp.csv', label_cols=0, text_cols=["text"])
     assert len(data3.classes) == 1
+    data4 = TextLMDataBunch.from_csv(path, 'tmp.csv', test='tmp.csv', label_cols=0, text_cols=["text"], max_vocab=5)  
+    assert len(data4.train_ds.vocab.itos) == 7 # 5 + 2 (special UNK and PAD token)
+
     os.remove(path/'tmp.csv')
 
 def test_should_load_backwards_lm():


### PR DESCRIPTION
It's currently not possible to pass a `max_vocab` parameter when creating a `TextLMDataBunch`. I added a test and also fixed it.
