### PR TITLE
Few small fixes for edge cases that appears when one writes functional tests.

### DIFF
--- a/fastai/basic_data.py
+++ b/fastai/basic_data.py
@@ -44,6 +44,7 @@ class DeviceDataLoader():
 
     def __iter__(self):
         "Process and returns items from `DataLoader`."
+        assert not self.skip_size1 or self.batch_size > 1, "Batch size cannot be one if skip_size1 is set to True"
         for b in self.dl:
             y = b[1][0] if is_listy(b[1]) else b[1]
             if not self.skip_size1 or y.size(0) != 1: yield self.proc_batch(b)

--- a/fastai/core.py
+++ b/fastai/core.py
@@ -40,8 +40,11 @@ OptStrList = Optional[StrList]
 
 np.set_printoptions(precision=6, threshold=50, edgeitems=4, linewidth=120)
 
+turn_off_parallel_execution = False
 def num_cpus()->int:
     "Get number of cpus"
+
+    if turn_off_parallel_execution: return 1
     try:                   return len(os.sched_getaffinity(0))
     except AttributeError: return os.cpu_count()
 

--- a/fastai/core.py
+++ b/fastai/core.py
@@ -40,11 +40,8 @@ OptStrList = Optional[StrList]
 
 np.set_printoptions(precision=6, threshold=50, edgeitems=4, linewidth=120)
 
-turn_off_parallel_execution = False
 def num_cpus()->int:
     "Get number of cpus"
-
-    if turn_off_parallel_execution: return 1
     try:                   return len(os.sched_getaffinity(0))
     except AttributeError: return os.cpu_count()
 

--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -145,10 +145,10 @@ class TextDataBunch(DataBunch):
     @classmethod#TODO: test
     def from_tokens(cls, path:PathOrStr, trn_tok:Collection[Collection[str]], trn_lbls:Collection[Union[int,float]],
                  val_tok:Collection[Collection[str]], val_lbls:Collection[Union[int,float]], vocab:Vocab=None,
-                 tst_tok:Collection[Collection[str]]=None, classes:Collection[Any]=None,tokenizer:Tokenizer=None, **kwargs) -> DataBunch:
+                 tst_tok:Collection[Collection[str]]=None, classes:Collection[Any]=None, **kwargs) -> DataBunch:
         "Create a `TextDataBunch` from tokens and labels."
         p_kwargs, kwargs = split_kwargs_by_func(kwargs, _get_processor)
-        processor = _get_processor(tokenizer=tokenizer, vocab=vocab, **p_kwargs)[1]
+        processor = _get_processor(tokenizer=None, vocab=vocab, **p_kwargs)[1]
         src = ItemLists(path, TextList(trn_tok, path=path, processor=processor),
                         TextList(val_tok, path=path, processor=processor))
         src = src.label_for_lm() if cls==TextLMDataBunch else src.label_from_lists(trn_lbls, val_lbls, classes=classes)

--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -40,6 +40,13 @@ class LanguageModelLoader():
     def __len__(self) -> int: return (self.n-1) // self.bptt
     def __getattr__(self,k:str)->Any: return getattr(self.dataset, k)
 
+    @property
+    def batch_size(self):
+        return self.bs
+    @batch_size.setter
+    def batch_size(self, v):
+        self.bs = v
+
     def batchify(self, data:np.ndarray) -> LongTensor:
         "Split the corpus `data` in batches."
         nb = data.shape[0] // self.bs

--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -147,13 +147,13 @@ class TextDataBunch(DataBunch):
     @classmethod#TODO: test
     def from_tokens(cls, path:PathOrStr, trn_tok:Collection[Collection[str]], trn_lbls:Collection[Union[int,float]],
                  val_tok:Collection[Collection[str]], val_lbls:Collection[Union[int,float]], vocab:Vocab=None,
-                 tst_tok:Collection[Collection[str]]=None, classes:Collection[Any]=None, **kwargs) -> DataBunch:
+                 tst_tok:Collection[Collection[str]]=None, classes:Collection[Any]=None,tokenizer:Tokenizer=None, **kwargs) -> DataBunch:
         "Create a `TextDataBunch` from tokens and labels."
         p_kwargs, kwargs = split_kwargs_by_func(kwargs, _get_processor)
