### PR TITLE
Optionally run AWD-LSTM from pre-computed embeddings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,6 @@ of that change.
 ### New:
 
 - `Learner.destroy`: completely free up `learn`, leaving an empty shell (to replace `gc.collect` eye-sore)
-- `Learner.hibernate`: `learn.export` + `learn.destroy` shortcut method
 - support `pynvx` instead of `pynvml` on OSX
 
 ### Changed:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ of that change.
 
 - `Learner.destroy`: completely free up `learn`, leaving an empty shell (to replace `gc.collect` eye-sore)
 - support `pynvx` instead of `pynvml` on OSX
+- added NVML query support on OSX via pynvx
 
 ### Changed:
 

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ test-fast: ## run tests in parallel (requires pip install pytest-xdist)
 	pytest -n 3
 
 test-full: ## run all tests, including slow ones, print summary
-	pytest --runslow -ra -regtestapidb
+	pytest --runslow -ra --testapireg
 
 test-cpu: ## run tests with the default python and CUDA_VISIBLE_DEVICES=""
 	CUDA_VISIBLE_DEVICES="" python setup.py --quiet test

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ test-fast: ## run tests in parallel (requires pip install pytest-xdist)
 	pytest -n 3
 
 test-full: ## run all tests, including slow ones, print summary
-	pytest --runslow -ra
+	pytest --runslow -ra -regtestapidb
 
 test-cpu: ## run tests with the default python and CUDA_VISIBLE_DEVICES=""
 	CUDA_VISIBLE_DEVICES="" python setup.py --quiet test

--- a/docs/basic_train.html
+++ b/docs/basic_train.html
@@ -39,7 +39,7 @@ summary: "Learner class and training loop"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h2 id="Learner"><code>class</code> <code>Learner</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L134" class="source_link">[source]</a></h2><blockquote><p><code>Learner</code>(<strong><code>data</code></strong>:<a href="/basic_data.html#DataBunch"><code>DataBunch</code></a>, <strong><code>model</code></strong>:<a href="https://pytorch.org/docs/stable/nn.html#torch.nn.Module"><code>Module</code></a>, <strong><code>opt_func</code></strong>:<code>Callable</code>=<strong><em><code>'Adam'</code></em></strong>, <strong><code>loss_func</code></strong>:<code>Callable</code>=<strong><em><code>None</code></em></strong>, <strong><code>metrics</code></strong>:<code>Collection</code>[<code>Callable</code>]=<strong><em><code>None</code></em></strong>, <strong><code>true_wd</code></strong>:<code>bool</code>=<strong><em><code>True</code></em></strong>, <strong><code>bn_wd</code></strong>:<code>bool</code>=<strong><em><code>True</code></em></strong>, <strong><code>wd</code></strong>:<code>Floats</code>=<strong><em><code>0.01</code></em></strong>, <strong><code>train_bn</code></strong>:<code>bool</code>=<strong><em><code>True</code></em></strong>, <strong><code>path</code></strong>:<code>str</code>=<strong><em><code>None</code></em></strong>, <strong><code>model_dir</code></strong>:<code>str</code>=<strong><em><code>'models'</code></em></strong>, <strong><code>callback_fns</code></strong>:<code>Collection</code>[<code>Callable</code>]=<strong><em><code>None</code></em></strong>, <strong><code>callbacks</code></strong>:<code>Collection</code>[<a href="/callback.html#Callback"><code>Callback</code></a>]=<strong><em><code>&lt;factory&gt;</code></em></strong>, <strong><code>layer_groups</code></strong>:<code>ModuleList</code>=<strong><em><code>None</code></em></strong>)</p>
+<h2 id="Learner"><code>class</code> <code>Learner</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L132" class="source_link">[source]</a></h2><blockquote><p><code>Learner</code>(<strong><code>data</code></strong>:<a href="/basic_data.html#DataBunch"><code>DataBunch</code></a>, <strong><code>model</code></strong>:<a href="https://pytorch.org/docs/stable/nn.html#torch.nn.Module"><code>Module</code></a>, <strong><code>opt_func</code></strong>:<code>Callable</code>=<strong><em><code>'Adam'</code></em></strong>, <strong><code>loss_func</code></strong>:<code>Callable</code>=<strong><em><code>None</code></em></strong>, <strong><code>metrics</code></strong>:<code>Collection</code>[<code>Callable</code>]=<strong><em><code>None</code></em></strong>, <strong><code>true_wd</code></strong>:<code>bool</code>=<strong><em><code>True</code></em></strong>, <strong><code>bn_wd</code></strong>:<code>bool</code>=<strong><em><code>True</code></em></strong>, <strong><code>wd</code></strong>:<code>Floats</code>=<strong><em><code>0.01</code></em></strong>, <strong><code>train_bn</code></strong>:<code>bool</code>=<strong><em><code>True</code></em></strong>, <strong><code>path</code></strong>:<code>str</code>=<strong><em><code>None</code></em></strong>, <strong><code>model_dir</code></strong>:<code>str</code>=<strong><em><code>'models'</code></em></strong>, <strong><code>callback_fns</code></strong>:<code>Collection</code>[<code>Callable</code>]=<strong><em><code>None</code></em></strong>, <strong><code>callbacks</code></strong>:<code>Collection</code>[<a href="/callback.html#Callback"><code>Callback</code></a>]=<strong><em><code>&lt;factory&gt;</code></em></strong>, <strong><code>layer_groups</code></strong>:<code>ModuleList</code>=<strong><em><code>None</code></em></strong>)</p>
 </blockquote>
 <p>Trainer for <code>model</code> using <code>data</code> to minimize <code>loss_func</code> with optimizer <code>opt_func</code>.</p>
 
@@ -195,7 +195,7 @@ summary: "Learner class and training loop"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Learner.fit"><code>fit</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L170" class="source_link">[source]</a></h4><blockquote><p><code>fit</code>(<strong><code>epochs</code></strong>:<code>int</code>, <strong><code>lr</code></strong>:<code>Union</code>[<code>float</code>, <code>Collection</code>[<code>float</code>], <code>slice</code>]=<strong><em><code>slice(None, 0.003, None)</code></em></strong>, <strong><code>wd</code></strong>:<code>Floats</code>=<strong><em><code>None</code></em></strong>, <strong><code>callbacks</code></strong>:<code>Collection</code>[<a href="/callback.html#Callback"><code>Callback</code></a>]=<strong><em><code>None</code></em></strong>)</p>
+<h4 id="Learner.fit"><code>fit</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L168" class="source_link">[source]</a></h4><blockquote><p><code>fit</code>(<strong><code>epochs</code></strong>:<code>int</code>, <strong><code>lr</code></strong>:<code>Union</code>[<code>float</code>, <code>Collection</code>[<code>float</code>], <code>slice</code>]=<strong><em><code>slice(None, 0.003, None)</code></em></strong>, <strong><code>wd</code></strong>:<code>Floats</code>=<strong><em><code>None</code></em></strong>, <strong><code>callbacks</code></strong>:<code>Collection</code>[<a href="/callback.html#Callback"><code>Callback</code></a>]=<strong><em><code>None</code></em></strong>)</p>
 </blockquote>
 <p>Fit the model on this learner with <code>lr</code> learning rate, <code>wd</code> weight decay for <code>epochs</code> with <code>callbacks</code>.</p>
 
@@ -341,7 +341,7 @@ Total time: 00:04 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Learner.predict"><code>predict</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L334" class="source_link">[source]</a></h4><blockquote><p><code>predict</code>(<strong><code>item</code></strong>:<a href="/core.html#ItemBase"><code>ItemBase</code></a>, <strong>**<code>kwargs</code></strong>)</p>
+<h4 id="Learner.predict"><code>predict</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L328" class="source_link">[source]</a></h4><blockquote><p><code>predict</code>(<strong><code>item</code></strong>:<a href="/core.html#ItemBase"><code>ItemBase</code></a>, <strong>**<code>kwargs</code></strong>)</p>
 </blockquote>
 <p>Return predicted class, label and probabilities for <code>item</code>.</p>
 
@@ -580,7 +580,7 @@ Total time: 00:04 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Learner.get_preds"><code>get_preds</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L304" class="source_link">[source]</a></h4><blockquote><p><code>get_preds</code>(<strong><code>ds_type</code></strong>:<a href="/basic_data.html#DatasetType"><code>DatasetType</code></a>=<strong><em><code>&lt;DatasetType.Valid: 2&gt;</code></em></strong>, <strong><code>with_loss</code></strong>:<code>bool</code>=<strong><em><code>False</code></em></strong>, <strong><code>n_batch</code></strong>:<code>Optional</code>[<code>int</code>]=<strong><em><code>None</code></em></strong>, <strong><code>pbar</code></strong>:<code>Union</code>[<code>MasterBar</code>, <code>ProgressBar</code>, <code>NoneType</code>]=<strong><em><code>None</code></em></strong>) → <code>List</code>[<code>Tensor</code>]</p>
+<h4 id="Learner.get_preds"><code>get_preds</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L298" class="source_link">[source]</a></h4><blockquote><p><code>get_preds</code>(<strong><code>ds_type</code></strong>:<a href="/basic_data.html#DatasetType"><code>DatasetType</code></a>=<strong><em><code>&lt;DatasetType.Valid: 2&gt;</code></em></strong>, <strong><code>with_loss</code></strong>:<code>bool</code>=<strong><em><code>False</code></em></strong>, <strong><code>n_batch</code></strong>:<code>Optional</code>[<code>int</code>]=<strong><em><code>None</code></em></strong>, <strong><code>pbar</code></strong>:<code>Union</code>[<code>MasterBar</code>, <code>ProgressBar</code>, <code>NoneType</code>]=<strong><em><code>None</code></em></strong>) → <code>List</code>[<code>Tensor</code>]</p>
 </blockquote>
 <p>Return predictions and targets on <code>ds_type</code> dataset.</p>
 
@@ -947,7 +947,7 @@ Total time: 00:04 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Learner.validate"><code>validate</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L348" class="source_link">[source]</a></h4><blockquote><p><code>validate</code>(<strong><code>dl</code></strong>=<strong><em><code>None</code></em></strong>, <strong><code>callbacks</code></strong>=<strong><em><code>None</code></em></strong>, <strong><code>metrics</code></strong>=<strong><em><code>None</code></em></strong>)</p>
+<h4 id="Learner.validate"><code>validate</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L342" class="source_link">[source]</a></h4><blockquote><p><code>validate</code>(<strong><code>dl</code></strong>=<strong><em><code>None</code></em></strong>, <strong><code>callbacks</code></strong>=<strong><em><code>None</code></em></strong>, <strong><code>metrics</code></strong>=<strong><em><code>None</code></em></strong>)</p>
 </blockquote>
 <p>Validate on <code>dl</code> with potential <code>callbacks</code> and <code>metrics</code>.</p>
 
@@ -1098,7 +1098,7 @@ Total time: 00:04 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Learner.show_results"><code>show_results</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L358" class="source_link">[source]</a></h4><blockquote><p><code>show_results</code>(<strong><code>ds_type</code></strong>=<strong><em><code>&lt;DatasetType.Valid: 2&gt;</code></em></strong>, <strong><code>rows</code></strong>:<code>int</code>=<strong><em><code>5</code></em></strong>, <strong>**<code>kwargs</code></strong>)</p>
+<h4 id="Learner.show_results"><code>show_results</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L352" class="source_link">[source]</a></h4><blockquote><p><code>show_results</code>(<strong><code>ds_type</code></strong>=<strong><em><code>&lt;DatasetType.Valid: 2&gt;</code></em></strong>, <strong><code>rows</code></strong>:<code>int</code>=<strong><em><code>5</code></em></strong>, <strong>**<code>kwargs</code></strong>)</p>
 </blockquote>
 <p>Show <code>rows</code> result of predictions on <code>ds_type</code> dataset.</p>
 
@@ -1188,7 +1188,7 @@ Total time: 00:04 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Learner.pred_batch"><code>pred_batch</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L311" class="source_link">[source]</a></h4><blockquote><p><code>pred_batch</code>(<strong><code>ds_type</code></strong>:<a href="/basic_data.html#DatasetType"><code>DatasetType</code></a>=<strong><em><code>&lt;DatasetType.Valid: 2&gt;</code></em></strong>, <strong><code>batch</code></strong>:<code>Tuple</code>=<strong><em><code>None</code></em></strong>, <strong><code>reconstruct</code></strong>:<code>bool</code>=<strong><em><code>False</code></em></strong>) → <code>List</code>[<code>Tensor</code>]</p>
+<h4 id="Learner.pred_batch"><code>pred_batch</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L305" class="source_link">[source]</a></h4><blockquote><p><code>pred_batch</code>(<strong><code>ds_type</code></strong>:<a href="/basic_data.html#DatasetType"><code>DatasetType</code></a>=<strong><em><code>&lt;DatasetType.Valid: 2&gt;</code></em></strong>, <strong><code>batch</code></strong>:<code>Tuple</code>=<strong><em><code>None</code></em></strong>, <strong><code>reconstruct</code></strong>:<code>bool</code>=<strong><em><code>False</code></em></strong>) → <code>List</code>[<code>Tensor</code>]</p>
 </blockquote>
 <p>Return output of the model on one batch from <code>ds_type</code> dataset.</p>
 
@@ -1774,7 +1774,7 @@ Total time: 00:06 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Learner.lr_range"><code>lr_range</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L163" class="source_link">[source]</a></h4><blockquote><p><code>lr_range</code>(<strong><code>lr</code></strong>:<code>Union</code>[<code>float</code>, <code>slice</code>]) → <code>ndarray</code></p>
+<h4 id="Learner.lr_range"><code>lr_range</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L161" class="source_link">[source]</a></h4><blockquote><p><code>lr_range</code>(<strong><code>lr</code></strong>:<code>Union</code>[<code>float</code>, <code>slice</code>]) → <code>ndarray</code></p>
 </blockquote>
 <p>Build differential learning rates from <code>lr</code>.</p>
 
@@ -1832,7 +1832,7 @@ Total time: 00:06 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Learner.unfreeze"><code>unfreeze</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L204" class="source_link">[source]</a></h4><blockquote><p><code>unfreeze</code>()</p>
+<h4 id="Learner.unfreeze"><code>unfreeze</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L202" class="source_link">[source]</a></h4><blockquote><p><code>unfreeze</code>()</p>
 </blockquote>
 <p>Unfreeze entire model.</p>
 
@@ -1860,7 +1860,7 @@ Total time: 00:06 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Learner.freeze"><code>freeze</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L198" class="source_link">[source]</a></h4><blockquote><p><code>freeze</code>()</p>
+<h4 id="Learner.freeze"><code>freeze</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L196" class="source_link">[source]</a></h4><blockquote><p><code>freeze</code>()</p>
 </blockquote>
 <p>Freeze up to last layer.</p>
 
@@ -1888,7 +1888,7 @@ Total time: 00:06 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Learner.freeze_to"><code>freeze_to</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L190" class="source_link">[source]</a></h4><blockquote><p><code>freeze_to</code>(<strong><code>n</code></strong>:<code>int</code>)</p>
+<h4 id="Learner.freeze_to"><code>freeze_to</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L188" class="source_link">[source]</a></h4><blockquote><p><code>freeze_to</code>(<strong><code>n</code></strong>:<code>int</code>)</p>
 </blockquote>
 <p>Freeze layers up to layer <code>n</code>.</p>
 
@@ -1909,7 +1909,7 @@ Total time: 00:06 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Learner.split"><code>split</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L185" class="source_link">[source]</a></h4><blockquote><p><code>split</code>(<strong><code>split_on</code></strong>:<code>SplitFuncOrIdxList</code>)</p>
+<h4 id="Learner.split"><code>split</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L183" class="source_link">[source]</a></h4><blockquote><p><code>split</code>(<strong><code>split_on</code></strong>:<code>SplitFuncOrIdxList</code>)</p>
 </blockquote>
 <p>Split the model at <code>split_on</code>.</p>
 
@@ -1950,7 +1950,7 @@ Total time: 00:06 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Learner.save"><code>save</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L229" class="source_link">[source]</a></h4><blockquote><p><code>save</code>(<strong><code>name</code></strong>:<code>PathOrStr</code>, <strong><code>return_path</code></strong>:<code>bool</code>=<strong><em><code>False</code></em></strong>, <strong><code>with_opt</code></strong>:<code>bool</code>=<strong><em><code>True</code></em></strong>)</p>
+<h4 id="Learner.save"><code>save</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L223" class="source_link">[source]</a></h4><blockquote><p><code>save</code>(<strong><code>name</code></strong>:<code>PathOrStr</code>, <strong><code>return_path</code></strong>:<code>bool</code>=<strong><em><code>False</code></em></strong>, <strong><code>with_opt</code></strong>:<code>bool</code>=<strong><em><code>True</code></em></strong>)</p>
 </blockquote>
 <p>Save model and optimizer state (if <code>with_opt</code>) with <code>name</code> to <code>self.model_dir</code>.</p>
 
@@ -2013,7 +2013,7 @@ Total time: 00:06 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Learner.load"><code>load</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L242" class="source_link">[source]</a></h4><blockquote><p><code>load</code>(<strong><code>name</code></strong>:<code>PathOrStr</code>, <strong><code>device</code></strong>:<a href="https://pytorch.org/docs/stable/tensor_attributes.html#torch-device"><code>device</code></a>=<strong><em><code>None</code></em></strong>, <strong><code>strict</code></strong>:<code>bool</code>=<strong><em><code>True</code></em></strong>, <strong><code>with_opt</code></strong>:<code>bool</code>=<strong><em><code>None</code></em></strong>, <strong><code>purge</code></strong>:<code>bool</code>=<strong><em><code>True</code></em></strong>)</p>
+<h4 id="Learner.load"><code>load</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L236" class="source_link">[source]</a></h4><blockquote><p><code>load</code>(<strong><code>name</code></strong>:<code>PathOrStr</code>, <strong><code>device</code></strong>:<a href="https://pytorch.org/docs/stable/tensor_attributes.html#torch-device"><code>device</code></a>=<strong><em><code>None</code></em></strong>, <strong><code>strict</code></strong>:<code>bool</code>=<strong><em><code>True</code></em></strong>, <strong><code>with_opt</code></strong>:<code>bool</code>=<strong><em><code>None</code></em></strong>, <strong><code>purge</code></strong>:<code>bool</code>=<strong><em><code>True</code></em></strong>)</p>
 </blockquote>
 <p>Load model and optimizer state (if <code>with_opt</code>) <code>name</code> from <code>self.model_dir</code> using <code>device</code>.</p>
 
@@ -2060,7 +2060,7 @@ Total time: 00:06 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Learner.export"><code>export</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L209" class="source_link">[source]</a></h4><blockquote><p><code>export</code>(<strong><code>fname</code></strong>:<code>str</code>=<strong><em><code>'export.pkl'</code></em></strong>)</p>
+<h4 id="Learner.export"><code>export</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L207" class="source_link">[source]</a></h4><blockquote><p><code>export</code>(<strong><code>fname</code></strong>:<code>str</code>=<strong><em><code>'export.pkl'</code></em></strong>, <strong><code>destroy</code></strong>=<strong><em><code>False</code></em></strong>)</p>
 </blockquote>
 <p>Export the state of the <a href="/basic_train.html#Learner"><code>Learner</code></a> in <code>self.path/fname</code>.</p>
 
@@ -2074,6 +2074,7 @@ Total time: 00:06 <p><table style='width:300px; margin-bottom:10px'>
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
+<p>Passing <code>destroy=True</code> will destroy the <a href="/basic_train.html#Learner"><code>Learner</code></a>, freeing most of its memory consumption. For specifics see <a href="/basic_train.html#Learner.destroy"><code>Learner.destroy</code></a>.</p>
 <p>This method only works with the <a href="/basic_train.html#Learner"><code>Learner</code></a> whose <a href="/vision.data.html#vision.data"><code>data</code></a> was created through the <a href="/data_block.html">data block API</a>.</p>
 <p>Otherwise, you will have to create a <a href="/basic_train.html#Learner"><code>Learner</code></a> yourself at inference and load the model with <a href="/basic_train.html#Learner.load"><code>Learner.load</code></a>.</p>
 
@@ -2145,7 +2146,7 @@ Total time: 00:06 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="load_learner"><code>load_learner</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L530" class="source_link">[source]</a></h4><blockquote><p><code>load_learner</code>(<strong><code>path</code></strong>:<code>PathOrStr</code>, <strong><code>fname</code></strong>:<code>PathOrStr</code>=<strong><em><code>'export.pkl'</code></em></strong>, <strong><code>test</code></strong>:<a href="/data_block.html#ItemList"><code>ItemList</code></a>=<strong><em><code>None</code></em></strong>)</p>
+<h4 id="load_learner"><code>load_learner</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L524" class="source_link">[source]</a></h4><blockquote><p><code>load_learner</code>(<strong><code>path</code></strong>:<code>PathOrStr</code>, <strong><code>fname</code></strong>:<code>PathOrStr</code>=<strong><em><code>'export.pkl'</code></em></strong>, <strong><code>test</code></strong>:<a href="/data_block.html#ItemList"><code>ItemList</code></a>=<strong><em><code>None</code></em></strong>)</p>
 </blockquote>
 <p>Load a <a href="/basic_train.html#Learner"><code>Learner</code></a> object saved with <code>export_state</code> in <code>path/fn</code> with empty data, optionally add <code>test</code> and load on <code>cpu</code>.</p>
 
@@ -2208,7 +2209,7 @@ Total time: 00:06 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Learner.purge"><code>purge</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L277" class="source_link">[source]</a></h4><blockquote><p><code>purge</code>(<strong><code>clear_opt</code></strong>:<code>bool</code>=<strong><em><code>True</code></em></strong>)</p>
+<h4 id="Learner.purge"><code>purge</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L271" class="source_link">[source]</a></h4><blockquote><p><code>purge</code>(<strong><code>clear_opt</code></strong>:<code>bool</code>=<strong><em><code>True</code></em></strong>)</p>
 </blockquote>
 <p>Purge the <a href="/basic_train.html#Learner"><code>Learner</code></a> of all cached attributes to release some GPU memory.</p>
 
