### PR TITLE
Fix: Make torchvision compatible with pytorch

### DIFF
--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -96,7 +96,7 @@ dependencies:
 - prompt_toolkit
 #- pytest
 - pip:
-  - torchvision>=0.1.9
+  - torchvision==0.1.9
   - opencv-python
   - isoweek
   - pandas_summary

--- a/environment.yml
+++ b/environment.yml
@@ -97,7 +97,7 @@ dependencies:
 #- pytest
 - cython
 - pip:
-  - torchvision>=0.1.9
+  - torchvision==0.1.9
   - opencv-python
   - isoweek
   - pandas_summary==0.0.5


### PR DESCRIPTION
torchvision >= 0.1.9 was incompatible with pytorch<0.4. The fix ensures compatibility between these two libraries.

Fixes #1290

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
