### PR TITLE
Fixes issue #1311 of not being able to to run installation with pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,12 +38,11 @@ requirements = to_list("""
     pandas
     Pillow
     pyyaml
-    regex
+    regex==2018.01.10
     requests
     scipy
     spacy==2.0.16
     thinc==6.12.0
-    regex
     cymem
     torchvision
     torch


### PR DESCRIPTION
Removal of duplicate 'regex' package in requirements list, and ensuring
version is set to 2018.01.10, otherwise this is then incompatible with
'spacy' package.

error: regex 2018.11.22 is installed but regex==2018.01.10 is required
by {'fastai', 'spacy'}

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
