### PR TITLE
Fix multilabel classification for text

### DIFF
--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -162,7 +162,9 @@ class TextDataBunch(DataBunch):
         "Create a `TextDataBunch` from DataFrames."
         p_kwargs, kwargs = split_kwargs_by_func(kwargs, _get_processor)
         processor = _get_processor(tokenizer=tokenizer, vocab=vocab, **p_kwargs)
-        if classes is None and label_cols: classes = label_cols
+        if classes is None and label_cols:
+            if len(label_cols) == 0:   classes = [0]
+            elif len(label_cols) > 1:  classes = label_cols
         src = ItemLists(path, TextList.from_df(train_df, path, cols=text_cols, processor=processor),
                         TextList.from_df(valid_df, path, cols=text_cols, processor=processor))
         src = src.label_for_lm() if cls==TextLMDataBunch else src.label_from_df(cols=label_cols, classes=classes, sep=label_delim)

--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -162,6 +162,7 @@ class TextDataBunch(DataBunch):
         "Create a `TextDataBunch` from DataFrames."
         p_kwargs, kwargs = split_kwargs_by_func(kwargs, _get_processor)
         processor = _get_processor(tokenizer=tokenizer, vocab=vocab, **p_kwargs)
+        if classes is None and label_cols: classes = label_cols
         src = ItemLists(path, TextList.from_df(train_df, path, cols=text_cols, processor=processor),
                         TextList.from_df(valid_df, path, cols=text_cols, processor=processor))
         src = src.label_for_lm() if cls==TextLMDataBunch else src.label_from_df(cols=label_cols, classes=classes, sep=label_delim)
@@ -318,7 +319,7 @@ class TextList(ItemList):
 class LMLabel(CategoryList):
     def predict(self, res): return res
     def reconstruct(self,t:Tensor): return 0
-        
+
 class LMTextList(TextList):
     "Special `TextList` for a language model."
     _bunch = TextLMDataBunch

--- a/tests/test_text_train.py
+++ b/tests/test_text_train.py
@@ -81,7 +81,7 @@ def text_df(n_labels):
     return df
 
 def test_classifier():
-    for n_labels in [1]: # , 8 - does not work for multilclass yet
+    for n_labels in [1, 8]:
         path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data', 'tmp')
         os.makedirs(path)
         try:
@@ -93,7 +93,6 @@ def test_classifier():
             assert len(data.train_dl) == math.ceil(len(data.train_ds)/data.train_dl.batch_size)
             assert next(iter(data.train_dl))[0].shape == (9, 2)
             assert next(iter(data.valid_dl))[0].shape == (9, 2)
-            classifier.fit(1)
         finally:
             shutil.rmtree(path)
 


### PR DESCRIPTION
I think this broke in the refactor for Datablock (https://github.com/fastai/fastai/pull/1156)

Marking @sgugger : may be it was intended to set the `classes` consistently at 1 place somewhere else, but the **missing** thing which was making the multilabel classification work earlier was 
```
        if classes is None:
            if len(label_cols) == 0:   classes = [0]
            elif len(label_cols) > 1:  classes = label_cols
```
inside `TextDataset.from_df()` (which was refactored out)