### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -110,5 +110,5 @@ dependencies:
   - ipywidgets
   - nbconvert
   - PyHamcrest
-  - pdpbox=0.1.0
+  - pdpbox==0.1.0
   - scikit-misc


### PR DESCRIPTION
fixed error appeared importing to ubuntu 

Invalid requirement: 'pdpbox=0.1.0'
= is not a valid operator. Did you mean == ?

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
