### PR TITLE
Throw exception when column we want to normalize isn't numerical.

### DIFF
--- a/fastai/tabular/transform.py
+++ b/fastai/tabular/transform.py
@@ -1,5 +1,6 @@
 "Cleaning and feature engineering functions for structured data"
 from ..torch_core import *
+from pandas.api.types import is_numeric_dtype
 
 __all__ = ['add_datepart', 'Categorify', 'FillMissing', 'FillStrategy', 'Normalize', 'TabularProc']
 
@@ -92,6 +93,10 @@ class Normalize(TabularProc):
         "Comput the means and stds of `self.cont_names` columns to normalize them."
         self.means,self.stds = {},{}
         for n in self.cont_names:
+            if not is_numeric_dtype(df[n]):
+                raise Exception(f"""Cannot normalize '{n}' column as it isn't numerical.
+                Are you sure it doesn't belong in the categorical set of columns?""")
+
             self.means[n],self.stds[n] = df.loc[:,n].mean(),df.loc[:,n].std()
             df.loc[:,n] = (df.loc[:,n]-self.means[n]) / (1e-7 + self.stds[n])
 

--- a/fastai/tabular/transform.py
+++ b/fastai/tabular/transform.py
@@ -93,10 +93,8 @@ class Normalize(TabularProc):
         "Comput the means and stds of `self.cont_names` columns to normalize them."
         self.means,self.stds = {},{}
         for n in self.cont_names:
-            if not is_numeric_dtype(df[n]):
-                raise Exception(f"""Cannot normalize '{n}' column as it isn't numerical.
+            assert is_numeric_dtype(df[n]), (f"""Cannot normalize '{n}' column as it isn't numerical.
                 Are you sure it doesn't belong in the categorical set of columns?""")
-
             self.means[n],self.stds[n] = df.loc[:,n].mean(),df.loc[:,n].std()
             df.loc[:,n] = (df.loc[:,n]-self.means[n]) / (1e-7 + self.stds[n])
 


### PR DESCRIPTION
So I was creating a learner with a large (~2gb) data set, like so:

```python
procs = [Categorify, Normalize]
data = (TabularList.from_df(df,
                            path=data_folder,
                            cat_names=category_names,
                            cont_names=continuous_names,
                            procs=procs)
        .split_by_idx(valid_idx)
        .label_from_df(cols=dep_var, label_cls=FloatList)
        .databunch())
```

But execution would mysteriously stop someway in the middle, Python would hang and I would have no idea what went wrong. By peppering the fastai library with logs I figured out that I was sending a categorical column in as a continuous one, leading to a failure when normalizing it.

This commit, which just adds a check to make sure a column is numerical before normalizing it, will perhaps help future users of fastai to avoid having to spend half a day debugging it as I had to!

// Erich