### PR TITLE
Added plot_multi_top_losses() for Interpretation upon multi-labeled datasets

### DIFF
--- a/docs_src/vision.learner.ipynb
+++ b/docs_src/vision.learner.ipynb
@@ -856,7 +856,7 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/docs_src/vision.learner.ipynb
+++ b/docs_src/vision.learner.ipynb
@@ -857,18 +857,6 @@
    "language": "python",
    "name": "python3"
   },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.2"
-  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/docs_src/vision.learner.ipynb
+++ b/docs_src/vision.learner.ipynb
@@ -601,6 +601,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_doc(ClassificationInterpretation.plot_multi_top_losses)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Similar to `plot_top_losses()` but aimed at multi-labeled datasets. It plots misclassified samples sorted by their respective loss. \n",
+    "Since you can have multiple labels for a single sample, they can easily overlap in a grid plot. So it plots just one sample per row.  \n",
+    "Note that you can pass `save_misclassified=True` (by default it's `False`). In such case, the method will return a list containing the misclassified images which you can use to debug your model and/or tune its hyperparameters. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "hide_input": true
    },
@@ -826,23 +844,6 @@
    "source": [
     "## New Methods - Please document or move to the undocumented section"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "show_doc(ClassificationInterpretation.plot_multi_top_losses)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Similar to `plot_top_losses()` but aimed at multi-labeled datasets. It plots misclassified samples sorted by their respective loss. \n",
-    "Since you can have multiple labels for a single sample, they can easily overlap in a grid plot. So it plots just one sample per row. "
-   ]
   }
  ],
  "metadata": {
@@ -866,7 +867,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,

--- a/docs_src/vision.learner.ipynb
+++ b/docs_src/vision.learner.ipynb
@@ -514,7 +514,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `k` items are arranged as a square, so it will look best if `k` is a square number (4, 9, 16, etc). The title of each image shows: prediction, actual, loss, probability of actual class."
+    "The `k` items are arranged as a square, so it will look best if `k` is a square number (4, 9, 16, etc). The title of each image shows: prediction, actual, loss, probability of actual class.\n",
+    "`plot_top_losses()` should be used with single-labeled datasets. See `plot_multi_top_losses()` below for a version capable of handling multi-labeled datasets."
    ]
   },
   {
@@ -825,6 +826,23 @@
    "source": [
     "## New Methods - Please document or move to the undocumented section"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_doc(ClassificationInterpretation.plot_multi_top_losses)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Similar to `plot_top_losses()` but aimed at multi-labeled datasets. It plots misclassified samples sorted by their respective loss. \n",
+    "Since you can have multiple labels for a single sample, they can easily overlap in a grid plot. So it plots just one sample per row. "
+   ]
   }
  ],
  "metadata": {
@@ -837,6 +855,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -113,7 +113,7 @@ class ClassificationInterpretation():
             im.show(ax=axes.flat[i], title=
                 f'{classes[self.pred_class[idx]]}/{classes[cl]} / {self.losses[idx]:.2f} / {self.probs[idx][cl]:.2f}')
             
-    def plot_multi_top_losses(self, samples:int=3, figsz:Tuple[int,int]=(8,8)):
+    def plot_multi_top_losses(self, samples:int=3, figsz:Tuple[int,int]=(8,8), save_misclassified:bool=False):
         "Show images in `top_losses` along with their prediction, actual, loss, and probability of predicted class in a multilabeled dataset."
         if samples >20:
             print("Max 20 samples")
@@ -149,6 +149,9 @@ class ClassificationInterpretation():
                                Actual: {actualclasses}, Loss: {infolist[ordlosses_idxs[sampleN]][3]}, 
                                Probability: {infolist[ordlosses_idxs[sampleN]][4]}""")
             plt.show()
+            if save_misclassified:
+                return mismatchescontainer
+            
 
     def confusion_matrix(self, slice_size:int=None):
         "Confusion matrix as an `np.ndarray`."

--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -124,12 +124,12 @@ class ClassificationInterpretation():
         classes_ids=[k for k in enumerate(self.data.classes)]
         predclass=np.asarray(self.pred_class)
         for i, pred in enumerate(predclass):
-            dove_truth=np.nonzero((truthlabels[i]>0))[0]
-            mismatch=np.all(pred!=dove_truth)
+            where_truth=np.nonzero((truthlabels[i]>0))[0]
+            mismatch=np.all(pred!=where_truth)
             if mismatch: 
                 mismatches_idxs.append(i)
                 losses_mismatches.append((losses[i][pred],i))
-            infotup=(i, pred, dove_truth, losses[i][pred], np.round(self.probs[i], decimals=3)[pred], mismatch)
+            infotup=(i, pred, where_truth, losses[i][pred], np.round(self.probs[i], decimals=3)[pred], mismatch)
             infolist.append(infotup)
         mismatches = self.data.valid_ds[mismatches_idxs]
         ordlosses=sorted(losses_mismatches, key = lambda x: x[0], reverse=True)

--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -124,8 +124,8 @@ class ClassificationInterpretation():
         classes_ids=[k for k in enumerate(self.data.classes)]
         predclass=np.asarray(self.pred_class)
         for i, pred in enumerate(predclass):
-            dove_truth=np.nonzero((truthlabels[i]>0))[0] # [0] since it's a tuple
-            mismatch=np.all(pred!=dove_truth) # if True, the prediction is wrong!
+            dove_truth=np.nonzero((truthlabels[i]>0))[0]
+            mismatch=np.all(pred!=dove_truth)
             if mismatch: 
                 mismatches_idxs.append(i)
                 losses_mismatches.append((losses[i][pred],i))

--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -136,7 +136,6 @@ class ClassificationInterpretation():
         for w in ordlosses: ordlosses_idxs.append(w[1])
         mismatches_ordered_byloss=self.data.valid_ds[ordlosses_idxs]
         print(mismatches)
-        mismatchescontainer=[]
         for ima in range(len(mismatches_ordered_byloss)):
             mismatchescontainer.append(mismatches_ordered_byloss[ima][0]) 
         for sampleN in range(samples):
@@ -149,9 +148,7 @@ class ClassificationInterpretation():
                                Actual: {actualclasses}, Loss: {infolist[ordlosses_idxs[sampleN]][3]}, 
                                Probability: {infolist[ordlosses_idxs[sampleN]][4]}""")
             plt.show()
