### PR TITLE
vision.image docs transforms not showing for mask, points and bbox

### DIFF
--- a/docs_src/vision.image.ipynb
+++ b/docs_src/vision.image.ipynb
@@ -1544,8 +1544,8 @@
     "_, axs = plt.subplots(2,4,figsize=(12,6))\n",
     "for ax in axs.flatten():\n",
     "    img,mask = get_seg_ex()\n",
-    "    img.apply_tfms(tfms[0], size=224)\n",
-    "    mask.apply_tfms(tfms[0], do_resolve=False, size=224)\n",
+    "    img = img.apply_tfms(tfms[0], size=224)\n",
+    "    mask = mask.apply_tfms(tfms[0], do_resolve=False, size=224)\n",
     "    img.show(ax=ax, y=mask)"
    ]
   },
@@ -1606,8 +1606,8 @@
     "_, axs = plt.subplots(2,4,figsize=(12,6))\n",
     "for ax in axs.flatten():\n",
     "    img,pnts = get_pnt_ex()\n",
-    "    img.apply_tfms(tfms[0], size=224)\n",
-    "    pnts.apply_tfms(tfms[0], do_resolve=False, size=224)\n",
+    "    img = img.apply_tfms(tfms[0], size=224)\n",
+    "    pnts = pnts.apply_tfms(tfms[0], do_resolve=False, size=224)\n",
     "    img.show(ax=ax, y=pnts)"
    ]
   },
@@ -1641,8 +1641,8 @@
     "_, axs = plt.subplots(2,4,figsize=(12,6))\n",
     "for ax in axs.flatten():\n",
     "    img,bbox = get_bb_ex()\n",
-    "    img.apply_tfms(tfms[0], size=224)\n",
-    "    bbox.apply_tfms(tfms[0], do_resolve=False, size=224)\n",
+    "    img = img.apply_tfms(tfms[0], size=224)\n",
+    "    bbox = bbox.apply_tfms(tfms[0], do_resolve=False, size=224)\n",
     "    img.show(ax=ax, y=bbox)"
    ]
   },
@@ -3219,6 +3219,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I was going through documents to try out different transforms on a particular bounding box data. In vision.image docs all the example images seemed untransformed (including point and mask). I thought maybe those are little changes that human eye can't distinguish but when I checked in my notebook with `p_affine=1` it was still the same with same code chunk. Then I figured that transformed `img` and correspond `y` are not assigned to variables that been used to show in docs. Little change, though it may help people to not get confused like me :D  