-        processor = _get_processor(tokenizer=None, vocab=vocab, **p_kwargs)[1]
+        processor = _get_processor(tokenizer=tokenizer, vocab=vocab, **p_kwargs)[1]
         src = ItemLists(path, TextList(trn_tok, path=path, processor=processor),
                         TextList(val_tok, path=path, processor=processor))
-        src = src.label_for_lm() if cls==TextLMDataBunch else src.label_from_lists(trn_lbls, val_lbls)
+        src = src.label_for_lm() if cls==TextLMDataBunch else src.label_from_lists(trn_lbls, val_lbls, classes=classes)
         if tst_tok is not None: src.add_test(TextList(tst_tok, path=path))
         return src.databunch(**kwargs)
 
@@ -163,7 +163,7 @@ class TextDataBunch(DataBunch):
                 label_cols:IntsOrStrs=0, label_delim:str=None, **kwargs) -> DataBunch:
         "Create a `TextDataBunch` from DataFrames."
         p_kwargs, kwargs = split_kwargs_by_func(kwargs, _get_processor)
-        processor = _get_processor(tokenizer=None, vocab=vocab, **p_kwargs)
+        processor = _get_processor(tokenizer=tokenizer, vocab=vocab, **p_kwargs)
         src = ItemLists(path, TextList.from_df(train_df, path, cols=text_cols, processor=processor),
                         TextList.from_df(valid_df, path, cols=text_cols, processor=processor))
         src = src.label_for_lm() if cls==TextLMDataBunch else src.label_from_df(cols=label_cols, classes=classes, sep=label_delim)
@@ -189,7 +189,7 @@ class TextDataBunch(DataBunch):
         "Create a `TextDataBunch` from text files in folders."
         path = Path(path).absolute()
         p_kwargs, kwargs = split_kwargs_by_func(kwargs, _get_processor)
-        processor = [OpenFileProcessor()] + _get_processor(tokenizer=None, vocab=vocab, **p_kwargs)
+        processor = [OpenFileProcessor()] + _get_processor(tokenizer=tokenizer, vocab=vocab, **p_kwargs)
         src = (TextList.from_folder(path, processor=processor)
                        .split_by_folder(train=train, valid=valid))
         src = src.label_for_lm() if cls==TextLMDataBunch else src.label_from_folder(classes=classes)

--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -41,11 +41,9 @@ class LanguageModelLoader():
     def __getattr__(self,k:str)->Any: return getattr(self.dataset, k)
 
     @property
-    def batch_size(self):
-        return self.bs
+    def batch_size(self): return self.bs
     @batch_size.setter
-    def batch_size(self, v):
-        self.bs = v
+    def batch_size(self, v): self.bs = v
 
     def batchify(self, data:np.ndarray) -> LongTensor:
         "Split the corpus `data` in batches."

--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -126,8 +126,8 @@ class TextDataBunch(DataBunch):
                  valid_lbls:Collection[Union[int,float]]=None, classes:Collection[Any]=None,
                  processor:PreProcessor=None, **kwargs) -> DataBunch:
         "Create a `TextDataBunch` from ids, labels and a dictionary."
-        src = ItemLists(path, TextList(train_ids, vocab, path=path, processor=[]),
-                        TextList(valid_ids, vocab, path=path, processor=[]))
+        src = ItemLists(path, TextList(train_ids, vocab, path=path, processor=[ToIntsProcessor()]),
+                        TextList(valid_ids, vocab, path=path, processor=[ToIntsProcessor()]))
         src = src.label_for_lm() if cls==TextLMDataBunch else src.label_from_lists(train_lbls, valid_lbls, classes=classes, processor=[])
         if test_ids is not None: src.add_test(TextList(test_ids, vocab, path=path))
         src.valid.x.processor = ifnone(processor, [TokenizeProcessor(), NumericalizeProcessor(vocab=vocab)])
