### PR TITLE
Image downloader

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -50,6 +50,7 @@ requirements:
   run:
     - dataclasses # [py36]
     - fastprogress >=0.1.18
+    - google_images_download
     - matplotlib
     - numpy >=1.12
     - pandas

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -49,8 +49,8 @@ requirements:
 # note: "module # [py36]" tells conda-build that this requirement is only for python3.6, it's not a comment.
   run:
     - dataclasses # [py36]
+    - bs4
     - fastprogress >=0.1.18
-    - google_images_download
     - matplotlib
     - numpy >=1.12
     - pandas

--- a/docs/install.md
+++ b/docs/install.md
@@ -49,7 +49,7 @@ Below you will find the groups of dependencies for you to choose from. `fastai.b
 ```
 fastai.base:
 
-   "matplotlib" "numpy>=1.12" "pandas" "fastprogress>=0.1.18" "bottleneck" "numexpr" "Pillow" "requests" "scipy" "typing" "pyyaml" "pytorch" "packaging" "nvidia-ml-py3"
+   "matplotlib" "numpy>=1.12" "pandas" "fastprogress>=0.1.18" "bottleneck" "google_images_download" "numexpr" "Pillow" "requests" "scipy" "typing" "pyyaml" "pytorch" "packaging" "nvidia-ml-py3"
 
 fastai.text:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -49,7 +49,7 @@ Below you will find the groups of dependencies for you to choose from. `fastai.b
 ```
 fastai.base:
 
-   "matplotlib" "numpy>=1.12" "pandas" "fastprogress>=0.1.18" "bottleneck" "google_images_download" "numexpr" "Pillow" "requests" "scipy" "typing" "pyyaml" "pytorch" "packaging" "nvidia-ml-py3"
+   "matplotlib" "numpy>=1.12" "pandas" "fastprogress>=0.1.18" "bottleneck" "bs4" "numexpr" "Pillow" "requests" "scipy" "typing" "pyyaml" "pytorch" "packaging" "nvidia-ml-py3"
 
 fastai.text:
 

--- a/docs/widgets.html
+++ b/docs/widgets.html
@@ -193,6 +193,7 @@ sidebar: home_sidebar
 <div class="text_cell_render border-box-sizing rendered_html">
 <p><a href="/widgets.image_downloader.html#ImageDownloader"><code>ImageDownloader</code></a> widget gives you a way to quickly bootstrap your image dataset without leaving the notebook. It searches and downloads images that match the search criteria and resolution / quality requirements and stores them on your filesystem within the provided <code>path</code>.</p>
 <p>Images for each search query (or label) are stored in a separate folder within <code>path</code>. For example, if you pupulate <code>tiger</code> with a <code>path</code> setup to <code>./data</code>, you'll get a folder <code>./data/tiger/</code> with the tiger images in it.</p>
+<p><a href="/widgets.image_downloader.html#ImageDownloader"><code>ImageDownloader</code></a> will automatically clean up and verify the downloaded images with <a href="/vision.data.html#verify_images"><code>verify_images()</code></a> after downloading them.</p>
 
 </div>
 </div>
@@ -240,7 +241,7 @@ sidebar: home_sidebar
        <span class="o">.</span><span class="n">random_split_by_pct</span><span class="p">()</span>
        <span class="o">.</span><span class="n">label_from_folder</span><span class="p">()</span>
        <span class="o">.</span><span class="n">transform</span><span class="p">(</span><span class="n">get_transforms</span><span class="p">(),</span> <span class="n">size</span><span class="o">=</span><span class="mi">224</span><span class="p">))</span>
-<span class="n">db</span>  <span class="o">=</span> <span class="n">src</span><span class="o">.</span><span class="n">databunch</span><span class="p">(</span><span class="n">bs</span><span class="o">=</span><span class="mi">4</span><span class="p">)</span>
+<span class="n">db</span>  <span class="o">=</span> <span class="n">src</span><span class="o">.</span><span class="n">databunch</span><span class="p">(</span><span class="n">bs</span><span class="o">=</span><span class="mi">16</span><span class="p">)</span>
 </pre></div>
 
     </div>
