### PR TITLE
Support for DataBunches with no Validation DL

### DIFF
--- a/fastai/basic_data.py
+++ b/fastai/basic_data.py
@@ -132,8 +132,12 @@ class DataBunch():
                 self.fix_dl)
 
     @property
-    def dls(self):
-        res = [self.train_dl, self.valid_dl, self.fix_dl, self.single_dl]
+    def dls(self)->List[DeviceDataLoader]:
+        "Returns a list of all DeviceDataLoaders. If you need a specific DeviceDataLoader, access via the relevant property (`train_dl`, `valid_dl`, etc) as the index of DLs in this list is not guaranteed to remain constant."
+        res = [self.train_dl, self.fix_dl, self.single_dl]
+        # Preserve the original ordering of Train, Valid, Fix, Single, Test Data Loaders
+        # (Unknown/not verified as of 1.0.47 whether there are other methods explicitly using DLs their list index)
+        if self.valid_dl: res.insert(1, self.valid_dl) 
         return res if not self.test_dl else res + [self.test_dl]
 
     def add_tfm(self,tfm:Callable)->None:

--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -167,7 +167,8 @@ class ImageDataBunch(DataBunch):
     def batch_stats(self, funcs:Collection[Callable]=None)->Tensor:
         "Grab a batch of data and call reduction function `func` per channel"
         funcs = ifnone(funcs, [torch.mean,torch.std])
-        x = self.one_batch(ds_type=DatasetType.Valid, denorm=False)[0].cpu()
+        ds_type = DatasetType.Valid if self.valid_dl else DatasetType.Train
+        x = self.one_batch(ds_type=ds_type, denorm=False)[0].cpu()
         return [func(channel_view(x), 1) for func in funcs]
 
     def normalize(self, stats:Collection[Tensor]=None, do_x:bool=True, do_y:bool=False)->None:

--- a/tests/test_basic_data.py
+++ b/tests/test_basic_data.py
@@ -23,12 +23,26 @@ def test_DataBunch_Create():
     train_ds,valid_ds = TensorDataset(x_train, y_train),TensorDataset(x_valid, y_valid)
     data = DataBunch.create(train_ds, valid_ds, bs=bs)
     this_tests(data.create)
-
+    
+    assert 4 == len(data.dls)
     assert 3 == len(data.train_dl)
     assert 18 == len(data.train_ds)
     assert 2 == len(data.valid_dl)
     assert 9 == len(data.valid_ds)
 
+def test_DataBunch_no_valid_dl():
+    x_train,y_train =  fake_basedata(n_in=3, batch_size=6),fake_basedata(n_in=3, batch_size=6)
+    bs=5
+    train_ds = TensorDataset(x_train, y_train)
+    data = DataBunch.create(train_ds, None, bs=bs)
+    this_tests(data.create)
+    data.valid_dl = None
+    
+    assert 3 == len(data.dls)
+    assert 3 == len(data.train_dl)
+    assert 18 == len(data.train_ds)
+    assert None == data.valid_dl    
+    
 ## TO DO (?)ideally, call one_batch with type dataloader
 def test_DataBunch_onebatch():
     data = fake_data(n_in=4, n_out=5, batch_size=6)

--- a/tests/test_vision_data.py
+++ b/tests/test_vision_data.py
@@ -118,6 +118,8 @@ def test_normalize(path):
     assert abs(x.std()-1) < abs(m-1)
 
     with pytest.raises(Exception): data.normalize()
+    data.valid_dl = None
+    with pytest.raises(Exception): data.normalize()
 
 def test_denormalize(path):
     data = ImageDataBunch.from_folder(path, ds_tfms=(rand_pad(2, 28), []))


### PR DESCRIPTION
Reworks `Databunch.dls()` to not return the empty `valid_dl` (if it is set to `None`). `ImageDataBunch. batch_stats()` is  updated to fallback to using the Training DL if there is no `valid_dl` to use for calculating batch stats.

Added some testing to verify this all works.