@@ -276,6 +276,10 @@ class NumericalizeProcessor(PreProcessor):
         if self.vocab is None: self.vocab = Vocab.create(ds.items, self.max_vocab, self.min_freq)
         ds.vocab = self.vocab
         super().process(ds)
+
+class ToIntsProcessor(PreProcessor):
+    def process_one(self, item):  return np.array(item, dtype=np.int64)
+
 
 class OpenFileProcessor(PreProcessor):
     def process_one(self,item):

--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -84,7 +84,7 @@ class SortishSampler(Sampler):
         ck_idx = [sort_idx[i:i+sz] for i in range(0, len(sort_idx), sz)]
         max_ck = np.argmax([self.key(ck[0]) for ck in ck_idx])  # find the chunk with the largest key,
         ck_idx[0],ck_idx[max_ck] = ck_idx[max_ck],ck_idx[0]     # then make sure it goes first.
-        sort_idx = np.concatenate(np.random.permutation(ck_idx[1:]))
+        sort_idx = np.concatenate(np.random.permutation(ck_idx[1:])) if len(ck_idx) > 1 else np.array([],dtype=np.int)
         sort_idx = np.concatenate((ck_idx[0], sort_idx))
         return iter(sort_idx)
 

--- a/tests/test_text_data.py
+++ b/tests/test_text_data.py
@@ -39,7 +39,7 @@ def test_from_folder():
     shutil.rmtree(path/'temp')
 
 
-def sepcial_fastai_test_rule(s): return s.replace("fast ai", "@fastdotai")
+def special_fastai_test_rule(s): return s.replace("fast ai", "@fastdotai")
 
 def test_from_csv_and_from_df():
     path = untar_data(URLs.IMDB_SAMPLE)
@@ -50,7 +50,7 @@ def test_from_csv_and_from_df():
     df = text_df(['neg','pos','neg pos'])
     data2 = TextClasDataBunch.from_df(path, train_df=df, valid_df=df, test_df=df,
                                   label_cols=0, text_cols=["text"], label_delim=' ',
-                                  tokenizer=Tokenizer(pre_rules=[sepcial_fastai_test_rule]))
+                                  tokenizer=Tokenizer(pre_rules=[special_fastai_test_rule]))
     assert len(data2.classes) == 2
     x,y = data2.train_ds[0]
     assert len(y.data) == 2
@@ -63,7 +63,7 @@ def test_from_csv_and_from_df():
 
     # Test that the tokenizer parameter is used in from_csv
     data4 = TextLMDataBunch.from_csv(path, 'tmp.csv', test='tmp.csv', label_cols=0, text_cols=["text"],
-                                     tokenizer=Tokenizer(pre_rules=[sepcial_fastai_test_rule]))
+                                     tokenizer=Tokenizer(pre_rules=[special_fastai_test_rule]))
     assert '@fastdotai' in data4.train_ds.vocab.itos, "It seems that our custom tokenzier was not used by TextClasDataBunch"
 
     os.remove(path/'tmp.csv')

--- a/tests/test_text_data.py
+++ b/tests/test_text_data.py
@@ -86,3 +86,33 @@ def test_load_and_save_test():
     str2 = np.array([str(o) for o in data1.train_ds.y])
     assert np.all(str1 == str2)
     shutil.rmtree(path/'tmp')
