### PR TITLE
ENH: DeviceDataLoader now accepts dict based Dataset

### DIFF
--- a/fastai/core.py
+++ b/fastai/core.py
@@ -50,6 +50,7 @@ defaults = SimpleNamespace(cpus=_default_cpus, cmap='viridis')
 
 def is_listy(x:Any)->bool: return isinstance(x, (tuple,list))
 def is_tuple(x:Any)->bool: return isinstance(x, tuple)
+def is_dict(x:Any)->bool: return isinstance(x, dict)
 def noop(x): return x
 
 def chunks(l:Collection, n:int)->Iterable:

--- a/fastai/torch_core.py
+++ b/fastai/torch_core.py
@@ -108,6 +108,7 @@ def to_device(b:Tensors, device:torch.device):
     "Recursively put `b` on `device`."
     device = ifnone(device, defaults.device)
     if is_listy(b): return [to_device(o, device) for o in b]
+    if is_dict(b): return {k: to_device(v, device) for k, v in b.items()}
     return b.to(device)
 
 def data_collate(batch:ItemsList)->Tensor:

--- a/tests/test_basic_data.py
+++ b/tests/test_basic_data.py
@@ -54,3 +54,13 @@ def test_DataBunch_show_batch(capsys):
 ##def test_DataBunch_export():
 ##     data = fake_data()
 ##     data.export()
+
+def test_DeviceDataLoader_getitem():
+    class DictDataset(Dataset):
+        def __getitem__(self, idx):
+            return {"a":np.ones((3,)),"b":np.zeros((2,))}
+        def __len__(self):
+            return 10
+
+    ds = DictDataset()
+    next(iter(DeviceDataLoader.create(ds)))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -53,6 +53,11 @@ def test_tuple():
     assert is_tuple([1])         == False
     assert is_tuple(1)           == False
 
+def test_dict():
+    assert is_dict({1:2,3:4})  == True
+    assert is_dict([1,2,3])    == False
+    assert is_dict((1,2,3))    == False
+
 def test_noop():
     assert noop(1) is 1
 


### PR DESCRIPTION
- from #1575

# Changes

Before this PR, the below code raises an error: 
```python
# for test dataset class
class DictDataset(Dataset):
    def __getitem__(self, idx):
        return {"a":np.array([1,2,3]),"b":np.array([2,3,4])}
    def __len__(self):
        return 10
dl=DeviceDataLoader.create(DictDataset(), batch_size=3)
next(iter(dl))
```
```
~/work/fastai/fastai/torch_core.py in to_device(b, device)
    109     device = ifnone(device, defaults.device)
    110     if is_listy(b): return [to_device(o, device) for o in b]
--> 111     return b.to(device)
    112 
    113 def data_collate(batch:ItemsList)->Tensor:
AttributeError: 'dict' object has no attribute 'to'
```

However, in this commit, the code raises no error.

# Why I create this PR

That's because pytorch's `DataLoader` supports dict based `Dataset`, i.e. the below code raises no error.
```python
dl=DataLoader(DictDataset(), batch_size=3)
next(iter(dl))
```