### PR TITLE
Fix process_one() for CategoryProcessor

### DIFF
--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -272,8 +272,8 @@ class CategoryProcessor(PreProcessor):
         return uniqueify(items)
 
     def process_one(self,item):
-        try: return self.c2i.get(item)
-        except:
+        try: return self.c2i[item]
+        except KeyError:
             raise Exception("Your validation data contains a label that isn't present in the training set, please fix your data.")
 
     def process(self, ds):

--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -273,7 +273,7 @@ class CategoryProcessor(PreProcessor):
 
     def process_one(self,item):
         try: return self.c2i[item]
-        except KeyError:
+        except:
             raise Exception("Your validation data contains a label that isn't present in the training set, please fix your data.")
 
     def process(self, ds):

--- a/tests/test_category.py
+++ b/tests/test_category.py
@@ -1,3 +1,5 @@
+import pytest
+
 from fastai import *
 
 def chk(a,b): assert np.array_equal(a,b)
@@ -71,3 +73,23 @@ def test_multi_category():
     exp[c2i[t[1]]] = 1.
     chk(y[1].data, exp)
 
+def test_category_processor_existing_class():
+    c1 = [1,3,2,3,1]
+    c2 = list('cabbc')
+    df = pd.DataFrame(dict(c1=c1,c2=c2))
+
+    l1 = ItemList.from_df(df, col=0)
+    sd = l1.split_by_idx([2, 4])
+    ll = sd.label_from_df(1)
+    ll.y.processor[0].process_one('a')
+
+def test_category_processor_non_existing_class():
+    c1 = [1,3,2,3,1]
+    c2 = list('cabbc')
+    df = pd.DataFrame(dict(c1=c1,c2=c2))
+
+    l1 = ItemList.from_df(df, col=0)
+    sd = l1.split_by_idx([2, 4])
+    ll = sd.label_from_df(1)
+    with pytest.raises(Exception):
+        ll.y.processor[0].process_one('d')


### PR DESCRIPTION
Exception that should be thrown when we try to get the index of class we didn't see before was silenced causing `None` to be returned (`dict.get()` returns None if not found)