### PR TITLE
Added a save method and load classmethod to Vocab Class

### DIFF
--- a/fastai/text/transform.py
+++ b/fastai/text/transform.py
@@ -140,6 +140,11 @@ class Vocab():
         self.itos = state['itos']
         self.stoi = collections.defaultdict(int,{v:k for k,v in enumerate(self.itos)})
 
+    def save(self, path):
+        "Save the itos in path"
+        with open(path, 'wb') as f:
+            pickle.dump(self.itos, f)
+
     @classmethod
     def create(cls, tokens:Tokens, max_vocab:int, min_freq:int) -> 'Vocab':
         "Create a vocabulary from a set of `tokens`."
@@ -148,4 +153,11 @@ class Vocab():
         for o in reversed(defaults.text_spec_tok):
             if o in itos: itos.remove(o)
             itos.insert(0, o)
+        return cls(itos)
+    
+    @classmethod
+    def load(cls, path):
+        "Load the Vocab contained in path"
+        with open(path, 'rb') as f:
+            itos = pickle.load(f)
         return cls(itos)

--- a/fastai/text/transform.py
+++ b/fastai/text/transform.py
@@ -141,9 +141,8 @@ class Vocab():
         self.stoi = collections.defaultdict(int,{v:k for k,v in enumerate(self.itos)})
 
     def save(self, path):
-        "Save the itos in path"
-        with open(path, 'wb') as f:
-            pickle.dump(self.itos, f)
+        "Save `self.itos` in `path`"
+        pickle.dump(self.itos, open(path, 'wb'))
 
     @classmethod
     def create(cls, tokens:Tokens, max_vocab:int, min_freq:int) -> 'Vocab':
@@ -157,7 +156,6 @@ class Vocab():
     
     @classmethod
     def load(cls, path):
-        "Load the Vocab contained in path"
-        with open(path, 'rb') as f:
-            itos = pickle.load(f)
+        "Load the `Vocab` contained in `path`"
+        itos = pickle.load(open(path, 'rb'))
         return cls(itos)


### PR DESCRIPTION
Since 1.0.44, saving TextDataBunch has been changed. As a result, the itos.pkl file containing the Vocab of the language model has to be saved on its own. This PR adds a save(self, path) method and a load(clas, path) classmethod that allows you to save or load a vocab directly from the vocab class as suggested by sgugger in https://forums.fast.ai/t/saving-vocab-in-1-0-44/38313. 

