### PR TITLE
Add simple test for text, vision, tabular and collab for model summary

### DIFF
--- a/fastai/callbacks/hooks.py
+++ b/fastai/callbacks/hooks.py
@@ -108,9 +108,8 @@ def hook_params(modules:Collection[nn.Module]) -> Hooks:
 def params_size(m: nn.Module, size: tuple = (64, 64)) -> Tuple[Sizes, Tensor, Hooks]:
     "Pass a dummy input through the model to get the various sizes. Returns (res,x,hooks) if `full`"
     if isinstance(m, Learner):
-        dl = m.data.train_dl
-        m = m.model
-        x = next(iter(dl))[0]
+        x = m.data.one_batch()[0]
+        m = m.model        
         print('Input Size override by Learner.data.train_dl')
     elif isinstance(m, nn.Module): 
         ch_in = in_channels(m)

--- a/fastai/callbacks/hooks.py
+++ b/fastai/callbacks/hooks.py
@@ -105,7 +105,7 @@ def num_features_model(m:nn.Module)->int:
 def total_params(m:nn.Module)->int:
     params = 0
     if hasattr(m, "weight") and hasattr(m.weight, "size"): params += m.weight.numel()
-    if hasattr(m, "bias") and hasattr(m.bias, "size"): params += m.bias.numel()
+    if hasattr(m, "bias") and hasattr(m.bias, "size"):     params += m.bias.numel()
     return params
 
 def hook_params(modules:Collection[nn.Module])->Hooks:

--- a/tests/test_callbacks_hooks.py
+++ b/tests/test_callbacks_hooks.py
@@ -8,7 +8,7 @@ from fastai.collab import *
 
 def test_model_summary_vision():
     path = untar_data(URLs.MNIST_TINY)
-    data = ImageDataBunch.from_folder(path, ds_tfms=(rand_pad(2, 28), []), bs=64)
+    data = ImageDataBunch.from_folder(path, ds_tfms=([], []), bs=2)
     learn = create_cnn(data, models.resnet18, metrics=accuracy)
     model_summary(learn)
 
@@ -26,7 +26,7 @@ def test_model_summary_tabular():
     cont_names = ['age', 'fnlwgt', 'education-num']
     procs = [FillMissing, Categorify]
     df = pd.read_csv(path/'adult.csv')
