### PR TITLE
Add `return_fig` argument to all plot functions

### DIFF
--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -468,18 +468,21 @@ class Recorder(LearnerCallback):
         "Add `names` to the inner metric names."
         self._added_met_names = names
 
-    def plot_lr(self, show_moms=False)->None:
+    def plot_lr(self, show_moms=False, return_fig:bool=None)->Optional[plt.Figure]:
         "Plot learning rate, `show_moms` to include momentum."
         iterations = range_of(self.lrs)
         if show_moms:
-            _, axs = plt.subplots(1,2, figsize=(12,4))
+            fig, axs = plt.subplots(1,2, figsize=(12,4))
             axs[0].plot(iterations, self.lrs)
             axs[0].set_xlabel('Iterations')
             axs[0].set_ylabel('Learning Rate')
             axs[1].plot(iterations, self.moms)
             axs[1].set_xlabel('Iterations')
             axs[1].set_ylabel('Momentum')
-        else: plt.plot(iterations, self.lrs)
+        else:
+            fig, ax = plt.subplots()
+            ax.plot(iterations, self.lrs)
+        if ifnone(return_fig, defaults.return_fig): return fig
 
     @staticmethod
     def smoothen_by_spline(xs, ys, **kwargs):
@@ -488,13 +491,14 @@ class Recorder(LearnerCallback):
         ys = spl(xs)
         return ys
 
-    def plot(self, skip_start:int=10, skip_end:int=5, suggestion:bool=False, **kwargs)->None:
+    def plot(self, skip_start:int=10, skip_end:int=5, suggestion:bool=False, return_fig:bool=None,
+             **kwargs)->Optional[plt.Figure]:
         "Plot learning rate and losses, trimmed between `skip_start` and `skip_end`. Optionally plot and return min gradient"
         lrs = self.lrs[skip_start:-skip_end] if skip_end > 0 else self.lrs[skip_start:]
         losses = self.losses[skip_start:-skip_end] if skip_end > 0 else self.losses[skip_start:]
         losses = [x.item() for x in losses]
         if 'k' in kwargs: losses = self.smoothen_by_spline(lrs, losses, **kwargs)
-        _, ax = plt.subplots(1,1)
+        fig, ax = plt.subplots(1,1)
         ax.plot(lrs, losses)
         ax.set_ylabel("Loss")
         ax.set_xlabel("Learning Rate")
@@ -508,12 +512,13 @@ class Recorder(LearnerCallback):
             print(f"Min numerical gradient: {lrs[mg]:.2E}")
             ax.plot(lrs[mg],losses[mg],markersize=10,marker='o',color='red')
             self.min_grad_lr = lrs[mg]
+        if ifnone(return_fig, defaults.return_fig): return fig
 
-    def plot_losses(self, last:int=None)->None:
+    def plot_losses(self, last:int=None, return_fig:bool=None)->Optional[plt.Figure]:
         "Plot training and validation losses."
         last = ifnone(last,len(self.nb_batches))
         assert last<=len(self.nb_batches), f"We can only plot up to the last {len(self.nb_batches)} epochs. Please adapt 'last' parameter accordingly."
-        _, ax = plt.subplots(1,1)
+        fig, ax = plt.subplots(1,1)
         l_b = np.sum(self.nb_batches[-last:])
         iterations = range_of(self.losses)[-l_b:]
         ax.plot(iterations, self.losses[-l_b:], label='Train')
@@ -523,17 +528,19 @@ class Recorder(LearnerCallback):
         ax.set_ylabel('Loss')
         ax.set_xlabel('Batches processed')
         ax.legend()
+        if ifnone(return_fig, defaults.return_fig): return fig
 
-    def plot_metrics(self)->None:
+    def plot_metrics(self, return_fig:bool=None)->Optional[plt.Figure]:
         "Plot metrics collected during training."
         assert len(self.metrics) != 0, "There are no metrics to plot."
-        _, axes = plt.subplots(len(self.metrics[0]),1,figsize=(6, 4*len(self.metrics[0])))
+        fig, axes = plt.subplots(len(self.metrics[0]),1,figsize=(6, 4*len(self.metrics[0])))
         val_iter = self.nb_batches
         val_iter = np.cumsum(val_iter)
         axes = axes.flatten() if len(self.metrics[0]) != 1 else [axes]
         for i, ax in enumerate(axes):
             values = [met[i] for met in self.metrics]
             ax.plot(val_iter, values)
