### PR TITLE
Add HTTPS command examples to PR How-to Step 1a

### DIFF
--- a/docs/dev/git.md
+++ b/docs/dev/git.md
@@ -97,9 +97,16 @@ If it's your first time, you just need to make a fork of the original repository
    for any of the `fastai` project repositories, except `fastprogress` where it doesn't exist.
 
    Finally, let's setup this fork to track the upstream:
+   
+   * Using SSH:
 
    ```
    git remote add upstream git@github.com:fastai/fastai.git
+   ```
+   * Using HTTPS:
+   
+   ```
+   git remote add upstream https://github.com/fastai/fastai.git
    ```
 
    You can check your setup:
@@ -108,11 +115,22 @@ If it's your first time, you just need to make a fork of the original repository
    ```
 
    It should show:
+   
+   * If you used SSH:
+   
    ```
    origin  git@github.com:USERNAME/fastai.git (fetch)
    origin  git@github.com:USERNAME/fastai.git (push)
-   upstream        git@github.com:fastai/fastai.git (fetch)
-   upstream        git@github.com:fastai/fastai.git (push)
+   upstream  git@github.com:fastai/fastai.git (fetch)
+   upstream  git@github.com:fastai/fastai.git (push)
+   ```
+   * If you used HTTPS:
+   
+   ```
+   origin  https://github.com/USERNAME/fastai.git (fetch)
+   origin  https://github.com/USERNAME/fastai.git (push)
+   upstream  https://github.com/fastai/fastai.git (fetch)
+   upstream  https://github.com/fastai/fastai.git (push)
    ```
 
    You can now proceed to step 2.


### PR DESCRIPTION
I noticed that some of the commands in Step 1a of the `How to Make a Pull Request (PR)` section in `git.md` only had an SSH example. When following these instructions I unwittingly created an upstream using SSH (even though I had intended to use HTTPS).  I was later momentarily confused as to why git was complaining about a certificate when I went to fetch. 

I hope that with HTTPS  examples for setting upstream and the expected appearance of a proper setup, future users will be less likely to make the same mistake I did.
