### PR TITLE
Docs: utils.mem demoting class/tuple headers

### DIFF
--- a/docs/utils.mem.html
+++ b/docs/utils.mem.html
@@ -242,7 +242,7 @@ sidebar: home_sidebar
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h2 id="GPUMemory"><code>class</code> <code>GPUMemory</code></h2><blockquote><p><code>GPUMemory</code>(<strong><code>total</code></strong>, <strong><code>used</code></strong>, <strong><code>free</code></strong>) :: <code>tuple</code></p>
+<h4 id="GPUMemory"><code>class</code> <code>GPUMemory</code></h4><blockquote><p><code>GPUMemory</code>(<strong><code>total</code></strong>, <strong><code>used</code></strong>, <strong><code>free</code></strong>) :: <code>tuple</code></p>
 </blockquote>
 <p>GPUMemory(total, used, free)</p>
 
@@ -304,7 +304,7 @@ sidebar: home_sidebar
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h2 id="GPUMemTrace"><code>class</code> <code>GPUMemTrace</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L98" class="source_link">[source]</a></h2><blockquote><p><code>GPUMemTrace</code>(<strong><code>silent</code></strong>=<strong><em><code>False</code></em></strong>)</p>
+<h4 id="GPUMemTrace"><code>class</code> <code>GPUMemTrace</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L98" class="source_link">[source]</a></h4><blockquote><p><code>GPUMemTrace</code>(<strong><code>silent</code></strong>=<strong><em><code>False</code></em></strong>)</p>
 </blockquote>
 <p>Trace GPU allocated and peak memory usage</p>
 
@@ -404,7 +404,7 @@ depending on its value:</p>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h2 id="gpu_mem_restore_ctx"><code>class</code> <code>gpu_mem_restore_ctx</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L90" class="source_link">[source]</a></h2><blockquote><p><code>gpu_mem_restore_ctx</code>()</p>
+<h4 id="gpu_mem_restore_ctx"><code>class</code> <code>gpu_mem_restore_ctx</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L90" class="source_link">[source]</a></h4><blockquote><p><code>gpu_mem_restore_ctx</code>()</p>
 </blockquote>
 <p>context manager to reclaim RAM if an exception happened under ipython</p>
 

--- a/docs_src/utils.mem.ipynb
+++ b/docs_src/utils.mem.ipynb
@@ -287,7 +287,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h2 id=\"GPUMemory\"><code>class</code> <code>GPUMemory</code></h2>\n",
+       "<h4 id=\"GPUMemory\"><code>class</code> <code>GPUMemory</code></h4>\n",
        "\n",
        "> <code>GPUMemory</code>(**`total`**, **`used`**, **`free`**) :: `tuple`\n",
        "\n",
@@ -302,7 +302,7 @@
     }
    ],
    "source": [
-    "show_doc(GPUMemory)"
+    "show_doc(GPUMemory, title_level=4)"
    ]
   },
   {
@@ -364,7 +364,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h2 id=\"GPUMemTrace\"><code>class</code> <code>GPUMemTrace</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L98\" class=\"source_link\">[source]</a></h2>\n",
+       "<h4 id=\"GPUMemTrace\"><code>class</code> <code>GPUMemTrace</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L98\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>GPUMemTrace</code>(**`silent`**=***`False`***)\n",
        "\n",
@@ -379,7 +379,7 @@
     }
    ],
    "source": [
-    "show_doc(GPUMemTrace)"
+    "show_doc(GPUMemTrace, title_level=4)"
    ]
   },
   {
@@ -483,7 +483,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h2 id=\"gpu_mem_restore_ctx\"><code>class</code> <code>gpu_mem_restore_ctx</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L90\" class=\"source_link\">[source]</a></h2>\n",
+       "<h4 id=\"gpu_mem_restore_ctx\"><code>class</code> <code>gpu_mem_restore_ctx</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L90\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>gpu_mem_restore_ctx</code>()\n",
        "\n",
@@ -498,7 +498,7 @@
     }
    ],
    "source": [
-    "show_doc(gpu_mem_restore_ctx)"
+    "show_doc(gpu_mem_restore_ctx, title_level=4)"
    ]
   },
   {


### PR DESCRIPTION
https://forums.fast.ai/t/documentation-improvements/32550/76?u=ashaw

Currently `class GPUMemory` in TOC is a level 2 header. Should be level 4

@stas00 - not sure if I did this right. Feel free to close it and format how you'd like