### PR TITLE
Replaced "LINK REQUIRED" with link to the referred paper & datasets

### DIFF
--- a/courses/dl2/imdb.ipynb
+++ b/courses/dl2/imdb.ipynb
@@ -190,7 +190,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The pandas dataframe is used to store text data in a newly evolving standard format of label followed by text columns. This was influenced by a paper by Yann LeCun (LINK REQUIRED). Fastai adopts this new format for NLP datasets. In the case of IMDB, there is only one text column."
+    "The pandas dataframe is used to store text data in a newly evolving standard format of label followed by text columns. This was influenced by a paper by Yann LeCun ([Link to Paper](https://arxiv.org/pdf/1509.01626.pdf) [Link to Paper’s Datasets](https://drive.google.com/drive/u/0/folders/0Bz8a_Dbh9Qhbfll6bVpmNUtUcFdjYmF2SEpmZUZUcVNiMUw1TWN6RDV3a0JHT3kxLVhVR2M)). Fastai adopts this new format for NLP datasets. In the case of IMDB, there is only one text column."
    ]
   },
   {


### PR DESCRIPTION
I believe this is the arXiv paper referenced in the missing link.  "Character-level Convolutional Networks for Text Classification" by Xiang Zhang, Junbo Zhao and Yann LeCun (NIPS 2015 - arXiv:1509.01626v3 [cs.LG] ) is where they utilized eight datasets and stored them each with an associated "test.csv",  "train.csv" and "classes.txt".   This matches @jph00  explanation from the course video when describing the reason for utilizing this newly evolving standard format.  

(Structure of the actual datasets can be seen by the link to Xiang Zhang's google drive link with the associated datasets from the paper. )
<img width="501" alt="screen shot 2019-02-03 at 2 36 43 pm" src="https://user-images.githubusercontent.com/12835712/52183908-78c72800-27c1-11e9-9ef6-4af6e88f0ba4.png">

Lesson 10 video at the time where @jph00  talks about this section:
https://youtu.be/h5Tz7gZT9Fo?t=1451
