### PR TITLE
Remove nb_conda dependency

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -57,7 +57,6 @@ requirements:
     - pandas
     - bottleneck
     - numexpr
-    - nb_conda
     - nvidia-ml-py3
     - packaging
     - pillow


### PR DESCRIPTION
AFAICS `fastai` the library doesn't depend on `nb_conda` at all so it shouldn't be specified in the dependencies of the library.

If you want to suggest a default environment for users to run then it should be included in the [`environment.yml`](https://github.com/fastai/fastai/blob/master/environment.yml) rather than directly in the library dependencies.

***xref:*** https://github.com/fastai/fastai/commit/1673cbc964f0faa15a773261ada3ea55cafb3419


I really don't like `nb_conda` and I don't want to be forced to install it in my environment - it makes intrusive changes I don't want to the behaviour of notebook kernel discovery. More to the point it's [currently broken](https://github.com/AnacondaRecipes/nb_conda_kernels-feedstock/issues/1), thereby preventing me from using `fastai`