@@ -266,13 +267,115 @@ sidebar: home_sidebar
 
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="n">learn</span><span class="o">.</span><span class="n">fit</span><span class="p">(</span><span class="mi">3</span><span class="p">)</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">learn</span><span class="o">.</span><span class="n">fit_one_cycle</span><span class="p">(</span><span class="mi">3</span><span class="p">)</span>
 </pre></div>
 
     </div>
 </div>
 </div>
 
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<h4 id="Downloading-more-than-a-hundred-images">Downloading more than a hundred images<a class="anchor-link" href="#Downloading-more-than-a-hundred-images">&#182;</a></h4><p>To fetch more than a hundred images, <a href="/widgets.image_downloader.html#ImageDownloader"><code>ImageDownloader</code></a> uses <code>selenium</code> and <code>chromedriver</code> to scroll through the Google Images search results page and scrape image URLs. They're not required as dependencies by default. If you don't have them installed on your system, the widget will show you an error message.</p>
+<p>To install <code>selenium</code>, just <code>pip install selenium</code> in your fastai environment.</p>
+<p><strong>On a mac</strong>, you can install <code>chromedriver</code> with <code>brew cask install chromedriver</code>.</p>
+<p><strong>On Ubuntu</strong>
+Take a look at the latest Chromedriver version available, then something like:</p>
+
+<pre><code>wget https://chromedriver.storage.googleapis.com/2.45/chromedriver_linux64.zip
+unzip chromedriver_linux64.zip</code></pre>
+
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<h4 id="Downloading-images-in-python-scripts-outside-Jupyter-notebooks">Downloading images in python scripts outside Jupyter notebooks<a class="anchor-link" href="#Downloading-images-in-python-scripts-outside-Jupyter-notebooks">&#182;</a></h4>
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">path</span> <span class="o">=</span> <span class="n">Path</span><span class="p">(</span><span class="s1">&#39;image_downloader_data&#39;</span><span class="p">)</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">download_google_images</span><span class="p">(</span><span class="n">path</span><span class="p">,</span> <span class="s1">&#39;aussie shepherd&#39;</span><span class="p">,</span> <span class="n">size</span><span class="o">=</span><span class="s1">&#39;&gt;1024*768&#39;</span><span class="p">,</span> <span class="n">n_images</span><span class="o">=</span><span class="mi">150</span><span class="p">)</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">show_doc</span><span class="p">(</span><span class="n">download_google_images</span><span class="p">)</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+<div class="output_wrapper">
+<div class="output">
+
+<div class="output_area">
+
+
+<div class="output_markdown rendered_html output_subarea ">
+<h4 id="download_google_images"><code>download_google_images</code><a href="https://github.com/fastai/fastai/blob/master/fastai/widgets/image_downloader.py#L93" class="source_link">[source]</a></h4><blockquote><p><code>download_google_images</code>(<code>path</code>:<code>PathOrStr</code>, <code>search_term</code>:<code>str</code>, <code>size</code>:<code>str</code>=<code>'&gt;400*300'</code>, <code>n_images</code>:<code>int</code>=<code>10</code>, <code>format</code>:<code>str</code>=<code>'jpg'</code>, <code>max_workers</code>:<code>int</code>=<code>8</code>, <code>timeout</code>:<code>int</code>=<code>4</code>) → <code>FilePathList</code></p>
+</blockquote>
+<p>Search for <code>n_images</code> images on Google, matching <code>search_term</code> and <code>size</code> requirements, and download them into <code>path</code>/<code>search_term</code> directory.</p>
+<p>Automatically <a href="/vision.data.html#verify_images"><code>verify_images</code></a> and return the image file names list.</p>
+<p>Uses <code>max_workers</code> threads to download and verify images.</p>
+
+</div>
+
+</div>
+
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<p>Note that downloading under 100 images doesn't require any dependencies other than fastai itself, however downloading more than a hundred images <a href="/widgets.ipynb#Downloading-more-than-a-hundred-images">uses <code>selenium</code> and <code>chromedriver</code></a>.</p>
+<p><code>size</code> can be one of:</p>
+
+<pre><code>'&gt;400*300'
+'&gt;640*480'
+'&gt;800*600'
+'&gt;1024*768'
+'&gt;2MP'
+'&gt;4MP'
+'&gt;6MP'
+'&gt;8MP'
+'&gt;10MP'
+'&gt;12MP'
+'&gt;15MP'
+'&gt;20MP'
+'&gt;40MP'
+'&gt;70MP'</code></pre>
+
+</div>
+</div>
 </div>
 </div>
  

--- a/docs/widgets.html
+++ b/docs/widgets.html
@@ -60,6 +60,19 @@ sidebar: home_sidebar
 
 <div class="inner_cell">
     <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">data</span><span class="o">.</span><span class="n">show_batch</span><span class="p">()</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+
+<div class="inner_cell">
+    <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">learn</span> <span class="o">=</span> <span class="n">create_cnn</span><span class="p">(</span><span class="n">data</span><span class="p">,</span> <span class="n">models</span><span class="o">.</span><span class="n">resnet18</span><span class="p">,</span> <span class="n">metrics</span><span class="o">=</span><span class="n">error_rate</span><span class="p">)</span>
 </pre></div>
 
@@ -77,41 +90,6 @@ sidebar: home_sidebar
 </pre></div>
 
     </div>
-</div>
-</div>
-
-<div class="output_wrapper">
-<div class="output">
-
-<div class="output_area">
-
-
-<div class="output_html rendered_html output_subarea ">
-Total time: 00:17 <p><table style='width:300px; margin-bottom:10px'>
-  <tr>
-    <th>epoch</th>
-    <th>train_loss</th>
-    <th>valid_loss</th>
-    <th>error_rate</th>
-  </tr>
-  <tr>
-    <th>1</th>
-    <th>0.189243</th>
-    <th>0.111312</th>
-    <th>0.038763</th>
-  </tr>
-  <tr>
-    <th>2</th>
-    <th>0.108558</th>
-    <th>0.081179</th>
-    <th>0.027969</th>
-  </tr>
-</table>
-
-</div>
-
-</div>
-
 </div>
 </div>
 
@@ -204,19 +182,94 @@ Total time: 00:17 <p><table style='width:300px; margin-bottom:10px'>
 </div>
 </div>
 
-<div class="output_wrapper">
-<div class="output">
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<h3 id="ImageDownloader">ImageDownloader<a class="anchor-link" href="#ImageDownloader">&#182;</a></h3>
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<p><a href="/widgets.image_downloader.html#ImageDownloader"><code>ImageDownloader</code></a> widget gives you a way to quickly bootstrap your image dataset without leaving the notebook. It searches and downloads images that match the search criteria and resolution / quality requirements and stores them on your filesystem within the provided <code>path</code>.</p>
+<p>Images for each search query (or label) are stored in a separate folder within <code>path</code>. For example, if you pupulate <code>tiger</code> with a <code>path</code> setup to <code>./data</code>, you'll get a folder <code>./data/tiger/</code> with the tiger images in it.</p>
 
-<div class="output_area">
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
 
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">path</span> <span class="o">=</span> <span class="n">Path</span><span class="p">(</span><span class="s1">&#39;./image_downloader_data&#39;</span><span class="p">)</span>
+<span class="n">ImageDownloader</span><span class="p">(</span><span class="n">path</span><span class="p">)</span>
+</pre></div>
 
-
-<div class="output_text output_subarea output_execute_result">
-<pre>&lt;fastai.widgets.image_cleaner.ImageCleaner at 0x7f75cac064a8&gt;</pre>
+    </div>
+</div>
 </div>
 
 </div>
+<div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<p>After populating images with <a href="/widgets.image_downloader.html#ImageDownloader"><code>ImageDownloader</code></a>, you can get a an <a href="/vision.data.html#ImageDataBunch"><code>ImageDataBunch</code></a> by calling <code>ImageDataBunch.from_folder(path, size=size)</code>, or using the data block API.</p>
 
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">path</span><span class="o">.</span><span class="n">ls</span><span class="p">()</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">src</span> <span class="o">=</span> <span class="p">(</span><span class="n">ImageItemList</span><span class="o">.</span><span class="n">from_folder</span><span class="p">(</span><span class="n">path</span><span class="p">)</span>
+       <span class="o">.</span><span class="n">random_split_by_pct</span><span class="p">()</span>
+       <span class="o">.</span><span class="n">label_from_folder</span><span class="p">()</span>
+       <span class="o">.</span><span class="n">transform</span><span class="p">(</span><span class="n">get_transforms</span><span class="p">(),</span> <span class="n">size</span><span class="o">=</span><span class="mi">224</span><span class="p">))</span>
+<span class="n">db</span>  <span class="o">=</span> <span class="n">src</span><span class="o">.</span><span class="n">databunch</span><span class="p">(</span><span class="n">bs</span><span class="o">=</span><span class="mi">4</span><span class="p">)</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">learn</span> <span class="o">=</span> <span class="n">create_cnn</span><span class="p">(</span><span class="n">db</span><span class="p">,</span> <span class="n">models</span><span class="o">.</span><span class="n">resnet34</span><span class="p">,</span> <span class="n">metrics</span><span class="o">=</span><span class="p">[</span><span class="n">accuracy</span><span class="p">])</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">learn</span><span class="o">.</span><span class="n">fit</span><span class="p">(</span><span class="mi">3</span><span class="p">)</span>
+</pre></div>
+
+    </div>
 </div>
 </div>
 

--- a/docs_src/widgets.ipynb
+++ b/docs_src/widgets.ipynb
@@ -232,13 +232,6 @@
    "source": [
     "learn.fit(3)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs_src/widgets.ipynb
+++ b/docs_src/widgets.ipynb
@@ -212,7 +212,7 @@
     "       .random_split_by_pct()\n",
     "       .label_from_folder()\n",
     "       .transform(get_transforms(), size=224))\n",
-    "db  = src.databunch(bs=4)"
+    "db  = src.databunch(bs=16)"
    ]
   },
   {
@@ -232,6 +232,13 @@
    "source": [
     "learn.fit(3)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -239,6 +246,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,

--- a/docs_src/widgets.ipynb
+++ b/docs_src/widgets.ipynb
@@ -28,7 +28,7 @@
    "outputs": [],
    "source": [
     "from fastai.vision import *\n",
-    "from fastai.widgets import DatasetFormatter, ImageCleaner"
+    "from fastai.widgets import DatasetFormatter, ImageCleaner, ImageDownloader"
    ]
   },
   {
@@ -69,6 +69,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "data.show_batch()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "learn = create_cnn(data, models.resnet18, metrics=error_rate)"
    ]
   },
