### PR TITLE
Mlflow tracking support

### DIFF
--- a/fastai/callbacks/mlflow.py
+++ b/fastai/callbacks/mlflow.py
@@ -1,0 +1,44 @@
+"A `Callback` that saves tracked metrics and notebook file into MLflow server."
+from ..torch_core import *
+from ..callback import *
+from ..basic_train import Learner, LearnerCallback
+#This is an optional dependency in fastai.  Must install separately.
+try: import mlflow
+except: pass
+
+class MLFlowTracker(LearnerCallback):
+    "A `TrackerCallback` that tracks the loss and metrics into MLFlow"
+    def __init__(self, learn:Learner, exp_name: str, params: dict, nb_path: str, uri: str = "http://localhost:5000"):
+        super().__init__(learn)
+        self.learn = learn
+        self.exp_name = exp_name
+        self.params = params
+        self.nb_path = nb_path
+        self.uri = uri
+        self.metrics_names = ['train_loss', 'valid_loss'] + [o.__name__ for o in learn.metrics]
+
+    def on_train_begin(self, **kwargs: Any) -> None:
+        "Prepare MLflow experiment and log params"
+        self.client = mlflow.tracking.MlflowClient(self.uri)
+        exp = self.client.get_experiment_by_name(self.exp_name)
+        if exp is None:
+            self.exp_id = self.client.create_experiment(self.exp_name)
+        else:
+            self.exp_id = exp.experiment_id
+        run = self.client.create_run(experiment_id=self.exp_id)
+        self.run = run.info.run_uuid
+        for k,v in self.params.items():
+            self.client.log_param(run_id=self.run, key=k, value=v)
+
+    def on_epoch_end(self, epoch, **kwargs:Any)->None:
+        "Send loss and metrics values to MLFlow after each epoch"
+        if kwargs['smooth_loss'] is None or kwargs["last_metrics"] is None:
+            return
+        metrics = [kwargs['smooth_loss']] + kwargs["last_metrics"]
+        for name, val in zip(self.metrics_names, metrics):
+            self.client.log_metric(self.run, name, np.float(val))
+        
+    def on_train_end(self, **kwargs: Any) -> None:  
+        "Store the notebook and stop run"
+        self.client.log_artifact(run_id=self.run, local_path=self.nb_path)
+        self.client.set_terminated(run_id=self.run)


### PR DESCRIPTION
This PR add support for tracking metrics, parameters and notebooks to [MLflow](https://mlflow.org/). Details and motivation has been mentioned on this [thread on the forum](https://forums.fast.ai/t/mlflow-tracking-support/38893). MLflow supports tracking of models not only for deep learning but also from sklearn, boosting models etc. Therefore teams using other models can combine FastAI models tracking with their established models as well. 

To use this feature add callback function learner as 
`learn.callback_fns.append(partial(MLFlowTracker, exp_name="lesson1-pets", params=params, nb_path="/data/course-v3/nbs/dl1/lesson1-pets-Copy1.ipynb"))`
