### PR TITLE
Now SaveModelCallback prints out a message when a better model is saved.

### DIFF
--- a/fastai/callbacks/tracker.py
+++ b/fastai/callbacks/tracker.py
@@ -92,7 +92,7 @@ class SaveModelCallback(TrackerCallback):
         else: #every="improvement"
             current = self.get_monitor_value()
             if current is not None and self.operator(current, self.best):
-                print(f'better model found at epoch {epoch} with {self.monitor} value: {current}.')
+                print(f'Better model found at epoch {epoch} with {self.monitor} value: {current}.')
                 self.best = current
                 self.learn.save(f'{self.name}')
 

--- a/fastai/callbacks/tracker.py
+++ b/fastai/callbacks/tracker.py
@@ -92,6 +92,7 @@ class SaveModelCallback(TrackerCallback):
         else: #every="improvement"
             current = self.get_monitor_value()
             if current is not None and self.operator(current, self.best):
+                print(f'better model found at epoch {epoch} with {self.monitor} value: {current}.')
                 self.best = current
                 self.learn.save(f'{self.name}')
 


### PR DESCRIPTION
This is a very minor convenience patch. All it does is that now when training with SaveModelCallback and a better model is found after an epoch, the callback will prints out a message that says something like:

better model found at epoch 4 with accuracy value: 0.975.

It is helpful in the sense that the user can immediately know the best metrics score his saved model has obtained.

Sometimes, we need a lot of epochs. Sometimes, metrics score drops after an epoch. Sometimes, we need to look through all the output to find the best metrics score. With this minor patch, we can just look at the bottom of the output and there the best score will lie. Cheers!