@@ -2236,7 +2237,7 @@ Total time: 00:06 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Learner.destroy"><code>destroy</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L260" class="source_link">[source]</a></h4><blockquote><p><code>destroy</code>()</p>
+<h4 id="Learner.destroy"><code>destroy</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L254" class="source_link">[source]</a></h4><blockquote><p><code>destroy</code>()</p>
 </blockquote>
 <p>Free the Learner internals, leaving just an empty shell that consumes no memory</p>
 
@@ -2251,34 +2252,7 @@ Total time: 00:06 <p><table style='width:300px; margin-bottom:10px'>
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>If you need to free the memory consumed by the <a href="/basic_train.html#Learner"><code>Learner</code></a> object, call this method.</p>
-
-</div>
-</div>
-</div>
-<div class="cell border-box-sizing code_cell rendered">
-
-<div class="output_wrapper">
-<div class="output">
-
-<div class="output_area">
-
-
-<div class="output_markdown rendered_html output_subarea ">
-<h4 id="Learner.hibernate"><code>hibernate</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L224" class="source_link">[source]</a></h4><blockquote><p><code>hibernate</code>(<strong><code>fname</code></strong>:<code>str</code>=<strong><em><code>'export.pkl'</code></em></strong>)</p>
-</blockquote>
-<p>Export the state of the <a href="/basic_train.html#Learner"><code>Learner</code></a> in <code>self.path/fname</code> and remove the object from memory. Use <a href="/basic_train.html#load_learner"><code>load_learner</code></a> to restore.</p>
-
-</div>
-
-</div>
-
-</div>
-</div>
-
-</div>
-<div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
-<div class="text_cell_render border-box-sizing rendered_html">
-<p>This is just a convenience method that combines <code>export</code> and <code>destroy</code> in one method. As such, this method only works with the <a href="/basic_train.html#Learner"><code>Learner</code></a> whose <a href="/vision.data.html#vision.data"><code>data</code></a> was created through the <a href="/data_block.html">data block API</a>. See <a href="/basic_train.html#Learner.export"><code>Learner.export</code></a>.</p>
+<p>It can also be automatically invoked through <a href="/basic_train.html#Learner.export"><code>Learner.export</code></a> via its <code>destroy=True</code> argument.</p>
 
 </div>
 </div>
@@ -2298,7 +2272,7 @@ Total time: 00:06 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Learner.init"><code>init</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L161" class="source_link">[source]</a></h4><blockquote><p><code>init</code>(<strong><code>init</code></strong>)</p>
+<h4 id="Learner.init"><code>init</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L159" class="source_link">[source]</a></h4><blockquote><p><code>init</code>(<strong><code>init</code></strong>)</p>
 </blockquote>
 
 </div>
@@ -2353,7 +2327,7 @@ Total time: 00:06 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Learner.backward"><code>backward</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L327" class="source_link">[source]</a></h4><blockquote><p><code>backward</code>(<strong><code>item</code></strong>)</p>
+<h4 id="Learner.backward"><code>backward</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L321" class="source_link">[source]</a></h4><blockquote><p><code>backward</code>(<strong><code>item</code></strong>)</p>
 </blockquote>
 <p>Pass <code>item</code> through the model and computes the gradient. Useful if <code>backward_hooks</code> are attached.</p>
 
@@ -2374,7 +2348,7 @@ Total time: 00:06 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Learner.create_opt"><code>create_opt</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L181" class="source_link">[source]</a></h4><blockquote><p><code>create_opt</code>(<strong><code>lr</code></strong>:<code>Floats</code>, <strong><code>wd</code></strong>:<code>Floats</code>=<strong><em><code>0.0</code></em></strong>)</p>
+<h4 id="Learner.create_opt"><code>create_opt</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L179" class="source_link">[source]</a></h4><blockquote><p><code>create_opt</code>(<strong><code>lr</code></strong>:<code>Floats</code>, <strong><code>wd</code></strong>:<code>Floats</code>=<strong><em><code>0.0</code></em></strong>)</p>
 </blockquote>
 <p>Create optimizer with <code>lr</code> learning rate and <code>wd</code> weight decay.</p>
 
@@ -2402,7 +2376,7 @@ Total time: 00:06 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Learner.dl"><code>dl</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L238" class="source_link">[source]</a></h4><blockquote><p><code>dl</code>(<strong><code>ds_type</code></strong>:<a href="/basic_data.html#DatasetType"><code>DatasetType</code></a>=<strong><em><code>&lt;DatasetType.Valid: 2&gt;</code></em></strong>)</p>
+<h4 id="Learner.dl"><code>dl</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L232" class="source_link">[source]</a></h4><blockquote><p><code>dl</code>(<strong><code>ds_type</code></strong>:<a href="/basic_data.html#DatasetType"><code>DatasetType</code></a>=<strong><em><code>&lt;DatasetType.Valid: 2&gt;</code></em></strong>)</p>
 </blockquote>
 <p>Return DataLoader for DatasetType <code>ds_type</code>.</p>
 
@@ -2481,7 +2455,7 @@ Total time: 00:06 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h2 id="Recorder"><code>class</code> <code>Recorder</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L409" class="source_link">[source]</a></h2><blockquote><p><code>Recorder</code>(<strong><code>learn</code></strong>:<a href="/basic_train.html#Learner"><code>Learner</code></a>) :: <a href="/basic_train.html#LearnerCallback"><code>LearnerCallback</code></a></p>
+<h2 id="Recorder"><code>class</code> <code>Recorder</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L403" class="source_link">[source]</a></h2><blockquote><p><code>Recorder</code>(<strong><code>learn</code></strong>:<a href="/basic_train.html#Learner"><code>Learner</code></a>) :: <a href="/basic_train.html#LearnerCallback"><code>LearnerCallback</code></a></p>
 </blockquote>
 <p>A <a href="/basic_train.html#LearnerCallback"><code>LearnerCallback</code></a> that records epoch, loss, opt and metric data during training.</p>
 
@@ -2515,7 +2489,7 @@ Total time: 00:06 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Recorder.plot"><code>plot</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L479" class="source_link">[source]</a></h4><blockquote><p><code>plot</code>(<strong><code>skip_start</code></strong>:<code>int</code>=<strong><em><code>10</code></em></strong>, <strong><code>skip_end</code></strong>:<code>int</code>=<strong><em><code>5</code></em></strong>)</p>
+<h4 id="Recorder.plot"><code>plot</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L473" class="source_link">[source]</a></h4><blockquote><p><code>plot</code>(<strong><code>skip_start</code></strong>:<code>int</code>=<strong><em><code>10</code></em></strong>, <strong><code>skip_end</code></strong>:<code>int</code>=<strong><em><code>5</code></em></strong>)</p>
 </blockquote>
 <p>Plot learning rate and losses, trimmed between <code>skip_start</code> and <code>skip_end</code>. Optionally plot and return min gradient</p>
 
@@ -2608,7 +2582,7 @@ Min numerical gradient: 7.59E-03
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Recorder.plot_losses"><code>plot_losses</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L494" class="source_link">[source]</a></h4><blockquote><p><code>plot_losses</code>(<strong><code>last</code></strong>:<code>int</code>=<strong><em><code>None</code></em></strong>)</p>
+<h4 id="Recorder.plot_losses"><code>plot_losses</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L488" class="source_link">[source]</a></h4><blockquote><p><code>plot_losses</code>(<strong><code>last</code></strong>:<code>int</code>=<strong><em><code>None</code></em></strong>)</p>
 </blockquote>
 <p>Plot training and validation losses.</p>
 
@@ -2715,7 +2689,7 @@ Total time: 00:22 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Recorder.plot_lr"><code>plot_lr</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L466" class="source_link">[source]</a></h4><blockquote><p><code>plot_lr</code>(<strong><code>show_moms</code></strong>=<strong><em><code>False</code></em></strong>)</p>
+<h4 id="Recorder.plot_lr"><code>plot_lr</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L460" class="source_link">[source]</a></h4><blockquote><p><code>plot_lr</code>(<strong><code>show_moms</code></strong>=<strong><em><code>False</code></em></strong>)</p>
 </blockquote>
 <p>Plot learning rate, <code>show_moms</code> to include momentum.</p>
 
@@ -2798,7 +2772,7 @@ Total time: 00:22 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Recorder.plot_metrics"><code>plot_metrics</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L509" class="source_link">[source]</a></h4><blockquote><p><code>plot_metrics</code>()</p>
+<h4 id="Recorder.plot_metrics"><code>plot_metrics</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L503" class="source_link">[source]</a></h4><blockquote><p><code>plot_metrics</code>()</p>
 </blockquote>
 <p>Plot metrics collected during training.</p>
 
@@ -2870,7 +2844,7 @@ Total time: 00:22 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Recorder.on_backward_begin"><code>on_backward_begin</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L433" class="source_link">[source]</a></h4><blockquote><p><code>on_backward_begin</code>(<strong><code>smooth_loss</code></strong>:<code>Tensor</code>, <strong>**<code>kwargs</code></strong>:<code>Any</code>)</p>
+<h4 id="Recorder.on_backward_begin"><code>on_backward_begin</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L427" class="source_link">[source]</a></h4><blockquote><p><code>on_backward_begin</code>(<strong><code>smooth_loss</code></strong>:<code>Tensor</code>, <strong>**<code>kwargs</code></strong>:<code>Any</code>)</p>
 </blockquote>
 <p>Record the loss before any other callback has a chance to modify it.</p>
 
@@ -2891,7 +2865,7 @@ Total time: 00:22 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Recorder.on_batch_begin"><code>on_batch_begin</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L427" class="source_link">[source]</a></h4><blockquote><p><code>on_batch_begin</code>(<strong><code>train</code></strong>, <strong>**<code>kwargs</code></strong>:<code>Any</code>)</p>
+<h4 id="Recorder.on_batch_begin"><code>on_batch_begin</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L421" class="source_link">[source]</a></h4><blockquote><p><code>on_batch_begin</code>(<strong><code>train</code></strong>, <strong>**<code>kwargs</code></strong>:<code>Any</code>)</p>
 </blockquote>
 <p>Record learning rate and momentum at beginning of batch.</p>
 
@@ -2912,7 +2886,7 @@ Total time: 00:22 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Recorder.on_epoch_end"><code>on_epoch_end</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L439" class="source_link">[source]</a></h4><blockquote><p><code>on_epoch_end</code>(<strong><code>epoch</code></strong>:<code>int</code>, <strong><code>num_batch</code></strong>:<code>int</code>, <strong><code>smooth_loss</code></strong>:<code>Tensor</code>, <strong><code>last_metrics</code></strong>=<strong><em><code>typing.Collection[typing.Union[torch.Tensor, numbers.Number]]</code></em></strong>, <strong>**<code>kwargs</code></strong>:<code>Any</code>) → <code>bool</code></p>
+<h4 id="Recorder.on_epoch_end"><code>on_epoch_end</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L433" class="source_link">[source]</a></h4><blockquote><p><code>on_epoch_end</code>(<strong><code>epoch</code></strong>:<code>int</code>, <strong><code>num_batch</code></strong>:<code>int</code>, <strong><code>smooth_loss</code></strong>:<code>Tensor</code>, <strong><code>last_metrics</code></strong>=<strong><em><code>typing.Collection[typing.Union[torch.Tensor, numbers.Number]]</code></em></strong>, <strong>**<code>kwargs</code></strong>:<code>Any</code>) → <code>bool</code></p>
 </blockquote>
 <p>Save epoch info: num_batch, smooth_loss, metrics.</p>
 
@@ -2933,7 +2907,7 @@ Total time: 00:22 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Recorder.on_train_begin"><code>on_train_begin</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L418" class="source_link">[source]</a></h4><blockquote><p><code>on_train_begin</code>(<strong><code>pbar</code></strong>:<code>PBar</code>, <strong><code>metrics_names</code></strong>:<code>StrList</code>, <strong>**<code>kwargs</code></strong>:<code>Any</code>)</p>
+<h4 id="Recorder.on_train_begin"><code>on_train_begin</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L412" class="source_link">[source]</a></h4><blockquote><p><code>on_train_begin</code>(<strong><code>pbar</code></strong>:<code>PBar</code>, <strong><code>metrics_names</code></strong>:<code>StrList</code>, <strong>**<code>kwargs</code></strong>:<code>Any</code>)</p>
 </blockquote>
 <p>Initialize recording status at beginning of training.</p>
 
@@ -2967,7 +2941,7 @@ Total time: 00:22 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Recorder.add_metrics"><code>add_metrics</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L458" class="source_link">[source]</a></h4><blockquote><p><code>add_metrics</code>(<strong><code>metrics</code></strong>)</p>
+<h4 id="Recorder.add_metrics"><code>add_metrics</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L452" class="source_link">[source]</a></h4><blockquote><p><code>add_metrics</code>(<strong><code>metrics</code></strong>)</p>
 </blockquote>
 <p>Add <code>metrics</code> to the inner stats.</p>
 
@@ -2988,7 +2962,7 @@ Total time: 00:22 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Recorder.add_metric_names"><code>add_metric_names</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L462" class="source_link">[source]</a></h4><blockquote><p><code>add_metric_names</code>(<strong><code>names</code></strong>)</p>
+<h4 id="Recorder.add_metric_names"><code>add_metric_names</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L456" class="source_link">[source]</a></h4><blockquote><p><code>add_metric_names</code>(<strong><code>names</code></strong>)</p>
 </blockquote>
 <p>Add <code>names</code> to the inner metric names.</p>
 
@@ -3009,7 +2983,7 @@ Total time: 00:22 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Recorder.format_stats"><code>format_stats</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L451" class="source_link">[source]</a></h4><blockquote><p><code>format_stats</code>(<strong><code>stats</code></strong>:<code>MetricsList</code>)</p>
+<h4 id="Recorder.format_stats"><code>format_stats</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L445" class="source_link">[source]</a></h4><blockquote><p><code>format_stats</code>(<strong><code>stats</code></strong>:<code>MetricsList</code>)</p>
 </blockquote>
 <p>Format stats before printing.</p>
 
@@ -3043,7 +3017,7 @@ Total time: 00:22 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="fit"><code>fit</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L73" class="source_link">[source]</a></h4><blockquote><p><code>fit</code>(<strong><code>epochs</code></strong>:<code>int</code>, <strong><code>model</code></strong>:<a href="https://pytorch.org/docs/stable/nn.html#torch.nn.Module"><code>Module</code></a>, <strong><code>loss_func</code></strong>:<code>LossFunction</code>, <strong><code>opt</code></strong>:<a href="https://pytorch.org/docs/stable/optim.html#torch.optim.Optimizer"><code>Optimizer</code></a>, <strong><code>data</code></strong>:<a href="/basic_data.html#DataBunch"><code>DataBunch</code></a>, <strong><code>callbacks</code></strong>:<code>Optional</code>[<code>Collection</code>[<a href="/callback.html#Callback"><code>Callback</code></a>]]=<strong><em><code>None</code></em></strong>, <strong><code>metrics</code></strong>:<code>OptMetrics</code>=<strong><em><code>None</code></em></strong>)</p>
+<h4 id="fit"><code>fit</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L71" class="source_link">[source]</a></h4><blockquote><p><code>fit</code>(<strong><code>epochs</code></strong>:<code>int</code>, <strong><code>model</code></strong>:<a href="https://pytorch.org/docs/stable/nn.html#torch.nn.Module"><code>Module</code></a>, <strong><code>loss_func</code></strong>:<code>LossFunction</code>, <strong><code>opt</code></strong>:<a href="https://pytorch.org/docs/stable/optim.html#torch.optim.Optimizer"><code>Optimizer</code></a>, <strong><code>data</code></strong>:<a href="/basic_data.html#DataBunch"><code>DataBunch</code></a>, <strong><code>callbacks</code></strong>:<code>Optional</code>[<code>Collection</code>[<a href="/callback.html#Callback"><code>Callback</code></a>]]=<strong><em><code>None</code></em></strong>, <strong><code>metrics</code></strong>:<code>OptMetrics</code>=<strong><em><code>None</code></em></strong>)</p>
 </blockquote>
 <p>Fit the <code>model</code> on <code>data</code> and learn using <code>loss_func</code> and <code>opt</code>.</p>
 
@@ -3071,7 +3045,7 @@ Total time: 00:22 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="train_epoch"><code>train_epoch</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L64" class="source_link">[source]</a></h4><blockquote><p><code>train_epoch</code>(<strong><code>model</code></strong>:<a href="https://pytorch.org/docs/stable/nn.html#torch.nn.Module"><code>Module</code></a>, <strong><code>dl</code></strong>:<a href="https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader"><code>DataLoader</code></a>, <strong><code>opt</code></strong>:<a href="https://pytorch.org/docs/stable/optim.html#torch.optim.Optimizer"><code>Optimizer</code></a>, <strong><code>loss_func</code></strong>:<code>LossFunction</code>)</p>
+<h4 id="train_epoch"><code>train_epoch</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L62" class="source_link">[source]</a></h4><blockquote><p><code>train_epoch</code>(<strong><code>model</code></strong>:<a href="https://pytorch.org/docs/stable/nn.html#torch.nn.Module"><code>Module</code></a>, <strong><code>dl</code></strong>:<a href="https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader"><code>DataLoader</code></a>, <strong><code>opt</code></strong>:<a href="https://pytorch.org/docs/stable/optim.html#torch.optim.Optimizer"><code>Optimizer</code></a>, <strong><code>loss_func</code></strong>:<code>LossFunction</code>)</p>
 </blockquote>
 <p>Simple training of <code>model</code> for 1 epoch of <code>dl</code> using optim <code>opt</code> and loss function <code>loss_func</code>.</p>
 
@@ -3099,7 +3073,7 @@ Total time: 00:22 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="validate"><code>validate</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L46" class="source_link">[source]</a></h4><blockquote><p><code>validate</code>(<strong><code>model</code></strong>:<a href="https://pytorch.org/docs/stable/nn.html#torch.nn.Module"><code>Module</code></a>, <strong><code>dl</code></strong>:<a href="https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader"><code>DataLoader</code></a>, <strong><code>loss_func</code></strong>:<code>OptLossFunc</code>=<strong><em><code>None</code></em></strong>, <strong><code>cb_handler</code></strong>:<code>Optional</code>[<a href="/callback.html#CallbackHandler"><code>CallbackHandler</code></a>]=<strong><em><code>None</code></em></strong>, <strong><code>pbar</code></strong>:<code>Union</code>[<code>MasterBar</code>, <code>ProgressBar</code>, <code>NoneType</code>]=<strong><em><code>None</code></em></strong>, <strong><code>average</code></strong>=<strong><em><code>True</code></em></strong>, <strong><code>n_batch</code></strong>:<code>Optional</code>[<code>int</code>]=<strong><em><code>None</code></em></strong>) → <code>Iterator</code>[<code>Tuple</code>[<code>IntOrTensor</code>, <code>Ellipsis</code>]]</p>
+<h4 id="validate"><code>validate</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L44" class="source_link">[source]</a></h4><blockquote><p><code>validate</code>(<strong><code>model</code></strong>:<a href="https://pytorch.org/docs/stable/nn.html#torch.nn.Module"><code>Module</code></a>, <strong><code>dl</code></strong>:<a href="https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader"><code>DataLoader</code></a>, <strong><code>loss_func</code></strong>:<code>OptLossFunc</code>=<strong><em><code>None</code></em></strong>, <strong><code>cb_handler</code></strong>:<code>Optional</code>[<a href="/callback.html#CallbackHandler"><code>CallbackHandler</code></a>]=<strong><em><code>None</code></em></strong>, <strong><code>pbar</code></strong>:<code>Union</code>[<code>MasterBar</code>, <code>ProgressBar</code>, <code>NoneType</code>]=<strong><em><code>None</code></em></strong>, <strong><code>average</code></strong>=<strong><em><code>True</code></em></strong>, <strong><code>n_batch</code></strong>:<code>Optional</code>[<code>int</code>]=<strong><em><code>None</code></em></strong>) → <code>Iterator</code>[<code>Tuple</code>[<code>IntOrTensor</code>, <code>Ellipsis</code>]]</p>
 </blockquote>
 <p>Calculate <code>loss_func</code> of <code>model</code> on <code>dl</code> in evaluation mode.</p>
 
@@ -3127,7 +3101,7 @@ Total time: 00:22 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="get_preds"><code>get_preds</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L37" class="source_link">[source]</a></h4><blockquote><p><code>get_preds</code>(<strong><code>model</code></strong>:<a href="https://pytorch.org/docs/stable/nn.html#torch.nn.Module"><code>Module</code></a>, <strong><code>dl</code></strong>:<a href="https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader"><code>DataLoader</code></a>, <strong><code>pbar</code></strong>:<code>Union</code>[<code>MasterBar</code>, <code>ProgressBar</code>, <code>NoneType</code>]=<strong><em><code>None</code></em></strong>, <strong><code>cb_handler</code></strong>:<code>Optional</code>[<a href="/callback.html#CallbackHandler"><code>CallbackHandler</code></a>]=<strong><em><code>None</code></em></strong>, <strong><code>activ</code></strong>:<a href="https://pytorch.org/docs/stable/nn.html#torch.nn.Module"><code>Module</code></a>=<strong><em><code>None</code></em></strong>, <strong><code>loss_func</code></strong>:<code>OptLossFunc</code>=<strong><em><code>None</code></em></strong>, <strong><code>n_batch</code></strong>:<code>Optional</code>[<code>int</code>]=<strong><em><code>None</code></em></strong>) → <code>List</code>[<code>Tensor</code>]</p>
+<h4 id="get_preds"><code>get_preds</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L35" class="source_link">[source]</a></h4><blockquote><p><code>get_preds</code>(<strong><code>model</code></strong>:<a href="https://pytorch.org/docs/stable/nn.html#torch.nn.Module"><code>Module</code></a>, <strong><code>dl</code></strong>:<a href="https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader"><code>DataLoader</code></a>, <strong><code>pbar</code></strong>:<code>Union</code>[<code>MasterBar</code>, <code>ProgressBar</code>, <code>NoneType</code>]=<strong><em><code>None</code></em></strong>, <strong><code>cb_handler</code></strong>:<code>Optional</code>[<a href="/callback.html#CallbackHandler"><code>CallbackHandler</code></a>]=<strong><em><code>None</code></em></strong>, <strong><code>activ</code></strong>:<a href="https://pytorch.org/docs/stable/nn.html#torch.nn.Module"><code>Module</code></a>=<strong><em><code>None</code></em></strong>, <strong><code>loss_func</code></strong>:<code>OptLossFunc</code>=<strong><em><code>None</code></em></strong>, <strong><code>n_batch</code></strong>:<code>Optional</code>[<code>int</code>]=<strong><em><code>None</code></em></strong>) → <code>List</code>[<code>Tensor</code>]</p>
 </blockquote>
 <p>Tuple of predictions and targets, and optional losses (if <code>loss_func</code>) using <code>dl</code>, max batches <code>n_batch</code>.</p>
 
