### PR TITLE
Add a use_partial_data to the data block api

### DIFF
--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -111,6 +111,13 @@ class ItemList():
 
     def _relative_item_path(self, i): return self.items[i].relative_to(self.path)
     def _relative_item_paths(self):   return [self._relative_item_path(i) for i in range_of(self.items)]
+                
+    def use_partial_data(self, sample_pct:float=1.0, seed:int=None)->'ItemList':
+        "Use only a sample of the full dataset.  "
+        if seed is not None: np.random.seed(seed)
+        rand_idx = np.random.permutation(range_of(self))
+        cut = int(sample_pct * len(self))
+        return self[rand_idx[:cut]]
 
     def to_text(self, fn:str):
         "Save `self.items` to `fn` in `self.path`."

--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -113,7 +113,7 @@ class ItemList():
     def _relative_item_paths(self):   return [self._relative_item_path(i) for i in range_of(self.items)]
                 
     def use_partial_data(self, sample_pct:float=1.0, seed:int=None)->'ItemList':
-        "Use only a sample of the full dataset.  "
+        "Use only a sample of `sample_pct`of the full dataset and an optional `seed`."
         if seed is not None: np.random.seed(seed)
         rand_idx = np.random.permutation(range_of(self))
         cut = int(sample_pct * len(self))


### PR DESCRIPTION
This would allow somebody to easily take a smaller sample of the data.  By default it would use 100% of the data, but that could be lowered by setting sample_pct to a lower number.  For example, by using sample_pct=0.01, it would select a random 1% of the samples.

Here is the thread for discussion and I am open to suggestions if there is a better way to structure this.  

https://forums.fast.ai/t/add-a-use-partial-data-to-the-data-block-api/31718

I would also appreciate help building a test to verify this works. 