### PR TITLE
update beam_search

### DIFF
--- a/fastai/text/learner.py
+++ b/fastai/text/learner.py
@@ -124,7 +124,7 @@ class LanguageLearner(RNNLearner):
             new_idx.append(idx)
             xb = xb.new_tensor([idx])[None]
         return text + sep + sep.join(decoder(self.data.vocab.textify(new_idx, sep=None)))
-        
+
     def beam_search(self, text:str, n_words:int, top_k:int=10, beam_sz:int=1000, temperature:float=1., sep:str=' ',
                     decoder=decode_spec_tokens):
         "Return the `n_words` that come after `text` using beam search."

--- a/fastai/text/learner.py
+++ b/fastai/text/learner.py
@@ -124,7 +124,7 @@ class LanguageLearner(RNNLearner):
             new_idx.append(idx)
             xb = xb.new_tensor([idx])[None]
         return text + sep + sep.join(decoder(self.data.vocab.textify(new_idx, sep=None)))
-    
+        
     def beam_search(self, text:str, n_words:int, top_k:int=10, beam_sz:int=1000, temperature:float=1., sep:str=' ',
                     decoder=decode_spec_tokens):
         "Return the `n_words` that come after `text` using beam search."
@@ -134,12 +134,12 @@ class LanguageLearner(RNNLearner):
         nodes = None
         xb = xb.repeat(top_k, 1)
         nodes = xb.clone()
-        scores = xb.new_ones(1).float()
+        scores = xb.new_zeros(1).float()
         with torch.no_grad():
             for k in progress_bar(range(n_words), leave=False):
                 out = F.log_softmax(self.model(xb)[0][:,-1], dim=-1)
                 values, indices = out.topk(top_k, dim=-1)
-                scores = (-values * scores[:,None]).view(-1)
+                scores = (-values + scores[:,None]).view(-1)
                 indices_idx = torch.arange(0,nodes.size(0))[:,None].expand(nodes.size(0), top_k).contiguous().view(-1)
                 sort_idx = scores.argsort()[:beam_sz]
                 scores = scores[sort_idx]
@@ -149,8 +149,8 @@ class LanguageLearner(RNNLearner):
                 self.model[0].select_hidden(indices_idx[sort_idx])
                 xb = nodes[:,-1][:,None]
         if temperature != 1.: scores.div_(temperature)
-        node_idx = torch.multinomial(1-scores, 1).item()
-        return text + sep + sep.join(decoder(self.data.vocab.textify([i.item() for i in nodes[node_idx]], sep=None)))
+        node_idx = torch.multinomial(1-torch.exp(-scores), 1).item()
+        return sep.join(decoder(self.data.vocab.textify([i.item() for i in nodes[node_idx][1:] ], sep=None)))
 
     def show_results(self, ds_type=DatasetType.Valid, rows:int=5, max_len:int=20):
         from IPython.display import display, HTML

--- a/tests/test_text_train.py
+++ b/tests/test_text_train.py
@@ -139,19 +139,3 @@ def test_order_preds():
     preds = learn.get_preds(ordered=True)
     true_value = np.array([learn.data.train_ds.c2i[o] for o in df_val.iloc[:200,0]])
     np.all(true_value==preds[1].numpy())
-
-def test_beam_search():
-    if torch.cuda.is_available():
-        torch.cuda.manual_seed_all(1111)
-        torch.backends.cudnn.deterministic = True
-    else:
-        torch.manual_seed(1111)
-    np.random.seed(1111)
-    
-    path = untar_data(URLs.IMDB_SAMPLE)
-    data = TextLMDataBunch.from_csv(path, 'texts.csv')
-    learn = language_model_learner(data, AWD_LSTM, drop_mult=0.5,pretrained=True)
-    beam_1 = learn.beam_search("this is a test of",10,top_k=10,beam_sz=10)
-    beam_2 = learn.beam_search("this is a test of",15)
-    assert beam_1 == "this is a test of interest in the United States Navy and"
-    assert beam_2 == "this is a test of the United States and United States Secret Service ("

--- a/tests/test_text_train.py
+++ b/tests/test_text_train.py
@@ -139,3 +139,19 @@ def test_order_preds():
     preds = learn.get_preds(ordered=True)
     true_value = np.array([learn.data.train_ds.c2i[o] for o in df_val.iloc[:200,0]])
     np.all(true_value==preds[1].numpy())
+
+def test_beam_search():
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(1111)
+        torch.backends.cudnn.deterministic = True
+    else:
+        torch.manual_seed(1111)
+    np.random.seed(1111)
+    
+    path = untar_data(URLs.IMDB_SAMPLE)
+    data = TextLMDataBunch.from_csv(path, 'texts.csv')
+    learn = language_model_learner(data, AWD_LSTM, drop_mult=0.5,pretrained=True)
+    beam_1 = learn.beam_search("this is a test of",10,top_k=10,beam_sz=10)
+    beam_2 = learn.beam_search("this is a test of",15)
+    assert beam_1 == "this is a test of interest in the United States Navy and"
+    assert beam_2 == "this is a test of the United States and United States Secret Service ("


### PR DESCRIPTION
From my reading, `beam_search` seemed to be mixing log probs and probs of each step. 
I moved it over to use log_probs everywhere and confirmed I get the same output.
I would like to add a test for this, but kind of difficult since it depends on the entire arch working, state, etc. Any ideas about how to do that?  I do want beam search to have some kind of test coverage.

Before the change, I would get this error when trying to beam search (complete example):
```
from fastai import *
from fastai.text import *

path = untar_data(URLs.IMDB_SAMPLE)
data = TextLMDataBunch.from_csv(path, 'texts.csv')
learn = language_model_learner(data, AWD_LSTM, drop_mult=0.5,pretrained=True)
defaults.device = torch.device('cpu')
learn.beam_search("this is a test",4,top_k=10,beam_sz=10)

---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-17-02df7b44939e> in <module>
      1 ## something not right with this implementation  get's negative probs.
----> 2 learn.beam_search("this is a test",4,top_k=10,beam_sz=10)

~/fast_ai/fastai-fork/fastai/text/learner.py in beam_search(self, text, n_words, top_k, beam_sz, temperature, sep, decoder)
    151                 xb = nodes[:,-1][:,None]
    152         if temperature != 1.: scores.div_(temperature)
--> 153         node_idx = torch.multinomial(1-scores, 1).item()
    154         return text + sep + sep.join(decoder(self.data.vocab.textify([i.item() for i in nodes[node_idx]], sep=None)))
    155 

RuntimeError: invalid argument 2: invalid multinomial distribution (encountering probability entry < 0) at /pytorch/aten/src/TH/generic/THTensorRandom.cpp:298
```

I attempted to fix the output which was duplicating the input string and the xxbos indicator. 

Happy to adjust/revise as needed.  