### PR TITLE
Correct small typo

### DIFF
--- a/docs/vision.data.html
+++ b/docs/vision.data.html
@@ -604,7 +604,7 @@ summary: "Basic dataset for computer vision and helper function to get a DataBun
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Refer to <a href="#ImageDataBunch.create_from_ll"><code>create_from_ll</code></a> to see all the <code>**kwargs</code> arguments.</p>
-<p>Same as <a href="/vision.data.html#ImageDataBunch.from_csv"><code>ImageDataBunch.from_csv</code></a>, but passing in a <code>DataFrame</code> instead of a csv file. E.gL</p>
+<p>Same as <a href="/vision.data.html#ImageDataBunch.from_csv"><code>ImageDataBunch.from_csv</code></a>, but passing in a <code>DataFrame</code> instead of a csv file. E.g</p>
 
 </div>
 </div>


### PR DESCRIPTION
While reading the documentation https://docs.fast.ai/vision.data.html#ImageDataBunch found there is a small typo saying  **E.gL** which should be just **E.g**. As documentation serves as the main entry point for all developers. I feel its better to correct any small typos. 

PS: I am not a native English speaker if it's true please accept if not kindly provide a reason & reject the PR.

