### PR TITLE
fix some links in the documentation

### DIFF
--- a/docs_src/metrics.ipynb
+++ b/docs_src/metrics.ipynb
@@ -45,7 +45,7 @@
       "text/markdown": [
        "<h4 id=\"accuracy\"><code>accuracy</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/metrics.py#L24\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
-       "> <code>accuracy</code>(**`input`**:`Tensor`, **`targs`**:`Tensor`) → `Rank0Tensor`\n",
+       "> <code>accuracy</code>(<b>`input`</b>:`Tensor`, <b>`targs`</b>:`Tensor`) → `Rank0Tensor`\n",
        "\n",
        "Compute accuracy with `targs` when `input` is bs * n_classes.  "
       ],
@@ -97,7 +97,7 @@
       "text/markdown": [
        "<h4 id=\"accuracy_thresh\"><code>accuracy_thresh</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/metrics.py#L31\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
-       "> <code>accuracy_thresh</code>(**`y_pred`**:`Tensor`, **`y_true`**:`Tensor`, **`thresh`**:`float`=***`0.5`***, **`sigmoid`**:`bool`=***`True`***) → `Rank0Tensor`\n",
+       "> <code>accuracy_thresh</code>(<b>`y_pred`</b>:`Tensor`, <b>`y_true`</b>:`Tensor`, <b>`thresh`</b>:`float`=<b><i>`0.5`</i></b>, <b>`sigmoid`</b>:`bool`=<b><i>`True`</i></b>) → `Rank0Tensor`\n",
        "\n",
        "Compute accuracy when `y_pred` and `y_true` are the same size.  "
       ],
@@ -156,7 +156,7 @@
       "text/markdown": [
        "<h4 id=\"top_k_accuracy\"><code>top_k_accuracy</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/metrics.py#L36\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
-       "> <code>top_k_accuracy</code>(**`input`**:`Tensor`, **`targs`**:`Tensor`, **`k`**:`int`=***`5`***) → `Rank0Tensor`\n",
+       "> <code>top_k_accuracy</code>(<b>`input`</b>:`Tensor`, <b>`targs`</b>:`Tensor`, <b>`k`</b>:`int`=<b><i>`5`</i></b>) → `Rank0Tensor`\n",
        "\n",
        "Computes the Top-k accuracy (target is in the top k predictions).  "
       ],
@@ -184,7 +184,7 @@
       "text/markdown": [
        "<h4 id=\"dice\"><code>dice</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/metrics.py#L47\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
-       "> <code>dice</code>(**`input`**:`Tensor`, **`targs`**:`Tensor`, **`iou`**:`bool`=***`False`***) → `Rank0Tensor`\n",
+       "> <code>dice</code>(<b>`input`</b>:`Tensor`, <b>`targs`</b>:`Tensor`, <b>`iou`</b>:`bool`=<b><i>`False`</i></b>) → `Rank0Tensor`\n",
        "\n",
        "Dice coefficient metric for binary target. If iou=True, returns iou metric, classic for segmentation problems.  "
       ],
@@ -212,7 +212,7 @@
       "text/markdown": [
        "<h4 id=\"error_rate\"><code>error_rate</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/metrics.py#L43\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
-       "> <code>error_rate</code>(**`input`**:`Tensor`, **`targs`**:`Tensor`) → `Rank0Tensor`\n",
+       "> <code>error_rate</code>(<b>`input`</b>:`Tensor`, <b>`targs`</b>:`Tensor`) → `Rank0Tensor`\n",
        "\n",
        "1 - [`accuracy`](/metrics.html#accuracy)  "
       ],
@@ -240,7 +240,7 @@
       "text/markdown": [
        "<h4 id=\"mean_squared_error\"><code>mean_squared_error</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/metrics.py#L69\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
-       "> <code>mean_squared_error</code>(**`pred`**:`Tensor`, **`targ`**:`Tensor`) → `Rank0Tensor`\n",
+       "> <code>mean_squared_error</code>(<b>`pred`</b>:`Tensor`, <b>`targ`</b>:`Tensor`) → `Rank0Tensor`\n",
        "\n",
        "Mean squared error between `pred` and `targ`.  "
       ],
@@ -268,7 +268,7 @@
       "text/markdown": [
        "<h4 id=\"mean_absolute_error\"><code>mean_absolute_error</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/metrics.py#L64\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
-       "> <code>mean_absolute_error</code>(**`pred`**:`Tensor`, **`targ`**:`Tensor`) → `Rank0Tensor`\n",
+       "> <code>mean_absolute_error</code>(<b>`pred`</b>:`Tensor`, <b>`targ`</b>:`Tensor`) → `Rank0Tensor`\n",
        "\n",
        "Mean absolute error between `pred` and `targ`.  "
       ],