@@ -76,39 +85,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "Total time: 00:17 <p><table style='width:300px; margin-bottom:10px'>\n",
-       "  <tr>\n",
-       "    <th>epoch</th>\n",
-       "    <th>train_loss</th>\n",
-       "    <th>valid_loss</th>\n",
-       "    <th>error_rate</th>\n",
-       "  </tr>\n",
-       "  <tr>\n",
-       "    <th>1</th>\n",
-       "    <th>0.189243</th>\n",
-       "    <th>0.111312</th>\n",
-       "    <th>0.038763</th>\n",
-       "  </tr>\n",
-       "  <tr>\n",
-       "    <th>2</th>\n",
-       "    <th>0.108558</th>\n",
-       "    <th>0.081179</th>\n",
-       "    <th>0.027969</th>\n",
-       "  </tr>\n",
-       "</table>\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "learn.fit_one_cycle(2)"
    ]
@@ -178,48 +155,82 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fd19c6efaf5f44e8bb58d3dfa067f171",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(VBox(children=(Image(value=b'\\xff\\xd8\\xff\\xe0\\x00\\x10JFIF\\x00\\x01\\x01\\x01\\x00d\\x00d\\x00\\x00\\xff…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "89c3fe28ae374408b9b91dcae18c2f4c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Button(button_style='primary', description='Next Batch', layout=Layout(width='auto'), style=ButtonStyle())"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<fastai.widgets.image_cleaner.ImageCleaner at 0x7f75cac064a8>"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ImageCleaner(ds, idxs, path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### ImageDownloader"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[`ImageDownloader`](/widgets.image_downloader.html#ImageDownloader) widget gives you a way to quickly bootstrap your image dataset without leaving the notebook. It searches and downloads images that match the search criteria and resolution / quality requirements and stores them on your filesystem within the provided `path`.\n",
+    "\n",
+    "Images for each search query (or label) are stored in a separate folder within `path`. For example, if you pupulate `tiger` with a `path` setup to `./data`, you'll get a folder `./data/tiger/` with the tiger images in it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path = Path('./image_downloader_data')\n",
+    "ImageDownloader(path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After populating images with [`ImageDownloader`](/widgets.image_downloader.html#ImageDownloader), you can get a an [`ImageDataBunch`](/vision.data.html#ImageDataBunch) by calling `ImageDataBunch.from_folder(path, size=size)`, or using the data block API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path.ls()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "src = (ImageItemList.from_folder(path)\n",
+    "       .random_split_by_pct()\n",
+    "       .label_from_folder()\n",
+    "       .transform(get_transforms(), size=224))\n",
+    "db  = src.databunch(bs=4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn = create_cnn(db, models.resnet34, metrics=[accuracy])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn.fit(3)"
    ]
   }
  ],

