### PR TITLE
[MinorFix] Add skip_start to plot_losses 

### DIFF
--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -522,15 +522,16 @@ class Recorder(LearnerCallback):
             self.min_grad_lr = lrs[mg]
         if ifnone(return_fig, defaults.return_fig): return fig
 
-    def plot_losses(self, skip_start:int=None, skip_end:int=None, return_fig:bool=None)->Optional[plt.Figure]:
+    def plot_losses(self, skip_start:int=0, skip_end:int=1, return_fig:bool=None)->Optional[plt.Figure]:
         "Plot training and validation losses."
         if skip_end > 0:
             skip_end = -skip_end
 
         fig, ax = plt.subplots(1,1)
-        l_b = np.sum(self.nb_batches[skip_start:skip_end])
+        losses = self.losses[skip_start:skip_end]
         iterations = range_of(self.losses)[skip_start:skip_end]
-        ax.plot(iterations, self.losses[-l_b:], label='Train')
+        ax.plot(iterations, losses, label='Train')
+
         val_iter = np.cumsum(self.nb_batches)
         ax.plot(val_iter, self.val_losses, label='Validation')
         ax.set_ylabel('Loss')

--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -522,17 +522,14 @@ class Recorder(LearnerCallback):
             self.min_grad_lr = lrs[mg]
         if ifnone(return_fig, defaults.return_fig): return fig
 
-    def plot_losses(self, last:int=None, return_fig:bool=None)->Optional[plt.Figure]:
+    def plot_losses(self, skip_start:int=None, skip_end:int=None, return_fig:bool=None)->Optional[plt.Figure]:
         "Plot training and validation losses."
-        last = ifnone(last,len(self.nb_batches))
-        assert last<=len(self.nb_batches), f"We can only plot up to the last {len(self.nb_batches)} epochs. Please adapt 'last' parameter accordingly."
         fig, ax = plt.subplots(1,1)
-        l_b = np.sum(self.nb_batches[-last:])
-        iterations = range_of(self.losses)[-l_b:]
+        l_b = np.sum(self.nb_batches[skip_start:skip_end])
+        iterations = range_of(self.losses)[skip_start:skip_end]
         ax.plot(iterations, self.losses[-l_b:], label='Train')
-        val_iter = self.nb_batches[-last:]
-        val_iter = np.cumsum(val_iter)+np.sum(self.nb_batches[:-last])
-        ax.plot(val_iter, self.val_losses[-last:], label='Validation')
+        val_iter = np.cumsum(self.nb_batches)
+        ax.plot(val_iter, self.val_losses, label='Validation')
         ax.set_ylabel('Loss')
         ax.set_xlabel('Batches processed')
         ax.legend()

--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -524,6 +524,9 @@ class Recorder(LearnerCallback):
 
     def plot_losses(self, skip_start:int=None, skip_end:int=None, return_fig:bool=None)->Optional[plt.Figure]:
         "Plot training and validation losses."
+        if skip_end > 0:
+            skip_end = -skip_end
+
         fig, ax = plt.subplots(1,1)
         l_b = np.sum(self.nb_batches[skip_start:skip_end])
         iterations = range_of(self.losses)[skip_start:skip_end]

--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -531,7 +531,6 @@ class Recorder(LearnerCallback):
         losses = self.losses[skip_start:skip_end]
         iterations = range_of(self.losses)[skip_start:skip_end]
         ax.plot(iterations, losses, label='Train')
-
         val_iter = np.cumsum(self.nb_batches)
         ax.plot(val_iter, self.val_losses, label='Validation')
         ax.set_ylabel('Loss')


### PR DESCRIPTION
The `plot_loss` signature has been changed to include `skip_start:int=None, skip_end:int=None` instead of `last`.

Ref:
#1553
<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