-            if save_misclassified:
-                return mismatchescontainer
-            
+            if save_misclassified: return mismatchescontainer
 
     def confusion_matrix(self, slice_size:int=None):
         "Confusion matrix as an `np.ndarray`."

--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -113,7 +113,7 @@ class ClassificationInterpretation():
             im.show(ax=axes.flat[i], title=
                 f'{classes[self.pred_class[idx]]}/{classes[cl]} / {self.losses[idx]:.2f} / {self.probs[idx][cl]:.2f}')
             
-    def plot_multi_top_losses(self, samples:int=5, figsz:Tuple[int,int]=(8,8)):
+    def plot_multi_top_losses(self, samples:int=3, figsz:Tuple[int,int]=(8,8)):
         "Show images in `top_losses` along with their prediction, actual, loss, and probability of predicted class, multilabeled dataset version of the above."
         if samples >20:
             print("Max 20 samples")
@@ -129,7 +129,6 @@ class ClassificationInterpretation():
             if mismatch: 
                 mismatches_idxs.append(i)
                 losses_mismatches.append((losses[i][pred],i))
-            #infotup: sampleNo., pred, gr.truths, prob on prediction, loss on prediction, mismatch true/false
             infotup=(i, pred, dove_truth, losses[i][pred], np.round(self.probs[i], decimals=3)[pred], mismatch)
             granlista.append(infotup)
         mismatches = self.data.valid_ds[mismatches_idxs]

--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -119,7 +119,7 @@ class ClassificationInterpretation():
             print("Max 20 samples")
             return
         losses, idxs = self.top_losses(self.data.c)
-        granlista, ordlosses_idxs, mismatches_idxs, mismatches, losses_mismatches, mismatchescontainer = [],[],[],[],[],[]                                                      
+        infolist, ordlosses_idxs, mismatches_idxs, mismatches, losses_mismatches, mismatchescontainer = [],[],[],[],[],[]                                                      
         truthlabels=np.asarray(self.y_true, dtype=int) 
         classes_ids=[k for k in enumerate(self.data.classes)]
         predclass=np.asarray(self.pred_class)
@@ -130,7 +130,7 @@ class ClassificationInterpretation():
                 mismatches_idxs.append(i)
                 losses_mismatches.append((losses[i][pred],i))
             infotup=(i, pred, dove_truth, losses[i][pred], np.round(self.probs[i], decimals=3)[pred], mismatch)
