### PR TITLE
Fixing notebook lesson2-rf_interpretation from ML course

### DIFF
--- a/courses/ml1/lesson2-rf_interpretation.ipynb
+++ b/courses/ml1/lesson2-rf_interpretation.ipynb
@@ -3065,7 +3065,7 @@
    "source": [
     "def plot_pdp(feat, clusters=None, feat_name=None):\n",
     "    feat_name = feat_name or feat\n",
-    "    p = pdp.pdp_isolate(m, x, x.columns, feat)\n",
+    "    p = pdp.pdp_isolate(m, x, feat)\n",
     "    return pdp.pdp_plot(p, feat_name, plot_lines=True,\n",
     "                        cluster=clusters is not None,\n",
     "                        n_cluster_centers=clusters)"
@@ -3129,7 +3129,7 @@
    ],
    "source": [
     "feats = ['saleElapsed', 'YearMade']\n",
-    "p = pdp.pdp_interact(m, x, x.columns, feats)\n",
+    "p = pdp.pdp_interact(m, x, feats)\n",
     "pdp.pdp_interact_plot(p, feats)"
    ]
   },
@@ -4013,6 +4013,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -107,5 +107,5 @@ dependencies:
 #  - plotnine
   - kaggle-cli
   - ipywidgets
-#  - pdpbox<=0.1.0
+  - pdpbox<=0.1.0
   - treeinterpreter

--- a/environment.yml
+++ b/environment.yml
@@ -44,7 +44,7 @@ dependencies:
 - libsodium
 - libxml2
 - markupsafe
-- matplotlib
+- matplotlib=2.2.3
 - mistune
 - mkl
 - nbformat
@@ -105,8 +105,10 @@ dependencies:
   - graphviz
   - sklearn_pandas
   - feather-format
-#  - plotnine
+  - plotnine
   - kaggle-cli
   - ipywidgets
   - nbconvert
   - PyHamcrest
+  - pdpbox=0.1.0
+  - scikit-misc


### PR DESCRIPTION
The latest version of PDPbox has an issue with pdp.pdp_interact_plot as it only returns 1 plot instead of 3.

The changes made are for the environments for GPU and CPU to include the proper versions of PDPBox and matplotlib to work.

Also, function pdp.pdp_isolate() calls were modified on notebook to take 3 arguments and be compatible with previous versions
