### PR TITLE
Added unit tests for metrics.py

### DIFF
--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -21,7 +21,7 @@ def accuracy_thresh(y_pred:Tensor, y_true:Tensor, thresh:float=0.5, sigmoid:bool
     if sigmoid: y_pred = y_pred.sigmoid()
     return ((y_pred>thresh)==y_true.byte()).float().mean()
 
-def dice(input:Tensor, targs:Tensor, iou:bool=False)->Rank0Tensor:
+def dice(input:FloatTensor, targs:LongTensor, iou:bool=False)->Rank0Tensor:
     "Dice coefficient metric for binary target. If `iou=True`, return iou metric."
     n = targs.shape[0]
     input = input.argmax(dim=1).view(n,-1)
@@ -31,7 +31,7 @@ def dice(input:Tensor, targs:Tensor, iou:bool=False)->Rank0Tensor:
     if not iou: return (2. * intersect / union if union > 0 else union.new([1.]).squeeze())
     else: return intersect / (union-intersect+1.0)
 
-def accuracy(input:Tensor, targs:Tensor)->Rank0Tensor:
+def accuracy(input:Tensor, targs:LongTensor)->Rank0Tensor:
     "Compute accuracy with `targs` when `input` is bs * n_classes."
     n = targs.shape[0]
     input = input.argmax(dim=-1).view(n,-1)
@@ -42,8 +42,9 @@ def error_rate(input:Tensor, targs:Tensor)->Rank0Tensor:
     "1 - `accuracy`"
     return 1-accuracy(input, targs)
 
-def exp_rmspe(pred:Tensor, targ:Tensor)->Rank0Tensor:
+def exp_rmspe(pred:FloatTensor, targ:FloatTensor)->Rank0Tensor:
     "Exp RMSE between `pred` and `targ`."
+    assert pred.numel() == targ.numel(), "Expected same numbers of elements in pred & targ"
     if len(pred.shape)==2: pred=pred.squeeze(1)
     pred, targ = torch.exp(pred), torch.exp(targ)
     pct_var = (targ - pred)/targ

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,56 @@
+import pytest
+from fastai import *
+from fastai.metrics import *
+
+p1 = torch.Tensor([0,1,0,0,0]).expand(5,-1)
+p2 = torch.Tensor([[0,0,0,0,0],[0,1,0,0,0]]).expand(5,2,-1).float()
+t1 = torch.arange(5)
+t2 = torch.Tensor([1,1,1,1,0]).expand(5,-1)
+
+@pytest.mark.parametrize("p, t, expect", [
+    (p1, t1, 0.2),
+    (torch.eye(5), t1, 1),
+])
+def test_accuracy(p, t, expect):
+    assert np.isclose(accuracy(p, t).item(), expect)
+
+@pytest.mark.parametrize("p, t, expect", [
+    (p1, t1, 0.8),
+    (torch.eye(5), t1, 0),
+])
+def test_error_rate(p, t, expect):
+    assert np.isclose(error_rate(p, t).item(), expect)
+
+def test_exp_rmspe():
+    assert np.isclose(exp_rmspe(torch.ones(1,5), torch.ones(5)).item(), 0)
+
+def test_exp_rmspe_num_of_ele():
+    with pytest.raises(AssertionError):
+        exp_rmspe(p1, t1.float())
+
+def test_accuracy_thresh():
+    assert np.isclose(accuracy_thresh(torch.linspace(0,1,5), torch.ones(5)), 0.8)
+
+@pytest.mark.parametrize("p, t, expect", [
+    (p2, t2, 0.4),
+    (torch.zeros(5,2,5), torch.eye(5,5), 1/3),
+    (torch.zeros(5,2,5), torch.zeros(5,5), 0),
+])
+def test_dice(p, t, expect):
+    assert np.isclose(dice(p, t.long()).item(), expect)
+
+@pytest.mark.parametrize("p, t, expect", [
+    (p2, t2, 0.238095),
+    (p2, torch.eye(5,5), 0.1),
+    (p2, torch.zeros(5,5), 0),
+])
+def test_dice_iou(p, t, expect):
+    assert np.isclose(dice(p, t.long(), iou=True).item(), expect)
+
+@pytest.mark.parametrize("p, t, expect", [
+    (torch.ones(1,10), torch.ones(1,10), 1),
+    (torch.zeros(1,10), torch.zeros(1,10), 0),
+])
+def test_fbeta(p, t, expect):
+    assert np.isclose(fbeta(p, t).item(), expect)
+


### PR DESCRIPTION
Added some unit tests for metrics.py. Also added a tensor size check and its related unit test for exp_rmspe to prevent # of element mismatch since as long as the batch size matches it would still return a loss without explicitly failing the function call even if pred differs in size along other dims.