### PR TITLE
Use ThreadPoolExecutor on Windows 

### DIFF
--- a/old/fastai/structured.py
+++ b/old/fastai/structured.py
@@ -6,7 +6,7 @@ from pandas.api.types import is_string_dtype, is_numeric_dtype
 from sklearn.ensemble import forest
 from sklearn.tree import export_graphviz
 
-import platform;
+from platform import *;
 
 
 def set_plot_sizes(sml, med, big):
@@ -19,7 +19,7 @@ def set_plot_sizes(sml, med, big):
     plt.rc('figure', titlesize=big)  # fontsize of the figure title
 
 def parallel_trees(m, fn, n_jobs=8):
-    if(platform.system() == 'Windows'):
+    if(system() == 'Windows'):
         return list(ThreadPoolExecutor(n_jobs).map(fn, m.estimators_))
     else:
         return list(ProcessPoolExecutor(n_jobs).map(fn, m.estimators_))

--- a/old/fastai/structured.py
+++ b/old/fastai/structured.py
@@ -6,6 +6,8 @@ from pandas.api.types import is_string_dtype, is_numeric_dtype
 from sklearn.ensemble import forest
 from sklearn.tree import export_graphviz
 
+import platform;
+
 
 def set_plot_sizes(sml, med, big):
     plt.rc('font', size=sml)          # controls default text sizes
@@ -17,6 +19,9 @@ def set_plot_sizes(sml, med, big):
     plt.rc('figure', titlesize=big)  # fontsize of the figure title
 
 def parallel_trees(m, fn, n_jobs=8):
+    if(platform.system() == 'Windows'):
+        return list(ThreadPoolExecutor(n_jobs).map(fn, m.estimators_))
+    else:
         return list(ProcessPoolExecutor(n_jobs).map(fn, m.estimators_))
 
 def draw_tree(t, df, size=10, ratio=0.6, precision=0):


### PR DESCRIPTION
Calling parallel_trees function on windows crashes because it uses internally ProcessPoolExecutor that throws a BrokenProcessPool error.

Error thrown: 

> BrokenProcessPool: A process in the process pool was terminated abruptly while the future was running or pending.

This issue is fixed by rather using ThreadPoolExecutor on Windows systems