### PR TITLE
Fix: AttributeError: module ‘torch.nn.init’ has no attribute ‘kaiming_normal_’

### DIFF
--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -96,7 +96,7 @@ dependencies:
 - prompt_toolkit
 #- pytest
 - pip:
-  - torchvision>=0.1.9
+  - torchvision==0.1.9
   - opencv-python
   - isoweek
   - pandas_summary

--- a/environment.yml
+++ b/environment.yml
@@ -97,7 +97,7 @@ dependencies:
 #- pytest
 - cython
 - pip:
-  - torchvision>=0.1.9
+  - torchvision==0.1.9
   - opencv-python
   - isoweek
   - pandas_summary==0.0.5


### PR DESCRIPTION
Got this error, did a bit of digging and found this thread - https://forums.fast.ai/t/attributeerror-module-torch-nn-init-has-no-attribute-kaiming-normal/29278

So, this PR fixes the issue.