### PR TITLE
Fix windows compatibility issue

### DIFF
--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -253,7 +253,7 @@ class CategoryProcessor(PreProcessor):
         "Generate classes from `items` by taking the sorted unique values."
         return uniqueify(items)
 
-    def process_one(self,item): return self.c2i.get(item,None)
+    def process_one(self,item): return np.int64(self.c2i.get(item,None))
 
     def process(self, ds):
         if self.classes is None: self.create_classes(self.generate_classes(ds.items))

--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -174,7 +174,7 @@ class TextDataBunch(DataBunch):
                  label_cols:IntsOrStrs=0, label_delim:str=None, **kwargs) -> DataBunch:
         "Create a `TextDataBunch` from texts in csv files."
         df = pd.read_csv(Path(path)/csv_name, header=header)
-        idx = np.random.permutation(len(df))
+        df = df.iloc[np.random.permutation(len(df))]
         cut = int(valid_pct * len(df)) + 1
         train_df, valid_df = df[cut:], df[:cut]
         test_df = None if test is None else pd.read_csv(Path(path)/test, header=header)


### PR DESCRIPTION
In the [dogs_cats ](https://github.com/fastai/fastai/blob/master/examples/dogs_cats.ipynb )example prior to commit 0f12c1c6818aa1aed4d05a7913ebc1a6a3850f9b
`type(data.train_ds.y.items[0]) == int`
on both linux and windows and the following three lines of code worked perfectly (as long as num_workers=0 on windows)
```
data = ImageDataBunch.from_folder(path, ds_tfms=get_transforms(), size=224,num_workers=0).normalize(imagenet_stats)
learn = create_cnn(data, models.resnet34, metrics=accuracy)
learn.fit_one_cycle(1)
```
However following the change from
`def process(self, ds:Collection): ds.items = [self.process_one(item) for item in ds.items]`
to
`def process(self, ds:Collection): ds.items = array([self.process_one(item) for item in ds.items])`
`type(data.train_ds.y.items[0])  == np.int32`
on windows and
`type(data.train_ds.y.items[0])  == np.int64`
on linux, because the default type of a numpy array on windows is int32 and not int64 as on linux.

Because of this
`learn.fit_one_cycle(1)`
now throws the following error

> RuntimeError: Expected object of scalar type Long but got scalar type Int for argument #2 'target'

The proposed change to force categorical indices to be int64 as they already are on linux does not appear to cause any problems with the standard tests and it would be useful for windows users, to avoid having to manually change the below for each data set following the creation of a databunch
`data.train_ds.y.items = np.int64(data.train_ds.y.items)`

It would probably make more sense to do this in create_classes() when the enumeration index is returned, in case the enumeration is performed differently and it is possible for a key to be missing from the c2i dictionary.  If so I can change the pull request to the below?
`if classes is not None: self.c2i = {v:np.int64(k) for k,v in enumerate(classes)}`
