### PR TITLE
Support for (ch, h, w) size in vision transforms

### DIFF
--- a/fastai/vision/image.py
+++ b/fastai/vision/image.py
@@ -5,7 +5,7 @@ from io import BytesIO
 import PIL
 
 __all__ = ['PIL', 'Image', 'ImageBBox', 'ImageSegment', 'ImagePoints', 'FlowField', 'RandTransform', 'TfmAffine', 'TfmCoord',
-           'TfmCrop', 'TfmLighting', 'TfmPixel', 'Transform', 'bb2hw', 'image2np', 'open_image', 'open_mask',
+           'TfmCrop', 'TfmLighting', 'TfmPixel', 'Transform', 'bb2hw', 'image2np', 'open_image', 'open_mask', 'tis2hw',
            'pil2tensor', 'scale_flow', 'show_image', 'CoordFunc', 'TfmList', 'open_mask_rle', 'rle_encode',
            'rle_decode', 'ResizeMethod', 'plot_flat', 'plot_multi', 'show_multi', 'show_all']
 
@@ -26,6 +26,10 @@ def image2np(image:Tensor)->np.ndarray:
 def bb2hw(a:Collection[int])->np.ndarray:
     "Convert bounding box points from (width,height,center) to (height,width,top,left)."
     return np.array([a[1],a[0],a[3]-a[1],a[2]-a[0]])
+
+def tis2hw(size:Union[int,TensorImageSize]) -> Tuple[int,int]:
+    "Convert `int` or `TensorImageSize` to (height,width) of an image."
+    return listify(size, 2) if isinstance(size, int) else listify(size[-2:],2)
 
 def _draw_outline(o:Patch, lw:int):
     "Outline bounding box onto image `Patch`."
@@ -567,9 +571,9 @@ def _round_multiple(x:int, mult:int)->int:
     "Calc `x` to nearest multiple of `mult`."
     return (int(x/mult+0.5)*mult)
 
-def _get_crop_target(target_px:Union[int,Tuple[int,int]], mult:int=32)->Tuple[int,int]:
+def _get_crop_target(target_px:Union[int,TensorImageSize], mult:int=32)->Tuple[int,int]:
     "Calc crop shape of `target_px` to nearest multiple of `mult`."
-    target_r,target_c = listify(target_px, 2)
+    target_r,target_c = tis2hw(target_px)
     return _round_multiple(target_r,mult),_round_multiple(target_c,mult)
 
 def _get_resize_target(img, crop_target, do_crop=False)->TensorImageSize:

--- a/fastai/vision/transform.py
+++ b/fastai/vision/transform.py
@@ -118,15 +118,14 @@ pad = TfmPixel(_pad, order=-10)
 
 def _crop_default(x, size, row_pct:uniform=0.5, col_pct:uniform=0.5):
     "Crop `x` to `size` pixels. `row_pct`,`col_pct` select focal point of crop."
-    size = listify(size,2)
-    rows,cols = size
+    rows,cols = tis2hw(size)
     row = int((x.size(1)-rows+1) * row_pct)
     col = int((x.size(2)-cols+1) * col_pct)
     return x[:, row:row+rows, col:col+cols].contiguous()
 
 def _crop_image_points(x, size, row_pct=0.5, col_pct=0.5):
     h,w = x.size
-    rows,cols = listify(size, 2)
+    rows,cols = tis2hw(size)
     x.flow.flow.mul_(torch.Tensor([w/cols, h/rows])[None])
     row = int((h-rows+1) * row_pct)
     col = int((w-cols+1) * col_pct)
@@ -144,7 +143,7 @@ crop = TfmPixel(_crop)
 def _crop_pad_default(x, size, padding_mode='reflection', row_pct:uniform = 0.5, col_pct:uniform = 0.5):
     "Crop and pad tfm - `row_pct`,`col_pct` sets focal point."
     padding_mode = _pad_mode_convert[padding_mode]
-    size = listify(size,2)
+    size = tis2hw(size)
     if x.shape[1:] == torch.Size(size): return x
     rows,cols = size
     if x.size(1)<rows or x.size(2)<cols:
@@ -157,7 +156,7 @@ def _crop_pad_default(x, size, padding_mode='reflection', row_pct:uniform = 0.5,
     return x.contiguous() # without this, get NaN later - don't know why
 
 def _crop_pad_image_points(x, size, padding_mode='reflection', row_pct = 0.5, col_pct = 0.5):
-    size = listify(size,2)
+    size = tis2hw(size)
     rows,cols = size
     if x.size[0]<rows or x.size[1]<cols:
         row_pad = max((rows-x.size[0]+1)//2, 0)

--- a/tests/test_vision_image.py
+++ b/tests/test_vision_image.py
@@ -20,3 +20,16 @@ def test_rle_decode_empty_str():
     encoded_str = ''
     ans = np.array([[0, 0, 0], [0, 0, 0], [0, 0 ,0]])
     assert np.alltrue(rle_decode(encoded_str,(3,3)) == ans)
+
+def test_tis2hw_int():
+    size = 224
+    assert(tis2hw(size) == [224,224])
+
+def test_tis2hw_3dims():
+    size = (3, 224, 224)
+    assert(tis2hw(size) == [224,224])
+
+def test_tis2hw_2dims():
+    size = (224, 224)
+    assert(tis2hw(size) == [224,224])
+

--- a/tests/test_vision_transform.py
+++ b/tests/test_vision_transform.py
@@ -119,3 +119,9 @@ def test_crop_without_size():
     img = open_image(path/files[0])
     tfms = get_transforms()
     img = img.apply_tfms(tfms[0])
+
+def test_crops_with_tensor_image_sizes():
+    img = img_test([3,3])
+    crops = [crop(size=(1,4,4), row_pct=r, col_pct=c) for r,c in zip([0.,0.,0.5,0.99,0.99], [0.,0.99,0.5,0.,0.99])]
+    check_tfms(img, crops, [[3,3], [3,2],[2,2],[2,3],[2,2]])
+


### PR DESCRIPTION
I noticed `ImageDataBunch` exploded when providing `size=(3,244,244)`. The code seems to support it, but there were a couple places where some functions expected size to have just 2 elements if it's a tuple, and other expected 3. 

That resulted in trying to `listify((int,int,int),2` which throws a len mismatch error.

Fixed that: 
- `_get_crop_target()` is only used in `image.py`, so allowing it to receive tuple of len 3 is safe
- Added a helper function to safely cast size to (h,w)
- Added test for that helper
- Added tests for vision.transforms to make sure using that helper doesn't ruin the existing transforms that use size (crop). 


@stas00, @sgugger, please let me know if there's a better way to write and document such small PRs, or if you'd like any changes to my code styles, as well as more / other tests.
