### PR TITLE
Fix QRNN layer

### DIFF
--- a/docs/dev/test.md
+++ b/docs/dev/test.md
@@ -436,6 +436,8 @@ custom options:
    pytest --skipint
    ```
 
+* `cuda` - mark tests as requiring a CUDA device to run (skipped if no such device is present). These tests check CUDA-specific code, e.g., compiling and running kernels or GPU version of function's `forward`/`backward` methods.
+
 
 ### After test cleanup
 

--- a/fastai/text/models/forget_mult_cuda.cpp
+++ b/fastai/text/models/forget_mult_cuda.cpp
@@ -1,0 +1,31 @@
+#include <torch/torch.h>
+
+#include <vector>
+
+// CUDA forward declarations
+at::Tensor forget_mult_cuda_forward(at::Tensor x, at::Tensor f, at::Tensor output, bool batch_first);
+
+// C++ interface
+
+#define CHECK_CUDA(x) AT_ASSERTM(x.type().is_cuda(), #x " must be a CUDA tensor")
+#define CHECK_CONTIGUOUS(x) AT_ASSERTM(x.is_contiguous(), #x " must be contiguous")
+#define CHECK_INPUT(x) CHECK_CUDA(x); CHECK_CONTIGUOUS(x)
+
+at::Tensor forget_mult_forward(at::Tensor x, at::Tensor f, at::Tensor output, bool batch_first) {
+  CHECK_INPUT(x); CHECK_INPUT(f); CHECK_INPUT(output);
+  return forget_mult_cuda_forward(x, f, output, batch_first);
+}
+
+std::vector<at::Tensor> forget_mult_cuda_backward(at::Tensor x, at::Tensor f, at::Tensor output,
+                at::Tensor grad_output, bool batch_first);
+
+std::vector<at::Tensor> forget_mult_backward(at::Tensor x, at::Tensor f, at::Tensor output,
+                at::Tensor grad_output, bool batch_first) {
+  CHECK_INPUT(x); CHECK_INPUT(f); CHECK_INPUT(output);
+  return forget_mult_cuda_backward(x, f, output, grad_output, batch_first);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("forward", &forget_mult_forward, "ForgetMult forward (CUDA)");
+  m.def("backward", &forget_mult_backward, "ForgetMult backward (CUDA)");
+}

--- a/fastai/text/models/forget_mult_cuda_kernel.cu
+++ b/fastai/text/models/forget_mult_cuda_kernel.cu
@@ -1,4 +1,5 @@
 #include <ATen/ATen.h>
+#include <THC/THC.h>
 
 #include <cuda.h>
 #include <cuda_runtime.h>
@@ -83,6 +84,7 @@ at::Tensor forget_mult_cuda_forward(at::Tensor x, at::Tensor f, at::Tensor outpu
         seq_length, n_hidden, batch_first);
   }));
 
+  THCudaCheck(cudaGetLastError());
   return output;
 }
 
@@ -105,6 +107,7 @@ std::vector<at::Tensor> forget_mult_cuda_backward(at::Tensor x, at::Tensor f,
         seq_length, n_hidden, batch_first);
   }));
 
+  THCudaCheck(cudaGetLastError());
   return {grad_x, grad_f, grad_h};
 }
 

--- a/fastai/text/models/qrnn.py
+++ b/fastai/text/models/qrnn.py
@@ -5,9 +5,10 @@ from torch.autograd import Function
 __all__ = ['QRNNLayer', 'QRNN']
 
 import fastai
-fastai_path = Path(fastai.__path__[0])/'text'/'qrnn'
-files = ['forget_mult_cuda.cpp', 'forget_mult_cuda_kernel.cu']
-forget_mult_cuda = load(name='forget_mult_cuda', sources=[fastai_path/f for f in files])
+if torch.cuda.is_available():
+    fastai_path = Path(fastai.__path__[0])/'text'/'models'
+    files = ['forget_mult_cuda.cpp', 'forget_mult_cuda_kernel.cu']
+    forget_mult_cuda = load(name='forget_mult_cuda', sources=[fastai_path/f for f in files])
 
 class ForgetMultGPU(Function):
     

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,3 +16,4 @@ filterwarnings =
 markers =
     slow: mark a test as a slow-running (best done with a GPU, not run by default or in CI).
     integration: faster than slow, but not too fast
+    cuda: mark tests as requiring a CUDA device to run (skipped if no such device is present).

--- a/tests/test_text_qrnn.py
+++ b/tests/test_text_qrnn.py
@@ -1,0 +1,30 @@
+import pytest,torch
+from fastai.text.models import qrnn
+
+@pytest.mark.cuda
+def test_forget_mult_forward_gpu():
+    dtype = torch.double
+    x,f,h,expected = range(3,8),[0.5]*5,1,range(1,7)
+    x,f,expected = [torch.tensor(t, dtype=dtype)[None,:,None].cuda() for t in (x,f,expected)]
+    output = torch.zeros(1,6,1, dtype=dtype).cuda()
+    output[0,0,0] = h
+    qrnn.forget_mult_cuda.forward(x, f, output, True)
+    assert torch.allclose(output,expected)
+
+def random_inputs(shape, batch_first, **opts):
+    x = torch.randn(shape, **opts)
+    f = torch.randn(shape, **opts)
+    h = torch.randn((shape[0 if batch_first else 1], shape[2]), **opts)
+    return x, f, h
+
+@pytest.mark.cuda
+@pytest.mark.parametrize("batch_first", [True, False])
+@pytest.mark.parametrize("shape", [(1, 1, 1), (7, 11, 13)])
+def test_compare_forget_mult_forward_implementations(shape, batch_first):
+    x, f, h = random_inputs(shape, batch_first, dtype=torch.double)
+    forget_cpu = qrnn.ForgetMultCPU(batch_first)
+    output_cpu = forget_cpu(x, f, h)
+
+    forget_gpu = qrnn.ForgetMultGPU(batch_first)
+    output_gpu = forget_gpu(x.cuda(), f.cuda(), h.cuda()).cpu()
+    assert torch.allclose(output_cpu,output_gpu)

--- a/tests/utils/mem.py
+++ b/tests/utils/mem.py
@@ -5,12 +5,7 @@ from fastai.utils.mem import *
 
 # check if we can/should use nvidia gpu
 # handle the case where cuda is available, but it is pretended not to have one through setting env var CUDA_VISIBLE_DEVICES=""
-def can_use_gpu():
-    use_gpu = 1 if torch.cuda.is_available() else 0
-    if "CUDA_VISIBLE_DEVICES" in os.environ and not len(os.environ["CUDA_VISIBLE_DEVICES"]):
-        # print('detected no gpu env emulation with CUDA_VISIBLE_DEVICES=""')
-        use_gpu = 0
-    return use_gpu
+can_use_gpu = torch.cuda.is_available
 use_gpu = can_use_gpu()
 
 # This must run before any tests that measure gpu RAM

--- a/tests/utils/mem.py
+++ b/tests/utils/mem.py
@@ -5,7 +5,12 @@ from fastai.utils.mem import *
 
 # check if we can/should use nvidia gpu
 # handle the case where cuda is available, but it is pretended not to have one through setting env var CUDA_VISIBLE_DEVICES=""
-can_use_gpu = torch.cuda.is_available
+def can_use_gpu():
+    use_gpu = 1 if torch.cuda.is_available() else 0
+    if "CUDA_VISIBLE_DEVICES" in os.environ and not len(os.environ["CUDA_VISIBLE_DEVICES"]):
+        # print('detected no gpu env emulation with CUDA_VISIBLE_DEVICES=""')
+        use_gpu = 0
+    return use_gpu
 use_gpu = can_use_gpu()
 
 # This must run before any tests that measure gpu RAM


### PR DESCRIPTION
After investigating an issue with a near zero train accuracy of ULMFiT with QRNN I've noticed that forget_mult_cuda_* kernels are not run at all on my machine. The problem was that pytorch's CUDA version (9.0) and the system's default CUDA version (9.2) mismatched. Even though pytorch is mostly independent of system's CUDA, `torch.utils.cpp_extension.load` uses the default CUDA installation for JIT-compiling cpp extensions. As a result, the kernels were silently ignored.

This PR:
* adds checks of the last error after a kernel call. On a problematic environment a runtime exception (`CUDA driver version is insufficient for CUDA runtime version`) is raised.
* adds some basic tests of `ForgetMult*`
* restores forget_mult_cuda.cpp and updates path
* adds conditional loading of the cpp extension
* defines `cuda` pytest marker to denote tests that require CUDA to run
* simplifies `can_use_gpu` (checking of `CUDA_VISIBLE_DEVICES` was redundant, as `cuda.is_available()` checks it indirectly by making sure at least one CUDA device is available)