### PR TITLE
Update one_hot Method for MultiCategoryList

### DIFF
--- a/fastai/core.py
+++ b/fastai/core.py
@@ -207,7 +207,11 @@ def df_names_to_idx(names:IntsOrStrs, df:DataFrame):
 def one_hot(x:Collection[int], c:int):
     "One-hot encode `x` with `c` classes."
     res = np.zeros((c,), np.float32)
-    res[x] = 1.
+    if len(x) > 0:
+        for i in x:
+            res[i] = 1
+    else:
+        res[x] = 1.
     return res
 
 def index_row(a:Union[Collection,pd.DataFrame,pd.Series], idxs:Collection[int])->Any:


### PR DESCRIPTION
If x has more than one integers then it will throw IndexError which is generally happening in this case where the Text of one row of a DataFrame contain more than one label as Target..
For more reference: [visit this Issue](https://github.com/fastai/fastai/issues/1304)