### PR TITLE
Fixed a regression bug in databunch.show_batch(1) subplots handling

### DIFF
--- a/fastai/basic_data.py
+++ b/fastai/basic_data.py
@@ -157,12 +157,14 @@ class DataBunch():
     def show_batch(self, rows:int=5, ds_type:DatasetType=DatasetType.Train, **kwargs)->None:
         "Show a batch of data in `ds_type` on a few `rows`."
         x,y = self.one_batch(ds_type, True, True)
-        if self.train_ds.x._square_show: rows = rows ** 2
-        xs = [self.train_ds.x.reconstruct(grab_idx(x, i)) for i in range(rows)]
+        n_items = rows
+        if self.train_ds.x._square_show: n_items = n_items ** 2
+        if self.dl(ds_type).batch_size < n_items: n_items = self.dl(ds_type).batch_size
+        xs = [self.train_ds.x.reconstruct(grab_idx(x, i)) for i in range(n_items)]
         #TODO: get rid of has_arg if possible
         if has_arg(self.train_ds.y.reconstruct, 'x'):
             ys = [self.train_ds.y.reconstruct(grab_idx(y, i), x=x) for i,x in enumerate(xs)]
-        else : ys = [self.train_ds.y.reconstruct(grab_idx(y, i)) for i in range(rows)]
+        else : ys = [self.train_ds.y.reconstruct(grab_idx(y, i)) for i in range(n_items)]
         self.train_ds.x.show_xys(xs, ys, **kwargs)
 
     def export(self, fname:str='export.pkl'):

--- a/fastai/core.py
+++ b/fastai/core.py
@@ -308,6 +308,7 @@ def subplots(rows:int, cols:int, imgsize:int=4, figsize:Optional[Tuple[int,int]]
     "Like `plt.subplots` but with consistent axs shape, `kwargs` passed to `fig.suptitle` with `title`"
     figsize = ifnone(figsize, (imgsize*cols, imgsize*rows))
     fig, axs = plt.subplots(rows,cols,figsize=figsize)
+    if rows==cols==1: axs = [[axs]] # subplots(1,1) returns Axes, not [Axes]
     if (rows==1 and cols!=1) or (cols==1 and rows!=1): axs = [axs]
     if title is not None: fig.suptitle(title, **kwargs)
     return array(axs)

--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -303,7 +303,7 @@ class ImageItemList(ItemList):
         "Show the `xs` (inputs) and `ys` (targets) on a figure of `figsize`."
         rows = int(math.sqrt(len(xs)))
         axs = subplots(rows, rows, imgsize=imgsize, figsize=figsize)
-        for i, ax in enumerate(axs.flatten() if rows > 1 else [axs]):
+        for i, ax in enumerate(axs.flatten()):
             xs[i].show(ax=ax, y=ys[i], **kwargs)
         plt.tight_layout()
 
@@ -313,7 +313,7 @@ class ImageItemList(ItemList):
             title = 'Ground truth\nPredictions'
             rows = int(math.sqrt(len(xs)))
             axs = subplots(rows, rows, imgsize=imgsize, figsize=figsize, title=title, weight='bold', size=12)
-            for i, ax in enumerate(axs.flatten() if rows > 1 else [axs]):
+            for i, ax in enumerate(axs.flatten()):
                 xs[i].show(ax=ax, title=f'{str(ys[i])}\n{str(zs[i])}', **kwargs)
         else:
             title = 'Ground truth/Predictions'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -179,3 +179,14 @@ def test_df_names_to_idx():
 def test_one_hot():
     assert all(one_hot([0,-1], 5) == np.array([1,0,0,0,1]))
 
+def test_subplots_multi_row_cols():
+    axs = subplots(4, 4, figsize=(10, 10))
+    assert len(axs) == 4
+    assert (len(axs[0]) == 4)
+    assert (len(axs.flatten()) == 16)
+
+def test_subplots_single():
+    axs = subplots(1,1, figsize=(10, 10))
+    assert (len(axs) == 1)
+    assert (len(axs[0]) == 1)
+


### PR DESCRIPTION
@sgugger, seems like Jeremy implemented a workaround in `show_xys` to handle a situation when `subplots()` was called for a single subplot, but it stopped working. 

This handles subplots if a single row, column, or a single subplot (1x1) was requested and returns it as `[[ax]]`, and then `show_xys()` flattens it anyway. I also changed `show_xyzs()` to accommodate that. Checked if it brakes any tests or `docs_nbs` full tests: there are a few errors, but they're unrelated (!). Added a few tests for `subplots()` in `core` to make sure the output stays consistent.

With that, `show_batch(1)` should work. 

Also implemented a workaround for a situation when user wants to `show_batch()` for a databunch with small batch size, i.e. 

```
data = src.databunch(bs=4)
data.show_batch(5)
```

will render 2x2 images and won't raise an error.
