### PR TITLE
Fix typo?

### DIFF
--- a/docs_src/vision.learner.ipynb
+++ b/docs_src/vision.learner.ipynb
@@ -89,7 +89,7 @@
     "\n",
     "Alternatively, you can define your own `custom_head` to put on top of the backbone. If you want to specify where to split `arch` you should so in the argument `cut` which can either be the index of a specific layer (the result will not include that layer) or a function that, when passed the model, will return the backbone you want.\n",
     "\n",
-    "The final model obtained by stacking the backbone and the head (custom or defined as we saw) is then separated in groups for gradual unfreezing or differential learning rates. You can specify of to split the backbone in groups with the optional argument `split_on` (should be a function that returns those groups when given the backbone).  \n",
+    "The final model obtained by stacking the backbone and the head (custom or defined as we saw) is then separated in groups for gradual unfreezing or differential learning rates. You can specify how to split the backbone in groups with the optional argument `split_on` (should be a function that returns those groups when given the backbone).  \n",
     "\n",
     "The `kwargs` will be passed on to [`Learner`](/basic_train.html#Learner), so you can put here anything that [`Learner`](/basic_train.html#Learner) will accept ([`metrics`](/metrics.html#metrics), `loss_func`, `opt_func`...)"
    ]


### PR DESCRIPTION
I'm not sure how `split_on` argument works but "You can specify of to" is confusing.
