### PR TITLE
min_val variable in most_confused() unintuitive behavior

### DIFF
--- a/fastai/train.py
+++ b/fastai/train.py
@@ -145,12 +145,12 @@ class ClassificationInterpretation():
         plt.ylabel('Actual')
         plt.xlabel('Predicted')
 
-    def most_confused(self, min_val:int=0, slice_size:int=1)->Collection[Tuple[str,str,int]]:
+    def most_confused(self, min_val:int=1, slice_size:int=1)->Collection[Tuple[str,str,int]]:
         "Sorted descending list of largest non-diagonal entries of confusion matrix, presented as actual, predicted, number of occurrences."
         cm = self.confusion_matrix(slice_size=slice_size)
         np.fill_diagonal(cm, 0)
         res = [(self.data.classes[i],self.data.classes[j],cm[i,j])
-                for i,j in zip(*np.where(cm>min_val))]
+                for i,j in zip(*np.where(cm>=min_val))]
         return sorted(res, key=itemgetter(2), reverse=True)
     
     def top_losses(self, k:int=None, largest=True):


### PR DESCRIPTION
I don't know if someone has already suggested that, I couldn't find any forum threads or PR's on it, but I think that variable min_val in the function most_confused is well ... confusing :) 
As, for example, is shown in the notebook lesson1-pets.py this function outputs pairs of classes that are chosen wrongly by the model with number of occurrences of such mistake. My first thought when I saw  variable min_val was that it filters all records with this (or more) minimal value of occurrences. That as I think is more intuitive way to set this parameter (now it checks if this number is strictly more than min_val). So I've changed comparison and default value.
I am aware that it could be my personal view on default behavior that is just not coherent with most of users. So it's just a suggestion for community.

Sorry for style and stuff, as it's my first github experience (as well as first PR ever), I could done something wrong following your guide (although, I hope not :) ).