### PR TITLE
Optionally plot values inside the confusion matrix

### DIFF
--- a/fastai/train.py
+++ b/fastai/train.py
@@ -123,7 +123,7 @@ class ClassificationInterpretation():
         return to_np(cm)
 
     def plot_confusion_matrix(self, normalize:bool=False, title:str='Confusion matrix', cmap:Any="Blues", slice_size:int=1, 
-                              norm_dec:int=2, **kwargs)->None:
+                              norm_dec:int=2, plot_txt:bool=True, **kwargs)->None:
         "Plot the confusion matrix, with `title` and using `cmap`."
         # This function is mainly copied from the sklearn docs
         cm = self.confusion_matrix(slice_size=slice_size)
@@ -135,10 +135,11 @@ class ClassificationInterpretation():
         plt.xticks(tick_marks, self.data.y.classes, rotation=90)
         plt.yticks(tick_marks, self.data.y.classes, rotation=0)
 
-        thresh = cm.max() / 2.
-        for i, j in itertools.product(range(cm.shape[0]), range(cm.shape[1])):
-            coeff = f'{cm[i, j]:.{norm_dec}f}' if normalize else f'{cm[i, j]}'
-            plt.text(j, i, coeff, horizontalalignment="center", color="white" if cm[i, j] > thresh else "black")
+        if plot_txt:
+            thresh = cm.max() / 2.
+            for i, j in itertools.product(range(cm.shape[0]), range(cm.shape[1])):
+                coeff = f'{cm[i, j]:.{norm_dec}f}' if normalize else f'{cm[i, j]}'
+                plt.text(j, i, coeff, horizontalalignment="center", color="white" if cm[i, j] > thresh else "black")
 
         plt.tight_layout()
         plt.ylabel('Actual')


### PR DESCRIPTION
Hi. I'm adding a flag to optionally skip plotting the text inside the confusion matrix cells, because when there's a high number of classes it takes a while to render and it's usually not visible unless the figsize is too big. I'm not sure how to add an automated test for it, so I'm submitting the PR directy. Thanks in advance!

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