+
+def test_sortish_sampler():
+    ds = [1,2,3,4,5,6,7,8,9,10]
+    train_sampler = SortishSampler(ds, key=lambda t: ds[t], bs=2)
+    assert len(train_sampler) == 10
+    ds_srt = [ds[i] for i in train_sampler]
+    assert ds_srt[0] == 10
+
+    # test on small datasets
+    ds = [1, 10]
+    train_sampler = SortishSampler(ds, key=lambda t: ds[t], bs=2)
+    assert len(train_sampler) == 2
+    ds_srt = [ds[i] for i in train_sampler]
+    assert ds_srt[0] == 10
+
+def test_from_ids_works_for_equally_length_sentences():
+    ids = [np.array([0])]*10
+    lbl = [0]*10
+    data = TextClasDataBunch.from_ids('/tmp', vocab=Vocab({0: BOS, 1:PAD}),
+                                      train_ids=ids, train_lbls=lbl,
+                                      valid_ids=ids, valid_lbls=lbl, classes={0:0})
+    text_classifier_learner(data).fit(1)
+
+def test_from_ids_works_for_variable_length_sentences():
+    ids = [np.array([0]),np.array([0,1])]*5 # notice diffrent number of elements in arrays
+    lbl = [0]*10
+    data = TextClasDataBunch.from_ids('/tmp', vocab=Vocab({0: BOS, 1:PAD}),
+                                      train_ids=ids, train_lbls=lbl,
+                                      valid_ids=ids, valid_lbls=lbl, classes={0:0})
+    text_classifier_learner(data).fit(1)

--- a/tests/test_text_train.py
+++ b/tests/test_text_train.py
@@ -80,37 +80,6 @@ def text_df(n_labels):
     df = pd.DataFrame(data)
     return df
 
-def test_sortish_sampler():
-    ds = [1,2,3,4,5,6,7,8,9,10]
-    train_sampler = SortishSampler(ds, key=lambda t: ds[t], bs=2)
-    assert len(train_sampler) == 10
-    ds_srt = [ds[i] for i in train_sampler]
-    assert ds_srt[0] == 10
-
-    # test on small datasets
-    ds = [1, 10]
-    train_sampler = SortishSampler(ds, key=lambda t: ds[t], bs=2)
-    assert len(train_sampler) == 2
-    ds_srt = [ds[i] for i in train_sampler]
-    assert ds_srt[0] == 10
-
-@pytest.mark.skip(reason="It is broken currently")
-def test_from_ids_works_for_equally_length_sentences():
-    ids = [np.array([0])]*10
-    lbl = [0]*10
-    data = TextClasDataBunch.from_ids('/tmp', vocab=Vocab({0: BOS, 1:PAD}),
-                                      train_ids=ids, train_lbls=lbl,
-                                      valid_ids=ids, valid_lbls=lbl, classes={0:0})
-    text_classifier_learner(data).fit(1)
-
-def test_from_ids_works_for_variable_length_sentences():
-    ids = [np.array([0]),np.array([0,1])]*5 # notice diffrent number of elements in arrays
-    lbl = [0]*10
-    data = TextClasDataBunch.from_ids('/tmp', vocab=Vocab({0: BOS, 1:PAD}),
-                                      train_ids=ids, train_lbls=lbl,
-                                      valid_ids=ids, valid_lbls=lbl, classes={0:0})
-    text_classifier_learner(data).fit(1)
-
 def test_classifier():
     for n_labels in [1]: # , 8 - does not work for multilclass yet
         path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data', 'tmp')

--- a/tests/test_text_train.py
+++ b/tests/test_text_train.py
@@ -92,6 +92,23 @@ def text_df(n_labels):
     return df
 
 @pytest.mark.skip(reason="need to update")
+@pytest.mark.skip(reason="It is broken currently")
+def test_from_ids_works_for_equally_length_sentences():
+    ids = [np.array([0])]*10
+    lbl = [0]*10
+    data = TextClasDataBunch.from_ids('/tmp', vocab=Vocab({0: BOS, 1:PAD}),
+                                      train_ids=ids, train_lbls=lbl,
+                                      valid_ids=ids, valid_lbls=lbl, classes={0:0})
+    text_classifier_learner(data).fit(1)
+
+def test_from_ids_works_for_variable_length_sentences():
+    ids = [np.array([0]),np.array([0,1])]*5 # notice diffrent number of elements in arrays
+    lbl = [0]*10
+    data = TextClasDataBunch.from_ids('/tmp', vocab=Vocab({0: BOS, 1:PAD}),
+                                      train_ids=ids, train_lbls=lbl,
+                                      valid_ids=ids, valid_lbls=lbl, classes={0:0})
+    text_classifier_learner(data).fit(1)
+
 def test_classifier():
     for n_labels in [1, 8]:
         path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data', 'tmp')