@@ -296,7 +296,7 @@
       "text/markdown": [
        "<h4 id=\"mean_squared_logarithmic_error\"><code>mean_squared_logarithmic_error</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/metrics.py#L79\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
-       "> <code>mean_squared_logarithmic_error</code>(**`pred`**:`Tensor`, **`targ`**:`Tensor`) → `Rank0Tensor`\n",
+       "> <code>mean_squared_logarithmic_error</code>(<b>`pred`</b>:`Tensor`, <b>`targ`</b>:`Tensor`) → `Rank0Tensor`\n",
        "\n",
        "Mean squared logarithmic error between `pred` and `targ`.  "
       ],
@@ -324,7 +324,7 @@
       "text/markdown": [
        "<h4 id=\"exp_rmspe\"><code>exp_rmspe</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/metrics.py#L57\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
-       "> <code>exp_rmspe</code>(**`pred`**:`Tensor`, **`targ`**:`Tensor`) → `Rank0Tensor`\n",
+       "> <code>exp_rmspe</code>(<b>`pred`</b>:`Tensor`, <b>`targ`</b>:`Tensor`) → `Rank0Tensor`\n",
        "\n",
        "Exp RMSE between `pred` and `targ`.  "
       ],
@@ -352,7 +352,7 @@
       "text/markdown": [
        "<h4 id=\"root_mean_squared_error\"><code>root_mean_squared_error</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/metrics.py#L74\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
-       "> <code>root_mean_squared_error</code>(**`pred`**:`Tensor`, **`targ`**:`Tensor`) → `Rank0Tensor`\n",
+       "> <code>root_mean_squared_error</code>(<b>`pred`</b>:`Tensor`, <b>`targ`</b>:`Tensor`) → `Rank0Tensor`\n",
        "\n",
        "Root mean squared error between `pred` and `targ`.  "
       ],
@@ -380,7 +380,7 @@
       "text/markdown": [
        "<h4 id=\"fbeta\"><code>fbeta</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/metrics.py#L12\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
-       "> <code>fbeta</code>(**`y_pred`**:`Tensor`, **`y_true`**:`Tensor`, **`thresh`**:`float`=***`0.2`***, **`beta`**:`float`=***`2`***, **`eps`**:`float`=***`1e-09`***, **`sigmoid`**:`bool`=***`True`***) → `Rank0Tensor`\n",
+       "> <code>fbeta</code>(<b>`y_pred`</b>:`Tensor`, <b>`y_true`</b>:`Tensor`, <b>`thresh`</b>:`float`=<b><i>`0.2`</i></b>, <b>`beta`</b>:`float`=<b><i>`2`</i></b>, <b>`eps`</b>:`float`=<b><i>`1e-09`</i></b>, <b>`sigmoid`</b>:`bool`=<b><i>`True`</i></b>) → `Rank0Tensor`\n",
        "\n",
        "Computes the f_beta between `preds` and `targets`  "
       ],
@@ -439,7 +439,7 @@
       "text/markdown": [
        "<h4 id=\"explained_variance\"><code>explained_variance</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/metrics.py#L84\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
-       "> <code>explained_variance</code>(**`pred`**:`Tensor`, **`targ`**:`Tensor`) → `Rank0Tensor`\n",
+       "> <code>explained_variance</code>(<b>`pred`</b>:`Tensor`, <b>`targ`</b>:`Tensor`) → `Rank0Tensor`\n",
        "\n",
        "Explained variance between `pred` and `targ`.  "
       ],
@@ -467,7 +467,7 @@
       "text/markdown": [
        "<h4 id=\"r2_score\"><code>r2_score</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/metrics.py#L90\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
-       "> <code>r2_score</code>(**`pred`**:`Tensor`, **`targ`**:`Tensor`) → `Rank0Tensor`\n",
+       "> <code>r2_score</code>(<b>`pred`</b>:`Tensor`, <b>`targ`</b>:`Tensor`) → `Rank0Tensor`\n",
        "\n",
        "R2 score (coefficient of determination) between `pred` and `targ`.  "
       ],
@@ -558,7 +558,7 @@
       "text/markdown": [
        "<h3 id=\"Precision\"><code>class</code> <code>Precision</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/metrics.py#L211\" class=\"source_link\">[source]</a></h3>\n",
        "\n",
-       "> <code>Precision</code>(**`average`**:`Optional`\\[`str`\\]=***`'binary'`***, **`pos_label`**:`int`=***`1`***, **`eps`**:`float`=***`1e-09`***) :: [`CMScores`](/metrics.html#CMScores)\n",
+       "> <code>Precision</code>(<b>`average`</b>:`Optional`\\[`str`\\]=<b><i>`'binary'`</i></b>, <b>`pos_label`</b>:`int`=<b><i>`1`</i></b>, <b>`eps`</b>:`float`=<b><i>`1e-09`</i></b>) :: [`CMScores`](/metrics.html#CMScores)\n",
        "\n",
        "Compute the Precision.  "
       ],
