### PR TITLE
Fix. Should be mnist_stats instead of imagenet_stats, because it is a mnist dataset. Accuracy improoves to 0.997547 and 0.996535 accordingly.

### DIFF
--- a/examples/vision.ipynb
+++ b/examples/vision.ipynb
@@ -82,7 +82,7 @@
    ],
    "source": [
     "data = ImageDataBunch.from_folder(path, ds_tfms=(rand_pad(2, 28), []), bs=64)\n",
-    "data.normalize(imagenet_stats)\n",
+    "data.normalize(mnist_stats)\n",
     "img,label = data.train_ds[0]\n",
     "img"
    ]
@@ -211,7 +211,7 @@
    ],
    "source": [
     "data = ImageDataBunch.from_csv(path, ds_tfms=(rand_pad(2, 28), []), bs=64)\n",
-    "data.normalize(imagenet_stats)\n",
+    "data.normalize(mnist_stats)\n",
     "img,label = data.train_ds[0]\n",
     "img"
    ]


### PR DESCRIPTION
Small bug fix. Should by mnist_stats instead of imagenet_stats, because it is a mnist dataset. Accuracy improoves to 0.997547 and 0.996535 accordingly.

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->