### PR TITLE
Add linear and quadratic weight options to KappaScore

### DIFF
--- a/docs_src/metrics.ipynb
+++ b/docs_src/metrics.ipynb
@@ -715,6 +715,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ref.: https://github.com/scikit-learn/scikit-learn/blob/bac89c2/sklearn/metrics/classification.py"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -740,6 +747,21 @@
    ],
    "source": [
     "show_doc(KappaScore, title_level=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ref.: https://github.com/scikit-learn/scikit-learn/blob/bac89c2/sklearn/metrics/classification.py   \n",
+    "\n",
+    "`KappaScore` supports linear and quadratic weights on the off-diagonal cells in the `ConfusionMatrix`, in addition to the default unweighted calculation treating all misclassifications as equally weighted. Leaving `KappaScore`'s `weights` attribute as `None` returns the unweighted Kappa score. Updating `weights` to \"linear\" means off-diagonal ConfusionMatrix elements are weighted in linear proportion to their distance from the diagonal; \"quadratic\" means weights are squared proportional to their distance from the diagonal.\n",
+    "Specify linear or quadratic weights, if using, by first creating an instance of the metric and then updating the `weights` attribute, similar to as follows:  \n",
+    "```\n",
+    "kappa = KappaScore()\n",
+    "kappa.weights = \"quadratic\"\n",
+    "learn = create_cnn(data, model, metrics=[error_rate, kappa])\n",
+    "``` "
    ]
   },
   {

--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -237,14 +237,6 @@ class FBeta(CMScores):
 class KappaScore(ConfusionMatrix):
     """
     Compute the rate of agreement (Cohens Kappa).
-    Ref.: https://github.com/scikit-learn/scikit-learn/blob/bac89c2/sklearn/metrics/classification.py
-    
-    Parameters
-    ----------
-    weights : str, optional
-    Weighting type used to calculate the Kappa score. None means unweighted; 
-    "linear" means off-diagonal ConfusionMatrix elements are weighted in linear proportion to their distance from the diagonal;
-    "quadratic" means squared weights.
     """
     weights:Optional[str]=None      # None, `linear`, or `quadratic`
     
@@ -258,19 +250,15 @@ class KappaScore(ConfusionMatrix):
         elif self.weights == "linear" or self.weights == "quadratic":
             w = torch.zeros((self.n_classes, self.n_classes))
             w += torch.arange(self.n_classes, dtype=torch.float)
-            if self.weights == "linear":
-                w = torch.abs(w - torch.t(w))
-            else:
-                w = (w - torch.t(w)) ** 2
+            w = torch.abs(w - torch.t(w)) if self.weights == "linear" else (w - torch.t(w)) ** 2
         else:
-            raise ValueError("Unknown kappa weighting type.")
+            raise ValueError('Unknown weights attribute given. Expected None, "linear", or "quadratic".')
         k = torch.sum(w * self.cm) / torch.sum(w * expected)
         self.metric = 1 - k
 
 class MatthewsCorreff(ConfusionMatrix):
     """    
     Compute the Matthews correlation coefficient.
-    Ref.: https://github.com/scikit-learn/scikit-learn/blob/bac89c2/sklearn/metrics/classification.py
     """
 
     def on_epoch_end(self, **kwargs):

--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -252,7 +252,6 @@ class KappaScore(ConfusionMatrix):
         sum0 = self.cm.sum(dim=0)
         sum1 = self.cm.sum(dim=1)
         expected = torch.einsum('i,j->ij', (sum0, sum1)) / sum0.sum()
-        
         if self.weights is None:
             w = torch.ones((self.n_classes, self.n_classes))
             w[self.x, self.x] = 0
@@ -265,10 +264,8 @@ class KappaScore(ConfusionMatrix):
                 w = (w - torch.t(w)) ** 2
         else:
             raise ValueError("Unknown kappa weighting type.")
-    
         k = torch.sum(w * self.cm) / torch.sum(w * expected)
         self.metric = 1 - k
-        
 
 class MatthewsCorreff(ConfusionMatrix):
     """    


### PR DESCRIPTION
The KappaScore metric commonly has linear and quadratically weighted variants.
Like the prior, "unweighted" KappaScore, this PR follows the example of scikit-learn, translating from Numpy to Pytorch operators.