@@ -3182,7 +3156,7 @@ Total time: 00:22 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h3 id="LearnerCallback"><code>class</code> <code>LearnerCallback</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L391" class="source_link">[source]</a></h3><blockquote><p><code>LearnerCallback</code>(<strong><code>learn</code></strong>) :: <a href="/callback.html#Callback"><code>Callback</code></a></p>
+<h3 id="LearnerCallback"><code>class</code> <code>LearnerCallback</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L385" class="source_link">[source]</a></h3><blockquote><p><code>LearnerCallback</code>(<strong><code>learn</code></strong>) :: <a href="/callback.html#Callback"><code>Callback</code></a></p>
 </blockquote>
 <p>Base class for creating callbacks for a <a href="/basic_train.html#Learner"><code>Learner</code></a>.</p>
 
@@ -3203,7 +3177,7 @@ Total time: 00:22 <p><table style='width:300px; margin-bottom:10px'>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h3 id="RecordOnCPU"><code>class</code> <code>RecordOnCPU</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L386" class="source_link">[source]</a></h3><blockquote><p><code>RecordOnCPU</code>() :: <a href="/callback.html#Callback"><code>Callback</code></a></p>
+<h3 id="RecordOnCPU"><code>class</code> <code>RecordOnCPU</code><a href="https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L380" class="source_link">[source]</a></h3><blockquote><p><code>RecordOnCPU</code>() :: <a href="/callback.html#Callback"><code>Callback</code></a></p>
 </blockquote>
 <p>Store the <code>input</code> and <code>target</code> going through the model on the CPU.</p>
 

