### PR TITLE
Set tools/run-after-git-clone to use python3 by default

### DIFF
--- a/tools/run-after-git-clone
+++ b/tools/run-after-git-clone
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # if you're a fastai developer please make sure you do this:
 #


### PR DESCRIPTION
I just ran through the steps listed in the documentation contribution guide and encountered an error when running `tools/run-after-git-clone`. I am using OS X.

Here is the error message:

```python
  File "tools/run-after-git-clone", line 17
    cmd = f"{sys.executable} {script}"
                                     ^
SyntaxError: invalid syntax
```

By correcting the shebang of the file, the script will now run correctly regardless of the relative order of the paths of Python2 and Python3 in the user's $PATH variable.