-            granlista.append(infotup)
+            infolist.append(infotup)
         mismatches = self.data.valid_ds[mismatches_idxs]
         ordlosses=sorted(losses_mismatches, key = lambda x: x[0], reverse=True)
         for w in ordlosses: ordlosses_idxs.append(w[1])
@@ -141,11 +141,11 @@ class ClassificationInterpretation():
             mismatchescontainer.append(mismatches_ordered_byloss[ima][0]) 
         for sampleN in range(samples):
             actualclasses=''
-            for clas in granlista[ordlosses_idxs[sampleN]][2]:
+            for clas in infolist[ordlosses_idxs[sampleN]][2]:
                 actualclasses=actualclasses+' -- '+str(classes_ids[clas][1])
             imag=mismatches_ordered_byloss[sampleN][0]
             imag=show_image(imag, figsize=figsz)
-            imag.set_title(f'Predicted: {classes_ids[granlista[ordlosses_idxs[sampleN]][1]][1]}, Actual: {actualclasses}, Loss: {granlista[ordlosses_idxs[sampleN]][3]}, Probability: {granlista[ordlosses_idxs[sampleN]][4]}')
+            imag.set_title(f'Predicted: {classes_ids[infolist[ordlosses_idxs[sampleN]][1]][1]}, Actual: {actualclasses}, Loss: {infolist[ordlosses_idxs[sampleN]][3]}, Probability: {infolist[ordlosses_idxs[sampleN]][4]}')
             plt.show()
 
     def confusion_matrix(self, slice_size:int=None):

