### PR TITLE
Fix backpropagation of LSTM when trained on fp16

### DIFF
--- a/fastai/callbacks/rnn.py
+++ b/fastai/callbacks/rnn.py
@@ -27,8 +27,8 @@ class RNNTrainer(Callback):
         "Adjusts the lr to the sequence length and applies AR and TAR to `last_loss`."
         if self.adjust: self.learn.opt.lr *= last_input.size(1) / self.bptt
         #AR and TAR
-        if self.alpha != 0.:  last_loss += (self.alpha * self.out[-1].pow(2).mean()).sum()
+        if self.alpha != 0.:  last_loss += (self.alpha * self.out[-1].pow(2).mean()).sum().float()
         if self.beta != 0.:
             h = self.raw_out[-1]
-            if len(h)>1: last_loss += (self.beta * (h[1:] - h[:-1]).pow(2).mean()).sum()
+            if len(h)>1: last_loss += (self.beta * (h[1:] - h[:-1]).pow(2).mean()).sum().float()
         return last_loss


### PR DESCRIPTION
Otherwise, you get an error that the Backpropagation mixes fp16 with fp32. loss is fp32 while mean of weights is fp16. The proposed solution simply converts AR & TAR to fp32 always. This should be a noop in normal training and it fixes the issue during fp16 training.

I don't have a card that supports fp16 temporarily available so I can't test the changes.

fixes: #1335