### PR TITLE
WIP Add `split_subsets()` to ItemList

### DIFF
--- a/docs_src/data_block.ipynb
+++ b/docs_src/data_block.ipynb
@@ -1294,6 +1294,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_doc(ItemList.split_subsets)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This function is handy if you want to work with subsets of specific sizes, e.g., you want to use 20% of the data for the validation dataset, but you only want to train on a small subset of the rest of the data: `split_subsets(train_size=0.08, valid_size=0.2)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "hide_input": true
    },

--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -197,6 +197,17 @@ class ItemList():
         cut = int(valid_pct * len(self))
         return self.split_by_idx(rand_idx[:cut])
 
+    def split_subsets(self, train_size:float, valid_size:float, seed=None) -> 'ItemLists':
+        "Split the items into train set with size `train_size * n` and valid set with size `valid_size * n`."
+        assert 0 < train_size < 1
+        assert 0 < valid_size < 1
+        assert train_size + valid_size <= 1.
+        if seed is not None: np.random.seed(seed)
+        n = len(self.items)
+        rand_idx = np.random.permutation(range(n))
+        train_cut, valid_cut = int(train_size * n), int(valid_size * n)
+        return self.split_by_idxs(rand_idx[:train_cut], rand_idx[-valid_cut:])
+
     def split_by_valid_func(self, func:Callable)->'ItemLists':
         "Split the data by result of `func` (which returns `True` for validation set)."
         valid_idx = [i for i,o in enumerate(self.items) if func(o)]

--- a/tests/test_data_block.py
+++ b/tests/test_data_block.py
@@ -101,6 +101,18 @@ def test_splitdata_datasets():
     assert len(sd.valid)==ratio*n, 'Validation set is right size'
     assert set(list(sd.train.items)+list(sd.valid.items))==set(range(n)), 'All items covered'
 
+def test_split_subsets():
+    sd = ItemList(range(10)).split_subsets(train_size=.1, valid_size=.2).label_const(0)
+    assert len(sd.train)==1
+    assert len(sd.valid)==2
+
+    with pytest.raises(AssertionError):
+        ItemList(range(10)).split_subsets(train_size=.6, valid_size=.6).label_const(0)
+    with pytest.raises(AssertionError):
+        ItemList(range(10)).split_subsets(train_size=0.0, valid_size=0.5).label_const(0)
+    with pytest.raises(AssertionError):
+        ItemList(range(10)).split_subsets(train_size=0.5, valid_size=0.0).label_const(0)
+
 def test_regression():
     df = pd.DataFrame({'x':range(100), 'y':np.random.rand(100)})
     data = ItemList.from_df(df, path='.', cols=0).random_split_by_pct().label_from_df(cols=1).databunch()


### PR DESCRIPTION
I tend to work with a small subset of the data first, then increase the dataset size. The data block api offers the `use_partial_data` so select a subset of the data (independent of train and valid). I however want to use full valid ds and only train on a smaller train ds. With the current API your can achieve this by combining `use_partial_data`, some manual math, and `random_split_by_pct`, but this is a bit cumbersome.

I wrote a little function `split_subsets` which allows you to define the size of the train and valid ds independently. It looks something like this:
```python
# do the the normal split like random_split_by_pct
ImageList.from_csv(...).split_subsets(train_size=.8, valid_size=.2)
# only work with a tenth of the train ds but keep the valid ds size
ImageList.from_csv(...).split_subsets(train_size=.08, valid_size=.2)
```

I really think that the name of the method is not ideal. Any suggestions? `random_split_by_pct` has the word `random` in there, maybe this method should as well?

Once the name is fix I'll mention the method in the docs docs_src/data_block.ipynb.