### PR TITLE
handle corner case in bb_pad_collate

### DIFF
--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -45,13 +45,11 @@ def bb_pad_collate(samples:BatchSamples, pad_idx:int=0) -> Tuple[FloatTensor, Tu
     labels = torch.zeros(len(samples), max_len).long() + pad_idx
     imgs = []
     for i,s in enumerate(samples):
-        try:
-            imgs.append(s[0].data[None])
-            bbs, lbls = s[1].data
+        imgs.append(s[0].data[None])
+        bbs, lbls = s[1].data
+        if not (bbs.nelement() == 0):
             bboxes[i,-len(lbls):] = bbs
             labels[i,-len(lbls):] = tensor(lbls)
-        except:
-            pass
     return torch.cat(imgs,0), (bboxes,labels)
 
 def _maybe_add_crop_pad(tfms):

--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -45,10 +45,13 @@ def bb_pad_collate(samples:BatchSamples, pad_idx:int=0) -> Tuple[FloatTensor, Tu
     labels = torch.zeros(len(samples), max_len).long() + pad_idx
     imgs = []
     for i,s in enumerate(samples):
-        imgs.append(s[0].data[None])
-        bbs, lbls = s[1].data
-        bboxes[i,-len(lbls):] = bbs
-        labels[i,-len(lbls):] = tensor(lbls)
+        try:
+            imgs.append(s[0].data[None])
+            bbs, lbls = s[1].data
+            bboxes[i,-len(lbls):] = bbs
+            labels[i,-len(lbls):] = tensor(lbls)
+        except:
+            pass
     return torch.cat(imgs,0), (bboxes,labels)
 
 def _maybe_add_crop_pad(tfms):


### PR DESCRIPTION
When the `Image` didn't contain any object to detect (for example if it was croped) the line 

```
bboxes[i,-len(lbls):] = bbs
```
was throwing an error (and the next one would too).
It's ok to do nothing when there's no object to detect.