### PR TITLE
Fix windows compatibility issue

### DIFF
--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -33,7 +33,7 @@ class PreProcessor():
     "Basic class for a processor that will be applied to items at the end of the data block API."
     def __init__(self, ds:Collection=None):  self.ref_ds = ds
     def process_one(self, item:Any):         return item
-    def process(self, ds:Collection):        ds.items = array([self.process_one(item) for item in ds.items])
+    def process(self, ds:Collection):        ds.items = array([self.process_one(item) for item in ds.items],'int64')
 
 class ItemList():
     _bunch,_processor,_label_cls,_square_show = DataBunch,None,None,False

--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -174,7 +174,7 @@ class TextDataBunch(DataBunch):
                  label_cols:IntsOrStrs=0, label_delim:str=None, **kwargs) -> DataBunch:
         "Create a `TextDataBunch` from texts in csv files."
         df = pd.read_csv(Path(path)/csv_name, header=header)
-        idx = np.random.permutation(len(df))
+        df = df.iloc[np.random.permutation(len(df))]
         cut = int(valid_pct * len(df)) + 1
         train_df, valid_df = df[cut:], df[:cut]
         test_df = None if test is None else pd.read_csv(Path(path)/test, header=header)


### PR DESCRIPTION
In windows the default data type of a numpy array is Int32 not Int64 as on linux.  Because of this the following change from
`def process(self, ds:Collection):        ds.items = [self.process_one(item) for item in ds.items]`
to
`def process(self, ds:Collection):        ds.items = array([self.process_one(item) for item in ds.items])`
breaks fastai compatibility with windows.  

I know that the official docs have been changed to say that fastai is not compatible with windows, however given that
`type(ds.items[0]) == numpy.int64`
on linux, the following change to allow this to work again on windows should not hurt.
`def process(self, ds:Collection):        ds.items = array([self.process_one(item) for item in ds.items],'int64')`