+        if ifnone(return_fig, defaults.return_fig): return fig
 
 class FakeOptimizer():
     def step(self): pass

--- a/fastai/core.py
+++ b/fastai/core.py
@@ -46,7 +46,7 @@ def num_cpus()->int:
     except AttributeError: return os.cpu_count()
 
 _default_cpus = min(16, num_cpus())
-defaults = SimpleNamespace(cpus=_default_cpus, cmap='viridis')
+defaults = SimpleNamespace(cpus=_default_cpus, cmap='viridis', return_fig=False)
 
 def is_listy(x:Any)->bool: return isinstance(x, (tuple,list))
 def is_tuple(x:Any)->bool: return isinstance(x, tuple)

--- a/fastai/train.py
+++ b/fastai/train.py
@@ -162,13 +162,13 @@ class ClassificationInterpretation():
                 torch.add(cm, cm_slice, out=cm)
         return to_np(cm)
 
-    def plot_confusion_matrix(self, normalize:bool=False, title:str='Confusion matrix', cmap:Any="Blues", slice_size:int=1, 
-                              norm_dec:int=2, plot_txt:bool=True, **kwargs)->None:
+    def plot_confusion_matrix(self, normalize:bool=False, title:str='Confusion matrix', cmap:Any="Blues", slice_size:int=1,
+                              norm_dec:int=2, plot_txt:bool=True, return_fig:bool=None, **kwargs)->Optional[plt.Figure]:
         "Plot the confusion matrix, with `title` and using `cmap`."
         # This function is mainly copied from the sklearn docs
         cm = self.confusion_matrix(slice_size=slice_size)
         if normalize: cm = cm.astype('float') / cm.sum(axis=1)[:, np.newaxis]
-        plt.figure(**kwargs)
+        fig = plt.figure(**kwargs)
         plt.imshow(cm, interpolation='nearest', cmap=cmap)
         plt.title(title)
         tick_marks = np.arange(self.data.c)
@@ -185,6 +185,7 @@ class ClassificationInterpretation():
         plt.ylabel('Actual')
         plt.xlabel('Predicted')
         plt.grid(False)
+        if ifnone(return_fig, defaults.return_fig): return fig
 
     def most_confused(self, min_val:int=1, slice_size:int=1)->Collection[Tuple[str,str,int]]:
         "Sorted descending list of largest non-diagonal entries of confusion matrix, presented as actual, predicted, number of occurrences."

--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -102,7 +102,8 @@ def _cl_int_from_learner(cls, learn:Learner, ds_type:DatasetType=DatasetType.Val
     preds = learn.TTA(ds_type=ds_type, with_loss=True) if tta else learn.get_preds(ds_type=ds_type, with_loss=True)
     return cls(learn, *preds, ds_type=ds_type)
 
-def _cl_int_plot_top_losses(self, k, largest=True, figsize=(12,12), heatmap:bool=True, heatmap_thresh:int=16):
+def _cl_int_plot_top_losses(self, k, largest=True, figsize=(12,12), heatmap:bool=True, heatmap_thresh:int=16,
+                            return_fig:bool=None)->Optional[plt.Figure]:
     "Show images in `top_losses` along with their prediction, actual, loss, and probability of predicted class."
     tl_val,tl_idx = self.top_losses(k, largest)
     classes = self.data.classes
@@ -129,6 +130,7 @@ def _cl_int_plot_top_losses(self, k, largest=True, figsize=(12,12), heatmap:bool
                 mult = F.relu(((acts*grad_chan[...,None,None])).sum(0))
                 sz = im.shape[-1]
                 axes.flat[i].imshow(mult, alpha=0.6, extent=(0,sz,sz,0), interpolation='bilinear', cmap='magma')
+    if ifnone(return_fig, defaults.return_fig): return fig
 
 def _cl_int_plot_multi_top_losses(self, samples:int=3, figsize:Tuple[int,int]=(8,8), save_misclassified:bool=False):
     "Show images in `top_losses` along with their prediction, actual, loss, and probability of predicted class in a multilabeled dataset."


### PR DESCRIPTION
Fixed all remarks from #1725.

* add a global `return_fig` to `defaults`
* add `return_fig` flag to all plot functions
* use the global `default.return_fig` if `return_fig is None`

Here is a demo in a notebook :)
https://gist.github.com/sotte/633dc6f46367da5e0dbd38afd929e9a3

There is one more plot function `_cl_int_plot_multi_top_losses`. I didn't touch that one because the behaviour of `save_misclassified` is a bit special.