### PR TITLE
Added heatmap boolean variable to plot_top_losses. By default this va…

### DIFF
--- a/fastai/train.py
+++ b/fastai/train.py
@@ -100,12 +100,13 @@ Learner.clip_grad = clip_grad
 
 class ClassificationInterpretation():
     "Interpretation methods for classification models."
-    def __init__(self, data:DataBunch, probs:Tensor, y_true:Tensor, losses:Tensor, ds_type:DatasetType=DatasetType.Valid):
-        self.data,self.probs,self.y_true,self.losses,self.ds_type = data,probs,y_true,losses,ds_type
+    def __init__(self, data:DataBunch, learn:Learner, probs:Tensor, y_true:Tensor, losses:Tensor, ds_type:DatasetType=DatasetType.Valid):
+        self.data,self.probs,self.y_true,self.losses,self.ds_type, self.learn= data,probs,y_true,losses,ds_type,learn
         self.pred_class = self.probs.argmax(dim=1)
+        
 
     @classmethod
-    def from_learner(cls, learn:Learner, ds_type:DatasetType=DatasetType.Valid):
+    def from_learner(cls, learn: Learner,  ds_type:DatasetType=DatasetType.Valid):
         "Create an instance of `ClassificationInterpretation`"
         preds = learn.get_preds(ds_type=ds_type, with_loss=True)
         return cls(learn.data, *preds)

--- a/fastai/train.py
+++ b/fastai/train.py
@@ -109,7 +109,7 @@ class ClassificationInterpretation():
     def from_learner(cls, learn: Learner,  ds_type:DatasetType=DatasetType.Valid):
         "Create an instance of `ClassificationInterpretation`"
         preds = learn.get_preds(ds_type=ds_type, with_loss=True)
-        return cls(learn.data, *preds)
+        return cls(learn, *preds)
 
     def confusion_matrix(self, slice_size:int=1):
         "Confusion matrix as an `np.ndarray`."

--- a/fastai/train.py
+++ b/fastai/train.py
@@ -100,8 +100,8 @@ Learner.clip_grad = clip_grad
 
 class ClassificationInterpretation():
     "Interpretation methods for classification models."
-    def __init__(self, data:DataBunch, learn:Learner, probs:Tensor, y_true:Tensor, losses:Tensor, ds_type:DatasetType=DatasetType.Valid):
-        self.data,self.probs,self.y_true,self.losses,self.ds_type, self.learn= data,probs,y_true,losses,ds_type,learn
+    def __init__(self, learn:Learner, probs:Tensor, y_true:Tensor, losses:Tensor, ds_type:DatasetType=DatasetType.Valid):
+        self.data,self.probs,self.y_true,self.losses,self.ds_type, self.learn= learn.data,probs,y_true,losses,ds_type,learn
         self.pred_class = self.probs.argmax(dim=1)
         
 

--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -6,7 +6,7 @@ from .image import *
 from . import models
 from ..callback import *
 from ..layers import *
-from ..callbacks.hooks import num_features_model
+from ..callbacks.hooks import *
 from ..train import ClassificationInterpretation
 
 __all__ = ['create_cnn', 'create_body', 'create_head', 'unet_learner']
