### PR TITLE
Replace OpenFileProcessor in TextDataBunch.from_folder

### DIFF
--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -233,7 +233,7 @@ class TextDataBunch(DataBunch):
                     min_freq:int=2, mark_fields:bool=False, **kwargs):
         "Create a `TextDataBunch` from text files in folders."
         path = Path(path).absolute()
-        processor = _get_processor(tokenizer=tokenizer, vocab=vocab, chunksize=chunksize, max_vocab=max_vocab,
+        processor = [OpenFileProcessor()] + _get_processor(tokenizer=tokenizer, vocab=vocab, chunksize=chunksize, max_vocab=max_vocab,
                                    min_freq=min_freq, mark_fields=mark_fields)
         src = (TextList.from_folder(path, processor=processor)
                        .split_by_folder(train=train, valid=valid))


### PR DESCRIPTION
I'm fairly certain that removing OpenFileProcessor was a typo.  With that gone, it tries to read the directory list as the text, resulting in a language model dataset that contains just the path name.

