### PR TITLE
Handle timouts in download_url

### DIFF
--- a/docs_src/core.ipynb
+++ b/docs_src/core.ipynb
@@ -57,7 +57,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"has_arg\"><code>has_arg</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L244\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"has_arg\"><code>has_arg</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L246\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>has_arg</code>(<b>`func`</b>, <b>`arg`</b>) → `bool`\n",
        "\n",
@@ -535,7 +535,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"arange_of\"><code>arange_of</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L193\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"arange_of\"><code>arange_of</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L195\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>arange_of</code>(<b>`x`</b>)\n",
        "\n",
@@ -603,7 +603,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"array\"><code>array</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L254\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"array\"><code>array</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L256\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>array</code>(<b>`a`</b>, <b>`dtype`</b>:`type`=<b><i>`None`</i></b>, <b>`kwargs`</b>) → `ndarray`\n",
        "\n",
@@ -935,7 +935,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"df_names_to_idx\"><code>df_names_to_idx</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L218\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"df_names_to_idx\"><code>df_names_to_idx</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L220\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>df_names_to_idx</code>(<b>`names`</b>:`IntsOrStrs`, <b>`df`</b>:`DataFrame`)\n",
        "\n",
@@ -1119,7 +1119,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"index_row\"><code>index_row</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L230\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"index_row\"><code>index_row</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L232\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>index_row</code>(<b>`a`</b>:`Union`\\[`Collection`\\[`T_co`\\], `DataFrame`, `Series`\\], <b>`idxs`</b>:`Collection`\\[`int`\\]) → `Any`\n",
        "\n",
@@ -1513,13 +1513,13 @@
       "text/plain": [
        "[(array([[ 0,  1],\n",
        "         [ 2,  3],\n",
-       "         [ 4,  5],\n",
+       "         [ 6,  7],\n",
        "         [ 8,  9],\n",
        "         [10, 11],\n",
-       "         [12, 13],\n",
-       "         [14, 15],\n",
        "         [16, 17],\n",
-       "         [18, 19]]),), (array([[6, 7]]),)]"
+       "         [18, 19]]),), (array([[ 4,  5],\n",
+       "         [12, 13],\n",
+       "         [14, 15]]),)]"
       ]
      },
      "execution_count": null,
