### PR TITLE
Minor docs fix, added comment - torch_core.defaults.device

### DIFF
--- a/docs/torch_core.html
+++ b/docs/torch_core.html
@@ -47,7 +47,15 @@ summary: "Basic functions using pytorch"
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p><code>default_device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')</code> <div style="text-align: right"><a href="https://github.com/fastai/fastai/blob/master/fastai/torch_core.py#L42">[source]</a></div></p>
+<p><code>defaults.device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')</code> <div style="text-align: right"><a href="https://github.com/fastai/fastai/blob/master/fastai/torch_core.py#L62">[source]</a></div></p>
+
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<p>If you are trying to make fastai run on the CPU, simply change the default device: <code>defaults.device = 'cpu'</code>.</p>
+<p>Alternatively, if not using wildcard imports: <code>fastai.torch_core.defaults.device = 'cpu'</code>.</p>
 
 </div>
 </div>

--- a/docs_src/torch_core.ipynb
+++ b/docs_src/torch_core.ipynb
@@ -51,7 +51,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`default_device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')` <div style=\"text-align: right\"><a href=\"https://github.com/fastai/fastai/blob/master/fastai/torch_core.py#L42\">[source]</a></div>"
+    "`defaults.device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')` <div style=\"text-align: right\"><a href=\"https://github.com/fastai/fastai/blob/master/fastai/torch_core.py#L62\">[source]</a></div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you are trying to make fastai run on the CPU, simply change the default device: `defaults.device = 'cpu'`. \n",
+    "\n",
+    "Alternatively, if not using wildcard imports: `fastai.torch_core.defaults.device = 'cpu'`."
    ]
   },
   {


### PR DESCRIPTION
There was a typo in torch_core documentation - `default_device` instead of `defaults.device`, also an incorrect line was linked under the "source" link. 

Added an explicit comment about how to make fastai run on CPU, as I have lost some time figuring it out myself.
