### PR TITLE
Fix cut parameter

### DIFF
--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -46,7 +46,7 @@ def cnn_config(arch):
     return model_meta.get(arch, _default_meta)
 
 def create_body(arch:Callable, pretrained:bool=True, cut:Optional[Union[int, Callable]]=None):
-    "Cut off the body of a typically pretrained `model` at `cut` or as specified by `body_fn`."
+    "Cut off the body of a typically pretrained `model` at `cut` (int) or cut the model as specified by `cut(model)` (function)."
     model = arch(pretrained)
     cut = ifnone(cut, cnn_config(arch)['cut'])
     if   isinstance(cut, int):      return nn.Sequential(*list(model.children())[:cut])

--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -45,12 +45,14 @@ def cnn_config(arch):
     torch.backends.cudnn.benchmark = True
     return model_meta.get(arch, _default_meta)
 
-def create_body(arch:Callable, pretrained:bool=True, cut:Optional[int]=None, body_fn:Callable[[nn.Module], nn.Module]=None):
+def create_body(arch:Callable, pretrained:bool=True, cut:Optional[Union[int, Callable]]=None):
     "Cut off the body of a typically pretrained `model` at `cut` or as specified by `body_fn`."
     model = arch(pretrained)
-    if not cut and not body_fn: cut = cnn_config(arch)['cut']
-    return (nn.Sequential(*list(model.children())[:cut]) if cut
-            else body_fn(model) if body_fn else model)
+    cut = ifnone(cut, cnn_config(arch)['cut'])
+    if   isinstance(cut, int):      return nn.Sequential(*list(model.children())[:cut])
+    elif isinstance(cut, Callable): return cut(model)
+    else:                           raise NamedError("cut must be either integer or a function")
+
 
 def create_head(nf:int, nc:int, lin_ftrs:Optional[Collection[int]]=None, ps:Floats=0.5, bn_final:bool=False):
     "Model head that takes `nf` features, runs through `lin_ftrs`, and about `nc` classes."
@@ -71,8 +73,10 @@ def create_cnn(data:DataBunch, arch:Callable, cut:Union[int,Callable]=None, pret
     "Build convnet style learner."
     meta = cnn_config(arch)
     body = create_body(arch, pretrained, cut)
-    nf = num_features_model(body) * 2
-    head = custom_head or create_head(nf, data.c, lin_ftrs, ps=ps, bn_final=bn_final)
+    if custom_head is None:
+        nf = num_features_model(nn.Sequential(*body.children())) * 2
+        head = create_head(nf, data.c, lin_ftrs, ps=ps, bn_final=bn_final)
+    else: head = custom_head
     model = nn.Sequential(body, head)
     learn = Learner(data, model, **learn_kwargs)
     learn.split(ifnone(split_on, meta['split']))


### PR DESCRIPTION
Hi there,
in my experiments with completely custom models I came across the following:
The `create_cnn()` method takes a `cut` parameter (either int or callable)
which is passed to `create_body()`. `create_body()` also takes a `body_fn` to support custom cuts (basically just doing `body_fn(model)`).
I found that the `create_cnn()` method only passes the first 3 parameters of the `create_body()` method without ever making use of that optionally callable nature of `cut`.

I changed the `create_body()` function so that its `cut` parameter can be a callable as well and check for its type inside there to take the appropriate action. 


In this same investigation I found that the `num_features_model()` method (which is called right after `create_body()`) assumes the model that is passed in to be an iterable. This is no problem for most archs, as their root module is a `nn.Sequential` (which is iterable). However, if the model is not a `nn.Sequential` it will fail. I basically changed this part so that every model that is passed into this method is converted to a `nn.Sequential` first.
Since this method has caused me even more trouble with fancier custom bodies, I have rearranged the checks for a custom head, so that it is not called when a custom head is supplied.