@@ -1539,15 +1539,16 @@
     {
      "data": {
       "text/plain": [
-       "[(array([[ 2,  3],\n",
+       "[(array([[ 0,  1],\n",
+       "         [ 2,  3],\n",
        "         [ 4,  5],\n",
        "         [ 6,  7],\n",
        "         [ 8,  9],\n",
        "         [10, 11],\n",
-       "         [16, 17],\n",
-       "         [18, 19]]),), (array([[ 0,  1],\n",
        "         [12, 13],\n",
-       "         [14, 15]]),)]"
+       "         [14, 15],\n",
+       "         [16, 17],\n",
+       "         [18, 19]]),), (array([], shape=(0, 2), dtype=int64),)]"
       ]
      },
      "execution_count": null,
@@ -1569,7 +1570,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"range_of\"><code>range_of</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L190\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"range_of\"><code>range_of</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L192\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>range_of</code>(<b>`x`</b>)\n",
        "\n",
@@ -1832,7 +1833,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"split_kwargs_by_func\"><code>split_kwargs_by_func</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L248\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"split_kwargs_by_func\"><code>split_kwargs_by_func</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L250\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>split_kwargs_by_func</code>(<b>`kwargs`</b>, <b>`func`</b>)\n",
        "\n",
@@ -2008,7 +2009,7 @@
       "text/markdown": [
        "<h4 id=\"download_url\"><code>download_url</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L159\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
-       "> <code>download_url</code>(<b>`url`</b>:`str`, <b>`dest`</b>:`str`, <b>`overwrite`</b>:`bool`=<b><i>`False`</i></b>, <b>`pbar`</b>:`ProgressBar`=<b><i>`None`</i></b>, <b>`show_progress`</b>=<b><i>`True`</i></b>, <b>`chunk_size`</b>=<b><i>`1048576`</i></b>, <b>`timeout`</b>=<b><i>`4`</i></b>, <b>`retries`</b>=<b><i>`5`</i></b>)\n",
+       "> <code>download_url</code>(<b>`url`</b>:`str`, <b>`dest`</b>:`str`, <b>`overwrite`</b>:`bool`=<b><i>`False`</i></b>, <b>`pbar`</b>:`ProgressBar`=<b><i>`None`</i></b>, <b>`show_progress`</b>=<b><i>`True`</i></b>, <b>`chunk_size`</b>=<b><i>`1048576`</i></b>, <b>`timeout`</b>=<b><i>`4`</i></b>, <b>`retries`</b>=<b><i>`1`</i></b>)\n",
        "\n",
        "Download `url` to `dest` unless it exists and not `overwrite`.  "
       ],
@@ -2062,7 +2063,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"join_path\"><code>join_path</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L199\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"join_path\"><code>join_path</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L201\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>join_path</code>(<b>`fname`</b>:`PathOrStr`, <b>`path`</b>:`PathOrStr`=<b><i>`'.'`</i></b>) → `Path`\n",
        "\n",
@@ -2090,7 +2091,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"join_paths\"><code>join_paths</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L203\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"join_paths\"><code>join_paths</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L205\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>join_paths</code>(<b>`fnames`</b>:`FilePathList`, <b>`path`</b>:`PathOrStr`=<b><i>`'.'`</i></b>) → `FilePathList`\n",
        "\n",
@@ -2118,7 +2119,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"loadtxt_str\"><code>loadtxt_str</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L208\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"loadtxt_str\"><code>loadtxt_str</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L210\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>loadtxt_str</code>(<b>`path`</b>:`PathOrStr`) → `ndarray`\n",
        "\n",
@@ -2146,7 +2147,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"save_texts\"><code>save_texts</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L213\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"save_texts\"><code>save_texts</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L215\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>save_texts</code>(<b>`fname`</b>:`PathOrStr`, <b>`texts`</b>:`StrList`)\n",
        "\n",
@@ -2209,7 +2210,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"parallel\"><code>parallel</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L296\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"parallel\"><code>parallel</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L298\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>parallel</code>(<b>`func`</b>, <b>`arr`</b>:`Collection`\\[`T_co`\\], <b>`max_workers`</b>:`int`=<b><i>`None`</i></b>)\n",
        "\n",
@@ -2398,7 +2399,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h3 id=\"Category\"><code>class</code> <code>Category</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L267\" class=\"source_link\">[source]</a></h3>\n",
+       "<h3 id=\"Category\"><code>class</code> <code>Category</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L269\" class=\"source_link\">[source]</a></h3>\n",
        "\n",
        "> <code>Category</code>(<b>`data`</b>, <b>`obj`</b>) :: [`ItemBase`](/core.html#ItemBase)\n",
        "\n",
@@ -2433,7 +2434,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h3 id=\"EmptyLabel\"><code>class</code> <code>EmptyLabel</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L262\" class=\"source_link\">[source]</a></h3>\n",
+       "<h3 id=\"EmptyLabel\"><code>class</code> <code>EmptyLabel</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L264\" class=\"source_link\">[source]</a></h3>\n",
        "\n",
        "> <code>EmptyLabel</code>() :: [`ItemBase`](/core.html#ItemBase)\n",
        "\n",
@@ -2461,7 +2462,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h3 id=\"MultiCategory\"><code>class</code> <code>MultiCategory</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L273\" class=\"source_link\">[source]</a></h3>\n",
+       "<h3 id=\"MultiCategory\"><code>class</code> <code>MultiCategory</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L275\" class=\"source_link\">[source]</a></h3>\n",
        "\n",
        "> <code>MultiCategory</code>(<b>`data`</b>, <b>`obj`</b>, <b>`raw`</b>) :: [`ItemBase`](/core.html#ItemBase)\n",
        "\n",
@@ -2579,7 +2580,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"func_args\"><code>func_args</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L239\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"func_args\"><code>func_args</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L241\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>func_args</code>(<b>`func`</b>) → `bool`\n",
        "\n",
@@ -2640,7 +2641,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"one_hot\"><code>one_hot</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L224\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"one_hot\"><code>one_hot</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L226\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>one_hot</code>(<b>`x`</b>:`Collection`\\[`int`\\], <b>`c`</b>:`int`)\n",
        "\n",
@@ -2668,7 +2669,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"subplots\"><code>subplots</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L305\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"subplots\"><code>subplots</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L307\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>subplots</code>(<b>`rows`</b>:`int`, <b>`cols`</b>:`int`, <b>`imgsize`</b>:`int`=<b><i>`4`</i></b>, <b>`figsize`</b>:`Optional`\\[`Tuple`\\[`int`, `int`\\]\\]=<b><i>`None`</i></b>, <b>`title`</b>=<b><i>`None`</i></b>, <b>`kwargs`</b>)\n",
        "\n",
@@ -2696,7 +2697,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"text2html_table\"><code>text2html_table</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L286\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"text2html_table\"><code>text2html_table</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L288\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>text2html_table</code>(<b>`items`</b>:`Tokens`, <b>`widths`</b>:`Collection`\\[`int`\\]) → `str`\n",
        "\n",
@@ -2726,29 +2727,6 @@
    "metadata": {},
    "source": [
     "## New Methods - Please document or move to the undocumented section"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "_=IPython.notebook.save_notebook()\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "%%javascript # prevent committing an unsaved notebook\n",
-    "_=IPython.notebook.save_notebook()"
    ]
   }
  ],

