### PR TITLE
Make load_pretreined support models with optimizer saved

### DIFF
--- a/fastai/text/learner.py
+++ b/fastai/text/learner.py
@@ -68,6 +68,7 @@ class RNNLearner(Learner):
         old_itos = pickle.load(open(itos_fname, 'rb'))
         old_stoi = {v:k for k,v in enumerate(old_itos)}
         wgts = torch.load(wgts_fname, map_location=lambda storage, loc: storage)
+        if 'model' in wgts: wgts = wgts['model']
         wgts = convert_weights(wgts, old_stoi, self.data.train_ds.vocab.itos)
         self.model.load_state_dict(wgts)
 


### PR DESCRIPTION
This is a workaround for ppl not to get into troubles if they saved their LM  along with the optimizer. Ideally, we should warn user with UserWarning but I haven't seen it in the code base so I haven't added it.

fixes: https://github.com/n-waves/ulmfit-multilingual/issues/20