--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -1,3 +1,9 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Jan 16 14:20:24 2019
+
+"""
+
 "`Learner` support for computer vision"
 from ..torch_core import *
 from ..basic_train import *
@@ -13,20 +19,14 @@ __all__ = ['create_cnn', 'create_body', 'create_head', 'ClassificationInterpreta
 def _default_split(m:nn.Module): return (m[1],)
 # Split a resnet style model
 def _resnet_split(m:nn.Module): return (m[0][6],m[1])
-# Split squeezenet model on maxpool layers
-def _squeezenet_split(m:nn.Module): return (m[0][0][5], m[0][0][8], m[1])
 
 _default_meta = {'cut':-1, 'split':_default_split}
 _resnet_meta  = {'cut':-2, 'split':_resnet_split }
-_squeezenet_meta = {'cut':-1, 'split': _squeezenet_split}
 
 model_meta = {
     models.resnet18 :{**_resnet_meta}, models.resnet34: {**_resnet_meta},
     models.resnet50 :{**_resnet_meta}, models.resnet101:{**_resnet_meta},
-    models.resnet152:{**_resnet_meta},
-
-    models.squeezenet1_0:{**_squeezenet_meta},
-    models.squeezenet1_1:{**_squeezenet_meta}}
+    models.resnet152:{**_resnet_meta}}
 
 def cnn_config(arch):
     "Get the metadata associated with `arch`."
@@ -112,7 +112,68 @@ class ClassificationInterpretation():
             cl = int(cl)
             im.show(ax=axes.flat[i], title=
                 f'{classes[self.pred_class[idx]]}/{classes[cl]} / {self.losses[idx]:.2f} / {self.probs[idx][cl]:.2f}')
-
+    
+    
+    def plot_multi_top_losses(self, samples=5, figsz=(8,8)):
+    
+        """
+        INPUT = Number of samples to plot (Int), figure size (tuple of Int)
+    
+        OUTPUT= Images of misclassified samples along with predicted/actual/loss/prob.
+            Furthermore, it saves those misclassified samples in a list (mismatchescontainer),
+            in case you want to train a few epochs just upon them
+        """
+        if samples >20:
+            print("Max 20 samples")
+            return
+        
+        losses, idxs = self.top_losses(self.data.c)
+        
+        granlista=[]                            # info tuples
+        ordlosses_idxs=[]                       # indexes of samples sorted by loss
+        mismatches_idxs = []                    # mismatches indexes from validation set
+        mismatches = []                         # data.valid_ds subset with wrongly predicted items, same format
+        losses_mismatches=[]                    # Losses of mismatched items
+        mismatchescontainer=[]                  # mismatched images, in case you want to move them into the training set
+        
+        kakkona=np.asarray(self.y_true, dtype=int) # ground truth labels validation set
+        
+        classes_ids=[k for k in enumerate(self.data.classes)]
+        
+        predclass=np.asarray(self.pred_class)
+        for i, pred in enumerate(predclass):
+            dove_truth=np.nonzero((kakkona[i]>0))[0] # [0] since it's a tuple
+            mismatch=np.all(pred!=dove_truth) # if True, the prediction is wrong!
+            if mismatch: 
+                mismatches_idxs.append(i)
+                losses_mismatches.append((losses[i][pred],i))
+            #infotup: sampleNo., pred, gr.truths, prob on prediction, loss on prediction, mismatch true/false
+            infotup=(i, pred, dove_truth, losses[i][pred], np.round(self.probs[i], decimals=3)[pred], mismatch)
+            granlista.append(infotup)
+        
+        mismatches = self.data.valid_ds[mismatches_idxs]
+        ordlosses=sorted(losses_mismatches, key = lambda x: x[0], reverse=True)
+        
+        for w in ordlosses:
+            ordlosses_idxs.append(w[1])
+        
+        mismatches_ordered_byloss=self.data.valid_ds[ordlosses_idxs]
+        print(mismatches)
+            
+        mismatchescontainer=[]
+        for ima in range(len(mismatches_ordered_byloss)):
+            mismatchescontainer.append(mismatches_ordered_byloss[ima][0])
+            
+        for sampleN in range(samples):
+            actualclasses=''
+            for clas in granlista[ordlosses_idxs[sampleN]][2]:
+                actualclasses=actualclasses+' -- '+str(classes_ids[clas][1])
+            imag=mismatches_ordered_byloss[sampleN][0]
+            imag=show_image(imag, figsize=figsz)
+            imag.set_title(f'Predicted: {classes_ids[granlista[ordlosses_idxs[sampleN]][1]][1]}, Actual: {actualclasses}, Loss: {granlista[ordlosses_idxs[sampleN]][3]}, Probability: {granlista[ordlosses_idxs[sampleN]][4]}')
+            plt.show()
+    
+    
     def confusion_matrix(self, slice_size:int=None):
         "Confusion matrix as an `np.ndarray`."
         x=torch.arange(0,self.data.c)
@@ -159,3 +220,4 @@ def _learner_interpret(learn:Learner, ds_type:DatasetType=DatasetType.Valid, tta
     "Create a `ClassificationInterpretation` object from `learner` on `ds_type` with `tta`."
     return ClassificationInterpretation.from_learner(learn, ds_type=ds_type, tta=tta)
 Learner.interpret = _learner_interpret
+

--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -114,7 +114,7 @@ class ClassificationInterpretation():
                 f'{classes[self.pred_class[idx]]}/{classes[cl]} / {self.losses[idx]:.2f} / {self.probs[idx][cl]:.2f}')
             
     def plot_multi_top_losses(self, samples:int=3, figsz:Tuple[int,int]=(8,8)):
-        "Show images in `top_losses` along with their prediction, actual, loss, and probability of predicted class, multilabeled dataset version of the above."
+        "Show images in `top_losses` along with their prediction, actual, loss, and probability of predicted class in a multilabeled dataset."
         if samples >20:
             print("Max 20 samples")
             return
@@ -145,7 +145,9 @@ class ClassificationInterpretation():
                 actualclasses=actualclasses+' -- '+str(classes_ids[clas][1])
             imag=mismatches_ordered_byloss[sampleN][0]
             imag=show_image(imag, figsize=figsz)
-            imag.set_title(f'Predicted: {classes_ids[infolist[ordlosses_idxs[sampleN]][1]][1]}, Actual: {actualclasses}, Loss: {infolist[ordlosses_idxs[sampleN]][3]}, Probability: {infolist[ordlosses_idxs[sampleN]][4]}')
+            imag.set_title(f"""Predicted: {classes_ids[infolist[ordlosses_idxs[sampleN]][1]][1]}, 
+                               Actual: {actualclasses}, Loss: {infolist[ordlosses_idxs[sampleN]][3]}, 
+                               Probability: {infolist[ordlosses_idxs[sampleN]][4]}""")
             plt.show()
 
     def confusion_matrix(self, slice_size:int=None):


### PR DESCRIPTION
plot_multi_top_losses() in vision/learner.py does upon multilabeled dataset the same that plot_top_losses() does upon single-labeled datasets.

I hope you will accept it.

Thanks.