### PR TITLE
Fixed an error while importing from 'imports'

### DIFF
--- a/old/fastai/structured.py
+++ b/old/fastai/structured.py
@@ -1,4 +1,4 @@
-from .imports import *
+from imports import *
 
 from sklearn_pandas import DataFrameMapper
 from sklearn.preprocessing import LabelEncoder, Imputer, StandardScaler


### PR DESCRIPTION
An error occurred as we were importing from '.imports' rather than 'imports'


