### PR TITLE
prototyping test_this function. Not yet for merge, faciliate design d…

### DIFF
--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -6,13 +6,19 @@ docs  : https://docs.fast.ai/train.html
 import pytest, fastai
 from utils.fakes import *
 from utils.text import *
+from utils.register import *
+#from fastai.gen_doc import *
 
-@pytest.fixture(scope="module")
+def test_loadTestAPIRegister():
+    loadTestAPIRegister()
+
+@pytest.fixture(scope="module") 
 def learn():
     learn = fake_learner(50,50)
     return learn
 
 def test_lr_find(learn):
+    this_tests(Learner.lr_find)
     wd, start_lr, num_it, end_lr = 0.002, 1e-06, 90, 10
     lr_find(learn=learn, start_lr=start_lr, end_lr=end_lr, num_it=num_it, stop_div=True, wd=wd)
     assert len(learn.recorder.moms) == len(learn.recorder.lrs)
@@ -22,15 +28,18 @@ def test_lr_find(learn):
     assert learn.recorder.opt.wd == wd
     lr_find(learn=learn, start_lr=start_lr, end_lr=end_lr, num_it=num_it, stop_div=False, wd=wd)
     assert len(learn.recorder.lrs) == num_it
-
+    
 def test_fit(learn):
+ ## TO DO CORRECT   
+    this_tests(Learner.lr_find)## incorrect, just for testin
     # Test confirms learning rate and momentum are stable, see difference to test_fit_one_cycle
     learning_rate, weight_decay, eps = 3e-3, 1e-2,  4
     with CaptureStdout() as cs:  learn.fit(epochs=eps, lr=learning_rate, wd=weight_decay)
     assert set(learn.recorder.lrs) == {learning_rate}
     assert set(learn.recorder.moms) == {learn.recorder.moms[0]}
-
+   
 def test_fit_one_cycle(learn):
+    this_tests(Learner.fit_one_cycle)
     # Test confirms expected behavior change of learning rate and momentum
     # see graphical representation here: output cell 17 of, learn.sched.plot_lr() in
     # https://github.com/sgugger/Deep-Learning/blob/master/Cyclical%20LR%20and%20momentums.ipynb
@@ -51,3 +60,6 @@ def test_fit_one_cycle(learn):
     val_lr, idx_lr = min((val, idx) for (idx, val) in enumerate(listlrs[maxlr_minmom:]))
     val_mom, idx_mom = max((val, idx) for (idx, val) in enumerate(listmoms[maxlr_minmom:]))
     assert idx_lr == idx_mom
+
+def test_saveTestAPIRegister():
+    saveTestAPIRegister()  

--- a/tests/utils/register.py
+++ b/tests/utils/register.py
@@ -1,0 +1,57 @@
+import inspect
+import json
+
+# customise Makefile
+# add cmd param to allow saving
+# why desctructor fo saving on --> function alone just does never a safe
+# maybe use an object really why is this set default method required
+# should this be below docs really?
+
+
+def full_name_with_qualname(klass):
+     return f'{klass.__module__}.{klass.__qualname__}' ##  __name__ for of qualname for short version
+
+def set_default(obj):
+     if isinstance(obj, set):
+          return list(obj)
+     raise TypeError 
+
+## TO DO: find path variable somewhere
+
+def loadTestAPIRegister():
+     with open('./fastai/TestAPIRegister.json', 'r') as f:
+          json.load(f)           
+
+def saveTestAPIRegister():
+     print('\n\n @@@ RegisterTestsperAPI.apiTestsMap \n\n')
+     print(RegisterTestsperAPI.apiTestsMap)
+     encoded_map = json.dumps(RegisterTestsperAPI.apiTestsMap, indent=2, default=set_default)
+     print('\n\n @@@ encoded_map \n\n')
+     print(encoded_map)
+     with open('./fastai/TestAPIRegister.json', 'w') as f:
+          json.dump(encoded_map,f, indent = 2)           
+
+def this_tests(testedapi):
+     previous_frame = inspect.currentframe().f_back 
+     (filename, line_number, 
+     test_function_name, lines, index) = inspect.getframeinfo(previous_frame)
+     
+     #print('\n\t filename: ' + str(filename))
+     #print('\n\t test_function_name: ' + str(test_function_name))
+     list_test = [{'file: '+ filename, 'test: ' + test_function_name}]
+     #print(list_test)  
+     fq_apiname = full_name_with_qualname(testedapi)
+     #print('\n\t' + fq_apiname)
+     if(fq_apiname in RegisterTestsperAPI.apiTestsMap):
+          RegisterTestsperAPI.apiTestsMap[fq_apiname] = RegisterTestsperAPI.apiTestsMap[fq_apiname]  + list_test
+     else:
+          RegisterTestsperAPI.apiTestsMap[fq_apiname] =  list_test   
+
+class RegisterTestsperAPI():
+     apiTestsMap = dict()
+
+
+   
+   
+     
+        


### PR DESCRIPTION
@stas00, submitting this code snippet to register Tests per Api ### as base for design discussion not meant to be merged already.

One design decision to make is how often to write the test-per-API entries to the json file. 

1. **load & save new information to file with every call of test_this**. This would seem not very elegant and on some platforms, this would be an anti-pattern. But since this is ‘just’ a one-time all test run, provided performance does not suffer so much, this might be the simplest option wrt code: we just call this_tests and inside this_tests we open, write and close the json file
2. **load & save information once per test file**. This is the pattern I implemented testwise for this PR. It does require 2 pseudo test method to load and save at the start and end of the file, so it's not super elegant and compared to (1) is more IO efficient but clutters the code.
3. **save all generated Tests per API entries once at the end of all tests**: In the Makefile after the tests run (make test), we could call a save()method once (would e.g. allow calling save via a command line comment). From the remarks in the wiki, this is probably what you had in mind and it would be the most efficient I/O method and leave the test scripts simple. The issue I see is that I would not be sure, how to cache the information collected. As far as I can see from the docs a class variable as I used it just gets dropped after the test ran one test class, so I need to save then (see option 2).  

Maybe there is some 'cool' cache-across-test-file-runs or file-write-design pattern to use here best? 

Other points worthwhile checking: 

- format dictionary: took json, key is the API and there could be several tests per API
- Name json file: need to agree on name (now: TestAPIRegister ) 
- Path: need to find a $PATH var to store under fastai folder to avoid hardcoding the path
- Open To do: extension of MANIFEST file
- new python file ‘register’  agree on file name, 
- new python file ‘register’ sits under path tests/utils. Saw your comment to place this under gen_docs. To me it seemed placing under test_utils could also be good (and I did have some issues getting to the package gen_docs / register with imports from tests, which should be solvable though)

Thx for your help!

 