--- a/docs_src/widgets.ipynb
+++ b/docs_src/widgets.ipynb
@@ -16,19 +16,21 @@
    "outputs": [],
    "source": [
     "%reload_ext autoreload\n",
-    "%autoreload 2"
+    "%autoreload 2\n",
+    "%matplotlib inline"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "hide_input": true
    },
    "outputs": [],
    "source": [
+    "from fastai.gen_doc.nbdoc import *\n",
     "from fastai.vision import *\n",
-    "from fastai.widgets import DatasetFormatter, ImageCleaner, ImageDownloader"
+    "from fastai.widgets import DatasetFormatter, ImageCleaner, ImageDownloader, download_google_images"
    ]
   },
   {
@@ -173,7 +175,9 @@
    "source": [
     "[`ImageDownloader`](/widgets.image_downloader.html#ImageDownloader) widget gives you a way to quickly bootstrap your image dataset without leaving the notebook. It searches and downloads images that match the search criteria and resolution / quality requirements and stores them on your filesystem within the provided `path`.\n",
     "\n",
-    "Images for each search query (or label) are stored in a separate folder within `path`. For example, if you pupulate `tiger` with a `path` setup to `./data`, you'll get a folder `./data/tiger/` with the tiger images in it."
+    "Images for each search query (or label) are stored in a separate folder within `path`. For example, if you pupulate `tiger` with a `path` setup to `./data`, you'll get a folder `./data/tiger/` with the tiger images in it.\n",
+    "\n",
+    "[`ImageDownloader`](/widgets.image_downloader.html#ImageDownloader) will automatically clean up and verify the downloaded images with [`verify_images()`](/vision.data.html#verify_images) after downloading them."
    ]
   },
   {
@@ -230,7 +234,109 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "learn.fit(3)"
+    "learn.fit_one_cycle(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Downloading more than a hundred images\n",
+    "\n",
+    "To fetch more than a hundred images, [`ImageDownloader`](/widgets.image_downloader.html#ImageDownloader) uses `selenium` and `chromedriver` to scroll through the Google Images search results page and scrape image URLs. They're not required as dependencies by default. If you don't have them installed on your system, the widget will show you an error message.\n",
+    "\n",
+    "To install `selenium`, just `pip install selenium` in your fastai environment.\n",
+    "\n",
+    "**On a mac**, you can install `chromedriver` with `brew cask install chromedriver`.\n",
+    "\n",
+    "**On Ubuntu**\n",
+    "Take a look at the latest Chromedriver version available, then something like:\n",
+    "\n",
+    "```\n",
+    "wget https://chromedriver.storage.googleapis.com/2.45/chromedriver_linux64.zip\n",
+    "unzip chromedriver_linux64.zip\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Downloading images in python scripts outside Jupyter notebooks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path = Path('image_downloader_data')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "download_google_images(path, 'aussie shepherd', size='>1024*768', n_images=150)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<h4 id=\"download_google_images\"><code>download_google_images</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/widgets/image_downloader.py#L93\" class=\"source_link\">[source]</a></h4>\n",
+       "\n",
+       "> <code>download_google_images</code>(`path`:`PathOrStr`, `search_term`:`str`, `size`:`str`=`'>400*300'`, `n_images`:`int`=`10`, `format`:`str`=`'jpg'`, `max_workers`:`int`=`8`, `timeout`:`int`=`4`) → `FilePathList`\n",
+       "\n",
+       "Search for `n_images` images on Google, matching `search_term` and `size` requirements, and download them into `path`/`search_term` directory.\n",
+       "\n",
+       "Automatically [`verify_images`](/vision.data.html#verify_images) and return the image file names list.\n",
+       "\n",
+       "Uses `max_workers` threads to download and verify images. "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "show_doc(download_google_images)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that downloading under 100 images doesn't require any dependencies other than fastai itself, however downloading more than a hundred images [uses `selenium` and `chromedriver`](/widgets.ipynb#Downloading-more-than-a-hundred-images).\n",
+    "\n",
+    "`size` can be one of:\n",
+    "\n",
+    "```\n",
+    "'>400*300'\n",
+    "'>640*480'\n",
+    "'>800*600'\n",
+    "'>1024*768'\n",
+    "'>2MP'\n",
+    "'>4MP'\n",
+    "'>6MP'\n",
+    "'>8MP'\n",
+    "'>10MP'\n",
+    "'>12MP'\n",
+    "'>15MP'\n",
+    "'>20MP'\n",
+    "'>40MP'\n",
+    "'>70MP'\n",
+    "```"
    ]
   }
  ],

