### PR TITLE
Make dummy batches size 2

### DIFF
--- a/fastai/callbacks/hooks.py
+++ b/fastai/callbacks/hooks.py
@@ -100,7 +100,7 @@ class ActivationStats(HookCallback):
 def dummy_batch(m: nn.Module, size:tuple=(64,64))->Tensor:
     "Create a dummy batch to go through `m` with `size`."
     ch_in = in_channels(m)
-    return one_param(m).new(1, ch_in, *size).requires_grad_(False).uniform_(-1.,1.)
+    return one_param(m).new(2, ch_in, *size).requires_grad_(False).uniform_(-1.,1.)
 
 def dummy_eval(m:nn.Module, size:tuple=(64,64)):
     "Pass a `dummy_batch` in evaluation mode in `m` with `size`."


### PR DESCRIPTION
Hi there,
I encountered issues with the `dummy_batch()` method in models where I use PyTorch's `squeeze()` method, as it removes the batch dimension for all dummy batches. Changing the dummy batches size to 2 fixes the problem. While this can also be resolved by not using `squeeze()` in that way, I believe it would be nice if the fastai methods are not affected by using `squeeze()`.