--- a/docs_src/core.ipynb
+++ b/docs_src/core.ipynb
@@ -57,7 +57,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"has_arg\"><code>has_arg</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L230\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"has_arg\"><code>has_arg</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L244\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>has_arg</code>(<b>`func`</b>, <b>`arg`</b>) → `bool`\n",
        "\n",
@@ -535,7 +535,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"arange_of\"><code>arange_of</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L179\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"arange_of\"><code>arange_of</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L193\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>arange_of</code>(<b>`x`</b>)\n",
        "\n",
@@ -603,7 +603,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"array\"><code>array</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L240\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"array\"><code>array</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L254\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>array</code>(<b>`a`</b>, <b>`dtype`</b>:`type`=<b><i>`None`</i></b>, <b>`kwargs`</b>) → `ndarray`\n",
        "\n",
@@ -935,7 +935,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"df_names_to_idx\"><code>df_names_to_idx</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L204\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"df_names_to_idx\"><code>df_names_to_idx</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L218\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>df_names_to_idx</code>(<b>`names`</b>:`IntsOrStrs`, <b>`df`</b>:`DataFrame`)\n",
        "\n",
@@ -1119,7 +1119,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"index_row\"><code>index_row</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L216\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"index_row\"><code>index_row</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L230\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>index_row</code>(<b>`a`</b>:`Union`\\[`Collection`\\[`T_co`\\], `DataFrame`, `Series`\\], <b>`idxs`</b>:`Collection`\\[`int`\\]) → `Any`\n",
        "\n",
@@ -1514,13 +1514,12 @@
        "[(array([[ 0,  1],\n",
        "         [ 2,  3],\n",
        "         [ 4,  5],\n",
-       "         [ 6,  7],\n",
        "         [ 8,  9],\n",
        "         [10, 11],\n",
        "         [12, 13],\n",
        "         [14, 15],\n",
        "         [16, 17],\n",
-       "         [18, 19]]),), (array([], shape=(0, 2), dtype=int64),)]"
+       "         [18, 19]]),), (array([[6, 7]]),)]"
       ]
      },
      "execution_count": null,
