### PR TITLE
Updates Readme to mention fastai v1 is necessary for the current, thi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ learn.fit(1)
 
 ## Note for [course.fast.ai](http://course.fast.ai) students
 
-If you are using `fastai` for any [course.fast.ai](http://course.fast.ai) course, you need to use `fastai 0.7`. Please ignore the rest of this document, which is written for `fastai v1`, and instead follow the installation instructions [here](https://forums.fast.ai/t/fastai-v0-install-issues-thread/24652).
+This document is written for `fastai v1`, which we use for the current, third version of the [course.fast.ai](http://course.fast.ai) course. If instead you are using `fastai` for the past two iterations of the course, you need to use `fastai 0.7`, so please follow the installation instructions [here](https://forums.fast.ai/t/fastai-v0-install-issues-thread/24652).
 
 *Note: If you want to learn how to use fastai v1 from its lead developer, Jeremy Howard, he will be teaching it in the [Deep Learning Part I](https://www.usfca.edu/data-institute/certificates/deep-learning-part-one) course at the University of San Francisco from Oct 22nd, 2018.*
 


### PR DESCRIPTION
Congrats on Course 3! This PR changes the Readme to advise that fastai v1 installations are good for the current course (3), and that students should follow the link for fastai v0.7 if they are on past lessons. It currently mentions fastai v0.7 is necessary for 'any' course.

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
