### PR TITLE
Fix bug with random permutation in TextDataBunch.from_csv()

### DIFF
--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -174,7 +174,7 @@ class TextDataBunch(DataBunch):
                  label_cols:IntsOrStrs=0, label_delim:str=None, **kwargs) -> DataBunch:
         "Create a `TextDataBunch` from texts in csv files."
         df = pd.read_csv(Path(path)/csv_name, header=header)
-        idx = np.random.permutation(len(df))
+        df = df.iloc[np.random.permutation(len(df))]
         cut = int(valid_pct * len(df)) + 1
         train_df, valid_df = df[cut:], df[:cut]
         test_df = None if test is None else pd.read_csv(Path(path)/test, header=header)


### PR DESCRIPTION
The current implementation of TextDataBunch.from_csv() misses a step when randomly sampling data for the training and validation sets.   Although the indices are permuted
`idx = np.random.permutation(len(df))`
these permuted indices are not used.

I am not sure what the most efficient way to do this in pandas is without testing, that said the pr contains the below simple change
`df = df.iloc[np.random.permutation(len(df))]`
which seems easier to grasp when quickly scanning through the source than
`train_df, valid_df = df.iloc[idx[cut:]], df.iloc[idx[:cut]]`