### PR TITLE
Fix `plot_confusion_matrix` when `normalize=True`

### DIFF
--- a/fastai/train.py
+++ b/fastai/train.py
@@ -127,6 +127,7 @@ class ClassificationInterpretation():
         "Plot the confusion matrix, with `title` and using `cmap`."
         # This function is mainly copied from the sklearn docs
         cm = self.confusion_matrix(slice_size=slice_size)
+        if normalize: cm = cm.astype('float') / cm.sum(axis=1)[:, np.newaxis]
         plt.figure(**kwargs)
         plt.imshow(cm, interpolation='nearest', cmap=cmap)
         plt.title(title)
@@ -134,7 +135,6 @@ class ClassificationInterpretation():
         plt.xticks(tick_marks, self.data.y.classes, rotation=90)
         plt.yticks(tick_marks, self.data.y.classes, rotation=0)
 
-        if normalize: cm = cm.astype('float') / cm.sum(axis=1)[:, np.newaxis]
         thresh = cm.max() / 2.
         for i, j in itertools.product(range(cm.shape[0]), range(cm.shape[1])):
             coeff = f'{cm[i, j]:.{norm_dec}f}' if normalize else f'{cm[i, j]}'


### PR DESCRIPTION
When `normalize=True` font color selection between black or white does not work properly - it is not taking into account normalized value, but the original one.
Move confusion matrix value normalization before plotting to fix font color choice behavior.

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
