### PR TITLE
add errors argument in add_datepart for invalid parsing

### DIFF
--- a/old/fastai/structured.py
+++ b/old/fastai/structured.py
@@ -73,7 +73,7 @@ def get_sample(df,n):
     idxs = sorted(np.random.permutation(len(df))[:n])
     return df.iloc[idxs].copy()
 
-def add_datepart(df, fldname, drop=True, time=False):
+def add_datepart(df, fldname, drop=True, time=False, errors="raise"):	
     """add_datepart converts a column of df from a datetime64 to many columns containing
     the information from the date. This applies changes inplace.
 
@@ -110,7 +110,7 @@ def add_datepart(df, fldname, drop=True, time=False):
         fld_dtype = np.datetime64
 
     if not np.issubdtype(fld_dtype, np.datetime64):
-        df[fldname] = fld = pd.to_datetime(fld, infer_datetime_format=True)
+        df[fldname] = fld = pd.to_datetime(fld, infer_datetime_format=True, errors=errors)
     targ_pre = re.sub('[Dd]ate$', '', fldname)
     attr = ['Year', 'Month', 'Week', 'Day', 'Dayofweek', 'Dayofyear',
             'Is_month_end', 'Is_month_start', 'Is_quarter_end', 'Is_quarter_start', 'Is_year_end', 'Is_year_start']


### PR DESCRIPTION
A small change in adding "errors" as an argument to add_datepart. I was having an issue when the dates were not in the correct format. So enabled an option for the user to specify whether to ignore/raise/coerce the invalid format.

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
