### PR TITLE
Non-existing ImagePoints.reconstruct() removed

### DIFF
--- a/docs_src/vision.image.ipynb
+++ b/docs_src/vision.image.ipynb
@@ -3282,37 +3282,6 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ImagePoints.reconstruct\"><code>reconstruct</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/image.py#L329\" class=\"source_link\">[source]</a></h4>\n",
-       "\n",
-       "> <code>reconstruct</code>(**`t`**, **`x`**)"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "show_doc(ImagePoints.reconstruct)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "hide_input": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
        "<h4 id=\"Transform.__init__.<locals>.<lambda>\"><code><lambda></code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/image.py#L456\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code><lambda></code>(**`x`**, **\\*`args`**, **\\*\\*`kwargs`**)"


### PR DESCRIPTION
Tests results.
Before:
```
(fastai) condor@rexcellentgames:~/fastai-fork/docs_src$ ./run_tests.sh vision.image.ipynb 
======================================================= test session starts ========================================================
platform linux -- Python 3.6.8, pytest-4.1.0, py-1.7.0, pluggy-0.8.1
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /home/condor/fastai-fork/docs_src, inifile: pytest.ini
plugins: xdist-1.26.1, repeat-0.7.0, random-order-1.0.4, forked-1.0.1
collected 106 items                                                                                                                

vision.image.ipynb ........................................................................................................F [ 99%]
.                                                                                                                            [100%]

============================================================= FAILURES =============================================================
___________________________________________________ vision.image.ipynb::Cell 104 ___________________________________________________
Notebook cell execution failed
Cell 104: Cell execution caused an exception

Input:
show_doc(ImagePoints.reconstruct)

Traceback:

---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-105-1bfba489dfc4> in <module>
----> 1 show_doc(ImagePoints.reconstruct)

AttributeError: type object 'ImagePoints' has no attribute 'reconstruct'

========================================================= warnings summary =========================================================
vision.image.ipynb::Cell 0
  /home/condor/anaconda3/envs/fastai/lib/python3.6/site-packages/jupyter_client/manager.py:62: DeprecationWarning: KernelManager._kernel_spec_manager_changed is deprecated in traitlets 4.1: use @observe and @unobserve instead.
    def _kernel_spec_manager_changed(self):

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================================== 1 failed, 105 passed, 1 warnings in 20.40 seconds =========================================
```

Now:

```
(fastai) condor@rexcellentgames:~/fastai-fork/docs_src$ ./run_tests.sh vision.image.ipynb 
======================================================= test session starts ========================================================
platform linux -- Python 3.6.8, pytest-4.1.0, py-1.7.0, pluggy-0.8.1
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /home/condor/fastai-fork/docs_src, inifile: pytest.ini
plugins: xdist-1.26.1, repeat-0.7.0, random-order-1.0.4, forked-1.0.1
collected 105 items                                                                                                                

vision.image.ipynb ......................................................................................................... [100%]

========================================================= warnings summary =========================================================
vision.image.ipynb::Cell 0
  /home/condor/anaconda3/envs/fastai/lib/python3.6/site-packages/jupyter_client/manager.py:62: DeprecationWarning: KernelManager._kernel_spec_manager_changed is deprecated in traitlets 4.1: use @observe and @unobserve instead.
    def _kernel_spec_manager_changed(self):

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================================= 105 passed, 1 warnings in 17.33 seconds ==============================================
```