-    data = (TabularList.from_df(df, path=path, cat_names=cat_names, cont_names=cont_names, procs=procs)
+    data = (TabularList.from_df(df, path=path, cat_names=cat_names, cont_names=cont_names, procs=procs, bs=2)
                                .split_by_idx(list(range(800,1000)))
                                .label_from_df(cols=dep_var)
                                .databunch())
@@ -37,21 +37,20 @@ def test_model_summary_collab():
     path = untar_data(URLs.ML_SAMPLE)
     ratings = pd.read_csv(path/'ratings.csv')
     series2cat(ratings, 'userId', 'movieId')
-    data = CollabDataBunch.from_df(ratings, seed=42)
+    data = CollabDataBunch.from_df(ratings, seed=42, bs=2)
     y_range = [0,5.5]
     learn = collab_learner(data, n_factors=50, y_range=y_range)
     model_summary(learn)
     
 def test_model_summary_nn_module():
-    model_summary(nn.Conv2d(16,32,3,padding=1))
+    model_summary(nn.Conv2d(16,16,3,padding=1))
     
 def test_model_summary_nn_modules():
     class BasicBlock(nn.Module):
         def __init__(self):
             super().__init__()
-            self.conv1 = conv2d(16,32,3,1)
-            self.conv2 = conv2d(32,32,3,1)
-
+            self.conv1 = conv2d(16,16,3,1)
+            self.conv2 = conv2d(16,16,3,1)
         def forward(self, x):
             x = self.conv1(x)
             x = self.conv2(x) 

--- a/tests/test_callbacks_hooks.py
+++ b/tests/test_callbacks_hooks.py
@@ -1,0 +1,42 @@
+import pytest, torch, fastai
+from fastai import *  
+from fastai.callbacks import *
+from fastai.vision import *
+from fastai.text import *
+from fastai.tabular import *
+from fastai.collab import *
+
+def test_model_summary_vision():
+    path = untar_data(URLs.MNIST_TINY)
+    data = ImageDataBunch.from_folder(path, ds_tfms=(rand_pad(2, 28), []), bs=64)
+    learn = create_cnn(data, models.resnet18, metrics=accuracy)
+    model_summary(learn.model)
+    
+def test_model_summary_text():
+    path = untar_data(URLs.IMDB_SAMPLE)
+    data_lm = TextLMDataBunch.from_csv(path, 'texts.csv')
+    learn = language_model_learner(data_lm, pretrained_model=None)
+    model_summary(learn.model)
+    
+def test_model_summary_tabular():
+    path = untar_data(URLs.ADULT_SAMPLE)
+    dep_var = '>=50k'
+    cat_names = ['workclass', 'education', 'marital-status', 'occupation', 'relationship', 'race']
+    cont_names = ['age', 'fnlwgt', 'education-num']
+    procs = [FillMissing, Categorify]
+    df = pd.read_csv(path/'adult.csv')
+    data = (TabularList.from_df(df, path=path, cat_names=cat_names, cont_names=cont_names, procs=procs)
+                               .split_by_idx(list(range(800,1000)))
+                               .label_from_df(cols=dep_var)
+                               .databunch())
+    learn = tabular_learner(data, layers=[200,100], metrics=accuracy)
+    model_summary(learn.model)
+    
+def test_model_summary_collab():
+    path = untar_data(URLs.ML_SAMPLE)
+    ratings = pd.read_csv(path/'ratings.csv')
+    series2cat(ratings, 'userId', 'movieId')
+    data = CollabDataBunch.from_df(ratings, seed=42)
+    y_range = [0,5.5]
+    learn = collab_learner(data, n_factors=50, y_range=y_range)
+    model_summary(learn.model)

--- a/tests/test_callbacks_hooks.py
+++ b/tests/test_callbacks_hooks.py
@@ -12,7 +12,7 @@ def test_model_summary_vision():
     learn = create_cnn(data, models.resnet18, metrics=accuracy)
     model_summary(learn)
 
-@pytest.mark.xfail(reason = "Expected Fail, Dataset should be passed instead.")      
+@pytest.mark.xfail(reason = "Expected Fail, text models not supported yet.")      
 def test_model_summary_text():
     path = untar_data(URLs.IMDB_SAMPLE)
     data_lm = TextLMDataBunch.from_csv(path, 'texts.csv')

--- a/tests/test_callbacks_hooks.py
+++ b/tests/test_callbacks_hooks.py
@@ -44,3 +44,17 @@ def test_model_summary_collab():
 def test_model_summary_nn_module():
     model_summary(nn.Conv2d(16,32,3,padding=1))
     
+def test_model_summary_nn_modules():
+    class BasicBlock(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv1 = conv2d(16,32,3,1)
+            self.conv2 = conv2d(32,32,3,1)
+
+        def forward(self, x):
+            x = self.conv1(x)
+            x = self.conv2(x) 
+            return x
+    model_summary(BasicBlock())
+    
+    

--- a/tests/test_callbacks_hooks.py
+++ b/tests/test_callbacks_hooks.py
@@ -40,3 +40,7 @@ def test_model_summary_collab():
     y_range = [0,5.5]
     learn = collab_learner(data, n_factors=50, y_range=y_range)
     model_summary(learn.model)
+    
+def test_model_summary_nn_module():
+    model_summary(nn.Conv2d(16,32,3,padding=1))
+    

--- a/tests/test_callbacks_hooks.py
+++ b/tests/test_callbacks_hooks.py
@@ -10,13 +10,14 @@ def test_model_summary_vision():
     path = untar_data(URLs.MNIST_TINY)
     data = ImageDataBunch.from_folder(path, ds_tfms=(rand_pad(2, 28), []), bs=64)
     learn = create_cnn(data, models.resnet18, metrics=accuracy)
-    model_summary(learn.model)
-    
+    model_summary(learn)
+
+@pytest.mark.xfail(reason = "Expected Fail, Dataset should be passed instead.")      
 def test_model_summary_text():
     path = untar_data(URLs.IMDB_SAMPLE)
     data_lm = TextLMDataBunch.from_csv(path, 'texts.csv')
     learn = language_model_learner(data_lm, pretrained_model=None)
-    model_summary(learn.model)
+    model_summary(learn)
     
 def test_model_summary_tabular():
     path = untar_data(URLs.ADULT_SAMPLE)
@@ -30,7 +31,7 @@ def test_model_summary_tabular():
                                .label_from_df(cols=dep_var)
                                .databunch())
     learn = tabular_learner(data, layers=[200,100], metrics=accuracy)
-    model_summary(learn.model)
+    model_summary(learn)
     
 def test_model_summary_collab():
     path = untar_data(URLs.ML_SAMPLE)
@@ -39,7 +40,7 @@ def test_model_summary_collab():
     data = CollabDataBunch.from_df(ratings, seed=42)
     y_range = [0,5.5]
     learn = collab_learner(data, n_factors=50, y_range=y_range)
-    model_summary(learn.model)
+    model_summary(learn)
     
 def test_model_summary_nn_module():
     model_summary(nn.Conv2d(16,32,3,padding=1))
@@ -56,5 +57,4 @@ def test_model_summary_nn_modules():
             x = self.conv2(x) 
             return x
     model_summary(BasicBlock())
-    
     


### PR DESCRIPTION
Previous PR for vision summary: https://github.com/fastai/fastai/pull/1198
Dev Project Index: https://forums.fast.ai/t/dev-projects-index/29849
Discussion thread on Forum: https://forums.fast.ai/t/model-summary-implementation/31193

**Plan for this PR**  
add:
* units tests for model_summary
* support for more fastai learner type
* support for pure PyTorch nn.Module
* model_summary takes both pure nn.Module and fastai Learner

**Plan for future PR**  

add:
* more information like trainable parameters
* graph visualization for model structure
* Backbone, head structure shown in summary

- [x] Add simple unit test for text, vision tabular and collab Learner
- [x] Add simple unit test for nn.Module
- [x] model_summary work for nn.Module and subclass of nn.Module consists multiple nn.Module
- [x] model summary work for all fastai Learner subclass
- [x] Combine them to have 1 model_summary work for all learner

 Note: Still not working for Text model, but other learner are fine.