### PR TITLE
Add nb examples for SaveModelCallback class

### DIFF
--- a/docs_src/callbacks.ipynb
+++ b/docs_src/callbacks.ipynb
@@ -531,6 +531,71 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "Total time: 00:13 <p><table style='width:300px; margin-bottom:10px'>\n",
+       "  <tr>\n",
+       "    <th>epoch</th>\n",
+       "    <th>train_loss</th>\n",
+       "    <th>valid_loss</th>\n",
+       "    <th>accuracy</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>1</th>\n",
+       "    <th>0.652836</th>\n",
+       "    <th>0.629737</th>\n",
+       "    <th>0.613346</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>2</th>\n",
+       "    <th>0.546113</th>\n",
+       "    <th>0.517567</th>\n",
+       "    <th>0.902355</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>3</th>\n",
+       "    <th>0.495621</th>\n",
+       "    <th>0.489153</th>\n",
+       "    <th>0.916585</th>\n",
+       "  </tr>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "learn = Learner(data, simple_cnn((3,16,16,2)), metrics=accuracy)\n",
+    "learn.fit_one_cycle(3,1e-4, callbacks=[SaveModelCallback(learn, every='epoch', monitor='accuracy')])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "bestmodel_1.pth  bestmodel_2.pth  bestmodel_3.pth\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!ls ~/.fastai/data/mnist_sample/models"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs_src/callbacks.tracker.ipynb
+++ b/docs_src/callbacks.tracker.ipynb
@@ -502,6 +502,183 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "Total time: 00:21 <p><table style='width:300px; margin-bottom:10px'>\n",
+       "  <tr>\n",
+       "    <th>epoch</th>\n",
+       "    <th>train_loss</th>\n",
+       "    <th>valid_loss</th>\n",
+       "    <th>accuracy</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>1</th>\n",
+       "    <th>0.688521</th>\n",
+       "    <th>0.667903</th>\n",
+       "    <th>0.834151</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>2</th>\n",
+       "    <th>0.538766</th>\n",
+       "    <th>0.486864</th>\n",
+       "    <th>0.920510</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>3</th>\n",
+       "    <th>0.348265</th>\n",
+       "    <th>0.316294</th>\n",
+       "    <th>0.934740</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>4</th>\n",
+       "    <th>0.263525</th>\n",
+       "    <th>0.258484</th>\n",
+       "    <th>0.933268</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>5</th>\n",
+       "    <th>0.247160</th>\n",
+       "    <th>0.250660</th>\n",
+       "    <th>0.932777</th>\n",
+       "  </tr>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "model = simple_cnn((3,16,16,2))\n",
+    "learn = Learner(data, model, metrics=[accuracy])\n",
+    "learn.fit_one_cycle(5,1e-4, callbacks=[SaveModelCallback(learn, every='epoch', monitor='accuracy', name='model')])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Choosing `every='epoch'` saves an individual model at the end of each epoch."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "model_1.pth  model_2.pth  model_3.pth  model_4.pth  model_5.pth\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!ls ~/.fastai/data/mnist_sample/models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "Total time: 00:21 <p><table style='width:300px; margin-bottom:10px'>\n",
+       "  <tr>\n",
+       "    <th>epoch</th>\n",
+       "    <th>train_loss</th>\n",
+       "    <th>valid_loss</th>\n",
+       "    <th>accuracy</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>1</th>\n",
+       "    <th>0.225827</th>\n",
+       "    <th>0.218552</th>\n",
+       "    <th>0.933759</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>2</th>\n",
+       "    <th>0.181150</th>\n",
+       "    <th>0.175551</th>\n",
+       "    <th>0.938175</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>3</th>\n",
+       "    <th>0.166091</th>\n",
+       "    <th>0.164049</th>\n",
+       "    <th>0.936703</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>4</th>\n",
+       "    <th>0.164511</th>\n",
+       "    <th>0.160625</th>\n",
+       "    <th>0.939647</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>5</th>\n",
+       "    <th>0.159156</th>\n",
+       "    <th>0.160258</th>\n",
+       "    <th>0.938665</th>\n",
+       "  </tr>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Better model found at epoch 1 with accuracy value: 0.9337586164474487.\n",
+      "Better model found at epoch 2 with accuracy value: 0.9381746649742126.\n",
+      "Better model found at epoch 4 with accuracy value: 0.9396467208862305.\n"
+     ]
+    }
+   ],
+   "source": [
+    "learn.fit_one_cycle(5,1e-4, callbacks=[SaveModelCallback(learn, every='improvement', monitor='accuracy', name='best')])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Choosing `every='improvement'` saves the single best model out of all epochs during training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "best.pth  model_1.pth  model_2.pth  model_3.pth  model_4.pth  model_5.pth\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!ls ~/.fastai/data/mnist_sample/models"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
It took some searching through the fast.ai forums for me to figure out how to properly use `SaveModelCallback()`, so I thought I'd add some notebook examples to the two pages in the docs that reference this class.

Hope these examples help future folks who encounter an error when they make the same mistake I did (specifying this callback when creating a `Learner()` object, as opposed to the correct way: doing so inside the `fit()` or `fit_one_cycle()` methods).