### PR TITLE
Update data.py

### DIFF
--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -322,7 +322,9 @@ def _join_texts(texts:Collection[str], mark_fields:bool=False):
     if not isinstance(texts, np.ndarray): texts = np.array(texts)
     if is1d(texts): texts = texts[:,None]
     df = pd.DataFrame({i:texts[:,i] for i in range(texts.shape[1])})
-    text_col = f'{BOS} {FLD} {1} ' + df[0] if mark_fields else  f'{BOS} ' + df[0]
+    #text_col = f'{BOS} {FLD} {1} ' + df[0] if mark_fields else  f'{BOS} ' + df[0]
+    text_col = f'{BOS} {FLD} {1} ' + df[0].astype(str) if mark_fields else  f'{BOS} ' + df[0].astype(str)
     for i in range(1,len(df.columns)):
-        text_col += (f' {FLD} {i+1} ' if mark_fields else ' ') + df[i]
+        #text_col += (f' {FLD} {i+1} ' if mark_fields else ' ') + df[i]
+        text_col += (f' {FLD} {i+1} ' if mark_fields else ' ') + df[i].astype(str)   
     return text_col.values


### PR DESCRIPTION
"It’s a casting problem. Sometimes pandas dataframe gets confused when adding columns if it’s a number in the data somewhere as the “word” or “token”. We are doing strictly text work in this python file and we always want string not integer operation for “adding”. Here’s the code fix (data.py):"

https://forums.fast.ai/t/textdatabunch-from-file-string/30730/11

credits - gob

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