--- a/fastai/widgets/__init__.py
+++ b/fastai/widgets/__init__.py
@@ -1,1 +1,2 @@
 from .image_cleaner import *
+from .image_downloader import *

--- a/fastai/widgets/image_downloader.py
+++ b/fastai/widgets/image_downloader.py
@@ -1,0 +1,106 @@
+from ..core import *
+from ipywidgets import widgets, Layout, Output, HBox, VBox, Text, BoundedIntText, Button, Dropdown, Box
+from IPython.display import clear_output, display
+from google_images_download import google_images_download
+
+__all__ = ['ImageDownloader']
+
+class ImageDownloader():
+    """
+    Displays a simple widget that allows searching and downloading images from google images search
+    in a Jupyter notebook.
+    """
+
+    def __init__(self, path:Union[Path,str]='data'):
+        "Setup path to save images to, init the UI, and render the widgets."
+        self._path = Path(path)
+        self._ui = self._init_ui()
+        self.render()
+
+    def _init_ui(self) -> VBox:
+        """
+        Initialize the widget UI and return the UI, 
+        only used to initially create all the components and setup event handlers."
+        """
+        self._search_input = Text(placeholder="What images to search for?")
+        self._count_input = BoundedIntText(placeholder="How many pics?", 
+                                        value=10, min=1, max=100, step=1, 
+                                        layout=Layout(width='60px'))
+        self._size_input = Dropdown(options= ['>400*300', '>640*480', '>800*600', '>1024*768', '>2MP', '>4MP', '>6MP', '>8MP', '>10MP'],
+                                    value='>400*300',
+                                    layout=Layout(width='120px'))
+        self._download_button = Button(description="Search & Download", icon="download", layout=Layout(width='200px'))
+        self._download_button.on_click(self.on_download_button_click) 
+
+        self._output = Output()
+
+        # Top horizontal controls bar
+        self._controls_pane  = HBox([self._search_input, 
+                                    self._count_input,
+                                    self._size_input,
+                                    self._download_button],
+                                    layout=Layout(width='auto', height='40px'))
+
+        self._heading = ""
+        self._download_complete_heading = "<h3>Download complete. Here are a few images</h3>"
+        self._preview_header = widgets.HTML(self._heading, layout=Layout(height='60px'))
+        self._img_pane = Box(layout=Layout(display='inline'))
+        return VBox([self._controls_pane, self._preview_header, self._img_pane])
+
+
+    def render(self) -> None:
+        "Render the image search widget."
+        clear_output()
+        display(self._ui)
+
+    def clear_imgs(self) -> None:
+        "Clear the widget's images preview pane."
+        self._preview_header.value = self._heading
+        self._img_pane.children = tuple()
+
+    def validate_search_input(self) -> bool:
+        "Check if input value is empty."
+        input = self._search_input
+        if input.value == str():
+            input.layout = Layout(border="solid 2px red", height='auto')
+        else:
+            self._search_input.layout = Layout()
+        return input.value != str()
+
+    def on_download_button_click(self, btn) -> None:
+        "Download button click handler: validate search term and download images."
+        term = self._search_input.value           
+        limit = int(self._count_input.value)
+        size = self._size_input.value
+
+        if not self.validate_search_input(): return
+        
+        self.clear_imgs() 
+        self.download_images(term, limit=limit, size=size)
+        self.display_images_widgets(self.get_preview_images_fnames(term)[:min(limit, 12)])
+        self._preview_header.value = self._download_complete_heading
+        self.render()
+        
+    def display_images_widgets(self, fnames:list) -> None:
+        "Display a few preview images in the notebook"
+        imgs = [widgets.Image(value=open(f, 'rb').read(), width='200px') for f in fnames]
+        self._img_pane.children = tuple(imgs)
+
+    def get_preview_images_fnames(self, keyword:str) -> list:  
+        "Fetch all the image file paths in for a given keyword"
+        image_file_formats = ['.jpg', '.jpeg', '.png']
+        return [i for i in (self._path/keyword).iterdir()
+            if i.is_file() and i.suffix in image_file_formats]
+        
+    def download_images(self, search_term:str, path:Union[Path,str]=None, 
+                        limit:int=10, size:str='>400*300') -> None:
+        "Download up to `limit` images from google search with `search_term`."
+        if path is None: path = self._path
+        dl = google_images_download.googleimagesdownload()
+        dl.download({
+            'limit':limit,
+            'output_directory': str(path),
+            'keywords':search_term, 
+            'size':size })
+        
+