@@ -1540,15 +1539,15 @@
     {
      "data": {
       "text/plain": [
-       "[(array([[ 0,  1],\n",
-       "         [ 2,  3],\n",
+       "[(array([[ 2,  3],\n",
        "         [ 4,  5],\n",
        "         [ 6,  7],\n",
        "         [ 8,  9],\n",
        "         [10, 11],\n",
+       "         [16, 17],\n",
+       "         [18, 19]]),), (array([[ 0,  1],\n",
        "         [12, 13],\n",
-       "         [14, 15],\n",
-       "         [18, 19]]),), (array([[16, 17]]),)]"
+       "         [14, 15]]),)]"
       ]
      },
      "execution_count": null,
@@ -1570,7 +1569,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"range_of\"><code>range_of</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L176\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"range_of\"><code>range_of</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L190\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>range_of</code>(<b>`x`</b>)\n",
        "\n",
@@ -1833,7 +1832,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"split_kwargs_by_func\"><code>split_kwargs_by_func</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L234\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"split_kwargs_by_func\"><code>split_kwargs_by_func</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L248\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>split_kwargs_by_func</code>(<b>`kwargs`</b>, <b>`func`</b>)\n",
        "\n",
@@ -2009,7 +2008,7 @@
       "text/markdown": [
        "<h4 id=\"download_url\"><code>download_url</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L159\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
-       "> <code>download_url</code>(<b>`url`</b>:`str`, <b>`dest`</b>:`str`, <b>`overwrite`</b>:`bool`=<b><i>`False`</i></b>, <b>`pbar`</b>:`ProgressBar`=<b><i>`None`</i></b>, <b>`show_progress`</b>=<b><i>`True`</i></b>, <b>`chunk_size`</b>=<b><i>`1048576`</i></b>, <b>`timeout`</b>=<b><i>`4`</i></b>)\n",
+       "> <code>download_url</code>(<b>`url`</b>:`str`, <b>`dest`</b>:`str`, <b>`overwrite`</b>:`bool`=<b><i>`False`</i></b>, <b>`pbar`</b>:`ProgressBar`=<b><i>`None`</i></b>, <b>`show_progress`</b>=<b><i>`True`</i></b>, <b>`chunk_size`</b>=<b><i>`1048576`</i></b>, <b>`timeout`</b>=<b><i>`4`</i></b>, <b>`retries`</b>=<b><i>`5`</i></b>)\n",
        "\n",
        "Download `url` to `dest` unless it exists and not `overwrite`.  "
       ],
@@ -2063,7 +2062,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"join_path\"><code>join_path</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L185\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"join_path\"><code>join_path</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L199\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>join_path</code>(<b>`fname`</b>:`PathOrStr`, <b>`path`</b>:`PathOrStr`=<b><i>`'.'`</i></b>) → `Path`\n",
        "\n",
@@ -2091,7 +2090,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"join_paths\"><code>join_paths</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L189\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"join_paths\"><code>join_paths</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L203\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>join_paths</code>(<b>`fnames`</b>:`FilePathList`, <b>`path`</b>:`PathOrStr`=<b><i>`'.'`</i></b>) → `FilePathList`\n",
        "\n",
@@ -2119,7 +2118,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"loadtxt_str\"><code>loadtxt_str</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L194\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"loadtxt_str\"><code>loadtxt_str</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L208\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>loadtxt_str</code>(<b>`path`</b>:`PathOrStr`) → `ndarray`\n",
        "\n",
@@ -2147,7 +2146,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"save_texts\"><code>save_texts</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L199\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"save_texts\"><code>save_texts</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L213\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>save_texts</code>(<b>`fname`</b>:`PathOrStr`, <b>`texts`</b>:`StrList`)\n",
        "\n",
@@ -2210,7 +2209,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"parallel\"><code>parallel</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L282\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"parallel\"><code>parallel</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L296\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>parallel</code>(<b>`func`</b>, <b>`arr`</b>:`Collection`\\[`T_co`\\], <b>`max_workers`</b>:`int`=<b><i>`None`</i></b>)\n",
        "\n",
@@ -2399,7 +2398,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h3 id=\"Category\"><code>class</code> <code>Category</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L253\" class=\"source_link\">[source]</a></h3>\n",
+       "<h3 id=\"Category\"><code>class</code> <code>Category</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L267\" class=\"source_link\">[source]</a></h3>\n",
        "\n",
        "> <code>Category</code>(<b>`data`</b>, <b>`obj`</b>) :: [`ItemBase`](/core.html#ItemBase)\n",
        "\n",
@@ -2434,7 +2433,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h3 id=\"EmptyLabel\"><code>class</code> <code>EmptyLabel</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L248\" class=\"source_link\">[source]</a></h3>\n",
+       "<h3 id=\"EmptyLabel\"><code>class</code> <code>EmptyLabel</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L262\" class=\"source_link\">[source]</a></h3>\n",
        "\n",
        "> <code>EmptyLabel</code>() :: [`ItemBase`](/core.html#ItemBase)\n",
        "\n",
@@ -2462,7 +2461,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h3 id=\"MultiCategory\"><code>class</code> <code>MultiCategory</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L259\" class=\"source_link\">[source]</a></h3>\n",
+       "<h3 id=\"MultiCategory\"><code>class</code> <code>MultiCategory</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L273\" class=\"source_link\">[source]</a></h3>\n",
        "\n",
        "> <code>MultiCategory</code>(<b>`data`</b>, <b>`obj`</b>, <b>`raw`</b>) :: [`ItemBase`](/core.html#ItemBase)\n",
        "\n",
@@ -2580,7 +2579,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"func_args\"><code>func_args</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L225\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"func_args\"><code>func_args</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L239\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>func_args</code>(<b>`func`</b>) → `bool`\n",
        "\n",
@@ -2641,7 +2640,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"one_hot\"><code>one_hot</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L210\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"one_hot\"><code>one_hot</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L224\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>one_hot</code>(<b>`x`</b>:`Collection`\\[`int`\\], <b>`c`</b>:`int`)\n",
        "\n",
@@ -2669,7 +2668,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"subplots\"><code>subplots</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L291\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"subplots\"><code>subplots</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L305\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>subplots</code>(<b>`rows`</b>:`int`, <b>`cols`</b>:`int`, <b>`imgsize`</b>:`int`=<b><i>`4`</i></b>, <b>`figsize`</b>:`Optional`\\[`Tuple`\\[`int`, `int`\\]\\]=<b><i>`None`</i></b>, <b>`title`</b>=<b><i>`None`</i></b>, <b>`kwargs`</b>)\n",
        "\n",
@@ -2697,7 +2696,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"text2html_table\"><code>text2html_table</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L272\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"text2html_table\"><code>text2html_table</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/core.py#L286\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>text2html_table</code>(<b>`items`</b>:`Tokens`, <b>`widths`</b>:`Collection`\\[`int`\\]) → `str`\n",
        "\n",
@@ -2727,6 +2726,29 @@
    "metadata": {},
    "source": [
     "## New Methods - Please document or move to the undocumented section"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "_=IPython.notebook.save_notebook()\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%javascript # prevent committing an unsaved notebook\n",
+    "_=IPython.notebook.save_notebook()"
    ]
   }
  ],

