### PR TITLE
Fix a bug in ItemList.from_csv method.

### DIFF
--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -98,6 +98,7 @@ class ItemList():
     @classmethod
     def from_csv(cls, path:PathOrStr, csv_name:str, cols:IntsOrStrs=0, header:str='infer', **kwargs)->'ItemList':
         "Create an `ItemList` in `path` from the inputs in the `cols` of `path/csv_name` opened with `header`."
+        path = Path(path)
         df = pd.read_csv(path/csv_name, header=header)
         return cls.from_df(df, path=path, cols=cols, **kwargs)
 

--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -98,8 +98,7 @@ class ItemList():
     @classmethod
     def from_csv(cls, path:PathOrStr, csv_name:str, cols:IntsOrStrs=0, header:str='infer', **kwargs)->'ItemList':
         "Create an `ItemList` in `path` from the inputs in the `cols` of `path/csv_name` opened with `header`."
-        path = Path(path)
-        df = pd.read_csv(path/csv_name, header=header)
+        df = pd.read_csv(Path(path)/csv_name, header=header)
         return cls.from_df(df, path=path, cols=cols, **kwargs)
 
     def _relative_item_path(self, i): return self.items[i].relative_to(self.path)


### PR DESCRIPTION
There is a bug in ItemList.from_csv method. When we pass a string instead of a Path object to the path parameter, this triggers the bug.

Fix for this bug is to convert string into Path object.