--- a/fastai/widgets/image_downloader.py
+++ b/fastai/widgets/image_downloader.py
@@ -1,7 +1,8 @@
 from ..core import *
 from ipywidgets import widgets, Layout, Output, HBox, VBox, Text, BoundedIntText, Button, Dropdown, Box
 from IPython.display import clear_output, display
-from google_images_download import google_images_download
+from urllib.parse import quote
+from bs4 import BeautifulSoup
 
 __all__ = ['ImageDownloader']
 
@@ -19,23 +20,23 @@ class ImageDownloader():
 
     def _init_ui(self) -> VBox:
         """
-        Initialize the widget UI and return the UI, 
+        Initialize the widget UI and return the UI,
         only used to initially create all the components and setup event handlers."
         """
         self._search_input = Text(placeholder="What images to search for?")
-        self._count_input = BoundedIntText(placeholder="How many pics?", 
-                                        value=10, min=1, max=100, step=1, 
+        self._count_input = BoundedIntText(placeholder="How many pics?",
+                                        value=10, min=1, max=100, step=1,
                                         layout=Layout(width='60px'))
         self._size_input = Dropdown(options= ['>400*300', '>640*480', '>800*600', '>1024*768', '>2MP', '>4MP', '>6MP', '>8MP', '>10MP'],
                                     value='>400*300',
                                     layout=Layout(width='120px'))
         self._download_button = Button(description="Search & Download", icon="download", layout=Layout(width='200px'))
-        self._download_button.on_click(self.on_download_button_click) 
+        self._download_button.on_click(self.on_download_button_click)
 
         self._output = Output()
 
         # Top horizontal controls bar
-        self._controls_pane  = HBox([self._search_input, 
+        self._controls_pane  = HBox([self._search_input,
                                     self._count_input,
                                     self._size_input,
                                     self._download_button],
@@ -69,38 +70,79 @@ class ImageDownloader():
 
     def on_download_button_click(self, btn) -> None:
         "Download button click handler: validate search term and download images."
-        term = self._search_input.value           
+        term = self._search_input.value
         limit = int(self._count_input.value)
         size = self._size_input.value
 
         if not self.validate_search_input(): return
-        
-        self.clear_imgs() 
+
+        self.clear_imgs()
         self.download_images(term, limit=limit, size=size)
         self.display_images_widgets(self.get_preview_images_fnames(term)[:min(limit, 12)])
         self._preview_header.value = self._download_complete_heading
         self.render()
-        
+
     def display_images_widgets(self, fnames:list) -> None:
         "Display a few preview images in the notebook"
         imgs = [widgets.Image(value=open(f, 'rb').read(), width='200px') for f in fnames]
         self._img_pane.children = tuple(imgs)
 
-    def get_preview_images_fnames(self, keyword:str) -> list:  
+    def get_preview_images_fnames(self, keyword:str) -> list:
         "Fetch all the image file paths in for a given keyword"
         image_file_formats = ['.jpg', '.jpeg', '.png']
         return [i for i in (self._path/keyword).iterdir()
             if i.is_file() and i.suffix in image_file_formats]
-        
-    def download_images(self, search_term:str, path:Union[Path,str]=None, 
+
+    def download_images(self, search_term:str, path:Union[Path,str]=None,
                         limit:int=10, size:str='>400*300') -> None:
         "Download up to `limit` images from google search with `search_term`."
         if path is None: path = self._path
-        dl = google_images_download.googleimagesdownload()
-        dl.download({
-            'limit':limit,
-            'output_directory': str(path),
-            'keywords':search_term, 
-            'size':size })
-        
+        google_images_parse_and_download(path, search_term, size=size, n_images=limit)
+
+
+def google_images_parse_and_download(path:PathOrStr, search_term:str, size:str='>400*300', n_images:int=10, format:str='jpg', max_workers:int=8) -> None:
+    "Search Google for images that match the `search_term` and `size`, up to `n_images` pics. Then download them into `path` subfolder."
+    search_url = google_images_search_url(search_term, size, format)
+    img_tuples = google_images_parse_urls(search_url, format=format, n_images=n_images)
+    google_images_download(path, search_term, img_tuples, max_workers=max_workers)
+
+def google_images_url_params(size:str='>400*300', format:str='jpg') -> str:
+    "Build Google Images Search Url params and return them as a string."
+    size_options = {'large':'isz:l','medium':'isz:m','icon':'isz:i','>400*300':'isz:lt,islt:qsvga','>640*480':'isz:lt,islt:vga','>800*600':'isz:lt,islt:svga','>1024*768':'visz:lt,islt:xga','>2MP':'isz:lt,islt:2mp','>4MP':'isz:lt,islt:4mp','>6MP':'isz:lt,islt:6mp','>8MP':'isz:lt,islt:8mp','>10MP':'isz:lt,islt:10mp','>12MP':'isz:lt,islt:12mp','>15MP':'isz:lt,islt:15mp','>20MP':'isz:lt,islt:20mp','>40MP':'isz:lt,islt:40mp','>70MP':'isz:lt,islt:70mp'}
+    format_options = {'jpg':'ift:jpg','gif':'ift:gif','png':'ift:png','bmp':'ift:bmp','svg':'ift:svg','webp':'webp','ico':'ift:ico'}
+    return "&tbs=" + size_options[size] + "," + format_options[format]
+
+def google_images_search_url(search_term:str, size:str='>400*300', format:str='jpg') -> str:
+    "Return a Google Images Search URL for a given search term."
+    return ( 'https://www.google.com/search?q=' +
+            quote(search_term) +
+            '&espv=2&biw=1366&bih=667&site=webhp&source=lnms&tbm=isch' +
+            google_images_url_params(size, format) +
+            '&sa=X&ei=XosDVaCXD8TasATItgE&ved=0CAcQ_AUoAg' )
+
+def img_fname(img_url:str) -> str:
+    "Return image file name including the extension given it's url."
+    return img_url.split('/')[-1]
+
+def google_images_parse_urls(url:str, format:str='jpg', n_images:int=10) -> list:
+    "Parse the Google Images Search for urls and return the image metadata as tuples (fname, url)."
+    headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'}
+    html = requests.get(url, headers=headers).text
+    bs = BeautifulSoup(html, 'html.parser')
+    img_tags = bs.find_all('div', {'class': 'rg_meta'})
+    metadata_dicts = (json.loads(e.text) for e in img_tags)
+    img_tuples = ((img_fname(d['ou']), d['ou']) for d in metadata_dicts if d['ity'] == format)
+    return list(itertools.islice(img_tuples, n_images))
+
+def google_images_download(path:PathOrStr, label:str, img_tuples:list, max_workers:int=8) -> None:
+    "Downloads images to `path`/`label`."
+    os.makedirs(Path(path)/label, exist_ok=True)
+    parallel( partial(_download_single_google_image, Path(path)/label), img_tuples, max_workers=max_workers)
+
+def _download_single_google_image(dest_folder:Path, img_tuple:tuple, i:int) -> None:
+    "Downloads a single image from Google Search results to `dest_folder`."
+    suffix = re.findall(r'\.\w+?(?=(?:\?|$))', img_tuple[1])
+    suffix = suffix[0] if len(suffix)>0  else '.jpg'
+    fname = f"{i:08d}{suffix}"
+    download_url(img_tuple[1], dest_folder/fname)
 

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ requirements = to_list("""
     cymem==2.0.2         # remove once spacy==2.0.18 is on anaconda channel
     dataclasses ; python_version<'3.7'
     fastprogress>=0.1.18
+    google_images_download
     matplotlib
     numexpr              # performance-improvement for numpy
     numpy>=1.12

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ requirements = to_list("""
     cymem==2.0.2         # remove once spacy==2.0.18 is on anaconda channel
     dataclasses ; python_version<'3.7'
     fastprogress>=0.1.18
-    google_images_download
+    bs4
     matplotlib
     numexpr              # performance-improvement for numpy
     numpy>=1.12

--- a/tests/test_widgets_image_cleaner.py
+++ b/tests/test_widgets_image_cleaner.py
@@ -28,3 +28,6 @@ def test_image_cleaner_wrong_input_type(data):
     path = untar_data(URLs.MNIST_TINY)
     n = len(data.valid_ds)
     ImageCleaner(data, np.arange(n), path)
+
+def test_image_downloader_with_path():
+    ImageDownloader('.tmp/data')


### PR DESCRIPTION
Proposing the `ImageDownloader` widget. Similarly to `ImageCleaner`, it's an ipywidget that works in Notebook or Lab, allows users to quickly research and download images from google search. 

[Here's the thread on fastai dev forums](https://forums.fast.ai/t/imagedownloader-widget/32776). 

**Why:** 

Building image classifiers in the first weeks of the MOOC is twice as fun with your own dataset, right? I noticed fastai v1 ships with a JS snippet to download images and that's mentioned in the new version of the MOOC's notebooks. 

`ImageDownloader` would allow people experiment with new datasets easily, we'll have more people implementing their own classifiers and apps based on them → more fun, and more inspiration for them and other students to learn and implement their ideas. 

**What works:**

`ImageDownloader()` works in Jupyter Notebook and Lab: 

- [x] User types in the search term / query, number of images, and image resolution they want. 
- [x] Downloads images from google, stores them in a directory. The directory is created automatically if it doesn't exist. 
- [x] Previews a few images from the download. 
- [x] Allows downloading >100 images per label, but requires `selenium` and `chromedriver` to do that. Shows an error message explaining how to install those if the user requests more than a hundred images. 
- [x] Uses fastai's `download_url()` and `parallel()` to speed things up ;-) 
- [x] Integrates with `fastprogress` and shows progress bar when downloading. 
- [x] Calls `verify_images()` after the download to clean up the dataset. 
- [x] Directory structure compatible with datablock API, i.e. `from_folder()` “just works”.
- [x] Also provides a function to download images in iPython / python scripts: `download_google_images()`, although it's in `fastai.widgets.image_downloader`. It maybe useful to move it to `fastai.visual.data`, but I wanted to start small and show @sgugger the diff first. 

**Also taken care of:** 

- [x] Docs: I created a section in `docs_src/widgets.ipynb`, documented both the widget, and the function, with examples, using `show_doc()`, and regenerated the html docs with `tools/build-docs`
- [x] Added a test to make sure the widget init runs without errors. 

**Ideas to improve this:**

- [ ] I'm working on a full example: fetch a dataset, train, save the model, and serve it as a REST API and a website, just to give other students some inspiration. Probably not for `fastai/examples`, I can post that outside of fastai if that'd be more appropriate.
- [ ] It'd be good to add some tests to test the widget internal logic, it's decoupled into several helper functions, but they're not unit tested.
- [ ] Since it's questionable whereas it's legal to scrape google search like that, maybe this can't be merged at all, or maybe it's a good idea to add a legal disclaimer to the docs? 

@fpingham, @sgugger, I'm not really a Python developer, and I'd be happy to improve the code, fix any smells, code styles, anything that comes up. I'd be happy to help in other projects as well, just wanted to start with something simple.

Thank you both very much for your work on fastai, for your comments on the forum thread, and for reviewing the PR. 

What do you think, @sgugger? 