--- a/docs/dev/develop.md
+++ b/docs/dev/develop.md
@@ -151,7 +151,7 @@ Here are the quick copy-n-paste recipes (that assume you don't have anything els
    ```
    tools/trust-origin-git-config -d
    tools/fastai-nbstripout -d nbs/*/*ipynb
-   git commit docs_src courses examples
+   git commit nbs
    git push
    tools/trust-origin-git-config -e
    ```
@@ -172,7 +172,7 @@ Here are the quick copy-n-paste recipes (that assume you don't have anything els
    ```
    python tools\trust-origin-git-config -d
    python tools\fastai-nbstripout -d nbs\*\*ipynb
-   git commit docs_src courses examples
+   git commit nbs
    git push
    python tools\trust-origin-git-config -e
    ```

--- a/docs/dev/develop.md
+++ b/docs/dev/develop.md
@@ -133,6 +133,50 @@ In the `fastai_docs` repo, we have two different types of notebooks: "code" and 
    tools/fastai-nbstripout -d docs/*ipynb docs/*/*ipynb
    ```
 
+Here are the quick copy-n-paste recipes (that assume you don't have anything else modified):
+
+* Unix:
+
+   The `fastai` repo:
+   ```
+   tools/trust-origin-git-config -d
+   tools/fastai-nbstripout -d docs_src/*ipynb courses/*/*ipynb examples/*ipynb
+   git commit docs_src courses examples
+   git push
+   tools/trust-origin-git-config -e
+   ```
+
+   The `course-v3` repo:
+
+   ```
+   tools/trust-origin-git-config -d
+   tools/fastai-nbstripout -d nbs/*/*ipynb
+   git commit docs_src courses examples
+   git push
+   tools/trust-origin-git-config -e
+   ```
+
+* Windows:
+
+   The `fastai` repo:
+   ```
+   python tools\trust-origin-git-config -d
+   python tools\fastai-nbstripout -d docs_src\*ipynb courses\*\*ipynb examples\*ipynb
+   git commit docs_src courses examples
+   git push
+   python tools\trust-origin-git-config -e
+   ```
+
+   The `course-v3` repo:
+
+   ```
+   python tools\trust-origin-git-config -d
+   python tools\fastai-nbstripout -d nbs\*\*ipynb
+   git commit docs_src courses examples
+   git push
+   python tools\trust-origin-git-config -e
+   ```
+
 
 ## Development Editable Install
 

--- a/docs/dev/test.md
+++ b/docs/dev/test.md
@@ -835,22 +835,20 @@ This section is currently focused on GPU RAM since it's the scarce resource, but
 
 In some situations you may want to remove randomness for your tests. To get identical reproducable results set, you'll need to set `num_workers=1` (or 0) in your DataLoader/DataBunch, and depending on whether you are using `torch`'s random functions, or python's (`numpy`) or both:
 
-* torch RNG
+```
+seed = 42
 
-   ```
-   import torch
-   torch.manual_seed(42)
-   torch.backends.cudnn.deterministic = True
-   ```
+# python RNG
+random.seed(seed)
 
-* python RNG
+# torch RNG
+import torch
+torch.manual_seed(seed)
+torch.backends.cudnn.deterministic = True
 
-   ```
-   random.seed(42)
-   ```
-
-
-
+# numpy NRG
+np.random.seed(seed)
+```
 
 ### Debugging tests
 

--- a/docs/utils.mem.html
+++ b/docs/utils.mem.html
@@ -34,7 +34,7 @@ sidebar: home_sidebar
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="gpu_mem_get"><code>gpu_mem_get</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L26" class="source_link">[source]</a></h4><blockquote><p><code>gpu_mem_get</code>(<strong><code>id</code></strong>=<strong><em><code>None</code></em></strong>)</p>
+<h4 id="gpu_mem_get"><code>gpu_mem_get</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L52" class="source_link">[source]</a></h4><blockquote><p><code>gpu_mem_get</code>(<strong><code>id</code></strong>=<strong><em><code>None</code></em></strong>)</p>
 </blockquote>
 <p>get total, used and free memory (in MBs) for gpu <code>id</code>. if <code>id</code> is not passed, currently selected torch device is used</p>
 
@@ -50,7 +50,7 @@ sidebar: home_sidebar
 <div class="text_cell_render border-box-sizing rendered_html">
 <p><a href="/utils.mem.html#gpu_mem_get"><code>gpu_mem_get</code></a></p>
 <ul>
-<li>for gpu returns <code>GPUMemory(total, used, free)</code></li>
+<li>for gpu returns <code>GPUMemory(total, free, used)</code></li>
 <li>for cpu returns <code>GPUMemory(0, 0, 0)</code></li>
 <li>for invalid gpu id returns <code>GPUMemory(0, 0, 0)</code></li>
 </ul>
@@ -67,7 +67,7 @@ sidebar: home_sidebar
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="gpu_mem_get_all"><code>gpu_mem_get_all</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L37" class="source_link">[source]</a></h4><blockquote><p><code>gpu_mem_get_all</code>()</p>
+<h4 id="gpu_mem_get_all"><code>gpu_mem_get_all</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L63" class="source_link">[source]</a></h4><blockquote><p><code>gpu_mem_get_all</code>()</p>
 </blockquote>
 <p>get total, used and free memory (in MBs) for each available gpu</p>
 
@@ -83,7 +83,7 @@ sidebar: home_sidebar
 <div class="text_cell_render border-box-sizing rendered_html">
 <p><a href="/utils.mem.html#gpu_mem_get_all"><code>gpu_mem_get_all</code></a></p>
 <ul>
-<li>for gpu returns <code>[ GPUMemory(total_0, used_0, free_0), GPUMemory(total_1, used_1, free_1), .... ]</code></li>
+<li>for gpu returns <code>[ GPUMemory(total_0, free_0, used_0), GPUMemory(total_1, free_1, used_1), .... ]</code></li>
 <li>for cpu returns <code>[]</code></li>
 </ul>
 
@@ -99,7 +99,7 @@ sidebar: home_sidebar
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="gpu_mem_get_free_no_cache"><code>gpu_mem_get_free_no_cache</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L42" class="source_link">[source]</a></h4><blockquote><p><code>gpu_mem_get_free_no_cache</code>()</p>
+<h4 id="gpu_mem_get_free_no_cache"><code>gpu_mem_get_free_no_cache</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L68" class="source_link">[source]</a></h4><blockquote><p><code>gpu_mem_get_free_no_cache</code>()</p>
 </blockquote>
 <p>get free memory (in MBs) for the currently selected gpu id, after emptying the cache</p>
 
@@ -127,7 +127,7 @@ sidebar: home_sidebar
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="gpu_mem_get_used_no_cache"><code>gpu_mem_get_used_no_cache</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L47" class="source_link">[source]</a></h4><blockquote><p><code>gpu_mem_get_used_no_cache</code>()</p>
+<h4 id="gpu_mem_get_used_no_cache"><code>gpu_mem_get_used_no_cache</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L73" class="source_link">[source]</a></h4><blockquote><p><code>gpu_mem_get_used_no_cache</code>()</p>
 </blockquote>
 <p>get used memory (in MBs) for the currently selected gpu id, after emptying the cache</p>
 
@@ -155,7 +155,7 @@ sidebar: home_sidebar
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="gpu_mem_get_used_fast"><code>gpu_mem_get_used_fast</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L52" class="source_link">[source]</a></h4><blockquote><p><code>gpu_mem_get_used_fast</code>(<strong><code>gpu_handle</code></strong>)</p>
+<h4 id="gpu_mem_get_used_fast"><code>gpu_mem_get_used_fast</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L78" class="source_link">[source]</a></h4><blockquote><p><code>gpu_mem_get_used_fast</code>(<strong><code>gpu_handle</code></strong>)</p>
 </blockquote>
 <p>get used memory (in MBs) for the currently selected gpu id, w/o emptying the cache, and needing the <code>gpu_handle</code> arg</p>
 
@@ -183,7 +183,7 @@ sidebar: home_sidebar
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="gpu_with_max_free_mem"><code>gpu_with_max_free_mem</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L57" class="source_link">[source]</a></h4><blockquote><p><code>gpu_with_max_free_mem</code>()</p>
+<h4 id="gpu_with_max_free_mem"><code>gpu_with_max_free_mem</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L83" class="source_link">[source]</a></h4><blockquote><p><code>gpu_with_max_free_mem</code>()</p>
 </blockquote>
 <p>get [gpu_id, its_free_ram] for the first gpu with highest available RAM</p>
 
@@ -215,7 +215,7 @@ sidebar: home_sidebar
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="preload_pytorch"><code>preload_pytorch</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L19" class="source_link">[source]</a></h4><blockquote><p><code>preload_pytorch</code>()</p>
+<h4 id="preload_pytorch"><code>preload_pytorch</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L45" class="source_link">[source]</a></h4><blockquote><p><code>preload_pytorch</code>()</p>
 </blockquote>
 
 </div>
@@ -242,9 +242,9 @@ sidebar: home_sidebar
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="GPUMemory"><code>class</code> <code>GPUMemory</code></h4><blockquote><p><code>GPUMemory</code>(<strong><code>total</code></strong>, <strong><code>used</code></strong>, <strong><code>free</code></strong>) :: <code>tuple</code></p>
+<h4 id="GPUMemory"><code>class</code> <code>GPUMemory</code></h4><blockquote><p><code>GPUMemory</code>(<strong><code>total</code></strong>, <strong><code>free</code></strong>, <strong><code>used</code></strong>) :: <code>tuple</code></p>
 </blockquote>
-<p>GPUMemory(total, used, free)</p>
+<p>GPUMemory(total, free, used)</p>
 
 </div>
 
@@ -270,7 +270,7 @@ sidebar: home_sidebar
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="b2mb"><code>b2mb</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L22" class="source_link">[source]</a></h4><blockquote><p><code>b2mb</code>(<strong><code>num</code></strong>)</p>
+<h4 id="b2mb"><code>b2mb</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L48" class="source_link">[source]</a></h4><blockquote><p><code>b2mb</code>(<strong><code>num</code></strong>)</p>
 </blockquote>
 <p>convert Bs to MBs and round down</p>
 
@@ -304,7 +304,7 @@ sidebar: home_sidebar
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="GPUMemTrace"><code>class</code> <code>GPUMemTrace</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L100" class="source_link">[source]</a></h4><blockquote><p><code>GPUMemTrace</code>(<strong><code>silent</code></strong>=<strong><em><code>False</code></em></strong>)</p>
+<h4 id="GPUMemTrace"><code>class</code> <code>GPUMemTrace</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L126" class="source_link">[source]</a></h4><blockquote><p><code>GPUMemTrace</code>(<strong><code>silent</code></strong>=<strong><em><code>False</code></em></strong>)</p>
 </blockquote>
 <p>Trace GPU allocated and peaked memory usage</p>
 
@@ -374,7 +374,7 @@ prevents <code>gc.collect()</code> from freeing those variables and leading to a
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="gpu_mem_restore"><code>gpu_mem_restore</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L71" class="source_link">[source]</a></h4><blockquote><p><code>gpu_mem_restore</code>(<strong><code>func</code></strong>)</p>
+<h4 id="gpu_mem_restore"><code>gpu_mem_restore</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L97" class="source_link">[source]</a></h4><blockquote><p><code>gpu_mem_restore</code>(<strong><code>func</code></strong>)</p>
 </blockquote>
 <p>Reclaim GPU RAM if CUDA out of memory happened, or execution was interrupted</p>
 
@@ -413,7 +413,7 @@ depending on its value:</p>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="gpu_mem_restore_ctx"><code>class</code> <code>gpu_mem_restore_ctx</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L91" class="source_link">[source]</a></h4><blockquote><p><code>gpu_mem_restore_ctx</code>()</p>
+<h4 id="gpu_mem_restore_ctx"><code>class</code> <code>gpu_mem_restore_ctx</code><a href="https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L117" class="source_link">[source]</a></h4><blockquote><p><code>gpu_mem_restore_ctx</code>()</p>
 </blockquote>
 <p>context manager to reclaim RAM if an exception happened under ipython</p>
 

--- a/docs/vision.data.html
+++ b/docs/vision.data.html
@@ -604,7 +604,7 @@ summary: "Basic dataset for computer vision and helper function to get a DataBun
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Refer to <a href="#ImageDataBunch.create_from_ll"><code>create_from_ll</code></a> to see all the <code>**kwargs</code> arguments.</p>
-<p>Same as <a href="/vision.data.html#ImageDataBunch.from_csv"><code>ImageDataBunch.from_csv</code></a>, but passing in a <code>DataFrame</code> instead of a csv file. E.gL</p>
+<p>Same as <a href="/vision.data.html#ImageDataBunch.from_csv"><code>ImageDataBunch.from_csv</code></a>, but passing in a <code>DataFrame</code> instead of a csv file. E.g</p>
 
 </div>
 </div>

--- a/docs/vision.data.html
+++ b/docs/vision.data.html
@@ -485,7 +485,7 @@ summary: "Basic dataset for computer vision and helper function to get a DataBun
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="ImageDataBunch.from_folder"><code>from_folder</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L101" class="source_link">[source]</a></h4><blockquote><p><code>from_folder</code>(<strong><code>path</code></strong>:<code>PathOrStr</code>, <strong><code>train</code></strong>:<code>PathOrStr</code>=<strong><em><code>'train'</code></em></strong>, <strong><code>valid</code></strong>:<code>PathOrStr</code>=<strong><em><code>'valid'</code></em></strong>, <strong><code>valid_pct</code></strong>=<strong><em><code>None</code></em></strong>, <strong><code>classes</code></strong>:<code>Collection</code>[<code>T_co</code>]=<strong><em><code>None</code></em></strong>, <strong>**<code>kwargs</code></strong>:<code>Any</code>) → <code>ImageDataBunch</code></p>
+<h4 id="ImageDataBunch.from_folder"><code>from_folder</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L102" class="source_link">[source]</a></h4><blockquote><p><code>from_folder</code>(<strong><code>path</code></strong>:<code>PathOrStr</code>, <strong><code>train</code></strong>:<code>PathOrStr</code>=<strong><em><code>'train'</code></em></strong>, <strong><code>valid</code></strong>:<code>PathOrStr</code>=<strong><em><code>'valid'</code></em></strong>, <strong><code>valid_pct</code></strong>=<strong><em><code>None</code></em></strong>, <strong><code>classes</code></strong>:<code>Collection</code>[<code>T_co</code>]=<strong><em><code>None</code></em></strong>, <strong>**<code>kwargs</code></strong>:<code>Any</code>) → <code>ImageDataBunch</code></p>
 </blockquote>
 <p>Create from imagenet style dataset in <code>path</code> with <code>train</code>,<code>valid</code>,<code>test</code> subfolders (or provide <code>valid_pct</code>).</p>
 
@@ -546,7 +546,7 @@ summary: "Basic dataset for computer vision and helper function to get a DataBun
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="ImageDataBunch.from_csv"><code>from_csv</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L121" class="source_link">[source]</a></h4><blockquote><p><code>from_csv</code>(<strong><code>path</code></strong>:<code>PathOrStr</code>, <strong><code>folder</code></strong>:<code>PathOrStr</code>=<strong><em><code>None</code></em></strong>, <strong><code>label_delim</code></strong>:<code>str</code>=<strong><em><code>None</code></em></strong>, <strong><code>csv_labels</code></strong>:<code>PathOrStr</code>=<strong><em><code>'labels.csv'</code></em></strong>, <strong><code>valid_pct</code></strong>:<code>float</code>=<strong><em><code>0.2</code></em></strong>, <strong><code>fn_col</code></strong>:<code>int</code>=<strong><em><code>0</code></em></strong>, <strong><code>label_col</code></strong>:<code>int</code>=<strong><em><code>1</code></em></strong>, <strong><code>suffix</code></strong>:<code>str</code>=<strong><em><code>''</code></em></strong>, <strong><code>delimiter</code></strong>:<code>str</code>=<strong><em><code>None</code></em></strong>, <strong><code>header</code></strong>:<code>Union</code>[<code>int</code>, <code>str</code>, <code>NoneType</code>]=<strong><em><code>'infer'</code></em></strong>, <strong>**<code>kwargs</code></strong>:<code>Any</code>) → <code>ImageDataBunch</code></p>
+<h4 id="ImageDataBunch.from_csv"><code>from_csv</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L122" class="source_link">[source]</a></h4><blockquote><p><code>from_csv</code>(<strong><code>path</code></strong>:<code>PathOrStr</code>, <strong><code>folder</code></strong>:<code>PathOrStr</code>=<strong><em><code>None</code></em></strong>, <strong><code>label_delim</code></strong>:<code>str</code>=<strong><em><code>None</code></em></strong>, <strong><code>csv_labels</code></strong>:<code>PathOrStr</code>=<strong><em><code>'labels.csv'</code></em></strong>, <strong><code>valid_pct</code></strong>:<code>float</code>=<strong><em><code>0.2</code></em></strong>, <strong><code>fn_col</code></strong>:<code>int</code>=<strong><em><code>0</code></em></strong>, <strong><code>label_col</code></strong>:<code>int</code>=<strong><em><code>1</code></em></strong>, <strong><code>suffix</code></strong>:<code>str</code>=<strong><em><code>''</code></em></strong>, <strong><code>delimiter</code></strong>:<code>str</code>=<strong><em><code>None</code></em></strong>, <strong><code>header</code></strong>:<code>Union</code>[<code>int</code>, <code>str</code>, <code>NoneType</code>]=<strong><em><code>'infer'</code></em></strong>, <strong>**<code>kwargs</code></strong>:<code>Any</code>) → <code>ImageDataBunch</code></p>
 </blockquote>
 <p>Create from a csv file in <code>path/csv_labels</code>.</p>
 
@@ -589,7 +589,7 @@ summary: "Basic dataset for computer vision and helper function to get a DataBun
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="ImageDataBunch.from_df"><code>from_df</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L112" class="source_link">[source]</a></h4><blockquote><p><code>from_df</code>(<strong><code>path</code></strong>:<code>PathOrStr</code>, <strong><code>df</code></strong>:<code>DataFrame</code>, <strong><code>folder</code></strong>:<code>PathOrStr</code>=<strong><em><code>None</code></em></strong>, <strong><code>label_delim</code></strong>:<code>str</code>=<strong><em><code>None</code></em></strong>, <strong><code>valid_pct</code></strong>:<code>float</code>=<strong><em><code>0.2</code></em></strong>, <strong><code>fn_col</code></strong>:<code>IntsOrStrs</code>=<strong><em><code>0</code></em></strong>, <strong><code>label_col</code></strong>:<code>IntsOrStrs</code>=<strong><em><code>1</code></em></strong>, <strong><code>suffix</code></strong>:<code>str</code>=<strong><em><code>''</code></em></strong>, <strong>**<code>kwargs</code></strong>:<code>Any</code>) → <code>ImageDataBunch</code></p>
+<h4 id="ImageDataBunch.from_df"><code>from_df</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L113" class="source_link">[source]</a></h4><blockquote><p><code>from_df</code>(<strong><code>path</code></strong>:<code>PathOrStr</code>, <strong><code>df</code></strong>:<code>DataFrame</code>, <strong><code>folder</code></strong>:<code>PathOrStr</code>=<strong><em><code>None</code></em></strong>, <strong><code>label_delim</code></strong>:<code>str</code>=<strong><em><code>None</code></em></strong>, <strong><code>valid_pct</code></strong>:<code>float</code>=<strong><em><code>0.2</code></em></strong>, <strong><code>fn_col</code></strong>:<code>IntsOrStrs</code>=<strong><em><code>0</code></em></strong>, <strong><code>label_col</code></strong>:<code>IntsOrStrs</code>=<strong><em><code>1</code></em></strong>, <strong><code>suffix</code></strong>:<code>str</code>=<strong><em><code>''</code></em></strong>, <strong>**<code>kwargs</code></strong>:<code>Any</code>) → <code>ImageDataBunch</code></p>
 </blockquote>
 <p>Create from a <code>DataFrame</code> <code>df</code>.</p>
 
@@ -604,7 +604,7 @@ summary: "Basic dataset for computer vision and helper function to get a DataBun
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Refer to <a href="#ImageDataBunch.create_from_ll"><code>create_from_ll</code></a> to see all the <code>**kwargs</code> arguments.</p>
-<p>Same as <a href="/vision.data.html#ImageDataBunch.from_csv"><code>ImageDataBunch.from_csv</code></a>, but passing in a <code>DataFrame</code> instead of a csv file. E.g</p>
+<p>Same as <a href="/vision.data.html#ImageDataBunch.from_csv"><code>ImageDataBunch.from_csv</code></a>, but passing in a <code>DataFrame</code> instead of a csv file. e.g</p>
 
 </div>
 </div>
@@ -723,7 +723,7 @@ summary: "Basic dataset for computer vision and helper function to get a DataBun
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="ImageDataBunch.from_name_re"><code>from_name_re</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L144" class="source_link">[source]</a></h4><blockquote><p><code>from_name_re</code>(<strong><code>path</code></strong>:<code>PathOrStr</code>, <strong><code>fnames</code></strong>:<code>FilePathList</code>, <strong><code>pat</code></strong>:<code>str</code>, <strong><code>valid_pct</code></strong>:<code>float</code>=<strong><em><code>0.2</code></em></strong>, <strong>**<code>kwargs</code></strong>)</p>
+<h4 id="ImageDataBunch.from_name_re"><code>from_name_re</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L148" class="source_link">[source]</a></h4><blockquote><p><code>from_name_re</code>(<strong><code>path</code></strong>:<code>PathOrStr</code>, <strong><code>fnames</code></strong>:<code>FilePathList</code>, <strong><code>pat</code></strong>:<code>str</code>, <strong><code>valid_pct</code></strong>:<code>float</code>=<strong><em><code>0.2</code></em></strong>, <strong>**<code>kwargs</code></strong>)</p>
 </blockquote>
 <p>Create from list of <code>fnames</code> in <code>path</code> with re expression <code>pat</code>.</p>
 
@@ -826,7 +826,7 @@ summary: "Basic dataset for computer vision and helper function to get a DataBun
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="ImageDataBunch.from_name_func"><code>from_name_func</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L138" class="source_link">[source]</a></h4><blockquote><p><code>from_name_func</code>(<strong><code>path</code></strong>:<code>PathOrStr</code>, <strong><code>fnames</code></strong>:<code>FilePathList</code>, <strong><code>label_func</code></strong>:<code>Callable</code>, <strong><code>valid_pct</code></strong>:<code>float</code>=<strong><em><code>0.2</code></em></strong>, <strong>**<code>kwargs</code></strong>)</p>
+<h4 id="ImageDataBunch.from_name_func"><code>from_name_func</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L142" class="source_link">[source]</a></h4><blockquote><p><code>from_name_func</code>(<strong><code>path</code></strong>:<code>PathOrStr</code>, <strong><code>fnames</code></strong>:<code>FilePathList</code>, <strong><code>label_func</code></strong>:<code>Callable</code>, <strong><code>valid_pct</code></strong>:<code>float</code>=<strong><em><code>0.2</code></em></strong>, <strong>**<code>kwargs</code></strong>)</p>
 </blockquote>
 <p>Create from list of <code>fnames</code> in <code>path</code> with <code>label_func</code>.</p>
 
@@ -887,7 +887,7 @@ summary: "Basic dataset for computer vision and helper function to get a DataBun
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="ImageDataBunch.from_lists"><code>from_lists</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L131" class="source_link">[source]</a></h4><blockquote><p><code>from_lists</code>(<strong><code>path</code></strong>:<code>PathOrStr</code>, <strong><code>fnames</code></strong>:<code>FilePathList</code>, <strong><code>labels</code></strong>:<code>StrList</code>, <strong><code>valid_pct</code></strong>:<code>float</code>=<strong><em><code>0.2</code></em></strong>, <strong>**<code>kwargs</code></strong>)</p>
+<h4 id="ImageDataBunch.from_lists"><code>from_lists</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L132" class="source_link">[source]</a></h4><blockquote><p><code>from_lists</code>(<strong><code>path</code></strong>:<code>PathOrStr</code>, <strong><code>fnames</code></strong>:<code>FilePathList</code>, <strong><code>labels</code></strong>:<code>StrList</code>, <strong><code>valid_pct</code></strong>:<code>float</code>=<strong><em><code>0.2</code></em></strong>, <strong><code>item_cls</code></strong>:<code>Callable</code>=<strong><em><code>None</code></em></strong>, <strong>**<code>kwargs</code></strong>)</p>
 </blockquote>
 <p>Create from list of <code>fnames</code> in <code>path</code>.</p>
 
@@ -948,7 +948,7 @@ summary: "Basic dataset for computer vision and helper function to get a DataBun
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="ImageDataBunch.create_from_ll"><code>create_from_ll</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L89" class="source_link">[source]</a></h4><blockquote><p><code>create_from_ll</code>(<strong><code>lls</code></strong>:<a href="/data_block.html#LabelLists"><code>LabelLists</code></a>, <strong><code>bs</code></strong>:<code>int</code>=<strong><em><code>64</code></em></strong>, <strong><code>val_bs</code></strong>:<code>int</code>=<strong><em><code>None</code></em></strong>, <strong><code>ds_tfms</code></strong>:<code>Union</code>[<code>Callable</code>, <code>Collection</code>[<code>Callable</code>], <code>NoneType</code>]=<strong><em><code>None</code></em></strong>, <strong><code>num_workers</code></strong>:<code>int</code>=<strong><em><code>4</code></em></strong>, <strong><code>dl_tfms</code></strong>:<code>Optional</code>[<code>Collection</code>[<code>Callable</code>]]=<strong><em><code>None</code></em></strong>, <strong><code>device</code></strong>:<a href="https://pytorch.org/docs/stable/tensor_attributes.html#torch-device"><code>device</code></a>=<strong><em><code>None</code></em></strong>, <strong><code>test</code></strong>:<code>Union</code>[<code>Path</code>, <code>str</code>, <code>NoneType</code>]=<strong><em><code>None</code></em></strong>, <strong><code>collate_fn</code></strong>:<code>Callable</code>=<strong><em><code>'data_collate'</code></em></strong>, <strong><code>size</code></strong>:<code>int</code>=<strong><em><code>None</code></em></strong>, <strong><code>no_check</code></strong>:<code>bool</code>=<strong><em><code>False</code></em></strong>, <strong><code>resize_method</code></strong>:<a href="/vision.image.html#ResizeMethod"><code>ResizeMethod</code></a>=<strong><em><code>None</code></em></strong>, <strong><code>mult</code></strong>:<code>int</code>=<strong><em><code>None</code></em></strong>, <strong><code>padding_mode</code></strong>:<code>str</code>=<strong><em><code>'reflection'</code></em></strong>, <strong><code>mode</code></strong>:<code>str</code>=<strong><em><code>'bilinear'</code></em></strong>) → <code>ImageDataBunch</code></p>
+<h4 id="ImageDataBunch.create_from_ll"><code>create_from_ll</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L89" class="source_link">[source]</a></h4><blockquote><p><code>create_from_ll</code>(<strong><code>lls</code></strong>:<a href="/data_block.html#LabelLists"><code>LabelLists</code></a>, <strong><code>bs</code></strong>:<code>int</code>=<strong><em><code>64</code></em></strong>, <strong><code>val_bs</code></strong>:<code>int</code>=<strong><em><code>None</code></em></strong>, <strong><code>ds_tfms</code></strong>:<code>Union</code>[<code>Callable</code>, <code>Collection</code>[<code>Callable</code>], <code>NoneType</code>]=<strong><em><code>None</code></em></strong>, <strong><code>num_workers</code></strong>:<code>int</code>=<strong><em><code>12</code></em></strong>, <strong><code>dl_tfms</code></strong>:<code>Optional</code>[<code>Collection</code>[<code>Callable</code>]]=<strong><em><code>None</code></em></strong>, <strong><code>device</code></strong>:<a href="https://pytorch.org/docs/stable/tensor_attributes.html#torch-device"><code>device</code></a>=<strong><em><code>None</code></em></strong>, <strong><code>test</code></strong>:<code>Union</code>[<code>Path</code>, <code>str</code>, <code>NoneType</code>]=<strong><em><code>None</code></em></strong>, <strong><code>collate_fn</code></strong>:<code>Callable</code>=<strong><em><code>'data_collate'</code></em></strong>, <strong><code>size</code></strong>:<code>int</code>=<strong><em><code>None</code></em></strong>, <strong><code>no_check</code></strong>:<code>bool</code>=<strong><em><code>False</code></em></strong>, <strong><code>resize_method</code></strong>:<a href="/vision.image.html#ResizeMethod"><code>ResizeMethod</code></a>=<strong><em><code>None</code></em></strong>, <strong><code>mult</code></strong>:<code>int</code>=<strong><em><code>None</code></em></strong>, <strong><code>padding_mode</code></strong>:<code>str</code>=<strong><em><code>'reflection'</code></em></strong>, <strong><code>mode</code></strong>:<code>str</code>=<strong><em><code>'bilinear'</code></em></strong>, <strong><code>tfm_y</code></strong>:<code>bool</code>=<strong><em><code>False</code></em></strong>) → <code>ImageDataBunch</code></p>
 </blockquote>
 <p>Create an <a href="/vision.data.html#ImageDataBunch"><code>ImageDataBunch</code></a> from <a href="/data_block.html#LabelLists"><code>LabelLists</code></a> <code>lls</code> with potential <code>ds_tfms</code>.</p>
 
@@ -976,7 +976,7 @@ summary: "Basic dataset for computer vision and helper function to get a DataBun
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="ImageDataBunch.single_from_classes"><code>single_from_classes</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L155" class="source_link">[source]</a></h4><blockquote><p><code>single_from_classes</code>(<strong><code>path</code></strong>:<code>PathOrStr</code>, <strong><code>classes</code></strong>:<code>StrList</code>, <strong><code>ds_tfms</code></strong>:<code>Union</code>[<code>Callable</code>, <code>Collection</code>[<code>Callable</code>]]=<strong><em><code>None</code></em></strong>, <strong>**<code>kwargs</code></strong>)</p>
+<h4 id="ImageDataBunch.single_from_classes"><code>single_from_classes</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L159" class="source_link">[source]</a></h4><blockquote><p><code>single_from_classes</code>(<strong><code>path</code></strong>:<code>PathOrStr</code>, <strong><code>classes</code></strong>:<code>StrList</code>, <strong><code>ds_tfms</code></strong>:<code>Union</code>[<code>Callable</code>, <code>Collection</code>[<code>Callable</code>]]=<strong><em><code>None</code></em></strong>, <strong>**<code>kwargs</code></strong>)</p>
 </blockquote>
 <p>Create an empty <a href="/vision.data.html#ImageDataBunch"><code>ImageDataBunch</code></a> in <code>path</code> with <code>classes</code>. Typically used for inference.</p>
 
@@ -1198,7 +1198,7 @@ summary: "Basic dataset for computer vision and helper function to get a DataBun
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="ImageDataBunch.batch_stats"><code>batch_stats</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L163" class="source_link">[source]</a></h4><blockquote><p><code>batch_stats</code>(<strong><code>funcs</code></strong>:<code>Collection</code>[<code>Callable</code>]=<strong><em><code>None</code></em></strong>) → <code>Tensor</code></p>
+<h4 id="ImageDataBunch.batch_stats"><code>batch_stats</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L167" class="source_link">[source]</a></h4><blockquote><p><code>batch_stats</code>(<strong><code>funcs</code></strong>:<code>Collection</code>[<code>Callable</code>]=<strong><em><code>None</code></em></strong>) → <code>Tensor</code></p>
 </blockquote>
 <p>Grab a batch of data and call reduction function <code>func</code> per channel</p>
 
@@ -1248,7 +1248,7 @@ summary: "Basic dataset for computer vision and helper function to get a DataBun
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="ImageDataBunch.normalize"><code>normalize</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L169" class="source_link">[source]</a></h4><blockquote><p><code>normalize</code>(<strong><code>stats</code></strong>:<code>Collection</code>[<code>Tensor</code>]=<strong><em><code>None</code></em></strong>, <strong><code>do_x</code></strong>:<code>bool</code>=<strong><em><code>True</code></em></strong>, <strong><code>do_y</code></strong>:<code>bool</code>=<strong><em><code>False</code></em></strong>)</p>
+<h4 id="ImageDataBunch.normalize"><code>normalize</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L173" class="source_link">[source]</a></h4><blockquote><p><code>normalize</code>(<strong><code>stats</code></strong>:<code>Collection</code>[<code>Tensor</code>]=<strong><em><code>None</code></em></strong>, <strong><code>do_x</code></strong>:<code>bool</code>=<strong><em><code>True</code></em></strong>, <strong><code>do_y</code></strong>:<code>bool</code>=<strong><em><code>False</code></em></strong>)</p>
 </blockquote>
 <p>Add normalize transform using <code>stats</code> (defaults to <code>DataBunch.batch_stats</code>)</p>
 
@@ -1539,7 +1539,7 @@ Test: None</pre>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h3 id="ImageItemList"><code>class</code> <code>ImageItemList</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L251" class="source_link">[source]</a></h3><blockquote><p><code>ImageItemList</code>(<strong>*<code>args</code></strong>, <strong><code>convert_mode</code></strong>=<strong><em><code>'RGB'</code></em></strong>, <strong>**<code>kwargs</code></strong>) :: <a href="/data_block.html#ItemList"><code>ItemList</code></a></p>
+<h3 id="ImageItemList"><code>class</code> <code>ImageItemList</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L255" class="source_link">[source]</a></h3><blockquote><p><code>ImageItemList</code>(<strong>*<code>args</code></strong>, <strong><code>convert_mode</code></strong>=<strong><em><code>'RGB'</code></em></strong>, <strong>**<code>kwargs</code></strong>) :: <a href="/data_block.html#ItemList"><code>ItemList</code></a></p>
 </blockquote>
 <p><a href="/data_block.html#ItemList"><code>ItemList</code></a> suitable for computer vision.</p>
 
@@ -1567,7 +1567,7 @@ Test: None</pre>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="ImageItemList.from_folder"><code>from_folder</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L270" class="source_link">[source]</a></h4><blockquote><p><code>from_folder</code>(<strong><code>path</code></strong>:<code>PathOrStr</code>=<strong><em><code>'.'</code></em></strong>, <strong><code>extensions</code></strong>:<code>StrList</code>=<strong><em><code>None</code></em></strong>, <strong>**<code>kwargs</code></strong>) → <a href="/data_block.html#ItemList"><code>ItemList</code></a></p>
+<h4 id="ImageItemList.from_folder"><code>from_folder</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L274" class="source_link">[source]</a></h4><blockquote><p><code>from_folder</code>(<strong><code>path</code></strong>:<code>PathOrStr</code>=<strong><em><code>'.'</code></em></strong>, <strong><code>extensions</code></strong>:<code>StrList</code>=<strong><em><code>None</code></em></strong>, <strong>**<code>kwargs</code></strong>) → <a href="/data_block.html#ItemList"><code>ItemList</code></a></p>
 </blockquote>
 <p>Get the list of files in <code>path</code> that have an image suffix. <code>recurse</code> determines if we search subfolders.</p>
 
@@ -1588,7 +1588,7 @@ Test: None</pre>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="ImageItemList.from_df"><code>from_df</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L276" class="source_link">[source]</a></h4><blockquote><p><code>from_df</code>(<strong><code>df</code></strong>:<code>DataFrame</code>, <strong><code>path</code></strong>:<code>PathOrStr</code>, <strong><code>cols</code></strong>:<code>IntsOrStrs</code>=<strong><em><code>0</code></em></strong>, <strong><code>folder</code></strong>:<code>PathOrStr</code>=<strong><em><code>None</code></em></strong>, <strong><code>suffix</code></strong>:<code>str</code>=<strong><em><code>''</code></em></strong>, <strong>**<code>kwargs</code></strong>) → <code>ItemList</code></p>
+<h4 id="ImageItemList.from_df"><code>from_df</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L280" class="source_link">[source]</a></h4><blockquote><p><code>from_df</code>(<strong><code>df</code></strong>:<code>DataFrame</code>, <strong><code>path</code></strong>:<code>PathOrStr</code>, <strong><code>cols</code></strong>:<code>IntsOrStrs</code>=<strong><em><code>0</code></em></strong>, <strong><code>folder</code></strong>:<code>PathOrStr</code>=<strong><em><code>None</code></em></strong>, <strong><code>suffix</code></strong>:<code>str</code>=<strong><em><code>''</code></em></strong>, <strong>**<code>kwargs</code></strong>) → <code>ItemList</code></p>
 </blockquote>
 <p>Get the filenames in <code>col</code> of <code>df</code> and will had <code>folder</code> in front of them, <code>suffix</code> at the end.</p>
 
@@ -1630,7 +1630,7 @@ Test: None</pre>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="ImageItemList.open"><code>open</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L260" class="source_link">[source]</a></h4><blockquote><p><code>open</code>(<strong><code>fn</code></strong>)</p>
+<h4 id="ImageItemList.open"><code>open</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L264" class="source_link">[source]</a></h4><blockquote><p><code>open</code>(<strong><code>fn</code></strong>)</p>
 </blockquote>
 <p>Open image in <code>fn</code>, subclass and overwrite for custom behavior.</p>
 
@@ -1651,7 +1651,7 @@ Test: None</pre>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="ImageItemList.show_xys"><code>show_xys</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L295" class="source_link">[source]</a></h4><blockquote><p><code>show_xys</code>(<strong><code>xs</code></strong>, <strong><code>ys</code></strong>, <strong><code>imgsize</code></strong>:<code>int</code>=<strong><em><code>4</code></em></strong>, <strong><code>figsize</code></strong>:<code>Optional</code>[<code>Tuple</code>[<code>int</code>, <code>int</code>]]=<strong><em><code>None</code></em></strong>, <strong>**<code>kwargs</code></strong>)</p>
+<h4 id="ImageItemList.show_xys"><code>show_xys</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L299" class="source_link">[source]</a></h4><blockquote><p><code>show_xys</code>(<strong><code>xs</code></strong>, <strong><code>ys</code></strong>, <strong><code>imgsize</code></strong>:<code>int</code>=<strong><em><code>4</code></em></strong>, <strong><code>figsize</code></strong>:<code>Optional</code>[<code>Tuple</code>[<code>int</code>, <code>int</code>]]=<strong><em><code>None</code></em></strong>, <strong>**<code>kwargs</code></strong>)</p>
 </blockquote>
 <p>Show the <code>xs</code> (inputs) and <code>ys</code> (targets) on a figure of <code>figsize</code>.</p>
 
@@ -1672,7 +1672,7 @@ Test: None</pre>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="ImageItemList.show_xyzs"><code>show_xyzs</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L303" class="source_link">[source]</a></h4><blockquote><p><code>show_xyzs</code>(<strong><code>xs</code></strong>, <strong><code>ys</code></strong>, <strong><code>zs</code></strong>, <strong><code>imgsize</code></strong>:<code>int</code>=<strong><em><code>4</code></em></strong>, <strong><code>figsize</code></strong>:<code>Optional</code>[<code>Tuple</code>[<code>int</code>, <code>int</code>]]=<strong><em><code>None</code></em></strong>, <strong>**<code>kwargs</code></strong>)</p>
+<h4 id="ImageItemList.show_xyzs"><code>show_xyzs</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L307" class="source_link">[source]</a></h4><blockquote><p><code>show_xyzs</code>(<strong><code>xs</code></strong>, <strong><code>ys</code></strong>, <strong><code>zs</code></strong>, <strong><code>imgsize</code></strong>:<code>int</code>=<strong><em><code>4</code></em></strong>, <strong><code>figsize</code></strong>:<code>Optional</code>[<code>Tuple</code>[<code>int</code>, <code>int</code>]]=<strong><em><code>None</code></em></strong>, <strong>**<code>kwargs</code></strong>)</p>
 </blockquote>
 <p>Show <code>xs</code> (inputs), <code>ys</code> (targets) and <code>zs</code> (predictions) on a figure of <code>figsize</code>.</p>
 
@@ -1693,7 +1693,7 @@ Test: None</pre>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h3 id="ObjectCategoryList"><code>class</code> <code>ObjectCategoryList</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L344" class="source_link">[source]</a></h3><blockquote><p><code>ObjectCategoryList</code>(<strong><code>items</code></strong>:<code>Iterator</code>[<code>T_co</code>], <strong><code>classes</code></strong>:<code>Collection</code>[<code>T_co</code>]=<strong><em><code>None</code></em></strong>, <strong><code>label_delim</code></strong>:<code>str</code>=<strong><em><code>None</code></em></strong>, <strong><code>one_hot</code></strong>:<code>bool</code>=<strong><em><code>False</code></em></strong>, <strong>**<code>kwargs</code></strong>) :: <a href="/data_block.html#MultiCategoryList"><code>MultiCategoryList</code></a></p>
+<h3 id="ObjectCategoryList"><code>class</code> <code>ObjectCategoryList</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L348" class="source_link">[source]</a></h3><blockquote><p><code>ObjectCategoryList</code>(<strong><code>items</code></strong>:<code>Iterator</code>[<code>T_co</code>], <strong><code>classes</code></strong>:<code>Collection</code>[<code>T_co</code>]=<strong><em><code>None</code></em></strong>, <strong><code>label_delim</code></strong>:<code>str</code>=<strong><em><code>None</code></em></strong>, <strong><code>one_hot</code></strong>:<code>bool</code>=<strong><em><code>False</code></em></strong>, <strong>**<code>kwargs</code></strong>) :: <a href="/data_block.html#MultiCategoryList"><code>MultiCategoryList</code></a></p>
 </blockquote>
 <p><a href="/data_block.html#ItemList"><code>ItemList</code></a> for labelled bounding boxes.</p>
 
@@ -1714,7 +1714,7 @@ Test: None</pre>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h3 id="ObjectItemList"><code>class</code> <code>ObjectItemList</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L360" class="source_link">[source]</a></h3><blockquote><p><code>ObjectItemList</code>(<strong>*<code>args</code></strong>, <strong><code>convert_mode</code></strong>=<strong><em><code>'RGB'</code></em></strong>, <strong>**<code>kwargs</code></strong>) :: <a href="/vision.data.html#ImageItemList"><code>ImageItemList</code></a></p>
+<h3 id="ObjectItemList"><code>class</code> <code>ObjectItemList</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L364" class="source_link">[source]</a></h3><blockquote><p><code>ObjectItemList</code>(<strong>*<code>args</code></strong>, <strong><code>convert_mode</code></strong>=<strong><em><code>'RGB'</code></em></strong>, <strong>**<code>kwargs</code></strong>) :: <a href="/vision.data.html#ImageItemList"><code>ImageItemList</code></a></p>
 </blockquote>
 <p><a href="/data_block.html#ItemList"><code>ItemList</code></a> suitable for object detection.</p>
 
@@ -1735,7 +1735,7 @@ Test: None</pre>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h3 id="SegmentationItemList"><code>class</code> <code>SegmentationItemList</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L381" class="source_link">[source]</a></h3><blockquote><p><code>SegmentationItemList</code>(<strong>*<code>args</code></strong>, <strong><code>convert_mode</code></strong>=<strong><em><code>'RGB'</code></em></strong>, <strong>**<code>kwargs</code></strong>) :: <a href="/vision.data.html#ImageItemList"><code>ImageItemList</code></a></p>
+<h3 id="SegmentationItemList"><code>class</code> <code>SegmentationItemList</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L385" class="source_link">[source]</a></h3><blockquote><p><code>SegmentationItemList</code>(<strong>*<code>args</code></strong>, <strong><code>convert_mode</code></strong>=<strong><em><code>'RGB'</code></em></strong>, <strong>**<code>kwargs</code></strong>) :: <a href="/vision.data.html#ImageItemList"><code>ImageItemList</code></a></p>
 </blockquote>
 <p><a href="/data_block.html#ItemList"><code>ItemList</code></a> suitable for segmentation tasks.</p>
 
@@ -1756,7 +1756,7 @@ Test: None</pre>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h3 id="SegmentationLabelList"><code>class</code> <code>SegmentationLabelList</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L369" class="source_link">[source]</a></h3><blockquote><p><code>SegmentationLabelList</code>(<strong><code>items</code></strong>:<code>Iterator</code>[<code>T_co</code>], <strong><code>classes</code></strong>:<code>Collection</code>[<code>T_co</code>]=<strong><em><code>None</code></em></strong>, <strong>**<code>kwargs</code></strong>) :: <a href="/vision.data.html#ImageItemList"><code>ImageItemList</code></a></p>
+<h3 id="SegmentationLabelList"><code>class</code> <code>SegmentationLabelList</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L373" class="source_link">[source]</a></h3><blockquote><p><code>SegmentationLabelList</code>(<strong><code>items</code></strong>:<code>Iterator</code>[<code>T_co</code>], <strong><code>classes</code></strong>:<code>Collection</code>[<code>T_co</code>]=<strong><em><code>None</code></em></strong>, <strong>**<code>kwargs</code></strong>) :: <a href="/vision.data.html#ImageItemList"><code>ImageItemList</code></a></p>
 </blockquote>
 <p><a href="/data_block.html#ItemList"><code>ItemList</code></a> for segmentation masks.</p>
 
@@ -1777,7 +1777,7 @@ Test: None</pre>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h3 id="PointsLabelList"><code>class</code> <code>PointsLabelList</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L390" class="source_link">[source]</a></h3><blockquote><p><code>PointsLabelList</code>(<strong><code>items</code></strong>:<code>Iterator</code>[<code>T_co</code>], <strong><code>path</code></strong>:<code>PathOrStr</code>=<strong><em><code>'.'</code></em></strong>, <strong><code>label_cls</code></strong>:<code>Callable</code>=<strong><em><code>None</code></em></strong>, <strong><code>xtra</code></strong>:<code>Any</code>=<strong><em><code>None</code></em></strong>, <strong><code>processor</code></strong>:<code>Union</code>[<a href="/data_block.html#PreProcessor"><code>PreProcessor</code></a>, <code>Collection</code>[<a href="/data_block.html#PreProcessor"><code>PreProcessor</code></a>]]=<strong><em><code>None</code></em></strong>, <strong><code>x</code></strong>:<code>ItemList</code>=<strong><em><code>None</code></em></strong>, <strong><code>ignore_empty</code></strong>:<code>bool</code>=<strong><em><code>False</code></em></strong>) :: <a href="/data_block.html#ItemList"><code>ItemList</code></a></p>
+<h3 id="PointsLabelList"><code>class</code> <code>PointsLabelList</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L394" class="source_link">[source]</a></h3><blockquote><p><code>PointsLabelList</code>(<strong><code>items</code></strong>:<code>Iterator</code>[<code>T_co</code>], <strong><code>path</code></strong>:<code>PathOrStr</code>=<strong><em><code>'.'</code></em></strong>, <strong><code>label_cls</code></strong>:<code>Callable</code>=<strong><em><code>None</code></em></strong>, <strong><code>inner_df</code></strong>:<code>Any</code>=<strong><em><code>None</code></em></strong>, <strong><code>processor</code></strong>:<code>Union</code>[<a href="/data_block.html#PreProcessor"><code>PreProcessor</code></a>, <code>Collection</code>[<a href="/data_block.html#PreProcessor"><code>PreProcessor</code></a>]]=<strong><em><code>None</code></em></strong>, <strong><code>x</code></strong>:<code>ItemList</code>=<strong><em><code>None</code></em></strong>, <strong><code>ignore_empty</code></strong>:<code>bool</code>=<strong><em><code>False</code></em></strong>) :: <a href="/data_block.html#ItemList"><code>ItemList</code></a></p>
 </blockquote>
 <p><a href="/data_block.html#ItemList"><code>ItemList</code></a> for points.</p>
 
@@ -1798,7 +1798,7 @@ Test: None</pre>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h3 id="PointsItemList"><code>class</code> <code>PointsItemList</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L403" class="source_link">[source]</a></h3><blockquote><p><code>PointsItemList</code>(<strong>*<code>args</code></strong>, <strong><code>convert_mode</code></strong>=<strong><em><code>'RGB'</code></em></strong>, <strong>**<code>kwargs</code></strong>) :: <a href="/vision.data.html#ImageItemList"><code>ImageItemList</code></a></p>
+<h3 id="PointsItemList"><code>class</code> <code>PointsItemList</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L407" class="source_link">[source]</a></h3><blockquote><p><code>PointsItemList</code>(<strong>*<code>args</code></strong>, <strong><code>convert_mode</code></strong>=<strong><em><code>'RGB'</code></em></strong>, <strong>**<code>kwargs</code></strong>) :: <a href="/vision.data.html#ImageItemList"><code>ImageItemList</code></a></p>
 </blockquote>
 <p><a href="/data_block.html#ItemList"><code>ItemList</code></a> for <a href="/vision.image.html#Image"><code>Image</code></a> to <a href="/vision.image.html#ImagePoints"><code>ImagePoints</code></a> tasks.</p>
 
@@ -1819,7 +1819,7 @@ Test: None</pre>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h3 id="ImageImageList"><code>class</code> <code>ImageImageList</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L407" class="source_link">[source]</a></h3><blockquote><p><code>ImageImageList</code>(<strong>*<code>args</code></strong>, <strong><code>convert_mode</code></strong>=<strong><em><code>'RGB'</code></em></strong>, <strong>**<code>kwargs</code></strong>) :: <a href="/vision.data.html#ImageItemList"><code>ImageItemList</code></a></p>
+<h3 id="ImageImageList"><code>class</code> <code>ImageImageList</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L411" class="source_link">[source]</a></h3><blockquote><p><code>ImageImageList</code>(<strong>*<code>args</code></strong>, <strong><code>convert_mode</code></strong>=<strong><em><code>'RGB'</code></em></strong>, <strong>**<code>kwargs</code></strong>) :: <a href="/vision.data.html#ImageItemList"><code>ImageItemList</code></a></p>
 </blockquote>
 <p><a href="/data_block.html#ItemList"><code>ItemList</code></a> suitable for <a href="/vision.image.html#Image"><code>Image</code></a> to <a href="/vision.image.html#Image"><code>Image</code></a> tasks.</p>
 
@@ -1853,7 +1853,7 @@ Test: None</pre>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="download_images"><code>download_images</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L187" class="source_link">[source]</a></h4><blockquote><p><code>download_images</code>(<strong><code>urls</code></strong>:<code>StrList</code>, <strong><code>dest</code></strong>:<code>PathOrStr</code>, <strong><code>max_pics</code></strong>:<code>int</code>=<strong><em><code>1000</code></em></strong>, <strong><code>max_workers</code></strong>:<code>int</code>=<strong><em><code>8</code></em></strong>, <strong><code>timeout</code></strong>=<strong><em><code>4</code></em></strong>)</p>
+<h4 id="download_images"><code>download_images</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L191" class="source_link">[source]</a></h4><blockquote><p><code>download_images</code>(<strong><code>urls</code></strong>:<code>StrList</code>, <strong><code>dest</code></strong>:<code>PathOrStr</code>, <strong><code>max_pics</code></strong>:<code>int</code>=<strong><em><code>1000</code></em></strong>, <strong><code>max_workers</code></strong>:<code>int</code>=<strong><em><code>8</code></em></strong>, <strong><code>timeout</code></strong>=<strong><em><code>4</code></em></strong>)</p>
 </blockquote>
 <p>Download images listed in text file <code>urls</code> to path <code>dest</code>, at most <code>max_pics</code></p>
 
@@ -1874,7 +1874,7 @@ Test: None</pre>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="verify_images"><code>verify_images</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L238" class="source_link">[source]</a></h4><blockquote><p><code>verify_images</code>(<strong><code>path</code></strong>:<code>PathOrStr</code>, <strong><code>delete</code></strong>:<code>bool</code>=<strong><em><code>True</code></em></strong>, <strong><code>max_workers</code></strong>:<code>int</code>=<strong><em><code>4</code></em></strong>, <strong><code>max_size</code></strong>:<code>int</code>=<strong><em><code>None</code></em></strong>, <strong><code>dest</code></strong>:<code>PathOrStr</code>=<strong><em><code>'.'</code></em></strong>, <strong><code>n_channels</code></strong>:<code>int</code>=<strong><em><code>3</code></em></strong>, <strong><code>interp</code></strong>=<strong><em><code>2</code></em></strong>, <strong><code>ext</code></strong>:<code>str</code>=<strong><em><code>None</code></em></strong>, <strong><code>img_format</code></strong>:<code>str</code>=<strong><em><code>None</code></em></strong>, <strong><code>resume</code></strong>:<code>bool</code>=<strong><em><code>None</code></em></strong>, <strong>**<code>kwargs</code></strong>)</p>
+<h4 id="verify_images"><code>verify_images</code><a href="https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L242" class="source_link">[source]</a></h4><blockquote><p><code>verify_images</code>(<strong><code>path</code></strong>:<code>PathOrStr</code>, <strong><code>delete</code></strong>:<code>bool</code>=<strong><em><code>True</code></em></strong>, <strong><code>max_workers</code></strong>:<code>int</code>=<strong><em><code>4</code></em></strong>, <strong><code>max_size</code></strong>:<code>int</code>=<strong><em><code>None</code></em></strong>, <strong><code>dest</code></strong>:<code>PathOrStr</code>=<strong><em><code>'.'</code></em></strong>, <strong><code>n_channels</code></strong>:<code>int</code>=<strong><em><code>3</code></em></strong>, <strong><code>interp</code></strong>=<strong><em><code>2</code></em></strong>, <strong><code>ext</code></strong>:<code>str</code>=<strong><em><code>None</code></em></strong>, <strong><code>img_format</code></strong>:<code>str</code>=<strong><em><code>None</code></em></strong>, <strong><code>resume</code></strong>:<code>bool</code>=<strong><em><code>None</code></em></strong>, <strong>**<code>kwargs</code></strong>)</p>
 </blockquote>
 <p>Check if the images in <code>path</code> aren't broken, maybe resize them and copy it in <code>dest</code>.</p>
 

--- a/docs_src/basic_train.ipynb
+++ b/docs_src/basic_train.ipynb
@@ -42,7 +42,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h2 id=\"Learner\"><code>class</code> <code>Learner</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L134\" class=\"source_link\">[source]</a></h2>\n",
+       "<h2 id=\"Learner\"><code>class</code> <code>Learner</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L132\" class=\"source_link\">[source]</a></h2>\n",
        "\n",
        "> <code>Learner</code>(**`data`**:[`DataBunch`](/basic_data.html#DataBunch), **`model`**:[`Module`](https://pytorch.org/docs/stable/nn.html#torch.nn.Module), **`opt_func`**:`Callable`=***`'Adam'`***, **`loss_func`**:`Callable`=***`None`***, **`metrics`**:`Collection`\\[`Callable`\\]=***`None`***, **`true_wd`**:`bool`=***`True`***, **`bn_wd`**:`bool`=***`True`***, **`wd`**:`Floats`=***`0.01`***, **`train_bn`**:`bool`=***`True`***, **`path`**:`str`=***`None`***, **`model_dir`**:`str`=***`'models'`***, **`callback_fns`**:`Collection`\\[`Callable`\\]=***`None`***, **`callbacks`**:`Collection`\\[[`Callback`](/callback.html#Callback)\\]=***`<factory>`***, **`layer_groups`**:`ModuleList`=***`None`***)\n",
        "\n",
@@ -196,7 +196,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.fit\"><code>fit</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L170\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.fit\"><code>fit</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L168\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>fit</code>(**`epochs`**:`int`, **`lr`**:`Union`\\[`float`, `Collection`\\[`float`\\], `slice`\\]=***`slice(None, 0.003, None)`***, **`wd`**:`Floats`=***`None`***, **`callbacks`**:`Collection`\\[[`Callback`](/callback.html#Callback)\\]=***`None`***)\n",
        "\n",
@@ -343,7 +343,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.predict\"><code>predict</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L334\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.predict\"><code>predict</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L328\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>predict</code>(**`item`**:[`ItemBase`](/core.html#ItemBase), **\\*\\*`kwargs`**)\n",
        "\n",
@@ -536,7 +536,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.get_preds\"><code>get_preds</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L304\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.get_preds\"><code>get_preds</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L298\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>get_preds</code>(**`ds_type`**:[`DatasetType`](/basic_data.html#DatasetType)=***`<DatasetType.Valid: 2>`***, **`with_loss`**:`bool`=***`False`***, **`n_batch`**:`Optional`\\[`int`\\]=***`None`***, **`pbar`**:`Union`\\[`MasterBar`, `ProgressBar`, `NoneType`\\]=***`None`***) → `List`\\[`Tensor`\\]\n",
        "\n",
@@ -830,7 +830,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.validate\"><code>validate</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L348\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.validate\"><code>validate</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L342\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>validate</code>(**`dl`**=***`None`***, **`callbacks`**=***`None`***, **`metrics`**=***`None`***)\n",
        "\n",
@@ -952,7 +952,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.show_results\"><code>show_results</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L358\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.show_results\"><code>show_results</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L352\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>show_results</code>(**`ds_type`**=***`<DatasetType.Valid: 2>`***, **`rows`**:`int`=***`5`***, **\\*\\*`kwargs`**)\n",
        "\n",
@@ -1031,7 +1031,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.pred_batch\"><code>pred_batch</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L311\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.pred_batch\"><code>pred_batch</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L305\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>pred_batch</code>(**`ds_type`**:[`DatasetType`](/basic_data.html#DatasetType)=***`<DatasetType.Valid: 2>`***, **`batch`**:`Tuple`=***`None`***, **`reconstruct`**:`bool`=***`False`***) → `List`\\[`Tensor`\\]\n",
        "\n",
@@ -1614,7 +1614,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.lr_range\"><code>lr_range</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L163\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.lr_range\"><code>lr_range</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L161\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>lr_range</code>(**`lr`**:`Union`\\[`float`, `slice`\\]) → `ndarray`\n",
        "\n",
@@ -1671,7 +1671,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.unfreeze\"><code>unfreeze</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L204\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.unfreeze\"><code>unfreeze</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L202\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>unfreeze</code>()\n",
        "\n",
@@ -1706,7 +1706,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.freeze\"><code>freeze</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L198\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.freeze\"><code>freeze</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L196\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>freeze</code>()\n",
        "\n",
@@ -1741,7 +1741,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.freeze_to\"><code>freeze_to</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L190\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.freeze_to\"><code>freeze_to</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L188\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>freeze_to</code>(**`n`**:`int`)\n",
        "\n",
@@ -1769,7 +1769,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.split\"><code>split</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L185\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.split\"><code>split</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L183\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>split</code>(**`split_on`**:`SplitFuncOrIdxList`)\n",
        "\n",
@@ -1818,7 +1818,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.save\"><code>save</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L229\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.save\"><code>save</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L223\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>save</code>(**`name`**:`PathOrStr`, **`return_path`**:`bool`=***`False`***, **`with_opt`**:`bool`=***`True`***)\n",
        "\n",
@@ -1875,7 +1875,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.load\"><code>load</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L242\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.load\"><code>load</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L236\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>load</code>(**`name`**:`PathOrStr`, **`device`**:[`device`](https://pytorch.org/docs/stable/tensor_attributes.html#torch-device)=***`None`***, **`strict`**:`bool`=***`True`***, **`with_opt`**:`bool`=***`None`***, **`purge`**:`bool`=***`True`***)\n",
        "\n",
@@ -1926,9 +1926,9 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.export\"><code>export</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L209\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.export\"><code>export</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L207\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
-       "> <code>export</code>(**`fname`**:`str`=***`'export.pkl'`***)\n",
+       "> <code>export</code>(**`fname`**:`str`=***`'export.pkl'`***, **`destroy`**=***`False`***)\n",
        "\n",
        "Export the state of the [`Learner`](/basic_train.html#Learner) in `self.path/fname`.  "
       ],
@@ -1948,9 +1948,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This method only works with the `Learner` whose `data` was created through the [data block API](/data_block.html).\n",
+    "Passing `destroy=True` will destroy the [`Learner`](/basic_train.html#Learner), freeing most of its memory consumption. For specifics see [`Learner.destroy`](/basic_train.html#Learner.destroy).\n",
     "\n",
-    "Otherwise, you will have to create a `Learner` yourself at inference and load the model with `Learner.load`."
+    "This method only works with the [`Learner`](/basic_train.html#Learner) whose [`data`](/vision.data.html#vision.data) was created through the [data block API](/data_block.html).\n",
+    "\n",
+    "Otherwise, you will have to create a [`Learner`](/basic_train.html#Learner) yourself at inference and load the model with [`Learner.load`](/basic_train.html#Learner.load)."
    ]
   },
   {
@@ -2002,7 +2004,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"load_learner\"><code>load_learner</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L530\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"load_learner\"><code>load_learner</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L524\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>load_learner</code>(**`path`**:`PathOrStr`, **`fname`**:`PathOrStr`=***`'export.pkl'`***, **`test`**:[`ItemList`](/data_block.html#ItemList)=***`None`***)\n",
        "\n",
@@ -2068,7 +2070,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.purge\"><code>purge</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L277\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.purge\"><code>purge</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L271\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>purge</code>(**`clear_opt`**:`bool`=***`True`***)\n",
        "\n",
@@ -2103,7 +2105,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.destroy\"><code>destroy</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L260\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.destroy\"><code>destroy</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L254\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>destroy</code>()\n",
        "\n",
@@ -2125,42 +2127,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you need to free the memory consumed by the [`Learner`](/basic_train.html#Learner) object, call this method. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "hide_input": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "<h4 id=\"Learner.hibernate\"><code>hibernate</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L224\" class=\"source_link\">[source]</a></h4>\n",
-       "\n",
-       "> <code>hibernate</code>(**`fname`**:`str`=***`'export.pkl'`***)\n",
-       "\n",
-       "Export the state of the [`Learner`](/basic_train.html#Learner) in `self.path/fname` and remove the object from memory. Use [`load_learner`](/basic_train.html#load_learner) to restore.  "
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "show_doc(Learner.hibernate)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This is just a convenience method that combines `export` and `destroy` in one method. As such, this method only works with the `Learner` whose `data` was created through the [data block API](/data_block.html). See `Learner.export`."
+    "If you need to free the memory consumed by the [`Learner`](/basic_train.html#Learner) object, call this method. \n",
+    "\n",
+    "It can also be automatically invoked through [`Learner.export`](/basic_train.html#Learner.export) via its `destroy=True` argument."
    ]
   },
   {
@@ -2180,7 +2149,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.init\"><code>init</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L161\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.init\"><code>init</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L159\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>init</code>(**`init`**)"
       ],
@@ -2248,7 +2217,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.backward\"><code>backward</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L327\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.backward\"><code>backward</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L321\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>backward</code>(**`item`**)\n",
        "\n",
@@ -2276,7 +2245,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.create_opt\"><code>create_opt</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L181\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.create_opt\"><code>create_opt</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L179\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>create_opt</code>(**`lr`**:`Floats`, **`wd`**:`Floats`=***`0.0`***)\n",
        "\n",
@@ -2311,7 +2280,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.dl\"><code>dl</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L238\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.dl\"><code>dl</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L232\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>dl</code>(**`ds_type`**:[`DatasetType`](/basic_data.html#DatasetType)=***`<DatasetType.Valid: 2>`***)\n",
        "\n",
@@ -2379,7 +2348,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h2 id=\"Recorder\"><code>class</code> <code>Recorder</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L409\" class=\"source_link\">[source]</a></h2>\n",
+       "<h2 id=\"Recorder\"><code>class</code> <code>Recorder</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L403\" class=\"source_link\">[source]</a></h2>\n",
        "\n",
        "> <code>Recorder</code>(**`learn`**:[`Learner`](/basic_train.html#Learner)) :: [`LearnerCallback`](/basic_train.html#LearnerCallback)\n",
        "\n",
@@ -2423,7 +2392,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Recorder.plot\"><code>plot</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L479\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Recorder.plot\"><code>plot</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L473\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>plot</code>(**`skip_start`**:`int`=***`10`***, **`skip_end`**:`int`=***`5`***)\n",
        "\n",
@@ -2510,7 +2479,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Recorder.plot_losses\"><code>plot_losses</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L494\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Recorder.plot_losses\"><code>plot_losses</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L488\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>plot_losses</code>(**`last`**:`int`=***`None`***)\n",
        "\n",
@@ -2617,7 +2586,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Recorder.plot_lr\"><code>plot_lr</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L466\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Recorder.plot_lr\"><code>plot_lr</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L460\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>plot_lr</code>(**`show_moms`**=***`False`***)\n",
        "\n",
@@ -2689,7 +2658,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Recorder.plot_metrics\"><code>plot_metrics</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L509\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Recorder.plot_metrics\"><code>plot_metrics</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L503\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>plot_metrics</code>()\n",
        "\n",
@@ -2760,7 +2729,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Recorder.on_backward_begin\"><code>on_backward_begin</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L433\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Recorder.on_backward_begin\"><code>on_backward_begin</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L427\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>on_backward_begin</code>(**`smooth_loss`**:`Tensor`, **\\*\\*`kwargs`**:`Any`)\n",
        "\n",
@@ -2788,7 +2757,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Recorder.on_batch_begin\"><code>on_batch_begin</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L427\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Recorder.on_batch_begin\"><code>on_batch_begin</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L421\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>on_batch_begin</code>(**`train`**, **\\*\\*`kwargs`**:`Any`)\n",
        "\n",
@@ -2816,7 +2785,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Recorder.on_epoch_end\"><code>on_epoch_end</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L439\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Recorder.on_epoch_end\"><code>on_epoch_end</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L433\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>on_epoch_end</code>(**`epoch`**:`int`, **`num_batch`**:`int`, **`smooth_loss`**:`Tensor`, **`last_metrics`**=***`typing.Collection[typing.Union[torch.Tensor, numbers.Number]]`***, **\\*\\*`kwargs`**:`Any`) → `bool`\n",
        "\n",
@@ -2844,7 +2813,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Recorder.on_train_begin\"><code>on_train_begin</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L418\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Recorder.on_train_begin\"><code>on_train_begin</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L412\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>on_train_begin</code>(**`pbar`**:`PBar`, **`metrics_names`**:`StrList`, **\\*\\*`kwargs`**:`Any`)\n",
        "\n",
@@ -2886,7 +2855,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Recorder.add_metrics\"><code>add_metrics</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L458\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Recorder.add_metrics\"><code>add_metrics</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L452\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>add_metrics</code>(**`metrics`**)\n",
        "\n",
@@ -2914,7 +2883,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Recorder.add_metric_names\"><code>add_metric_names</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L462\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Recorder.add_metric_names\"><code>add_metric_names</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L456\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>add_metric_names</code>(**`names`**)\n",
        "\n",
@@ -2942,7 +2911,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Recorder.format_stats\"><code>format_stats</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L451\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"Recorder.format_stats\"><code>format_stats</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L445\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>format_stats</code>(**`stats`**:`MetricsList`)\n",
        "\n",
@@ -2984,7 +2953,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"fit\"><code>fit</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L73\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"fit\"><code>fit</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L71\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>fit</code>(**`epochs`**:`int`, **`model`**:[`Module`](https://pytorch.org/docs/stable/nn.html#torch.nn.Module), **`loss_func`**:`LossFunction`, **`opt`**:[`Optimizer`](https://pytorch.org/docs/stable/optim.html#torch.optim.Optimizer), **`data`**:[`DataBunch`](/basic_data.html#DataBunch), **`callbacks`**:`Optional`\\[`Collection`\\[[`Callback`](/callback.html#Callback)\\]\\]=***`None`***, **`metrics`**:`OptMetrics`=***`None`***)\n",
        "\n",
@@ -3019,7 +2988,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"train_epoch\"><code>train_epoch</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L64\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"train_epoch\"><code>train_epoch</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L62\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>train_epoch</code>(**`model`**:[`Module`](https://pytorch.org/docs/stable/nn.html#torch.nn.Module), **`dl`**:[`DataLoader`](https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader), **`opt`**:[`Optimizer`](https://pytorch.org/docs/stable/optim.html#torch.optim.Optimizer), **`loss_func`**:`LossFunction`)\n",
        "\n",
@@ -3054,7 +3023,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"validate\"><code>validate</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L46\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"validate\"><code>validate</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L44\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>validate</code>(**`model`**:[`Module`](https://pytorch.org/docs/stable/nn.html#torch.nn.Module), **`dl`**:[`DataLoader`](https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader), **`loss_func`**:`OptLossFunc`=***`None`***, **`cb_handler`**:`Optional`\\[[`CallbackHandler`](/callback.html#CallbackHandler)\\]=***`None`***, **`pbar`**:`Union`\\[`MasterBar`, `ProgressBar`, `NoneType`\\]=***`None`***, **`average`**=***`True`***, **`n_batch`**:`Optional`\\[`int`\\]=***`None`***) → `Iterator`\\[`Tuple`\\[`IntOrTensor`, `Ellipsis`\\]\\]\n",
        "\n",
@@ -3089,7 +3058,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"get_preds\"><code>get_preds</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L37\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"get_preds\"><code>get_preds</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L35\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>get_preds</code>(**`model`**:[`Module`](https://pytorch.org/docs/stable/nn.html#torch.nn.Module), **`dl`**:[`DataLoader`](https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader), **`pbar`**:`Union`\\[`MasterBar`, `ProgressBar`, `NoneType`\\]=***`None`***, **`cb_handler`**:`Optional`\\[[`CallbackHandler`](/callback.html#CallbackHandler)\\]=***`None`***, **`activ`**:[`Module`](https://pytorch.org/docs/stable/nn.html#torch.nn.Module)=***`None`***, **`loss_func`**:`OptLossFunc`=***`None`***, **`n_batch`**:`Optional`\\[`int`\\]=***`None`***) → `List`\\[`Tensor`\\]\n",
        "\n",
@@ -3159,7 +3128,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h3 id=\"LearnerCallback\"><code>class</code> <code>LearnerCallback</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L391\" class=\"source_link\">[source]</a></h3>\n",
+       "<h3 id=\"LearnerCallback\"><code>class</code> <code>LearnerCallback</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L385\" class=\"source_link\">[source]</a></h3>\n",
        "\n",
        "> <code>LearnerCallback</code>(**`learn`**) :: [`Callback`](/callback.html#Callback)\n",
        "\n",
@@ -3187,7 +3156,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h3 id=\"RecordOnCPU\"><code>class</code> <code>RecordOnCPU</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L386\" class=\"source_link\">[source]</a></h3>\n",
+       "<h3 id=\"RecordOnCPU\"><code>class</code> <code>RecordOnCPU</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L380\" class=\"source_link\">[source]</a></h3>\n",
        "\n",
        "> <code>RecordOnCPU</code>() :: [`Callback`](/callback.html#Callback)\n",
        "\n",
@@ -3278,7 +3247,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"RecordOnCPU.on_batch_begin\"><code>on_batch_begin</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L388\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"RecordOnCPU.on_batch_begin\"><code>on_batch_begin</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/basic_train.py#L382\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>on_batch_begin</code>(**`last_input`**, **`last_target`**, **\\*\\*`kwargs`**)\n",
        "\n",

--- a/docs_src/tutorial.data.ipynb
+++ b/docs_src/tutorial.data.ipynb
@@ -37,7 +37,7 @@
      "data": {
       "text/markdown": [
        "<div markdown=\"span\" class=\"alert alert-info\" role=\"alert\"><i class=\"fa fa-info-circle\"></i> <b>Note: </b>As usual, this page is generated from a notebook that you can find in the docs_src folder of the\n",
-       "[fastai repo](https://github.com/fastai/fastai). The examples are all designed to run fast, which is why we use\n",
+       "<a href=\"https://github.com/fastai/fastai\">fastai repo</a>. The examples are all designed to run fast, which is why we use\n",
        "samples of the dataset, a resnet18 as a backbone and don't train for very long. You can change all of those parameters\n",
        "to run your own experiments!\n",
        "</div>"
@@ -52,7 +52,7 @@
    ],
    "source": [
     "jekyll_note(\"\"\"As usual, this page is generated from a notebook that you can find in the docs_src folder of the\n",
-    "[fastai repo](https://github.com/fastai/fastai). The examples are all designed to run fast, which is why we use\n",
+    "<a href=\"https://github.com/fastai/fastai\">fastai repo</a>. The examples are all designed to run fast, which is why we use\n",
     "samples of the dataset, a resnet18 as a backbone and don't train for very long. You can change all of those parameters\n",
     "to run your own experiments!\n",
     "\"\"\")"
@@ -479,7 +479,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To grab our data, we use this dictionary to label our items. We also use the [`PointsItemList`](/vision.data.html#PointsItemList) class to have the targets be of type [`ImagePoints`](/vision.image.html#ImagePoints) (which will make sure the data augmentation is properly applied to them). When calling [`transform`](/tabular.transform.html#tabular.transform) we make sure to set `tfm_y=True`."
+    "To grab our data, we use this dictionary to label our items. We also use the [`PointsItemList`](/vision.data.html#PointsItemList) class to have the targets be of type [`ImagePoints`](/vision.image.html#ImagePoints) (which will make sure the data augmentation is properly applied to them). When calling [`transform`](/data_block.html#ItemLists.transform) we make sure to set `tfm_y=True`."
    ]
   },
   {
@@ -1597,13 +1597,6 @@
    "source": [
     "learn.show_results()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs_src/utils.mem.ipynb
+++ b/docs_src/utils.mem.ipynb
@@ -36,7 +36,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"gpu_mem_get\"><code>gpu_mem_get</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L26\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"gpu_mem_get\"><code>gpu_mem_get</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L52\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>gpu_mem_get</code>(**`id`**=***`None`***)\n",
        "\n",
@@ -60,7 +60,7 @@
    "source": [
     "[`gpu_mem_get`](/utils.mem.html#gpu_mem_get)\n",
     "\n",
-    "* for gpu returns `GPUMemory(total, used, free)`\n",
+    "* for gpu returns `GPUMemory(total, free, used)`\n",
     "* for cpu returns `GPUMemory(0, 0, 0)`\n",
     "* for invalid gpu id returns `GPUMemory(0, 0, 0)`"
    ]
@@ -75,7 +75,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"gpu_mem_get_all\"><code>gpu_mem_get_all</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L37\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"gpu_mem_get_all\"><code>gpu_mem_get_all</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L63\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>gpu_mem_get_all</code>()\n",
        "\n",
@@ -98,7 +98,7 @@
    "metadata": {},
    "source": [
     "[`gpu_mem_get_all`](/utils.mem.html#gpu_mem_get_all)\n",
-    "* for gpu returns `[ GPUMemory(total_0, used_0, free_0), GPUMemory(total_1, used_1, free_1), .... ]`\n",
+    "* for gpu returns `[ GPUMemory(total_0, free_0, used_0), GPUMemory(total_1, free_1, used_1), .... ]`\n",
     "* for cpu returns `[]`\n"
    ]
   },
@@ -112,7 +112,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"gpu_mem_get_free_no_cache\"><code>gpu_mem_get_free_no_cache</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L42\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"gpu_mem_get_free_no_cache\"><code>gpu_mem_get_free_no_cache</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L68\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>gpu_mem_get_free_no_cache</code>()\n",
        "\n",
@@ -147,7 +147,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"gpu_mem_get_used_no_cache\"><code>gpu_mem_get_used_no_cache</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L47\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"gpu_mem_get_used_no_cache\"><code>gpu_mem_get_used_no_cache</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L73\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>gpu_mem_get_used_no_cache</code>()\n",
        "\n",
@@ -182,7 +182,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"gpu_mem_get_used_fast\"><code>gpu_mem_get_used_fast</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L52\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"gpu_mem_get_used_fast\"><code>gpu_mem_get_used_fast</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L78\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>gpu_mem_get_used_fast</code>(**`gpu_handle`**)\n",
        "\n",
@@ -217,7 +217,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"gpu_with_max_free_mem\"><code>gpu_with_max_free_mem</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L57\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"gpu_with_max_free_mem\"><code>gpu_with_max_free_mem</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L83\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>gpu_with_max_free_mem</code>()\n",
        "\n",
@@ -254,7 +254,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"preload_pytorch\"><code>preload_pytorch</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L19\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"preload_pytorch\"><code>preload_pytorch</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L45\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>preload_pytorch</code>()"
       ],
@@ -289,9 +289,9 @@
       "text/markdown": [
        "<h4 id=\"GPUMemory\"><code>class</code> <code>GPUMemory</code></h4>\n",
        "\n",
-       "> <code>GPUMemory</code>(**`total`**, **`used`**, **`free`**) :: `tuple`\n",
+       "> <code>GPUMemory</code>(**`total`**, **`free`**, **`used`**) :: `tuple`\n",
        "\n",
-       "GPUMemory(total, used, free)  "
+       "GPUMemory(total, free, used)  "
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -322,7 +322,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"b2mb\"><code>b2mb</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L22\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"b2mb\"><code>b2mb</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L48\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>b2mb</code>(**`num`**)\n",
        "\n",
@@ -364,7 +364,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"GPUMemTrace\"><code>class</code> <code>GPUMemTrace</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L100\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"GPUMemTrace\"><code>class</code> <code>GPUMemTrace</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L126\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>GPUMemTrace</code>(**`silent`**=***`False`***)\n",
        "\n",
@@ -448,7 +448,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"gpu_mem_restore\"><code>gpu_mem_restore</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L71\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"gpu_mem_restore\"><code>gpu_mem_restore</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L97\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>gpu_mem_restore</code>(**`func`**)\n",
        "\n",
@@ -494,7 +494,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"gpu_mem_restore_ctx\"><code>class</code> <code>gpu_mem_restore_ctx</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L91\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"gpu_mem_restore_ctx\"><code>class</code> <code>gpu_mem_restore_ctx</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mem.py#L117\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>gpu_mem_restore_ctx</code>()\n",
        "\n",

--- a/docs_src/vision.data.ipynb
+++ b/docs_src/vision.data.ipynb
@@ -457,7 +457,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ImageDataBunch.from_folder\"><code>from_folder</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L101\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ImageDataBunch.from_folder\"><code>from_folder</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L102\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>from_folder</code>(**`path`**:`PathOrStr`, **`train`**:`PathOrStr`=***`'train'`***, **`valid`**:`PathOrStr`=***`'valid'`***, **`valid_pct`**=***`None`***, **`classes`**:`Collection`\\[`T_co`\\]=***`None`***, **\\*\\*`kwargs`**:`Any`) → `ImageDataBunch`\n",
        "\n",
@@ -525,7 +525,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ImageDataBunch.from_csv\"><code>from_csv</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L121\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ImageDataBunch.from_csv\"><code>from_csv</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L122\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>from_csv</code>(**`path`**:`PathOrStr`, **`folder`**:`PathOrStr`=***`None`***, **`label_delim`**:`str`=***`None`***, **`csv_labels`**:`PathOrStr`=***`'labels.csv'`***, **`valid_pct`**:`float`=***`0.2`***, **`fn_col`**:`int`=***`0`***, **`label_col`**:`int`=***`1`***, **`suffix`**:`str`=***`''`***, **`delimiter`**:`str`=***`None`***, **`header`**:`Union`\\[`int`, `str`, `NoneType`\\]=***`'infer'`***, **\\*\\*`kwargs`**:`Any`) → `ImageDataBunch`\n",
        "\n",
@@ -573,7 +573,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ImageDataBunch.from_df\"><code>from_df</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L112\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ImageDataBunch.from_df\"><code>from_df</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L113\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>from_df</code>(**`path`**:`PathOrStr`, **`df`**:`DataFrame`, **`folder`**:`PathOrStr`=***`None`***, **`label_delim`**:`str`=***`None`***, **`valid_pct`**:`float`=***`0.2`***, **`fn_col`**:`IntsOrStrs`=***`0`***, **`label_col`**:`IntsOrStrs`=***`1`***, **`suffix`**:`str`=***`''`***, **\\*\\*`kwargs`**:`Any`) → `ImageDataBunch`\n",
        "\n",
@@ -711,7 +711,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ImageDataBunch.from_name_re\"><code>from_name_re</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L144\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ImageDataBunch.from_name_re\"><code>from_name_re</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L148\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>from_name_re</code>(**`path`**:`PathOrStr`, **`fnames`**:`FilePathList`, **`pat`**:`str`, **`valid_pct`**:`float`=***`0.2`***, **\\*\\*`kwargs`**)\n",
        "\n",
@@ -801,7 +801,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ImageDataBunch.from_name_func\"><code>from_name_func</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L138\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ImageDataBunch.from_name_func\"><code>from_name_func</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L142\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>from_name_func</code>(**`path`**:`PathOrStr`, **`fnames`**:`FilePathList`, **`label_func`**:`Callable`, **`valid_pct`**:`float`=***`0.2`***, **\\*\\*`kwargs`**)\n",
        "\n",
@@ -862,9 +862,9 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ImageDataBunch.from_lists\"><code>from_lists</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L131\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ImageDataBunch.from_lists\"><code>from_lists</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L132\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
-       "> <code>from_lists</code>(**`path`**:`PathOrStr`, **`fnames`**:`FilePathList`, **`labels`**:`StrList`, **`valid_pct`**:`float`=***`0.2`***, **\\*\\*`kwargs`**)\n",
+       "> <code>from_lists</code>(**`path`**:`PathOrStr`, **`fnames`**:`FilePathList`, **`labels`**:`StrList`, **`valid_pct`**:`float`=***`0.2`***, **`item_cls`**:`Callable`=***`None`***, **\\*\\*`kwargs`**)\n",
        "\n",
        "Create from list of `fnames` in `path`.  "
       ],
@@ -925,7 +925,7 @@
       "text/markdown": [
        "<h4 id=\"ImageDataBunch.create_from_ll\"><code>create_from_ll</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L89\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
-       "> <code>create_from_ll</code>(**`lls`**:[`LabelLists`](/data_block.html#LabelLists), **`bs`**:`int`=***`64`***, **`val_bs`**:`int`=***`None`***, **`ds_tfms`**:`Union`\\[`Callable`, `Collection`\\[`Callable`\\], `NoneType`\\]=***`None`***, **`num_workers`**:`int`=***`4`***, **`dl_tfms`**:`Optional`\\[`Collection`\\[`Callable`\\]\\]=***`None`***, **`device`**:[`device`](https://pytorch.org/docs/stable/tensor_attributes.html#torch-device)=***`None`***, **`test`**:`Union`\\[`Path`, `str`, `NoneType`\\]=***`None`***, **`collate_fn`**:`Callable`=***`'data_collate'`***, **`size`**:`int`=***`None`***, **`no_check`**:`bool`=***`False`***, **`resize_method`**:[`ResizeMethod`](/vision.image.html#ResizeMethod)=***`None`***, **`mult`**:`int`=***`None`***, **`padding_mode`**:`str`=***`'reflection'`***, **`mode`**:`str`=***`'bilinear'`***) → `ImageDataBunch`\n",
+       "> <code>create_from_ll</code>(**`lls`**:[`LabelLists`](/data_block.html#LabelLists), **`bs`**:`int`=***`64`***, **`val_bs`**:`int`=***`None`***, **`ds_tfms`**:`Union`\\[`Callable`, `Collection`\\[`Callable`\\], `NoneType`\\]=***`None`***, **`num_workers`**:`int`=***`12`***, **`dl_tfms`**:`Optional`\\[`Collection`\\[`Callable`\\]\\]=***`None`***, **`device`**:[`device`](https://pytorch.org/docs/stable/tensor_attributes.html#torch-device)=***`None`***, **`test`**:`Union`\\[`Path`, `str`, `NoneType`\\]=***`None`***, **`collate_fn`**:`Callable`=***`'data_collate'`***, **`size`**:`int`=***`None`***, **`no_check`**:`bool`=***`False`***, **`resize_method`**:[`ResizeMethod`](/vision.image.html#ResizeMethod)=***`None`***, **`mult`**:`int`=***`None`***, **`padding_mode`**:`str`=***`'reflection'`***, **`mode`**:`str`=***`'bilinear'`***, **`tfm_y`**:`bool`=***`False`***) → `ImageDataBunch`\n",
        "\n",
        "Create an [`ImageDataBunch`](/vision.data.html#ImageDataBunch) from [`LabelLists`](/data_block.html#LabelLists) `lls` with potential `ds_tfms`.  "
       ],
@@ -958,7 +958,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ImageDataBunch.single_from_classes\"><code>single_from_classes</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L155\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ImageDataBunch.single_from_classes\"><code>single_from_classes</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L159\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>single_from_classes</code>(**`path`**:`PathOrStr`, **`classes`**:`StrList`, **`ds_tfms`**:`Union`\\[`Callable`, `Collection`\\[`Callable`\\]\\]=***`None`***, **\\*\\*`kwargs`**)\n",
        "\n",
@@ -1159,7 +1159,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ImageDataBunch.batch_stats\"><code>batch_stats</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L163\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ImageDataBunch.batch_stats\"><code>batch_stats</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L167\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>batch_stats</code>(**`funcs`**:`Collection`\\[`Callable`\\]=***`None`***) → `Tensor`\n",
        "\n",
@@ -1207,7 +1207,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ImageDataBunch.normalize\"><code>normalize</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L169\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ImageDataBunch.normalize\"><code>normalize</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L173\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>normalize</code>(**`stats`**:`Collection`\\[`Tensor`\\]=***`None`***, **`do_x`**:`bool`=***`True`***, **`do_y`**:`bool`=***`False`***)\n",
        "\n",
@@ -1516,7 +1516,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h3 id=\"ImageItemList\"><code>class</code> <code>ImageItemList</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L251\" class=\"source_link\">[source]</a></h3>\n",
+       "<h3 id=\"ImageItemList\"><code>class</code> <code>ImageItemList</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L255\" class=\"source_link\">[source]</a></h3>\n",
        "\n",
        "> <code>ImageItemList</code>(**\\*`args`**, **`convert_mode`**=***`'RGB'`***, **\\*\\*`kwargs`**) :: [`ItemList`](/data_block.html#ItemList)\n",
        "\n",
@@ -1551,7 +1551,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ImageItemList.from_folder\"><code>from_folder</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L270\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ImageItemList.from_folder\"><code>from_folder</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L274\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>from_folder</code>(**`path`**:`PathOrStr`=***`'.'`***, **`extensions`**:`StrList`=***`None`***, **\\*\\*`kwargs`**) → [`ItemList`](/data_block.html#ItemList)\n",
        "\n",
@@ -1579,7 +1579,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ImageItemList.from_df\"><code>from_df</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L276\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ImageItemList.from_df\"><code>from_df</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L280\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>from_df</code>(**`df`**:`DataFrame`, **`path`**:`PathOrStr`, **`cols`**:`IntsOrStrs`=***`0`***, **`folder`**:`PathOrStr`=***`None`***, **`suffix`**:`str`=***`''`***, **\\*\\*`kwargs`**) → `ItemList`\n",
        "\n",
@@ -1635,7 +1635,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ImageItemList.open\"><code>open</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L260\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ImageItemList.open\"><code>open</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L264\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>open</code>(**`fn`**)\n",
        "\n",
@@ -1663,7 +1663,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ImageItemList.show_xys\"><code>show_xys</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L295\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ImageItemList.show_xys\"><code>show_xys</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L299\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>show_xys</code>(**`xs`**, **`ys`**, **`imgsize`**:`int`=***`4`***, **`figsize`**:`Optional`\\[`Tuple`\\[`int`, `int`\\]\\]=***`None`***, **\\*\\*`kwargs`**)\n",
        "\n",
@@ -1691,7 +1691,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ImageItemList.show_xyzs\"><code>show_xyzs</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L303\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ImageItemList.show_xyzs\"><code>show_xyzs</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L307\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>show_xyzs</code>(**`xs`**, **`ys`**, **`zs`**, **`imgsize`**:`int`=***`4`***, **`figsize`**:`Optional`\\[`Tuple`\\[`int`, `int`\\]\\]=***`None`***, **\\*\\*`kwargs`**)\n",
        "\n",
@@ -1719,7 +1719,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h3 id=\"ObjectCategoryList\"><code>class</code> <code>ObjectCategoryList</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L344\" class=\"source_link\">[source]</a></h3>\n",
+       "<h3 id=\"ObjectCategoryList\"><code>class</code> <code>ObjectCategoryList</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L348\" class=\"source_link\">[source]</a></h3>\n",
        "\n",
        "> <code>ObjectCategoryList</code>(**`items`**:`Iterator`\\[`T_co`\\], **`classes`**:`Collection`\\[`T_co`\\]=***`None`***, **`label_delim`**:`str`=***`None`***, **`one_hot`**:`bool`=***`False`***, **\\*\\*`kwargs`**) :: [`MultiCategoryList`](/data_block.html#MultiCategoryList)\n",
        "\n",
@@ -1747,7 +1747,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h3 id=\"ObjectItemList\"><code>class</code> <code>ObjectItemList</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L360\" class=\"source_link\">[source]</a></h3>\n",
+       "<h3 id=\"ObjectItemList\"><code>class</code> <code>ObjectItemList</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L364\" class=\"source_link\">[source]</a></h3>\n",
        "\n",
        "> <code>ObjectItemList</code>(**\\*`args`**, **`convert_mode`**=***`'RGB'`***, **\\*\\*`kwargs`**) :: [`ImageItemList`](/vision.data.html#ImageItemList)\n",
        "\n",
@@ -1775,7 +1775,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h3 id=\"SegmentationItemList\"><code>class</code> <code>SegmentationItemList</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L381\" class=\"source_link\">[source]</a></h3>\n",
+       "<h3 id=\"SegmentationItemList\"><code>class</code> <code>SegmentationItemList</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L385\" class=\"source_link\">[source]</a></h3>\n",
        "\n",
        "> <code>SegmentationItemList</code>(**\\*`args`**, **`convert_mode`**=***`'RGB'`***, **\\*\\*`kwargs`**) :: [`ImageItemList`](/vision.data.html#ImageItemList)\n",
        "\n",
@@ -1803,7 +1803,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h3 id=\"SegmentationLabelList\"><code>class</code> <code>SegmentationLabelList</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L369\" class=\"source_link\">[source]</a></h3>\n",
+       "<h3 id=\"SegmentationLabelList\"><code>class</code> <code>SegmentationLabelList</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L373\" class=\"source_link\">[source]</a></h3>\n",
        "\n",
        "> <code>SegmentationLabelList</code>(**`items`**:`Iterator`\\[`T_co`\\], **`classes`**:`Collection`\\[`T_co`\\]=***`None`***, **\\*\\*`kwargs`**) :: [`ImageItemList`](/vision.data.html#ImageItemList)\n",
        "\n",
@@ -1831,9 +1831,9 @@
     {
      "data": {
       "text/markdown": [
-       "<h3 id=\"PointsLabelList\"><code>class</code> <code>PointsLabelList</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L390\" class=\"source_link\">[source]</a></h3>\n",
+       "<h3 id=\"PointsLabelList\"><code>class</code> <code>PointsLabelList</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L394\" class=\"source_link\">[source]</a></h3>\n",
        "\n",
-       "> <code>PointsLabelList</code>(**`items`**:`Iterator`\\[`T_co`\\], **`path`**:`PathOrStr`=***`'.'`***, **`label_cls`**:`Callable`=***`None`***, **`xtra`**:`Any`=***`None`***, **`processor`**:`Union`\\[[`PreProcessor`](/data_block.html#PreProcessor), `Collection`\\[[`PreProcessor`](/data_block.html#PreProcessor)\\]\\]=***`None`***, **`x`**:`ItemList`=***`None`***, **`ignore_empty`**:`bool`=***`False`***) :: [`ItemList`](/data_block.html#ItemList)\n",
+       "> <code>PointsLabelList</code>(**`items`**:`Iterator`\\[`T_co`\\], **`path`**:`PathOrStr`=***`'.'`***, **`label_cls`**:`Callable`=***`None`***, **`inner_df`**:`Any`=***`None`***, **`processor`**:`Union`\\[[`PreProcessor`](/data_block.html#PreProcessor), `Collection`\\[[`PreProcessor`](/data_block.html#PreProcessor)\\]\\]=***`None`***, **`x`**:`ItemList`=***`None`***, **`ignore_empty`**:`bool`=***`False`***) :: [`ItemList`](/data_block.html#ItemList)\n",
        "\n",
        "[`ItemList`](/data_block.html#ItemList) for points.  "
       ],
@@ -1859,7 +1859,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h3 id=\"PointsItemList\"><code>class</code> <code>PointsItemList</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L403\" class=\"source_link\">[source]</a></h3>\n",
+       "<h3 id=\"PointsItemList\"><code>class</code> <code>PointsItemList</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L407\" class=\"source_link\">[source]</a></h3>\n",
        "\n",
        "> <code>PointsItemList</code>(**\\*`args`**, **`convert_mode`**=***`'RGB'`***, **\\*\\*`kwargs`**) :: [`ImageItemList`](/vision.data.html#ImageItemList)\n",
        "\n",
@@ -1887,7 +1887,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h3 id=\"ImageImageList\"><code>class</code> <code>ImageImageList</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L407\" class=\"source_link\">[source]</a></h3>\n",
+       "<h3 id=\"ImageImageList\"><code>class</code> <code>ImageImageList</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L411\" class=\"source_link\">[source]</a></h3>\n",
        "\n",
        "> <code>ImageImageList</code>(**\\*`args`**, **`convert_mode`**=***`'RGB'`***, **\\*\\*`kwargs`**) :: [`ImageItemList`](/vision.data.html#ImageItemList)\n",
        "\n",
@@ -1929,7 +1929,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"download_images\"><code>download_images</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L187\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"download_images\"><code>download_images</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L191\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>download_images</code>(**`urls`**:`StrList`, **`dest`**:`PathOrStr`, **`max_pics`**:`int`=***`1000`***, **`max_workers`**:`int`=***`8`***, **`timeout`**=***`4`***)\n",
        "\n",
@@ -1957,7 +1957,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"verify_images\"><code>verify_images</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L238\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"verify_images\"><code>verify_images</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L242\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>verify_images</code>(**`path`**:`PathOrStr`, **`delete`**:`bool`=***`True`***, **`max_workers`**:`int`=***`4`***, **`max_size`**:`int`=***`None`***, **`dest`**:`PathOrStr`=***`'.'`***, **`n_channels`**:`int`=***`3`***, **`interp`**=***`2`***, **`ext`**:`str`=***`None`***, **`img_format`**:`str`=***`None`***, **`resume`**:`bool`=***`None`***, **\\*\\*`kwargs`**)\n",
        "\n",
@@ -1997,7 +1997,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ImageItemList.get\"><code>get</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L264\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ImageItemList.get\"><code>get</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L268\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>get</code>(**`i`**)\n",
        "\n",
@@ -2049,7 +2049,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ImageItemList.from_csv\"><code>from_csv</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L286\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ImageItemList.from_csv\"><code>from_csv</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L290\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>from_csv</code>(**`path`**:`PathOrStr`, **`csv_name`**:`str`, **`header`**:`str`=***`'infer'`***, **\\*\\*`kwargs`**) → `ItemList`\n",
        "\n",
@@ -2075,7 +2075,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ObjectCategoryList.get\"><code>get</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L348\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ObjectCategoryList.get\"><code>get</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L352\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>get</code>(**`i`**)\n",
        "\n",
@@ -2101,7 +2101,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ImageItemList.get\"><code>get</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L264\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ImageItemList.get\"><code>get</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L268\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>get</code>(**`i`**)\n",
        "\n",
@@ -2127,7 +2127,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"SegmentationLabelList.reconstruct\"><code>reconstruct</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L379\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"SegmentationLabelList.reconstruct\"><code>reconstruct</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L383\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>reconstruct</code>(**`t`**:`Tensor`)\n",
        "\n",
@@ -2153,7 +2153,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ImageImageList.show_xys\"><code>show_xys</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L411\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ImageImageList.show_xys\"><code>show_xys</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L415\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>show_xys</code>(**`xs`**, **`ys`**, **`imgsize`**:`int`=***`4`***, **`figsize`**:`Optional`\\[`Tuple`\\[`int`, `int`\\]\\]=***`None`***, **\\*\\*`kwargs`**)\n",
        "\n",
@@ -2179,7 +2179,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ImageImageList.show_xyzs\"><code>show_xyzs</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L419\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ImageImageList.show_xyzs\"><code>show_xyzs</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L423\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>show_xyzs</code>(**`xs`**, **`ys`**, **`zs`**, **`imgsize`**:`int`=***`4`***, **`figsize`**:`Optional`\\[`Tuple`\\[`int`, `int`\\]\\]=***`None`***, **\\*\\*`kwargs`**)\n",
        "\n",
@@ -2205,7 +2205,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ImageItemList.open\"><code>open</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L260\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ImageItemList.open\"><code>open</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L264\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>open</code>(**`fn`**)\n",
        "\n",
@@ -2257,7 +2257,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"SegmentationLabelList.analyze_pred\"><code>analyze_pred</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L378\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"SegmentationLabelList.analyze_pred\"><code>analyze_pred</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L382\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>analyze_pred</code>(**`pred`**, **`thresh`**:`float`=***`0.5`***)\n",
        "\n",
@@ -2283,7 +2283,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ImageItemList.reconstruct\"><code>reconstruct</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L293\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ImageItemList.reconstruct\"><code>reconstruct</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L297\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>reconstruct</code>(**`t`**:`Tensor`)\n",
        "\n",
@@ -2309,7 +2309,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"SegmentationLabelList.open\"><code>open</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L377\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"SegmentationLabelList.open\"><code>open</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L381\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>open</code>(**`fn`**)\n",
        "\n",
@@ -2335,7 +2335,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ImageItemList.reconstruct\"><code>reconstruct</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L293\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ImageItemList.reconstruct\"><code>reconstruct</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L297\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>reconstruct</code>(**`t`**:`Tensor`)\n",
        "\n",
@@ -2361,7 +2361,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"resize_to\"><code>resize_to</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L194\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"resize_to\"><code>resize_to</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L198\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>resize_to</code>(**`img`**, **`targ_sz`**:`int`, **`use_min`**:`bool`=***`False`***)\n",
        "\n",
@@ -2387,7 +2387,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ObjectCategoryList.reconstruct\"><code>reconstruct</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L353\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ObjectCategoryList.reconstruct\"><code>reconstruct</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L357\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>reconstruct</code>(**`t`**, **`x`**)\n",
        "\n",
@@ -2413,7 +2413,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"PointsLabelList.reconstruct\"><code>reconstruct</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L401\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"PointsLabelList.reconstruct\"><code>reconstruct</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L405\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>reconstruct</code>(**`t`**, **`x`**)\n",
        "\n",
@@ -2439,7 +2439,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"PointsLabelList.analyze_pred\"><code>analyze_pred</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L400\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"PointsLabelList.analyze_pred\"><code>analyze_pred</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L404\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>analyze_pred</code>(**`pred`**, **`thresh`**:`float`=***`0.5`***)\n",
        "\n",
@@ -2465,7 +2465,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"PointsLabelList.get\"><code>get</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L396\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"PointsLabelList.get\"><code>get</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L400\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>get</code>(**`i`**)\n",
        "\n",
@@ -2500,7 +2500,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ObjectCategoryList.analyze_pred\"><code>analyze_pred</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L351\" class=\"source_link\">[source]</a></h4>\n",
+       "<h4 id=\"ObjectCategoryList.analyze_pred\"><code>analyze_pred</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/vision/data.py#L355\" class=\"source_link\">[source]</a></h4>\n",
        "\n",
        "> <code>analyze_pred</code>(**`pred`**)\n",
        "\n",

--- a/docs_src/vision.data.ipynb
+++ b/docs_src/vision.data.ipynb
@@ -597,7 +597,7 @@
    "source": [
     "Refer to [`create_from_ll`](#ImageDataBunch.create_from_ll) to see all the `**kwargs` arguments.\n",
     "\n",
-    "Same as [`ImageDataBunch.from_csv`](/vision.data.html#ImageDataBunch.from_csv), but passing in a `DataFrame` instead of a csv file. E.gL"
+    "Same as [`ImageDataBunch.from_csv`](/vision.data.html#ImageDataBunch.from_csv), but passing in a `DataFrame` instead of a csv file. e.g"
    ]
   },
   {

--- a/fastai/basic_data.py
+++ b/fastai/basic_data.py
@@ -224,12 +224,6 @@ class DataBunch():
         self.train_dl.batch_size,self.valid_dl.batch_size = v,v
         if self.test_dl is not None: self.test_dl.batch_size = v
 
-    @property
-    def classes(self): return self.train_ds.y.classes
-    @property
-    def c(self): return self.train_ds.y.c
-        #return len(self.train_ds.y[0].data)
-
     def sanity_check(self):
         "Check the underlying data in the training set can be properly loaded."
         final_message = "You can deactivate this warning by passing `no_check=True`."

--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -204,7 +204,7 @@ class Learner():
         self.freeze_to(0)
         self.create_opt(defaults.lr)
 
-    def export(self, fname:str='export.pkl'):
+    def export(self, fname:str='export.pkl', destroy=False):
         "Export the state of the `Learner` in `self.path/fname`."
         args = ['opt_func', 'loss_func', 'metrics', 'true_wd', 'bn_wd', 'wd', 'train_bn', 'model_dir', 'callback_fns']
         state = {a:getattr(self,a) for a in args}
@@ -218,11 +218,7 @@ class Learner():
         state['cls'] = self.__class__
         torch.save(state, open(self.path/fname, 'wb'))
         self.model.to(device)
-
-    def hibernate(self, fname:str='export.pkl'):
-        "Export the state of the `Learner` in `self.path/fname` and remove the object from memory. Use `load_learner` to restore."
-        self.export(fname)
-        self.destroy()
+        if destroy: self.destroy()
 
     def save(self, name:PathOrStr, return_path:bool=False, with_opt:bool=True):
         "Save model and optimizer state (if `with_opt`) with `name` to `self.model_dir`."

--- a/fastai/callbacks/rnn.py
+++ b/fastai/callbacks/rnn.py
@@ -7,7 +7,7 @@ __all__ = ['RNNTrainer']
 
 class RNNTrainer(LearnerCallback):
     "`Callback` that regroups lr adjustment to seq_len, AR and TAR."
-    def __init__(self, learn, alpha:float=0., beta:float=0.):
+    def __init__(self, learn:Learner, alpha:float=0., beta:float=0.):
         super().__init__(learn)
         self.not_min += ['raw_out', 'out']
         self.alpha,self.beta = alpha,beta

--- a/fastai/collab.py
+++ b/fastai/collab.py
@@ -100,7 +100,7 @@ def collab_learner(data, n_factors:int=None, use_nn:bool=False, emb_szs:Dict[str
                    bn_final:bool=False, **learn_kwargs)->Learner:
     "Create a Learner for collaborative filtering on `data`."
     emb_szs = data.get_emb_szs(ifnone(emb_szs, {}))
-    u,m = data.classes.values()
+    u,m = data.train_ds.x.classes.values()
     if use_nn: model = EmbeddingNN(emb_szs=emb_szs, layers=layers, ps=ps, emb_drop=emb_drop, y_range=y_range, 
                                    use_bn=use_bn, bn_final=bn_final, **learn_kwargs)
     else:      model = EmbeddingDotBias(n_factors, len(u), len(m), y_range=y_range)

--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -589,7 +589,7 @@ class LabelList(Dataset):
     def __getattr__(self,k:str)->Any:
         x = super().__getattribute__('x')
         res = getattr(x, k, None)
-        if res is not None: return res
+        if res is not None and k not in ['classes', 'c']: return res
         y = super().__getattribute__('y')
         res = getattr(y, k, None)
         if res is not None: return res

--- a/fastai/gen_doc/doctest.py
+++ b/fastai/gen_doc/doctest.py
@@ -28,7 +28,8 @@ class TestAPIRegistry:
             except:
                 raise Exception(f"'{func}' is not a function")
             if re.match(r'fastai\.', func_fq):
-                TestAPIRegistry.api_tests_map[func_fq].append(entry)
+                if entry not in TestAPIRegistry.api_tests_map[func_fq]: 
+                    TestAPIRegistry.api_tests_map[func_fq].append(entry)
             else:
                 raise Exception(f"'{func}' is not in the fastai API")
 

--- a/fastai/gen_doc/doctest.py
+++ b/fastai/gen_doc/doctest.py
@@ -1,5 +1,4 @@
 import sys, inspect, re, json
-from os.path import basename, split
 from pathlib import Path
 from collections import defaultdict
 
@@ -23,8 +22,14 @@ class TestAPIRegistry:
         parent_func_lineno, _ = get_parent_func(lineno, get_lines(filename))
         entry = [{'file': relative_test_path(filename), 'test': test_name , 'line': parent_func_lineno}]
         for func in funcs:
-            func_fq = get_func_fq_name(func)
-            if re.match(r'fastai\.', func_fq): TestAPIRegistry.api_tests_map[func_fq].append(entry)
+            try:
+                func_fq = get_func_fq_name(func)
+            except:
+                raise Exception(f"'{func}' is not a function")
+            if re.match(r'fastai\.', func_fq):
+                TestAPIRegistry.api_tests_map[func_fq].append(entry)
+            else:
+                raise Exception(f"'{func}' is not in the fastai API")
 
     def tests_failed(status=True):
         TestAPIRegistry.some_tests_failed = status

--- a/fastai/gen_doc/doctest.py
+++ b/fastai/gen_doc/doctest.py
@@ -43,8 +43,23 @@ class TestAPIRegistry:
 
 def this_tests(*funcs): TestAPIRegistry.this_tests(*funcs)
 
+def str2func(name):
+    "Converts 'fastai.foo.bar' into an function 'object' if such exists"
+    if isinstance(name, str): subpaths = name.split('.')
+    else:                     return None
+
+    module = subpaths.pop(0)
+    if module in sys.modules: obj = sys.modules[module]
+    else:                     return None
+
+    for subpath in subpaths:
+        obj = getattr(obj, subpath, None)
+        if obj == None: return None
+    return obj
+
 def get_func_fq_name(func):
     if inspect.ismodule(func): return func.__name__
+    if isinstance(func, str): func = str2func(func)
     name = func.__qualname__ if hasattr(func, '__qualname__') else func.__name__
     return f'{func.__module__}.{name}'
 

--- a/fastai/gen_doc/doctest.py
+++ b/fastai/gen_doc/doctest.py
@@ -7,7 +7,8 @@ __all__ = ['this_tests']
 DB_NAME = 'test_api_db.json'
 
 class RegisterTestsPerAPI:
-    apiTestsMap = dict()
+    api_tests_map = dict()
+    some_tests_failed = False
 
     @staticmethod
     def this_tests(*testedapis):
@@ -17,10 +18,12 @@ class RegisterTestsPerAPI:
         list_test = [{'file': relative_test_path(pathfilename), 'test': test_function_name , 'line': lineno_parentfunc}]
         for api in testedapis:
              fq_apiname = full_name_with_qualname(api)
-             if fq_apiname in RegisterTestsPerAPI.apiTestsMap:
-                 RegisterTestsPerAPI.apiTestsMap[fq_apiname] += list_test
-             else:
-                 RegisterTestsPerAPI.apiTestsMap[fq_apiname] = list_test
+             fastaimodule = re.match(r'^fastai\..*',fq_apiname)
+             if fastaimodule:
+                if fq_apiname in RegisterTestsPerAPI.api_tests_map:
+                    RegisterTestsPerAPI.api_tests_map[fq_apiname] += list_test
+                else:
+                    RegisterTestsPerAPI.api_tests_map[fq_apiname] = list_test
 
 def this_tests(*testedapis): RegisterTestsPerAPI.this_tests(*testedapis)
 

--- a/fastai/gen_doc/doctest.py
+++ b/fastai/gen_doc/doctest.py
@@ -1,6 +1,7 @@
-import sys, inspect, re, json
+import sys, re, json
 from pathlib import Path
 from collections import defaultdict
+from inspect import currentframe, getframeinfo, ismodule
 
 __all__ = ['this_tests']
 
@@ -17,8 +18,8 @@ class TestAPIRegistry:
 
     @staticmethod
     def this_tests(*funcs):
-        prev_frame = inspect.currentframe().f_back.f_back
-        filename, lineno, test_name, _, _ = inspect.getframeinfo(prev_frame)
+        prev_frame = currentframe().f_back.f_back
+        filename, lineno, test_name, _, _ = getframeinfo(prev_frame)
         parent_func_lineno, _ = get_parent_func(lineno, get_lines(filename))
         entry = [{'file': relative_test_path(filename), 'test': test_name , 'line': parent_func_lineno}]
         for func in funcs:
@@ -58,7 +59,7 @@ def str2func(name):
     return obj
 
 def get_func_fq_name(func):
-    if inspect.ismodule(func): return func.__name__
+    if ismodule(func): return func.__name__
     if isinstance(func, str): func = str2func(func)
     name = func.__qualname__ if hasattr(func, '__qualname__') else func.__name__
     return f'{func.__module__}.{name}'

--- a/fastai/gen_doc/nbtest.py
+++ b/fastai/gen_doc/nbtest.py
@@ -1,6 +1,5 @@
 "`gen_doc.nbtest` shows pytest documentation for module functions"
 
-
 import inspect, os, re
 from os.path import abspath, dirname, join
 from collections import namedtuple
@@ -8,13 +7,11 @@ from collections import namedtuple
 from fastai.gen_doc import nbdoc
 from ..imports.core import *
 from .core import ifnone
-from .doctest import get_parent_func, relative_test_path, full_name_with_qualname, DB_NAME
+from .doctest import get_parent_func, relative_test_path, get_func_fq_name, DB_NAME
 
 from nbconvert import HTMLExporter
 from IPython.core import page
 from IPython.core.display import display, Markdown, HTML
-
-
 
 __all__ = ['show_test', 'doctest', 'find_tests', 'lookup_db', 'find_test_matches', 'find_test_files', 'direct_test_match', 'fuzzy_test_match']
 
@@ -37,7 +34,7 @@ def show_test(elt, search=True, markdown:bool=True)->str:
             related = list(set(related) - set(db_matches) - set(direct))
             md += tests2markdown(direct, 'Direct tests')
             md += tests2markdown(related, 'Related tests')
-        except OSError as e: 
+        except OSError as e:
             print('Could not find fastai/tests folder. If you installed from conda, please install developer build instead.')
 
     if len(md)==0: md = f'No tests found for `{fn_name}`'
@@ -52,7 +49,7 @@ def tests2markdown(tests, type_label):
     for link,cmd in tests:
         md += f'\n * `{cmd}` [\[source\]]({link})'
     return f'\n\n{type_label}:' + md
-    
+
 def doctest(elt):
     "Inline notebook popup for `show_test`"
     md = show_test(elt, markdown=False)
@@ -63,14 +60,14 @@ def doctest(elt):
 def lookup_db(elt)->List[Dict]:
     "Finds `this_test` entries from test_api_db.json"
     db_file = Path(abspath(join(dirname( __file__ ), '..')))/DB_NAME
-    if not db_file.exists(): 
+    if not db_file.exists():
         print(f'Could not find {db_file}. Please make sure it exists at this location or run `make test`')
         return []
     with open(db_file, 'r') as f:
         db = json.load(f)
-    key = full_name_with_qualname(elt)
+    key = get_func_fq_name(elt)
     return db.get(key, {})
-    
+
 def find_tests(elt)->Tuple[List[Dict],List[Dict]]:
     "Searches `fastai/tests` folder for any test functions related to `elt`"
     test_dir = get_tests_dir(elt)
@@ -95,7 +92,7 @@ def find_test_files(elt, exact_match:bool=False)->List[Path]:
     "Searches in `fastai/tests` directory for module tests"
     test_dir = get_tests_dir(elt)
     matches = [test_dir/o.name for o in os.scandir(test_dir) if _is_file_match(elt, o.name)]
-    if len(matches) != 1: 
+    if len(matches) != 1:
         print('Could not find exact file match:', matches)
     return matches
 

--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -95,7 +95,7 @@ def r2_score(pred:Tensor, targ:Tensor)->Rank0Tensor:
 
 class RegMetrics(Callback):
     "Stores predictions and targets to perform calculations on epoch end."
-    def on_epoch_begin(self):
+    def on_epoch_begin(self, **kwargs):
         self.targs, self.preds = Tensor([]), Tensor([])
 
     def on_batch_end(self, last_output:Tensor, last_target:Tensor, **kwargs):
@@ -105,22 +105,22 @@ class RegMetrics(Callback):
 
 class R2Score(RegMetrics):
     "Compute the R2 score (coefficient of determination)."
-    def on_epoch_end(self):
+    def on_epoch_end(self, **kwargs):
         self.metric = r2_score(self.preds, self.targs)
 
 class ExplainedVariance(RegMetrics):
     "Compute the explained variance."
-    def on_epoch_end(self):
+    def on_epoch_end(self, **kwargs):
         self.metric = explained_variance(self.preds, self.targs)
 
 class RMSE(RegMetrics):
     "Compute the root mean squared error."
-    def on_epoch_end(self):
+    def on_epoch_end(self, **kwargs):
         self.metric = root_mean_squared_error(self.preds, self.targs)
 
 class ExpRMSPE(RegMetrics):
     "Compute the exponential of the root mean square error."
-    def on_epoch_end(self):
+    def on_epoch_end(self, **kwargs):
         self.metric = exp_rmspe(self.preds, self.targs)
 
 # Aliases
@@ -204,14 +204,12 @@ class CMScores(ConfusionMatrix):
 class Recall(CMScores):
     "Compute the Recall."
     def on_epoch_end(self, **kwargs):
-        self.metric = self._recall()
-            
+        self.metric = self._recall()           
 
 class Precision(CMScores):
     "Compute the Precision."
     def on_epoch_end(self, **kwargs):
-        self.metric = self._precision()
-            
+        self.metric = self._precision()         
             
 @dataclass
 class FBeta(CMScores):

--- a/fastai/text/learner.py
+++ b/fastai/text/learner.py
@@ -83,7 +83,7 @@ class RNNLearner(Learner):
         if ordered and hasattr(self.dl(ds_type), 'sampler'):
             sampler = [i for i in self.dl(ds_type).sampler]
             reverse_sampler = np.argsort(sampler)
-            preds[0],preds[1] = preds[0][reverse_sampler],preds[1][reverse_sampler]
+            preds = [p[reverse_sampler] for p in preds] 
         return(preds)
 
 def decode_spec_tokens(tokens):

--- a/fastai/text/models/awd_lstm.py
+++ b/fastai/text/models/awd_lstm.py
@@ -99,12 +99,13 @@ class AWD_LSTM(nn.Module):
         self.input_dp = RNNDropout(input_p)
         self.hidden_dps = nn.ModuleList([RNNDropout(hidden_p) for l in range(n_layers)])
 
-    def forward(self, input:LongTensor)->Tuple[Tensor,Tensor]:
-        bs,sl = input.size()
+    def forward(self, input:Tensor, from_embeddings:bool=False)->Tuple[Tensor,Tensor]:
+        if from_embeddings: bs,sl,es = input.size()
+        else: bs,sl = input.size()
         if bs!=self.bs:
             self.bs=bs
             self.reset()
-        raw_output = self.input_dp(self.encoder_dp(input))
+        raw_output = self.input_dp(input if from_embeddings else self.encoder_dp(input))
         new_hidden,raw_outputs,outputs = [],[],[]
         for l, (rnn,hid_dp) in enumerate(zip(self.rnns, self.hidden_dps)):
             raw_output, new_h = rnn(raw_output, self.hidden[l])

--- a/fastai/text/transform.py
+++ b/fastai/text/transform.py
@@ -77,7 +77,7 @@ def deal_caps(x:Collection[str]) -> Collection[str]:
     res = []
     for t in x:
         if t == '': continue
-        if t[0].isupper() and t[1:].islower(): res.append(TK_MAJ)
+        if t[0].isupper() and len(t) > 1 and t[1:].islower(): res.append(TK_MAJ)
         res.append(t.lower())
     return res
 

--- a/fastai/train.py
+++ b/fastai/train.py
@@ -5,7 +5,7 @@ from .basic_data import *
 from .basic_train import *
 
 __all__ = ['BnFreeze', 'GradientClipping', 'ShowGraph', 'ClassificationInterpretation', 'fit_one_cycle', 'lr_find', 'one_cycle_scheduler', 'to_fp16', 'to_fp32',
-           'mixup']
+           'mixup', 'AccumulateStepper']
 
 def one_cycle_scheduler(lr_max:float, **kwargs:Any)->OneCycleScheduler:
     "Instantiate a `OneCycleScheduler` with `lr_max`."
@@ -94,8 +94,48 @@ def clip_grad(learn:Learner, clip:float=0.1)->Learner:
     "Add gradient clipping of `clip` during training."
     learn.callback_fns.append(partial(GradientClipping, clip=clip))
     return learn
-
 Learner.clip_grad = clip_grad
+     
+class AccumulateStepper(LearnerCallback):
+    "Does accumlated step every nth step by accumulating gradients"
+
+    def __init__(self, learn:Learner, n_step:int = 1, drop_last:bool = False):
+        super().__init__(learn)
+        self.n_step,self.drop_last = n_step,drop_last
+ 
+    def on_train_begin(self, **kwargs):
+        "check if loss is reduction"
+        if hasattr(self.loss_func, "reduction") and (self.loss_func.reduction != "sum"):
+             warn("For better gradients consider 'reduction=sum'")
+        
+    def on_epoch_begin(self, **kwargs):
+        "init samples and batches, change optimizer"
+        self.acc_samples, self.acc_batches = 0., 0. 
+        
+    def on_batch_begin(self, last_input, last_target, **kwargs):
+        "accumulate samples and batches"
+        self.acc_samples += last_input.shape[0]
+        self.acc_batches += 1
+        
+    def on_backward_end(self, **kwargs):
+        "accumulated step and reset samples, True will result in no stepping"
+        if (self.acc_batches % self.n_step) == 0:
+            for p in (self.learn.model.parameters()):
+                if p.requires_grad: p.grad.div_(self.acc_samples)
+            self.acc_samples = 0
+        else: return True
+    
+    def on_step_end(self, **kwargs):
+        "zero gradients after stepping, True will result in no zeroing"
+        return (self.acc_batches % self.n_step) != 0
+    
+    def on_epoch_end(self, **kwargs):
+        "step the rest of the accumulated grads if not perfectly divisible"
+        for p in (self.learn.model.parameters()):
+                if p.requires_grad: p.grad.div_(self.acc_samples)
+        if not self.drop_last: self.learn.opt.step()
+        self.learn.opt.zero_grad()
+
 
 class ClassificationInterpretation():
     "Interpretation methods for classification models."

--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -259,7 +259,7 @@ class ImageItemList(ItemList):
         super().__init__(*args, **kwargs)
         self.convert_mode = convert_mode
         self.copy_new.append('convert_mode')
-        self.sizes={}
+        self.c,self.sizes = 3,{}
 
     def open(self, fn):
         "Open image in `fn`, subclass and overwrite for custom behavior."

--- a/fastai/vision/image.py
+++ b/fastai/vision/image.py
@@ -98,11 +98,12 @@ class Image(ItemBase):
                    mult:int=None, padding_mode:str='reflection', mode:str='bilinear', remove_out:bool=True)->TensorImage:
         "Apply all `tfms` to the `Image`, if `do_resolve` picks value for random args."
         if not (tfms or xtra or size): return self
+        tfms = listify(tfms)
         xtra = ifnone(xtra, {})
-        tfms = sorted(listify(tfms), key=lambda o: o.tfm.order)
         default_rsz = ResizeMethod.SQUISH if (size is not None and is_listy(size)) else ResizeMethod.CROP
         resize_method = ifnone(resize_method, default_rsz)
-        if resize_method <= 2: tfms = self._maybe_add_crop_pad(tfms)
+        if resize_method <= 2 and size is not None: tfms = self._maybe_add_crop_pad(tfms)
+        tfms = sorted(tfms, key=lambda o: o.tfm.order)
         if do_resolve: _resolve_tfms(tfms)
         x = self.clone()
         x.set_sample(padding_mode=padding_mode, mode=mode, remove_out=remove_out)

--- a/fastai/vision/transform.py
+++ b/fastai/vision/transform.py
@@ -164,6 +164,7 @@ crop = TfmPixel(_crop)
 def _crop_pad_default(x, size, padding_mode='reflection', row_pct:uniform = 0.5, col_pct:uniform = 0.5):
     "Crop and pad tfm - `row_pct`,`col_pct` sets focal point."
     padding_mode = _pad_mode_convert[padding_mode]
+    print(padding_mode)
     size = tis2hw(size)
     if x.shape[1:] == torch.Size(size): return x
     rows,cols = size

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ dep_groups = {
         packaging
         Pillow
         pyyaml
+        pynvx ; platform_system=="Darwin"  # only pypi at the moment
         requests
         scipy
         torch>=1.0.0

--- a/tests/test_basic_train.py
+++ b/tests/test_basic_train.py
@@ -3,12 +3,13 @@ module: basic_train.py - Model fitting methods
 docs  : https://docs.fast.ai/train.html
 """
 
-import pytest, fastai
+import pytest
 from fastai.vision import *
+from fastai.utils.mem import *
+from fastai.gen_doc.doctest import this_tests
 from utils.fakes import *
 from utils.text import *
 from utils.mem import *
-from fastai.utils.mem import *
 from math import isclose
 
 torch_preload_mem()
@@ -30,12 +31,14 @@ def learn(data): return learn_large_unfit(data)
 
 def test_get_preds():
     learn = fake_learner()
+    this_tests(learn.get_preds)
     with CaptureStdout() as cs:
         a = learn.get_preds()
     assert learn.data.batch_size == len(a[1])
 
 def test_freeze_to():
     learn = fake_learner(layer_group_count=3)
+    this_tests(learn.freeze_to)
     learn.freeze_to(1)
     for i, param in enumerate(learn.model.parameters()):
         # param 0 is weights in layer_group 0 and param 1 is bias in layer_group 0
@@ -45,6 +48,7 @@ def test_freeze_to():
 
 def test_freeze():
     learn = fake_learner(layer_group_count=3)
+    this_tests(learn.freeze)
     learn.freeze()
     for i, param in enumerate(learn.model.parameters()):
         # 2 layer groups with 1 param in each should be frozen
@@ -53,6 +57,7 @@ def test_freeze():
 
 def test_unfreeze():
     learn = fake_learner(layer_group_count=4)
+    this_tests(learn.unfreeze)
     for param in learn.model.parameters(): param.requires_grad=False
     learn.unfreeze()
     for param in learn.model.parameters(): assert param.requires_grad == True
@@ -65,6 +70,7 @@ def check_learner(learn, train_items):
     # XXX: could use more sanity checks
 
 def test_save_load(learn):
+    this_tests(learn.save, learn.load)
     name = 'mnist-tiny-test-save-load'
     train_items = len(learn.data.train_ds)
     # testing that all these various sequences don't break each other
@@ -131,6 +137,7 @@ def subtest_save_load_mem(data):
 def test_destroy():
     msg = "this object has been destroyed"
     learn = fake_learner()
+    this_tests(learn.destroy)
     with CaptureStdout() as cs: learn.destroy()
     assert "this Learner object self-destroyed" in cs.out
 
@@ -189,6 +196,7 @@ def test_export_load_learner():
     export_file = 'export.pkl'
     for should_destroy in [False, True]:
         learn = fake_learner()
+        this_tests(learn.export, load_learner)
         path = learn.path
         with CaptureStdout() as cs: learn.export(destroy=should_destroy)
         learn = load_learner(path)

--- a/tests/test_basic_train.py
+++ b/tests/test_basic_train.py
@@ -57,28 +57,28 @@ def test_unfreeze():
     learn.unfreeze()
     for param in learn.model.parameters(): assert param.requires_grad == True
 
-def check_learner(learn, train_ds_size):
+def check_learner(learn, train_items):
     # basic checks
     #assert learn.recorder
     assert learn.model
-    assert train_ds_size == len(learn.data.train_ds)
+    assert train_items == len(learn.data.train_ds.items)
     # XXX: could use more sanity checks
 
 def test_save_load(learn):
     name = 'mnist-tiny-test-save-load'
-    train_ds_size = len(learn.data.train_ds)
+    train_items = len(learn.data.train_ds)
     # testing that all these various sequences don't break each other
     model_path = learn.save(name, return_path=True)
     learn.load(name, purge=True)
     learn.data.sanity_check()
-    check_learner(learn, train_ds_size)
+    check_learner(learn, train_items)
 
     learn.purge()
     learn.load(name)
     learn.load(name)
     model_path = learn.save(name, return_path=True)
     learn.load(name, purge=True)
-    check_learner(learn, train_ds_size)
+    check_learner(learn, train_items)
     if os.path.exists(model_path): os.remove(model_path)
 
 def check_mem_expected(used_exp, peaked_exp, mtrace, abs_tol=2, ctx=None):
@@ -193,6 +193,6 @@ def test_export_load_learner():
         with CaptureStdout() as cs: learn.export(destroy=should_destroy)
         learn = load_learner(path)
         # export removes data
-        train_ds_size = 1 # XXX: not 0?
-        check_learner(learn, train_ds_size)
+        train_items = 0
+        check_learner(learn, train_items)
         if os.path.exists(export_file): os.remove(export_file)

--- a/tests/test_basic_train.py
+++ b/tests/test_basic_train.py
@@ -185,12 +185,12 @@ def test_memory(data):
     subtest_save_load_mem(data)
     subtest_destroy_mem(data)
 
-def test_export_load_learner_hibernate():
+def test_export_load_learner():
     export_file = 'export.pkl'
-    for m in ['export', 'hibernate']:
+    for should_destroy in [False, True]:
         learn = fake_learner()
         path = learn.path
-        with CaptureStdout() as cs: getattr(learn, m)()
+        with CaptureStdout() as cs: learn.export(destroy=should_destroy)
         learn = load_learner(path)
         # export removes data
         train_ds_size = 1 # XXX: not 0?

--- a/tests/test_gen_doc_nbtest.py
+++ b/tests/test_gen_doc_nbtest.py
@@ -73,6 +73,10 @@ def test_this_tests():
     # function by reference (and self test)
     this_tests(this_tests)
 
+    # multiple entries: same function twice on purpose, should result in just one entry,
+    # but also testing multiple entries - and this test tests only a single function.
+    this_tests(this_tests, this_tests)
+
     import fastai
     # explicit fully qualified function (requires all the sub-modules to be loaded)
     this_tests(fastai.gen_doc.doctest.this_tests)

--- a/tests/test_gen_doc_nbtest.py
+++ b/tests/test_gen_doc_nbtest.py
@@ -70,11 +70,24 @@ def test_get_tests_dir():
 
 def test_this_tests():
 
-    # self test
+    # function by reference (and self test)
     this_tests(this_tests)
 
-    # not a function
+    import fastai
+    # explicit fully qualified function (requires all the sub-modules to be loaded)
+    this_tests(fastai.gen_doc.doctest.this_tests)
+
+    # explicit fully qualified function as a string
+    this_tests('fastai.gen_doc.doctest.this_tests')
+
+    # not a real function
     func = 'foo bar'
+    try: this_tests(func)
+    except Exception as e: assert f"'{func}' is not a function" in str(e)
+    else: assert False, f'this_tests({func}) should have failed'
+
+    # not a function as a string that looks like fastai function, but it is not
+    func = 'fastai.gen_doc.doctest.doesntexistreally'
     try: this_tests(func)
     except Exception as e: assert f"'{func}' is not a function" in str(e)
     else: assert False, f'this_tests({func}) should have failed'

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -39,7 +39,7 @@ def test_fit_one_cycle(learn):
     # https://github.com/sgugger/Deep-Learning/blob/master/Cyclical%20LR%20and%20momentums.ipynb
     lr, cycle_length = 3e-3,  4
     with CaptureStdout() as cs: learn.fit_one_cycle(cycle_length, lr)
-    this_tests(learn.fit_one_cycle, learn.recorder.__class__)
+    this_tests(learn.fit_one_cycle)
     listlrs = list(learn.recorder.lrs)
     listmoms = list(learn.recorder.moms)
     # we confirm learning rate is at its max when momentum is at its min


### PR DESCRIPTION
This patch allows someone using AWD-LSTM to calculate the forward pass directly from the embedded input. The alternative would be copying-pasting the model and splitting the embedder and encoder, but that would complicate code maintenance and break compatibility with saved models. This is needed in case someone needs to calculate the sequential Jacobian (I'll send another patch for this) or re-use the embeddings somewhere else.

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
