### PR TITLE
Fixed _dihedral and _dihedral_affine uniform_int sampling

### DIFF
--- a/fastai/vision/transform.py
+++ b/fastai/vision/transform.py
@@ -72,7 +72,7 @@ def _flip_affine() -> TfmAffine:
             [0,  0, 1.]]
 flip_affine = TfmAffine(_flip_affine)
 
-def _dihedral(x, k:partial(uniform_int,0,8)):
+def _dihedral(x, k:partial(uniform_int,0,7)):
     "Randomly flip `x` image based on `k`."
     flips=[]
     if k&1: flips.append(1)
@@ -82,7 +82,7 @@ def _dihedral(x, k:partial(uniform_int,0,8)):
     return x.contiguous()
 dihedral = TfmPixel(_dihedral)
 
-def _dihedral_affine(k:partial(uniform_int,0,8)):
+def _dihedral_affine(k:partial(uniform_int,0,7)):
     "Randomly flip `x` image based on `k`."
     x = -1 if k&1 else 1
     y = -1 if k&2 else 1


### PR DESCRIPTION
Fixes in fastai/vision/transform.py

Refer to https://github.com/fastai/fastai/issues/1644 for more details. 

The fix will allow sampling between 0-7 (excl. 8) resulting in equal probability for all orientations (incl. no op).