### PR TITLE
adapt dummy input size for general cases

### DIFF
--- a/fastai/callbacks/hooks.py
+++ b/fastai/callbacks/hooks.py
@@ -114,7 +114,13 @@ def model_sizes(m:nn.Module, size:tuple=(64,64))->Tuple[Sizes,Tensor,Hooks]:
 
 def num_features_model(m:nn.Module)->int:
     "Return the number of output features for `model`."
-    return model_sizes(m)[-1][1]
+    sz = 64
+    while True:
+        try:
+            return model_sizes(m, size=(sz,sz))[-1][1]
+        except Exception as e:
+            sz *= 2
+            if sz > 2048: raise e
 
 def total_params(m:nn.Module)->int:
     params, trainable = 0, False

--- a/fastai/callbacks/hooks.py
+++ b/fastai/callbacks/hooks.py
@@ -116,8 +116,7 @@ def num_features_model(m:nn.Module)->int:
     "Return the number of output features for `model`."
     sz = 64
     while True:
-        try:
-            return model_sizes(m, size=(sz,sz))[-1][1]
+        try: return model_sizes(m, size=(sz,sz))[-1][1]
         except Exception as e:
             sz *= 2
             if sz > 2048: raise e


### PR DESCRIPTION
Issue #1504 : dummy input size in `num_features_model` is too small for some architectures (i.e., inceptionv4). 

Solution: double the input size until it works. Stop if input size is already pretty large, because in this case the error is probably not due to the input size.  