### PR TITLE
Added docs and error handling for vision.image.tis2hw

### DIFF
--- a/docs_src/vision.image.ipynb
+++ b/docs_src/vision.image.ipynb
@@ -1272,6 +1272,39 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<h4 id=\"tis2hw\"><code>tis2hw</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/image.py#L30\" class=\"source_link\">[source]</a></h4>\n",
+       "\n",
+       "> <code>tis2hw</code>(<b>`size`</b>:`Union`\\[`int`, `TensorImageSize`\\]) → `Tuple`\\[`int`, `int`\\]\n",
+       "\n",
+       "Convert `int` or `TensorImageSize` to (height,width) of an image.  "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "show_doc(tis2hw)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If a size is provided as `(int, int)`, `tis2hw` will return it as it is. If a size is passed in as `str`, `tis2hw` will raise a `RuntimeError`"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/fastai/vision/image.py
+++ b/fastai/vision/image.py
@@ -29,6 +29,8 @@ def bb2hw(a:Collection[int])->np.ndarray:
 
 def tis2hw(size:Union[int,TensorImageSize]) -> Tuple[int,int]:
     "Convert `int` or `TensorImageSize` to (height,width) of an image."
+    if type(size) is str:
+        raise RuntimeError("Expected size to be an int or a tuple, got a string.")
     return listify(size, 2) if isinstance(size, int) else listify(size[-2:],2)
 
 def _draw_outline(o:Patch, lw:int):

--- a/fastai/vision/image.py
+++ b/fastai/vision/image.py
@@ -29,8 +29,7 @@ def bb2hw(a:Collection[int])->np.ndarray:
 
 def tis2hw(size:Union[int,TensorImageSize]) -> Tuple[int,int]:
     "Convert `int` or `TensorImageSize` to (height,width) of an image."
-    if type(size) is str:
-        raise RuntimeError("Expected size to be an int or a tuple, got a string.")
+    if type(size) is str: raise RuntimeError("Expected size to be an int or a tuple, got a string.")
     return listify(size, 2) if isinstance(size, int) else listify(size[-2:],2)
 
 def _draw_outline(o:Patch, lw:int):

--- a/tests/test_vision_image.py
+++ b/tests/test_vision_image.py
@@ -33,3 +33,6 @@ def test_tis2hw_2dims():
     size = (224, 224)
     assert(tis2hw(size) == [224,224])
 
+def test_tis2hw_str_raises_an_erorr():
+    with pytest.raises(RuntimeError) as e:
+        tis2hw("224")


### PR DESCRIPTION
Accompanies the [yesterday's apply_tfms size pull request](https://github.com/fastai/fastai/pull/1410), I added an exported function to `vision.image` and didn't add docs for it, and it also didn't handle type mismatch very well. 

This adds docs to the appropriate notebook (ran nbstripout as well), and adds type mismatch handling, i.e. raise an error if size is passed in as a string.