### PR TITLE
Change formatting of CSV path

### DIFF
--- a/fastai/widgets/image_cleaner.py
+++ b/fastai/widgets/image_cleaner.py
@@ -208,7 +208,9 @@ class ImageCleaner():
 
     def write_csv(self):
         # Get first element's file path so we write CSV to same directory as our data
-        csv_path = self._path/'cleaned.csv'
+        import os
+        csv_path = os.path.join(self._path,'cleaned.csv')
+        # csv_path = self._path/'cleaned.csv'
         with open(csv_path, 'w') as f:
             csv_writer = csv.writer(f)
             csv_writer.writerow(['name','label'])


### PR DESCRIPTION
The assignment of csv_path in the Image Cleaner widget was generating an error on certain setups. The line:

csv_path = self._path/'cleaned.csv'

was generating the error:

TypeError: unsupported operand type(s) for /: 'str' and 'str'

So it thought that the / was an operand for some reason. Instead I  used os.path.join, which is much more universally compatible than the code used before.
