### PR TITLE
Additional description about the batch_stats function

### DIFF
--- a/docs_src/vision.data.ipynb
+++ b/docs_src/vision.data.ipynb
@@ -1163,7 +1163,7 @@
        "\n",
        "> <code>batch_stats</code>(**`funcs`**:`Collection`\\[`Callable`\\]=***`None`***) → `Tensor`\n",
        "\n",
-       "Grab a batch of data and call reduction function `func` per channel. The output of 'ImageDataBunch.batch_stats' is a list of two tensors, first being the mean for all individual channels and the other tensor corresponds to the standard deviation for those channels  "
+       "Grab a batch of data and call reduction function `func` per channel. The output of `ImageDataBunch.batch_stats` is a list of two tensors, first being the mean for all individual channels and the other tensor corresponds to the standard deviation for those channels  "
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"

--- a/docs_src/vision.data.ipynb
+++ b/docs_src/vision.data.ipynb
@@ -1163,7 +1163,7 @@
        "\n",
        "> <code>batch_stats</code>(**`funcs`**:`Collection`\\[`Callable`\\]=***`None`***) → `Tensor`\n",
        "\n",
-       "Grab a batch of data and call reduction function `func` per channel  "
+       "Grab a batch of data and call reduction function `func` per channel. The output of 'ImageDataBunch.batch_stats' is a list of two tensors, first being the mean for all individual channels and the other tensor corresponds to the standard deviation for those channels  "
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"


### PR DESCRIPTION
The output of 'ImageDataBunch.batch_stats' is a list of two tensors, first being the mean for all individual channels and the other tensor corresponds to the standard deviation for those channels

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
