### PR TITLE
vision.image docs minor change - tfms apply no longer inplace

### DIFF
--- a/docs_src/vision.image.ipynb
+++ b/docs_src/vision.image.ipynb
@@ -3219,18 +3219,6 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.1"
   }
  },
  "nbformat": 4,

--- a/docs_src/vision.image.ipynb
+++ b/docs_src/vision.image.ipynb
@@ -1544,8 +1544,8 @@
     "_, axs = plt.subplots(2,4,figsize=(12,6))\n",
     "for ax in axs.flatten():\n",
     "    img,mask = get_seg_ex()\n",
-    "    img.apply_tfms(tfms[0], size=224)\n",
-    "    mask.apply_tfms(tfms[0], do_resolve=False, size=224)\n",
+    "    img = img.apply_tfms(tfms[0], size=224)\n",
+    "    mask = mask.apply_tfms(tfms[0], do_resolve=False, size=224)\n",
     "    img.show(ax=ax, y=mask)"
    ]
   },
@@ -1606,8 +1606,8 @@
     "_, axs = plt.subplots(2,4,figsize=(12,6))\n",
     "for ax in axs.flatten():\n",
     "    img,pnts = get_pnt_ex()\n",
-    "    img.apply_tfms(tfms[0], size=224)\n",
-    "    pnts.apply_tfms(tfms[0], do_resolve=False, size=224)\n",
+    "    img = img.apply_tfms(tfms[0], size=224)\n",
+    "    pnts = pnts.apply_tfms(tfms[0], do_resolve=False, size=224)\n",
     "    img.show(ax=ax, y=pnts)"
    ]
   },
@@ -1641,8 +1641,8 @@
     "_, axs = plt.subplots(2,4,figsize=(12,6))\n",
     "for ax in axs.flatten():\n",
     "    img,bbox = get_bb_ex()\n",
-    "    img.apply_tfms(tfms[0], size=224)\n",
-    "    bbox.apply_tfms(tfms[0], do_resolve=False, size=224)\n",
+    "    img = img.apply_tfms(tfms[0], size=224)\n",
+    "    bbox = bbox.apply_tfms(tfms[0], do_resolve=False, size=224)\n",
     "    img.show(ax=ax, y=bbox)"
    ]
   },
@@ -3219,6 +3219,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Due to change to tfms apply not being inplace anymore docs don't show the transformed images for points, bbox and segmentations. 