@@ -586,7 +586,7 @@
       "text/markdown": [
        "<h3 id=\"Recall\"><code>class</code> <code>Recall</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/metrics.py#L205\" class=\"source_link\">[source]</a></h3>\n",
        "\n",
-       "> <code>Recall</code>(**`average`**:`Optional`\\[`str`\\]=***`'binary'`***, **`pos_label`**:`int`=***`1`***, **`eps`**:`float`=***`1e-09`***) :: [`CMScores`](/metrics.html#CMScores)\n",
+       "> <code>Recall</code>(<b>`average`</b>:`Optional`\\[`str`\\]=<b><i>`'binary'`</i></b>, <b>`pos_label`</b>:`int`=<b><i>`1`</i></b>, <b>`eps`</b>:`float`=<b><i>`1e-09`</i></b>) :: [`CMScores`](/metrics.html#CMScores)\n",
        "\n",
        "Compute the Recall.  "
       ],
@@ -1553,9 +1553,9 @@
    "title": "metrics"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python (fastai-dev)",
    "language": "python",
-   "name": "python3"
+   "name": "fastai-dev"
   }
  },
  "nbformat": 4,

--- a/docs_src/tabular.data.ipynb
+++ b/docs_src/tabular.data.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This module defines the main class to handle tabular data in the fastai library: [`TabularDataset`](/tabular.data.html#TabularDataset). As always, there is also a helper function to quickly get your data.\n",
+    "This module defines the main class to handle tabular data in the fastai library: [`TabularDataBunch`](/tabular.data.html#TabularDataBunch). As always, there is also a helper function to quickly get your data.\n",
     "\n",
     "To allow you to easily create a [`Learner`](/basic_train.html#Learner) for your data, it provides [`tabular_learner`](/tabular.data.html#tabular_learner)."
    ]

--- a/docs_src/tabular.transform.ipynb
+++ b/docs_src/tabular.transform.ipynb
@@ -30,12 +30,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This package contains the basic class to define a transformation for preprocessing dataframes of tabular data, as well as basic [`TabularTransform`](/tabular.transform.html#TabularTransform). Preprocessing includes things like\n",
+    "This package contains the basic class to define a transformation for preprocessing dataframes of tabular data, as well as basic [`TabularProc`](/tabular.transform.html#TabularProc). Preprocessing includes things like\n",
     "- replacing non-numerical variables by categories, then their ids,\n",
     "- filling missing values,\n",
     "- normalizing continuous variables.\n",
     "\n",
-    "In all those steps we have to be careful to use the correspondence we decide on our training set (which id we give to each category, what is the value we put for missing data, or how the mean/std we use to normalize) on our validation or test set. To deal with this, we use a special class called [`TabularTransform`](/tabular.transform.html#TabularTransform).\n",
+    "In all those steps we have to be careful to use the correspondence we decide on our training set (which id we give to each category, what is the value we put for missing data, or how the mean/std we use to normalize) on our validation or test set. To deal with this, we use a special class called [`TabularProc`](/tabular.transform.html#TabularProc).\n",
     "\n",
     "The data used in this document page is a subset of the [adult dataset](https://archive.ics.uci.edu/ml/datasets/adult). It gives a certain amount of data on individuals to train a model to predict wether their salary is greater than \\$50k or not."
    ]
