### PR TITLE
Fix can't convert CUDA tensor to numpy in dl1/lesson 2

### DIFF
--- a/old/fastai/model.py
+++ b/old/fastai/model.py
@@ -238,7 +238,7 @@ def validate(stepper, dl, metrics, epoch, seq_first=False, validate_skip = 0):
             preds, l = stepper.evaluate(VV(x), y)
             batch_cnts.append(batch_sz(x, seq_first=seq_first))
             loss.append(to_np(l))
-            res.append([to_np(f(datafy(preds), datafy(y))) for f in metrics])
+            res.append([to_np(f(datafy(preds.cpu()), datafy(y.cpu()))) for f in metrics])
     return [np.average(loss, 0, weights=batch_cnts)] + list(np.average(np.stack(res), 0, weights=batch_cnts))
 
 def get_prediction(x):


### PR DESCRIPTION
Fix an issue with torch 1.0.0 (installed with pip) while running the lesson 2 of the dl1 course.
The error happens on the line: lrf=learn.lr_find()
I think this is related to the new api from Pytorh that force to cast to cpu before converting to numpy array.
This is my first pull request so let me know if I need to do any additional steps.

Here is the error:
ypeError                                 Traceback (most recent call last)
<ipython-input-19-c69896a35d32> in <module>
----> 1 lrf=learn.lr_find()
      2 learn.sched.plot()

/fastai/courses/dl1/fastai/learner.py in lr_find(self, start_lr, end_lr, wds, linear, **kwargs)
    343         layer_opt = self.get_layer_opt(start_lr, wds)
    344         self.sched = LR_Finder(layer_opt, len(self.data.trn_dl), end_lr, linear=linear)
--> 345         self.fit_gen(self.model, self.data, layer_opt, 1, **kwargs)
    346         self.load('tmp')
    347 

/fastai/courses/dl1/fastai/learner.py in fit_gen(self, model, data, layer_opt, n_cycle, cycle_len, cycle_mult, cycle_save_name, best_save_name, use_clr, use_clr_beta, metrics, callbacks, use_wd_sched, norm_wds, wds_sched_mult, use_swa, swa_start, swa_eval_freq, **kwargs)
    247             metrics=metrics, callbacks=callbacks, reg_fn=self.reg_fn, clip=self.clip, fp16=self.fp16,
    248             swa_model=self.swa_model if use_swa else None, swa_start=swa_start,
--> 249             swa_eval_freq=swa_eval_freq, **kwargs)
    250 
    251     def get_layer_groups(self): return self.models.get_layer_groups()

/fastai/courses/dl1/fastai/model.py in fit(model, data, n_epochs, opt, crit, metrics, callbacks, stepper, swa_model, swa_start, swa_eval_freq, visualize, **kwargs)
    160 
    161         if not all_val:
--> 162             vals = validate(model_stepper, cur_data.val_dl, metrics, epoch, seq_first=seq_first, validate_skip = validate_skip)
    163             stop=False
    164             for cb in callbacks: stop = stop or cb.on_epoch_end(vals)

/fastai/courses/dl1/fastai/model.py in validate(stepper, dl, metrics, epoch, seq_first, validate_skip)
    239             batch_cnts.append(batch_sz(x, seq_first=seq_first))
    240             loss.append(to_np(l))
--> 241             res.append([to_np(f(datafy(preds), datafy(y))) for f in metrics])
    242     return [np.average(loss, 0, weights=batch_cnts)] + list(np.average(np.stack(res), 0, weights=batch_cnts))
    243 

/fastai/courses/dl1/fastai/model.py in <listcomp>(.0)
    239             batch_cnts.append(batch_sz(x, seq_first=seq_first))
    240             loss.append(to_np(l))
--> 241             res.append([to_np(f(datafy(preds), datafy(y))) for f in metrics])
    242     return [np.average(loss, 0, weights=batch_cnts)] + list(np.average(np.stack(res), 0, weights=batch_cnts))
    243 

/fastai/courses/dl1/planet.py in f2(preds, targs, start, end, step)
      9         warnings.simplefilter("ignore")
     10         return max([fbeta_score(targs, (preds>th), 2, average='samples')
---> 11                     for th in np.arange(start,end,step)])
     12 
     13 def opt_th(preds, targs, start=0.17, end=0.24, step=0.01):

/fastai/courses/dl1/planet.py in <listcomp>(.0)
      9         warnings.simplefilter("ignore")
     10         return max([fbeta_score(targs, (preds>th), 2, average='samples')
---> 11                     for th in np.arange(start,end,step)])
     12 
     13 def opt_th(preds, targs, start=0.17, end=0.24, step=0.01):

/usr/local/lib/python3.6/dist-packages/sklearn/metrics/classification.py in fbeta_score(y_true, y_pred, beta, labels, pos_label, average, sample_weight)
    832                                                  average=average,
    833                                                  warn_for=('f-score',),
--> 834                                                  sample_weight=sample_weight)
    835     return f
    836 

/usr/local/lib/python3.6/dist-packages/sklearn/metrics/classification.py in precision_recall_fscore_support(y_true, y_pred, beta, labels, pos_label, average, warn_for, sample_weight)
   1029         raise ValueError("beta should be >0 in the F-beta score")
   1030 
-> 1031     y_type, y_true, y_pred = _check_targets(y_true, y_pred)
   1032     check_consistent_length(y_true, y_pred, sample_weight)
   1033     present_labels = unique_labels(y_true, y_pred)

/usr/local/lib/python3.6/dist-packages/sklearn/metrics/classification.py in _check_targets(y_true, y_pred)
     70     """
     71     check_consistent_length(y_true, y_pred)
---> 72     type_true = type_of_target(y_true)
     73     type_pred = type_of_target(y_pred)
     74 

/usr/local/lib/python3.6/dist-packages/sklearn/utils/multiclass.py in type_of_target(y)
    247         raise ValueError("y cannot be class 'SparseSeries'.")
    248 
--> 249     if is_multilabel(y):
    250         return 'multilabel-indicator'
    251 

/usr/local/lib/python3.6/dist-packages/sklearn/utils/multiclass.py in is_multilabel(y)
    138     """
    139     if hasattr(y, '__array__'):
--> 140         y = np.asarray(y)
    141     if not (hasattr(y, "shape") and y.ndim == 2 and y.shape[1] > 1):
    142         return False

/usr/local/lib/python3.6/dist-packages/numpy/core/numeric.py in asarray(a, dtype, order)
    499 
    500     """
--> 501     return array(a, dtype, copy=False, order=order)
    502 
    503 

/usr/local/lib/python3.6/dist-packages/torch/tensor.py in __array__(self, dtype)
    448     def __array__(self, dtype=None):
    449         if dtype is None:
--> 450             return self.numpy()
    451         else:
    452             return self.numpy().astype(dtype, copy=False)

TypeError: can't convert CUDA tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
