### PR TITLE
show_doc: make the arguments/defaults stand out from types

### DIFF
--- a/fastai/gen_doc/nbdoc.py
+++ b/fastai/gen_doc/nbdoc.py
@@ -61,12 +61,13 @@ def partial_repr(t):
 def anno_repr(a): return type_repr(a)
 
 def format_param(p):
-    res = code_esc(p.name)
+    # bold the argument name and bold+italicize the default value, to make them standout from very complex at times annotations.
+    res = f"<b>{code_esc(p.name)}</b>"
     if hasattr(p, 'annotation') and p.annotation != p.empty: res += f':{anno_repr(p.annotation)}'
     if p.default != p.empty:
         default = getattr(p.default, 'func', p.default)
         default = getattr(default, '__name__', default)
-        res += f'=`{repr(default)}`'
+        res += f'=<b><i>`{repr(default)}`</i></b>'
     return res
 
 def format_ft_def(func, full_name:str=None)->str:
@@ -187,7 +188,7 @@ def import_mod(mod_name:str, ignore_errors=False):
         if len(splits) > 1 : mod = importlib.import_module('.' + '.'.join(splits[1:]), splits[0])
         else: mod = importlib.import_module(mod_name)
         return mod
-    except: 
+    except:
         if not ignore_errors: print(f"Module {mod_name} doesn't exist.")
 
 def show_doc_from_name(mod_name, ft_name:str, doc_string:bool=True, arg_comments:dict={}, alt_doc_string:str=''):
@@ -275,7 +276,7 @@ def show_video(url):
     return display(HTML(data))
 
 def show_video_from_youtube(code, start=0):
-    "Display video from Youtube with a `code` and a `start` time." 
+    "Display video from Youtube with a `code` and a `start` time."
     url = f'https://www.youtube.com/embed/{code}?start={start}&amp;rel=0&amp;controls=0&amp;showinfo=0'
     return show_video(url)
 


### PR DESCRIPTION
bold the argument name and bold+italicize the default value, to make them standout from very complex at times annotations, to improve function signature readability and quickly tell arguments from types (which otherwise is not easy when types are complex structures with commas, etc.)

before and after:

![snap5](https://user-images.githubusercontent.com/10676103/50387759-0b4fb400-06b9-11e9-943e-c63b5eb3676a.png)

