### PR TITLE
lesson1-vgg.ipynb issue | submitting the bug fix #1503

### DIFF
--- a/courses/dl1/lesson1-vgg.ipynb
+++ b/courses/dl1/lesson1-vgg.ipynb
@@ -372,7 +372,7 @@
    ],
    "source": [
     "log_preds,y = learn.TTA()\n",
-    "probs = np.mean(np.exp(log_preds),0)",
+    "probs = np.mean(np.exp(log_preds),0);",
     "accuracy_np(probs,y)"
    ]
   },


### PR DESCRIPTION
issue : line 21 couldn`t run locally
log_preds,y = learn.TTA()
probs = np.mean(np.exp(log_preds),0)accuracy_np(probs,y)

==============================================

missed a semicolon.
probs = np.mean(np.exp(log_preds),0); accuracy_np(probs,y)

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
