### PR TITLE
test coverage for show_batch

### DIFF
--- a/tests/test_text_data.py
+++ b/tests/test_text_data.py
@@ -125,3 +125,12 @@ def test_from_ids_works_for_variable_length_sentences():
                                       train_ids=ids, train_lbls=lbl,
                                       valid_ids=ids, valid_lbls=lbl, classes={0:0}, bs=8)
     text_classifier_learner(data).fit(1)
+
+def test_show_batch():
+    path = untar_data(URLs.IMDB_SAMPLE)
+    df = pd.read_csv(path/'texts.csv')
+    data_lm = TextDataBunch.from_csv(path, 'texts.csv')
+    data_lm.save()
+    data = TextDataBunch.load(path )
+    #  test to up coverage and ensure no exceptions
+    data.show_batch()


### PR DESCRIPTION
Up testcoverage for function show_batch, example TextDataBunch.

Check with: pytest -k 'show_batch' tests/test_text_data.py

Function allows to check show_batch works without exceptions. In the future can be used to verify adjustments. It can be extended to check scenarios with different batch sizes, e.g. when the batch is smaller than the default value of 5 records shown.

For a function targeted at end user for visual check, asserts are not evident. They be added in 2nd step on suggestion.