### PR TITLE
nbtest.doctest now returns pytest note syntax command

### DIFF
--- a/fastai/gen_doc/nbtest.py
+++ b/fastai/gen_doc/nbtest.py
@@ -156,7 +156,7 @@ def get_links(metadata)->Tuple[str,str]:
 
 def pytest_command(file:str, test:str, **kwargs)->str:
     "Returns CLI command to run specific test function"
-    return f'pytest -sv -k {test} {file}'
+    return f'pytest {file}::{test}'
 
 def source_link(line:int, file:Path, **kwargs)->str:
     "Github link to test function"


### PR DESCRIPTION
Fixes bug reported here:
https://forums.fast.ai/t/doc-test-project/38344/118