### PR TITLE
Don't assume categorical type. Explicit type conversion

### DIFF
--- a/old/fastai/structured.py
+++ b/old/fastai/structured.py
@@ -6,7 +6,6 @@ from pandas.api.types import is_string_dtype, is_numeric_dtype
 from sklearn.ensemble import forest
 from sklearn.tree import export_graphviz
 
-
 def set_plot_sizes(sml, med, big):
     plt.rc('font', size=sml)          # controls default text sizes
     plt.rc('axes', titlesize=sml)     # fontsize of the axes title
@@ -321,7 +320,7 @@ def numericalize(df, col, name, max_n_cat):
     2     3    a    1
     """
     if not is_numeric_dtype(col) and ( max_n_cat is None or len(col.cat.categories)>max_n_cat):
-        df[name] = col.cat.codes+1
+        df[name] = pd.Categorical(col).codes+1
 
 def scale_vars(df, mapper):
     warnings.filterwarnings('ignore', category=sklearn.exceptions.DataConversionWarning)
@@ -434,7 +433,7 @@ def proc_df(df, y_fld=None, skip_flds=None, ignore_flds=None, do_scale=False, na
     if preproc_fn: preproc_fn(df)
     if y_fld is None: y = None
     else:
-        if not is_numeric_dtype(df[y_fld]): df[y_fld] = df[y_fld].cat.codes
+        if not is_numeric_dtype(df[y_fld]): df[y_fld] = pd.Categorical(df[y_fld]).codes
         y = df[y_fld].values
         skip_flds += [y_fld]
     df.drop(skip_flds, axis=1, inplace=True)


### PR DESCRIPTION
Series.cat property is only available to Categorical data types, but is used where any type can be passed in. The code assumes that the data will be a Categorical type. As it stands now, passing in a DataFrame or Series will result in an error. Explicitly converting to a Categorical gets rid of this assumption.

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