@@ -384,7 +384,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The following [`TabularTransform`](/tabular.transform.html#TabularTransform) are implemented in the fastai library. Note that the replacement from categories to codes as well as the normalization of continuous variables are automatically done in a [`TabularDataset`](/tabular.data.html#TabularDataset)."
+    "The following [`TabularProc`](/tabular.transform.html#TabularProc) are implemented in the fastai library. Note that the replacement from categories to codes as well as the normalization of continuous variables are automatically done in a [`TabularDataBunch`](/tabular.data.html#TabularDataBunch)."
    ]
   },
   {
@@ -579,7 +579,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`cat_names` variables are left untouched (their missing value will be replaced by code 0 in the [`TabularDataset`](/tabular.data.html#TabularDataset)). [`fill_strategy`](#FillStrategy) is adopted to replace those nans and if `add_col` is True, whenever a column `c` has missing values, a column named `c_nan` is added and flags the line where the value was missing."
+    "`cat_names` variables are left untouched (their missing value will be replaced by code 0 in the [`TabularDataBunch`](/tabular.data.html#TabularDataBunch)). [`fill_strategy`](#FillStrategy) is adopted to replace those nans and if `add_col` is True, whenever a column `c` has missing values, a column named `c_nan` is added and flags the line where the value was missing."
    ]
   },
   {

--- a/docs_src/text.models.ipynb
+++ b/docs_src/text.models.ipynb
@@ -24,7 +24,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[`text.models`](/text.models.html#text.models) module fully implements the [AWD-LSTM](https://arxiv.org/pdf/1708.02182.pdf) from Stephen Merity et al. The main idea of the article is to use a [RNN](http://www.pnas.org/content/79/8/2554) with dropout everywhere, but in an intelligent way. There is a difference with the usual dropout, which is why you’ll see a [`RNNDropout`](/text.models.awd_lstm.html#RNNDropout) module: we zero things, as is usual in dropout, but we always zero the same thing according to the sequence dimension (which is the first dimension in pytorch). This ensures consistency when updating the hidden state through the whole sentences/articles. \n",
+    "[`text.models`](/text.models.html#text.models) module fully implements the [AWD-LSTM](https://arxiv.org/pdf/1708.02182.pdf) from Stephen Merity et al. The main idea of the article is to use a [RNN](http://www.pnas.org/content/79/8/2554) with dropout everywhere, but in an intelligent way. There is a difference with the usual dropout, which is why you’ll see a [`RNNDropout`](https://docs.fast.ai/text.models.html#RNNDropout) module: we zero things, as is usual in dropout, but we always zero the same thing according to the sequence dimension (which is the first dimension in pytorch). This ensures consistency when updating the hidden state through the whole sentences/articles. \n",
     "\n",
     "This being given, there are five different dropouts in the AWD-LSTM:\n",
     "\n",
@@ -489,7 +489,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Such a mask is then expanded in the sequence length dimension and multiplied by the input to do an [`RNNDropout`](/text.models.awd_lstm.html#RNNDropout)."
+    "Such a mask is then expanded in the sequence length dimension and multiplied by the input to do an [`RNNDropout`](https://docs.fast.ai/text.models.html#RNNDropout)."
    ]
   },
   {
@@ -594,7 +594,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create a the decoder to go on top of an [`RNNCore`](/text.models.awd_lstm.html#RNNCore) encoder and create a language model. `n_hid` is the dimension of the last hidden state of the encoder, `n_out` the size of the output. Dropout of `output_p` is applied. If a `tie_encoder` is passed, it will be used for the weights of the linear layer, that will have `bias` or not."
+    "Create a the decoder to go on top of an [`RNNCore`](https://docs.fast.ai/text.models.html#RNNCore) encoder and create a language model. `n_hid` is the dimension of the last hidden state of the encoder, `n_out` the size of the output. Dropout of `output_p` is applied. If a `tie_encoder` is passed, it will be used for the weights of the linear layer, that will have `bias` or not."
    ]
   },
   {
@@ -636,7 +636,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Text is passed by chunks of sequence length `bptt` and only the last `max_seq` outputs are kept for the next layer. `args` and `kwargs` are passed to the [`RNNCore`](/text.models.awd_lstm.html#RNNCore)."
+    "Text is passed by chunks of sequence length `bptt` and only the last `max_seq` outputs are kept for the next layer. `args` and `kwargs` are passed to the [`RNNCore`](https://docs.fast.ai/text.models.html#RNNCore)."
    ]
   },
   {

--- a/docs_src/vision.data.ipynb
+++ b/docs_src/vision.data.ipynb
@@ -90,7 +90,7 @@
     "\n",
     "As with all [`DataBunch`](/basic_data.html#DataBunch) usage,  a `train_dl` and a `valid_dl` are created that are of the type PyTorch [`DataLoader`](https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader). \n",
     "\n",
-    "If you want to have a look at a few images inside a batch, you can use [`ImageDataBunch.show_batch`](/vision.data.html#ImageDataBunch.show_batch). The `rows` argument is the number of rows and columns to display."
+    "If you want to have a look at a few images inside a batch, you can use [`DataBunch.show_batch`](/basic_data.html#DataBunch.show_batch). The `rows` argument is the number of rows and columns to display."
    ]
   },
   {
@@ -492,7 +492,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that this (and all factory methods in this section) pass any `kwargs` to [`ImageDataBunch.create`](/vision.data.html#ImageDataBunch.create)."
+    "Note that this (and all factory methods in this section) pass any `kwargs` to [`DataBunch.create`](/basic_data.html#DataBunch.create)."
    ]
   },
   {


### PR DESCRIPTION
As discussed in the documentation improvements thread. 

Not really sure why `** [...] **` was transformed in `<b> [...] </b>` and other similar stuff, I would appreciate pointers on how to fix that. 