@@ -100,9 +100,9 @@ def unet_learner(data:DataBunch, arch:Callable, pretrained:bool=True, blur_final
 def _cl_int_from_learner(cls, learn:Learner, ds_type:DatasetType=DatasetType.Valid, tta=False):
     "Create an instance of `ClassificationInterpretation`. `tta` indicates if we want to use Test Time Augmentation."
     preds = learn.TTA(ds_type=ds_type,with_loss=True) if tta else learn.get_preds(ds_type=ds_type, with_loss=True)
-    return cls(learn.data, *preds, ds_type=ds_type)
+    return cls(learn.data,learn, *preds, ds_type=ds_type)
 
-def _cl_int_plot_top_losses(self, k, largest=True, figsize=(12,12)):
+def _cl_int_plot_top_losses(self, k, largest=True, figsize=(12,12),heatmap:bool=True):
     "Show images in `top_losses` along with their prediction, actual, loss, and probability of predicted class."
     tl_val,tl_idx = self.top_losses(k,largest)
     classes = self.data.classes
@@ -114,6 +114,18 @@ def _cl_int_plot_top_losses(self, k, largest=True, figsize=(12,12)):
         cl = int(cl)
         im.show(ax=axes.flat[i], title=
             f'{classes[self.pred_class[idx]]}/{classes[cl]} / {self.losses[idx]:.2f} / {self.probs[idx][cl]:.2f}')
+        if(heatmap):
+            xb,_ = self.data.one_item(im)
+            xb = xb.cuda()
+            m = self.learn.model.eval()
+            with hook_output(m[0]) as hook_a:
+                with hook_output(m[0], grad= True) as hook_g:
+                    preds = m(xb)
+                    preds[0,cl].backward()
+            acts = hook_a.stored[0].cpu()
+            avg_acts =acts.mean(0)
+            sz = im.shape[-1]
+            axes.flat[i].imshow(avg_acts, alpha =0.6, extent= (0,sz,sz,0), interpolation='bilinear', cmap='magma')
 
 def _cl_int_plot_multi_top_losses(self, samples:int=3, figsz:Tuple[int,int]=(8,8), save_misclassified:bool=False):
     "Show images in `top_losses` along with their prediction, actual, loss, and probability of predicted class in a multilabeled dataset."

--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -124,7 +124,7 @@ def _cl_int_plot_top_losses(self, k, largest=True, figsize=(12,12),heatmap:bool=
             acts = hook_a.stored[0].cpu()
             grad = hook_g.stored[0][0].cpu()
             grad_chan = grad.mean(1).mean(1)
-            mult = (acts*grad_chan[...,None,None]).mean(0)
+            mult = F.relu(((acts*grad_chan[...,None,None])).sum(0))
             sz = im.shape[-1]
             axes.flat[i].imshow(mult, alpha =0.6, extent= (0,sz,sz,0), interpolation='bilinear', cmap='magma')
 

--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -100,7 +100,7 @@ def unet_learner(data:DataBunch, arch:Callable, pretrained:bool=True, blur_final
 def _cl_int_from_learner(cls, learn:Learner, ds_type:DatasetType=DatasetType.Valid, tta=False):
     "Create an instance of `ClassificationInterpretation`. `tta` indicates if we want to use Test Time Augmentation."
     preds = learn.TTA(ds_type=ds_type,with_loss=True) if tta else learn.get_preds(ds_type=ds_type, with_loss=True)
-    return cls(learn.data,learn, *preds, ds_type=ds_type)
+    return cls(learn, *preds, ds_type=ds_type)
 
 def _cl_int_plot_top_losses(self, k, largest=True, figsize=(12,12),heatmap:bool=True):
     "Show images in `top_losses` along with their prediction, actual, loss, and probability of predicted class."


### PR DESCRIPTION
Added heatmap boolean variable to plot_top_losses. By default this variable is True.

When true, plot_top_losses will overlay heat-maps on the top of images. Otherwise, plot_top_losses will display only images associated with top losses.

I am not sure how to write a test case. 
But here is two scenarios in which test worked well with and without my code.
(I assumed that passing of test is equivalent of displaying images associated with top losses).
I am looking forward to   learn more about it.

#####with my code 
path = untar_data(URLs.PETS); 
path_anno = path/'annotations'
path_img = path/'images'
np.random.seed(2)
pat = re.compile(r'/([^/]+)_\d+.jpg$')
data = ImageDataBunch.from_name_re(path_img, fnames, pat, ds_tfms=get_transforms(), size=224, bs=bs).normalize(imagenet_stats)
learn = create_cnn(data, models.resnet34, metrics=error_rate)
interp = ClassificationInterpretation.from_learner(learn)
losses,idxs = interp.top_losses()
len(data.valid_ds)==len(losses)==len(idxs)
interp.plot_top_losses(9, figsize=(15,11),heatmap=True)

###without my code
path = untar_data(URLs.PETS); 
path_anno = path/'annotations'
path_img = path/'images'
np.random.seed(2)
pat = re.compile(r'/([^/]+)_\d+.jpg$')
data = ImageDataBunch.from_name_re(path_img, fnames, pat, ds_tfms=get_transforms(), size=224, bs=bs).normalize(imagenet_stats)
learn = create_cnn(data, models.resnet34, metrics=error_rate)
interp = ClassificationInterpretation.from_learner(learn)
losses,idxs = interp.top_losses()
len(data.valid_ds)==len(losses)==len(idxs)
interp.plot_top_losses(9, figsize=(15,11))

