### PR TITLE
Fix typo in docs: basic_train.ipynb

### DIFF
--- a/docs_src/basic_train.ipynb
+++ b/docs_src/basic_train.ipynb
@@ -1216,7 +1216,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A [`Learner`](/basic_train.html#Learner) creates a [`Recorder`](/basic_train.html#Recorder) object automatically - you do not need to explicitly pass to `callback_fns` - because other callbacks rely on it being available. It stores the smoothed loss, hyperparameter values, and metrics each batch, and provides plotting methods for each. Note that [`Learner`](/basic_train.html#Learner) automatically sets an attribute with the snake-cased name of each callback, so you can access this through `Learner.recorder`, as shown below."
+    "A [`Learner`](/basic_train.html#Learner) creates a [`Recorder`](/basic_train.html#Recorder) object automatically - you do not need to explicitly pass it to `callback_fns` - because other callbacks rely on it being available. It stores the smoothed loss, hyperparameter values, and metrics for each batch, and provides plotting methods for each. Note that [`Learner`](/basic_train.html#Learner) automatically sets an attribute with the snake-cased name of each callback, so you can access this through `Learner.recorder`, as shown below."
    ]
   },
   {


### PR DESCRIPTION
A Learner creates a Recorder object automatically - you do not need to explicitly pass **_it_** to callback_fns - because other callbacks rely on it being available. It stores the smoothed loss, hyperparameter values, and metrics **_for_** each batch, and provides plotting methods for each. Note that Learner automatically sets an attribute with the snake-cased name of each callback, so you can access this through Learner.recorder, as shown below.