### PR TITLE
fix wrong type for vocab init w/ itos

### DIFF
--- a/fastai/text/transform.py
+++ b/fastai/text/transform.py
@@ -118,7 +118,7 @@ class Tokenizer():
 
 class Vocab():
     "Contain the correspondance between numbers and tokens and numericalize."
-    def __init__(self, itos:Dict[int,str]):
+    def __init__(self, itos:Collection[str]):
         self.itos = itos
         self.stoi = collections.defaultdict(int,{v:k for k,v in enumerate(self.itos)})
 


### PR DESCRIPTION
If `itos` is a dict, it silently fails  and sets `stoi` to `{0: 0, 1: 1, 2: 2 ..}`.