--- a/fastai/core.py
+++ b/fastai/core.py
@@ -177,10 +177,12 @@ def download_url(url:str, dest:str, overwrite:bool=False, pbar:ProgressBar=None,
                 f.write(chunk)
         except requests.exceptions.ConnectionError as e:
             fname = url.split('/')[-1]
+            from fastai.datasets import Config
+            data_dir = Config().data_path()
             timeout_txt =(f'\n Download of {url} has failed after {retries} retries\n'
                           f' Fix the download manually:\n'
-                          f'$ mkdir -p ~/.fastai/data\n'
-                          f'$ cd ~/.fastai/data\n'
+                          f'$ mkdir -p {data_dir}\n'
+                          f'$ cd {data_dir}\n'
                           f'$ wget -c {url}\n'
                           f'$ tar -zxvf {fname}\n\n'
                           f'And re-run your code once the download is successful\n')

--- a/fastai/core.py
+++ b/fastai/core.py
@@ -157,21 +157,35 @@ class ItemBase():
         return self
 
 def download_url(url:str, dest:str, overwrite:bool=False, pbar:ProgressBar=None,
-                 show_progress=True, chunk_size=1024*1024, timeout=4)->None:
+                 show_progress=True, chunk_size=1024*1024, timeout=4, retries=5)->None:
     "Download `url` to `dest` unless it exists and not `overwrite`."
     if os.path.exists(dest) and not overwrite: return
 
-    u = requests.get(url, stream=True, timeout=timeout)
+    s = requests.Session()
+    s.mount('http://',requests.adapters.HTTPAdapter(max_retries=retries))
+    u = s.get(url, stream=True, timeout=timeout)
     try: file_size = int(u.headers["Content-Length"])
     except: show_progress = False
 
     with open(dest, 'wb') as f:
         nbytes = 0
         if show_progress: pbar = progress_bar(range(file_size), auto_update=False, leave=False, parent=pbar)
-        for chunk in u.iter_content(chunk_size=chunk_size):
-            nbytes += len(chunk)
-            if show_progress: pbar.update(nbytes)
-            f.write(chunk)
+        try:
+            for chunk in u.iter_content(chunk_size=chunk_size):
+                nbytes += len(chunk)
+                if show_progress: pbar.update(nbytes)
+                f.write(chunk)
+        except requests.exceptions.ConnectionError as e:
+            fname = url.split('/')[-1]
+            timeout_txt =(f'\n Download of {url} has failed after {retries} retries\n'
+                          f' Fix the download manually:\n'
+                          f'$ mkdir -p ~/.fastai/data\n'
+                          f'$ cd ~/.fastai/data\n'
+                          f'$ wget -c {url}\n'
+                          f'$ tar -zxvf {fname}\n\n'
+                          f'And re-run your code once the download is successful\n')
+            print(timeout_txt)
+            import sys;sys.exit(1)
 
 def range_of(x):  
     "Create a range from 0 to `len(x)`."

--- a/fastai/datasets.py
+++ b/fastai/datasets.py
@@ -155,5 +155,6 @@ def untar_data(url:str, fname:PathOrStr=None, dest:PathOrStr=None, data=True) ->
         shutil.rmtree(dest)      
     if not dest.exists():
         fname = download_data(url, fname=fname, data=data)
+        assert _check_file(fname) == _checks[url], f"Downloaded file {fname} does not match checksum expected!  Remove the file from ~/.fastai/data and try your code again."
         tarfile.open(fname, 'r:gz').extractall(dest.parent)
     return dest