--- a/tests/test_text_train.py
+++ b/tests/test_text_train.py
@@ -91,7 +91,20 @@ def text_df(n_labels):
     df = pd.DataFrame(data)
     return df
 
-@pytest.mark.skip(reason="need to update")
+def test_sortish_sampler():
+    ds = [1,2,3,4,5,6,7,8,9,10]
+    train_sampler = SortishSampler(ds, key=lambda t: ds[t], bs=2)
+    assert len(train_sampler) == 10
+    ds_srt = [ds[i] for i in train_sampler]
+    assert ds_srt[0] == 10
+
+    # test on small datasets
+    ds = [1, 10]
+    train_sampler = SortishSampler(ds, key=lambda t: ds[t], bs=2)
+    assert len(train_sampler) == 2
+    ds_srt = [ds[i] for i in train_sampler]
+    assert ds_srt[0] == 10
+
 @pytest.mark.skip(reason="It is broken currently")
 def test_from_ids_works_for_equally_length_sentences():
     ids = [np.array([0])]*10
@@ -110,7 +123,6 @@ def test_from_ids_works_for_variable_length_sentences():
     text_classifier_learner(data).fit(1)
 
 def test_classifier():
-    for n_labels in [1, 8]:
         path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data', 'tmp')
         os.makedirs(path)
         try:

--- a/tests/test_text_train.py
+++ b/tests/test_text_train.py
@@ -68,17 +68,6 @@ def test_vocabs(learn):
         assert len(learn.data.train_ds.vocab.itos) == len(ds.vocab.itos)
         assert np.all(learn.data.train_ds.vocab.itos == ds.vocab.itos)
 
-def test_classifier(learn):
-    lm_vocab = learn.data.vocab
-    data = (TextList.from_df(df, path, cols='texts', vocab = lm_vocab)
-                .split_by_idx(list(range(len(df_trn),len(df))))
-                .label_from_df(cols=0)
-                .add_test(df['texts'].iloc[:200].values)
-                .databunch())
-    for ds in [data.train_ds, data.valid_ds, data.test_ds]:
-        assert len(lm_vocab.itos) == len(ds.vocab.itos)
-        assert np.all(lm_vocab.itos == ds.vocab.itos)
-
 @pytest.mark.skip(reason="need to update")
 def text_df(n_labels):
     data = []
@@ -123,13 +112,19 @@ def test_from_ids_works_for_variable_length_sentences():
     text_classifier_learner(data).fit(1)
 
 def test_classifier():
+    for n_labels in [1]: # , 8 - does not work for multilclass yet
         path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data', 'tmp')
         os.makedirs(path)
         try:
+            expected_classes = n_labels if n_labels > 1 else 2
             df = text_df(n_labels=n_labels)
-            data = TextClasDataBunch.from_df(path, train_df=df, valid_df=df, label_cols=list(range(n_labels)), text_cols=["text"])
-            classifier = text_classifier_learner(data)
-            assert last_layer(classifier.model).out_features == n_labels if n_labels > 1 else n_labels+1
+            data = TextClasDataBunch.from_df(path, train_df=df, valid_df=df, label_cols=list(range(n_labels)), text_cols=["text"], bs=4)
+            classifier = text_classifier_learner(data, bptt=10)
+            assert last_layer(classifier.model).out_features == expected_classes
+            assert len(data.train_dl) == math.ceil(len(data.train_ds)/data.train_dl.batch_size)
+            assert next(iter(data.train_dl))[0].shape == (9, 2)
+            assert next(iter(data.valid_dl))[0].shape == (9, 2)
+            classifier.fit(1)
         finally:
             shutil.rmtree(path)
 


### PR DESCRIPTION
The following fixes would save me quite some effort when I was developing tests for ulmfit-multilingual. It is often useful to run models on very small data sets and currently this is not supported 

The content of this PR is as per commit messages: 
- Add warning regarding batch_size=1 and skip_size1
- Make SortishSampler work on datasets if size 1
- Make it possible to turn off multiprocessing to allow PyCharm to debug tests.
