### PR TITLE
Updated apply_cats

### DIFF
--- a/old/fastai/structured.py
+++ b/old/fastai/structured.py
@@ -201,7 +201,8 @@ def apply_cats(df, trn):
     """
     for n,c in df.items():
         if (n in trn.columns) and (trn[n].dtype.name=='category'):
-            df[n] = pd.Categorical(c, categories=trn[n].cat.categories, ordered=True)
+            df[n] = c.astype('category').cat.as_ordered()
+            df[n].cat.set_categories(trn[n].cat.categories, ordered=True, inplace=True)
 
 def fix_missing(df, col, name, na_dict):
     """ Fill missing data in a column of df with the median, and add a {name}_na column


### PR DESCRIPTION
The previous method fails in below case where the column is of bool type but contains null values. 
df = pd.DataFrame({'col1' : [1, 2, 3], 'col2' : [np.NaN, False, True]})
df2 = pd.DataFrame({'col1' : [1, 2, 3], 'col2' : [np.NaN, False, True]})
So is_string_dtype will still be True for the column. And you will get error "buffer dtype mismatch, expected 'Python object' but got 'unsigned long' pd categorical"

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
