### PR TITLE
Split df automatically into continuous and categorical column names.

### DIFF
--- a/docs_src/tabular.transform.ipynb
+++ b/docs_src/tabular.transform.ipynb
@@ -1127,6 +1127,149 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Spliting data into cat and cont"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<h4 id=\"cont_cat_split\"><code>cont_cat_split</code></h4>\n",
+       "\n",
+       "> <code>cont_cat_split</code>(`df`, `max_card`=`20`, `dep_var`=`None`)\n",
+       "\n",
+       "Helper function that returns column names of cont and cat variables from given df.  "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "show_doc(cont_cat_split)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Parameters:\n",
+    "- df: A pandas data frame.\n",
+    "- max_card: Maximum cardinality of a continuous variable.\n",
+    "- dep_var: A dependent variable.\n",
+    "\n",
+    "Return:\n",
+    "- cont_names: A list of names of continuous variables.\n",
+    "- cat_names: A list of names of categorical variables."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>col1</th>\n",
+       "      <th>col2</th>\n",
+       "      <th>col3</th>\n",
+       "      <th>col4</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>a</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>ab</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>b</td>\n",
+       "      <td>1.2</td>\n",
+       "      <td>o</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>a</td>\n",
+       "      <td>7.5</td>\n",
+       "      <td>o</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   col1 col2  col3 col4\n",
+       "0     1    a   0.5   ab\n",
+       "1     2    b   1.2    o\n",
+       "2     3    a   7.5    o"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = pd.DataFrame({'col1': [1, 2, 3], 'col2': ['a', 'b', 'a'], 'col3': [0.5, 1.2, 7.5], 'col4': ['ab', 'o', 'o']})\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(['col3'], ['col1', 'col2'])"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cont_list, cat_list = cont_cat_split(df=df, max_card=20, dep_var='col4')\n",
+    "cont_list, cat_list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Undocumented Methods - Methods moved below this line will intentionally be hidden"
    ]
   },

--- a/docs_src/tabular.transform.ipynb
+++ b/docs_src/tabular.transform.ipynb
@@ -1162,7 +1162,7 @@
    "source": [
     "Parameters:\n",
     "- df: A pandas data frame.\n",
-    "- max_card: Maximum cardinality of a continuous variable.\n",
+    "- max_card: Maximum cardinality of a numerical categorical variable.\n",
     "- dep_var: A dependent variable.\n",
     "\n",
     "Return:\n",

--- a/fastai/tabular/transform.py
+++ b/fastai/tabular/transform.py
@@ -2,7 +2,7 @@
 from ..torch_core import *
 from pandas.api.types import is_numeric_dtype
 
-__all__ = ['add_datepart', 'Categorify', 'FillMissing', 'FillStrategy', 'Normalize', 'TabularProc']
+__all__ = ['add_datepart', 'cont_cat_split', 'Categorify', 'FillMissing', 'FillStrategy', 'Normalize', 'TabularProc']
 
 def add_datepart(df, fldname, drop=True, time=False):
     "Helper function that adds columns relevant to a date in the column `fldname` of `df`."
@@ -21,6 +21,15 @@ def add_datepart(df, fldname, drop=True, time=False):
     df[targ_pre + 'Elapsed'] = fld.astype(np.int64) // 10 ** 9
     if drop: df.drop(fldname, axis=1, inplace=True)
 
+def cont_cat_split(df, max_card=20, dep_var=None):
+    "Helper function that returns column names of cont and cat variables from given df."
+    cont_names, cat_names = [], []
+    for label in df:
+        if label == dep_var: continue
+        if len(set(df[label])) > max_card and df[label].dtype == int or df[label].dtype == float: cont_names.append(label)
+        else: cat_names.append(label)
+    return cont_names, cat_names
+        
 @dataclass
 class TabularProc():
     "A processor for tabular dataframes."


### PR DESCRIPTION
When we are handling tabular data Fastai assumes us to give column names of continuous and categorical values. This new function make it easier to get the column names. Int and float type columns will be returned as continuous if the cardinality is more than max else all other columns are categorical.