### PR TITLE
More flexible visual styling for ImagePoints.show

### DIFF
--- a/fastai/vision/image.py
+++ b/fastai/vision/image.py
@@ -316,7 +316,9 @@ class ImagePoints(Image):
         "Show the `ImagePoints` on `ax`."
         if ax is None: _,ax = plt.subplots(figsize=figsize)
         pnt = scale_flow(FlowField(self.size, self.data), to_unit=False).flow.flip(1)
-        ax.scatter(pnt[:, 0], pnt[:, 1], s=10, marker='.', c='r')
+        params = {'s': 10, 'marker': '.', 'c': 'r'}
+        params.update(**kwargs)
+        ax.scatter(pnt[:, 0], pnt[:, 1], **kwargs)
         if hide_axis: ax.axis('off')
         if title: ax.set_title(title)
 

--- a/fastai/vision/image.py
+++ b/fastai/vision/image.py
@@ -316,9 +316,8 @@ class ImagePoints(Image):
         "Show the `ImagePoints` on `ax`."
         if ax is None: _,ax = plt.subplots(figsize=figsize)
         pnt = scale_flow(FlowField(self.size, self.data), to_unit=False).flow.flip(1)
-        params = {'s': 10, 'marker': '.', 'c': 'r'}
-        params.update(**kwargs)
-        ax.scatter(pnt[:, 0], pnt[:, 1], **kwargs)
+        params = {'s': 10, 'marker': '.', 'c': 'r', **kwargs}
+        ax.scatter(pnt[:, 0], pnt[:, 1], **params)
         if hide_axis: ax.axis('off')
         if title: ax.set_title(title)
 


### PR DESCRIPTION
In this PR, an attempt to fix issue #1441 is made. The `ImagePoints.show` method `kwargs` are directly passed into `ax.scatter` (including original default values if nothing is overridden by caller).