### PR TITLE
Added axis labels for Recorder.plot_lr.

### DIFF
--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -437,7 +437,11 @@ class Recorder(LearnerCallback):
         if show_moms:
             _, axs = plt.subplots(1,2, figsize=(12,4))
             axs[0].plot(iterations, self.lrs)
+            axs[0].set_xlabel('Iterations')
+            axs[0].set_ylabel('Learning Rate')
             axs[1].plot(iterations, self.moms)
+            axs[1].set_xlabel('Iterations')
+            axs[1].set_ylabel('Momentum')
         else: plt.plot(iterations, self.lrs)
 
     def plot(self, skip_start:int=10, skip_end:int=5)->None:


### PR DESCRIPTION
Added axis labels for `Recorder.plot_lr` according to the style used by Sylvain Gugger in his [blog post](https://sgugger.github.io/the-1cycle-policy.html). The improvement makes the output of `Recorder.plot_lr(show_moms=True)` more understandable for new users.

It used to look like this:
![unknown](https://user-images.githubusercontent.com/8635094/52480565-10c07980-2be7-11e9-9948-5711e541e775.png)

Now it looks like this:
![unknown](https://user-images.githubusercontent.com/8635094/52480573-161dc400-2be7-11e9-876d-24df7347b991.png)