--- a/fastai/datasets.py
+++ b/fastai/datasets.py
@@ -39,26 +39,26 @@ class URLs():
     BIWI_HEAD_POSE = f"{S3_IMAGELOC}biwi_head_pose"
     LSUN_BEDROOMS = f'{S3_IMAGE}bedroom'
 
-_checks = {URLs.COCO_SAMPLE:(3245877008, '006cd55d633d94b36ecaf661467830ec'), 
-           URLs.COCO_TINY:(801038, '367467451ac4fba79a647753c2c66d3a'), 
-           URLs.MNIST_SAMPLE:(3214948, '2dbc7ec6f9259b583af0072c55816a88'), 
-           URLs.MNIST_TINY:(342207, '56143e8f24db90d925d82a5a74141875'), 
-           URLs.IMDB:(144440600, '90f9b1c4ff43a90d67553c9240dc0249'), 
-           URLs.IMDB_SAMPLE:(571827, '0842e61a9867caa2e6fbdb14fa703d61'), 
-           URLs.HUMAN_NUMBERS:(30252, '8a19c3bfa2bcb08cd787e741261f3ea2'), 
-           URLs.ADULT_SAMPLE:(968212, '64eb9d7e23732de0b138f7372d15492f'), 
-           URLs.ML_SAMPLE:(51790, '10961384dfe7c5181460390a460c1f77'), 
-           URLs.PLANET_SAMPLE:(15523994, '8bfb174b3162f07fbde09b54555bdb00'), 
-           URLs.BIWI_SAMPLE:(593774, '9179f4c1435f4b291f0d5b072d60c2c9'), 
-           URLs.PLANET_TINY:(997569, '490873c5683454d4b2611fb1f00a68a9'), 
-           URLs.CIFAR:(168168549, 'a5f8c31371b63a406b23368042812d3c'), 
-           URLs.WT103:(206789489, '76fd08236c78bf91b7fb76698d53afa3'), 
-           URLs.WT103_1:(165175630, '9cbe02e9e23b969fee10dc9b8dec6566'), 
-           URLs.DOGS:(839285364, '3e483c8d6ef2175e9d395a6027eb92b7'), 
-           URLs.PETS:(811706944, 'e4db5c768afd933bb91f5f594d7417a4'), 
+_checks = {URLs.COCO_SAMPLE:(3245877008, '006cd55d633d94b36ecaf661467830ec'),
+           URLs.COCO_TINY:(801038, '367467451ac4fba79a647753c2c66d3a'),
+           URLs.MNIST_SAMPLE:(3214948, '2dbc7ec6f9259b583af0072c55816a88'),
+           URLs.MNIST_TINY:(342207, '56143e8f24db90d925d82a5a74141875'),
+           URLs.IMDB:(144440600, '90f9b1c4ff43a90d67553c9240dc0249'),
+           URLs.IMDB_SAMPLE:(571827, '0842e61a9867caa2e6fbdb14fa703d61'),
+           URLs.HUMAN_NUMBERS:(30252, '8a19c3bfa2bcb08cd787e741261f3ea2'),
+           URLs.ADULT_SAMPLE:(968212, '64eb9d7e23732de0b138f7372d15492f'),
+           URLs.ML_SAMPLE:(51790, '10961384dfe7c5181460390a460c1f77'),
+           URLs.PLANET_SAMPLE:(15523994, '8bfb174b3162f07fbde09b54555bdb00'),
+           URLs.BIWI_SAMPLE:(593774, '9179f4c1435f4b291f0d5b072d60c2c9'),
+           URLs.PLANET_TINY:(997569, '490873c5683454d4b2611fb1f00a68a9'),
+           URLs.CIFAR:(168168549, 'a5f8c31371b63a406b23368042812d3c'),
+           URLs.WT103:(206789489, '76fd08236c78bf91b7fb76698d53afa3'),
+           URLs.WT103_1:(165175630, '9cbe02e9e23b969fee10dc9b8dec6566'),
+           URLs.DOGS:(839285364, '3e483c8d6ef2175e9d395a6027eb92b7'),
+           URLs.PETS:(811706944, 'e4db5c768afd933bb91f5f594d7417a4'),
            URLs.PETS1:(788208066, 'b6d7b491221c6ff5121dbd04166adcf1'),
-           URLs.MNIST:(15683414, '03639f83c4e3d19e0a3a53a8a997c487'), 
-           URLs.CAMVID:(598913237, '648371e4f3a833682afb39b08a3ce2aa'), 
+           URLs.MNIST:(15683414, '03639f83c4e3d19e0a3a53a8a997c487'),
+           URLs.CAMVID:(598913237, '648371e4f3a833682afb39b08a3ce2aa'),
            URLs.CAMVID_TINY:(2314212, '2cf6daf91b7a2083ecfa3e9968e9d915'),
            URLs.BIWI_HEAD_POSE:(452316199, '00f4ccf66e8cba184bc292fdc08fb237'),
            URLs.LSUN_BEDROOMS:(4579163978, '35d84f38f8a15fe47e66e460c8800d68')}
@@ -145,17 +145,17 @@ def _check_file(fname):
         hash_nb = hashlib.md5(f.read(2**20)).hexdigest()
     return size,hash_nb
 
-def untar_data(url:str, fname:PathOrStr=None, dest:PathOrStr=None, data=True,force_download=False) -> Path:
+def untar_data(url:str, fname:PathOrStr=None, dest:PathOrStr=None, data=True, force_download=False) -> Path:
     "Download `url` to `fname` if it doesn't exist, and un-tgz to folder `dest`."
     dest = Path(ifnone(dest, url2path(url, data)))
     fname = Path(ifnone(fname, _url2tgz(url, data)))
     if force_download or (fname.exists() and _check_file(fname) != _checks[url]):
         print(f"A new version of the {'dataset' if data else 'model'} is available.")
         os.remove(fname)
-        shutil.rmtree(dest)      
+        shutil.rmtree(dest)
     if not dest.exists():
         fname = download_data(url, fname=fname, data=data)
         data_dir = Config().data_path()
-        assert _check_file(fname) == _checks[url], f"Downloaded file {fname} does not match checksum expected!  Remove the file from {data_dir} and try your code again."
+        assert _check_file(fname) == _checks[url], f"Downloaded file {fname} does not match checksum expected! Remove that file from {data_dir} and try your code again."
         tarfile.open(fname, 'r:gz').extractall(dest.parent)
     return dest

--- a/fastai/datasets.py
+++ b/fastai/datasets.py
@@ -1,5 +1,6 @@
 from .core import *
 import hashlib
+# from fastai.datasets import Config
 
 __all__ = ['URLs', 'Config', 'untar_data', 'download_data', 'datapath4file', 'url2name', 'url2path']
 
@@ -145,16 +146,17 @@ def _check_file(fname):
         hash_nb = hashlib.md5(f.read(2**20)).hexdigest()
     return size,hash_nb
 
-def untar_data(url:str, fname:PathOrStr=None, dest:PathOrStr=None, data=True) -> Path:
+def untar_data(url:str, fname:PathOrStr=None, dest:PathOrStr=None, data=True,force_download=False) -> Path:
     "Download `url` to `fname` if it doesn't exist, and un-tgz to folder `dest`."
     dest = Path(ifnone(dest, url2path(url, data)))
     fname = Path(ifnone(fname, _url2tgz(url, data)))
-    if fname.exists() and _check_file(fname) != _checks[url]:
+    if force_download or (fname.exists() and _check_file(fname) != _checks[url]):
         print(f"A new version of the {'dataset' if data else 'model'} is available.")
         os.remove(fname)
         shutil.rmtree(dest)      
     if not dest.exists():
         fname = download_data(url, fname=fname, data=data)
-        assert _check_file(fname) == _checks[url], f"Downloaded file {fname} does not match checksum expected!  Remove the file from ~/.fastai/data and try your code again."
+        data_dir = Config().data_path()
+        assert _check_file(fname) == _checks[url], f"Downloaded file {fname} does not match checksum expected!  Remove the file from {data_dir} and try your code again."
         tarfile.open(fname, 'r:gz').extractall(dest.parent)
     return dest

--- a/fastai/datasets.py
+++ b/fastai/datasets.py
@@ -1,6 +1,5 @@
 from .core import *
 import hashlib
-# from fastai.datasets import Config
 
 __all__ = ['URLs', 'Config', 'untar_data', 'download_data', 'datapath4file', 'url2name', 'url2path']
 

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ dev_requirements = { 'dev' : to_list("""
     pip>=9.0.1
     pipreqs>=0.4.9
     pytest
+    responses                    # for requests testing
     traitlets
     wheel>=0.30.0
 """) }

--- a/tests/test_vision_data.py
+++ b/tests/test_vision_data.py
@@ -69,7 +69,7 @@ def test_denormalize(path):
     denormalized = denormalize(normalized_x, original_x.mean(), original_x.std())
     assert round(original_x.mean().item(), 3) == round(denormalized.mean().item(), 3)
     assert round(original_x.std().item(), 3) == round(denormalized.std().item(), 3)
-        
+
 def test_download_images():
     base_url = 'http://files.fast.ai/data/tst_images/'
     fnames = ['tst0.jpg', 'tst1.png', 'tst2.tif']
@@ -88,29 +88,29 @@ def test_download_images():
     finally:
         shutil.rmtree(tmp_path)
 
-@responses.activate                                                                              
+@responses.activate
 def test_trunc_download():
     from io import StringIO
     with StringIO('test_file_that_is_not_image') as cc_trunc:
-        file_io = cc_trunc.read()                                                                
-        mock_headers = {'Content-Type':'text/plain','Content-Length':'168168549'}                
-        responses.add(responses.GET, 'http://files.fast.ai/data/examples/coco_tiny.tgz',         
-                      body=file_io,status=200,headers=mock_headers)                              
+        file_io = cc_trunc.read()
+        mock_headers = {'Content-Type':'text/plain', 'Content-Length':'168168549'}
+        responses.add(responses.GET, 'http://files.fast.ai/data/examples/coco_tiny.tgz',
+                      body=file_io, status=200, headers=mock_headers)
 
         url = URLs.COCO_TINY
-        fname = f'{url2path(url)}.tgz'
+        fname = datapath4file(f'{url2name(url)}.tgz')
         try:
             coco = untar_data(url,force_download=True)
         except AssertionError as e:
             # from fastai.datasets import Config, url2name
             data_dir = Config().data_path()
-            expected_error =  f"Downloaded file {fname} does not match checksum expected!  Remove the file from {data_dir} and try your code again."
+            expected_error =  f"Downloaded file {fname} does not match checksum expected! Remove that file from {data_dir} and try your code again."
             assert e.args[0] == expected_error
         except:
             print(f"untar_data({URLs.COCO_TINY}) had Unexpected error:", sys.exc_info()[0])
         finally:
             if fname.exists(): os.remove(fname)
-        
+
 def test_verify_images(path):
     tmp_path = path/'tmp'
     os.makedirs(tmp_path, exist_ok=True)
@@ -192,14 +192,14 @@ def test_coco():
             .transform(get_transforms(), tfm_y=True)
             .databunch(bs=16, collate_fn=bb_pad_collate))
     _check_data(data, 160, 40)
