### PR TITLE
Fix exceptions in text tokenization

### DIFF
--- a/fastai/text/transform.py
+++ b/fastai/text/transform.py
@@ -32,8 +32,8 @@ class SpacyTokenizer(BaseTokenizer):
             self.tok.tokenizer.add_special_case(w, [{ORTH: w}])
 
 def spec_add_spaces(t:str) -> str:
-    "Add spaces around / and # in `t`."
-    return re.sub(r'([/#])', r' \1 ', t)
+    "Add spaces around / and # in `t`. \n"
+    return re.sub(r'([/#\n])', r' \1 ', t)
 
 def rm_useless_spaces(t:str) -> str:
     "Remove multiple spaces in `t`."
@@ -76,6 +76,7 @@ def deal_caps(x:Collection[str]) -> Collection[str]:
     "Replace all words in `x` by their lower version and add `TK_MAJ`."
     res = []
     for t in x:
+        if t == '': continue
         if t[0].isupper() and t[1:].islower(): res.append(TK_MAJ)
         res.append(t.lower())
     return res

--- a/tests/test_text_transform.py
+++ b/tests/test_text_transform.py
@@ -16,3 +16,15 @@ def test_tokenize():
     assert toks[1][:6] == ['xxmaj', 'lorem', 'ipsum', 'dolor', 'sit', 'amet,']
     assert ' '.join(toks[2]) == "xxmaj i'm suddenly xxup shouting xxup for xxup no xxup reason"
 
+def test_tokenize_handles_empty_lines():
+    texts = ['= Markdown Title =\n\nMakrdown Title does not have spaces around']
+    tokenizer = Tokenizer(BaseTokenizer)
+    toks = tokenizer.process_all(texts)
+    assert toks[0] == ['=', 'xxmaj', 'markdown', 'xxmaj', 'title', '=', '\n', '\n',
+                       'xxmaj', 'makrdown', 'xxmaj', 'title', 'does', 'not', 'have', 'spaces', 'around']
+
+def test_tokenize_ignores_extraneous_space():
+    texts = ['test ']
+    tokenizer = Tokenizer(BaseTokenizer)
+    toks = tokenizer.process_all(texts)
+    assert toks[0] == ['test']


### PR DESCRIPTION
The tokenization was joining empty lines together and was throwing an exception on an example that ends with whitespace.
