### PR TITLE
Declare conditional dataclasses dependency in a compatible way

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ requirements = to_list("""
     torchvision-nightly
     typing
     pyyaml
+    dataclasses ; python_version<'3.7'
 """)
 
 if sys.version_info < (3,7): requirements.append('dataclasses')


### PR DESCRIPTION
Latest release (1.0.33) moved dataclasses from a mandatory dependency to a
conditional dependency based on python version.

This condition was made with a Python condition in the setup.py. This works
fine when installing the source distribution but don't works with the wheel
distribution made with Python 3.7 as the condition isn't met at the time the
wheel is generated.

setuptool allows to define a conditional dependency based on python version
using the `python_version` environment marker. This way, the dependency is
explicitly marked as optional and always present on the wheel distribution.

See https://hynek.me/articles/conditional-python-dependencies/ for a good
summary of the possibilities.

I didn't updated the setup.py with the older way of declaring conditional
dependencies (with extra_requires) as the minimum version of setuptools that
support the `python_version` environment marker is more than one year old and
people having wheel support will likely have an up-to-date version of
setuptools.

I didn't removed the Python condition from the `setup.py` file either because
I don't know if fastai supports old environments with an old setuptools
version.

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