-    
+
 def test_coco_same_size():
     def get_y_func(fname):
         cat = fname.parent.name
         bbox = torch.cat([torch.randint(0,5,(2,)), torch.randint(23,28,(2,))])
         bbox = list(bbox.float().numpy())
         return [[bbox, bbox], [cat, cat]]
-    
+
     coco = untar_data(URLs.MNIST_TINY)
     bs = 16
     data = (ObjectItemList.from_folder(coco)
@@ -256,7 +256,7 @@ def test_image_to_image_different_tfms():
     y1 = y[0]
     x1r = flip_lr(Image(x1)).data
     assert (y1 == x1r).all()
-    
+
 def test_vision_pil2tensor():
     path  = Path(__file__).parent / "data/test/images"
     files = list(Path(path).glob("**/*.*"))

--- a/tests/test_vision_data.py
+++ b/tests/test_vision_data.py
@@ -298,5 +298,3 @@ def test_vision_pil2tensor_numpy():
     arr  = np.random.rand(16,16,3)
     diff = np.sort( pil2tensor(arr,np.float).data.numpy().flatten() ) - np.sort(arr.flatten())
     assert( np.sum(diff==0)==len(arr.flatten()) )
-
-            

--- a/tests/test_vision_data.py
+++ b/tests/test_vision_data.py
@@ -109,7 +109,7 @@ def test_trunc_download():
         except:
             print(f"untar_data({URLs.COCO_TINY}) had Unexpected error:", sys.exc_info()[0])
         finally:
-            os.remove(fname)
+            if fname.exists(): os.remove(fname)
         
 def test_verify_images(path):
     tmp_path = path/'tmp'


### PR DESCRIPTION
* Handle the timeouts for `download_url` to retry 5 times.  If failed, raise a verbose message about how to manually download.
* Added `force_download` param to `untar_data`
* Added test to `test_vision_data.py` to handle partial-download of tar file.  Returns sensible message about what broke.

Please let me know if there are any stylistic improvements. This is my first PR touching code (that is, beyond doc examples) and I tried to be concise with the code style but it might not be what you are looking for.
