### PR TITLE
Separate creating cnn arch from cnn learner

### DIFF
--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -9,7 +9,7 @@ from ..layers import *
 from ..callbacks.hooks import *
 from ..train import ClassificationInterpretation
 
-__all__ = ['create_cnn_learner', 'create_cnn', 'create_body', 'create_head', 'unet_learner']
+__all__ = ['cnn_learner', 'create_cnn', 'create_body', 'create_head', 'unet_learner']
 # By default split models between first and second layer
 def _default_split(m:nn.Module): return (m[1],)
 # Split a resnet style model

--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -9,7 +9,7 @@ from ..layers import *
 from ..callbacks.hooks import *
 from ..train import ClassificationInterpretation
 
-__all__ = ['create_cnn', 'create_body', 'create_head', 'unet_learner']
+__all__ = ['create_cnn_learner', 'create_cnn', 'create_body', 'create_head', 'unet_learner']
 # By default split models between first and second layer
 def _default_split(m:nn.Module): return (m[1],)
 # Split a resnet style model
@@ -66,20 +66,25 @@ def create_head(nf:int, nc:int, lin_ftrs:Optional[Collection[int]]=None, ps:Floa
     if bn_final: layers.append(nn.BatchNorm1d(lin_ftrs[-1], momentum=0.01))
     return nn.Sequential(*layers)
 
-def create_cnn(data:DataBunch, arch:Callable, cut:Union[int,Callable]=None, pretrained:bool=True,
-               lin_ftrs:Optional[Collection[int]]=None, ps:Floats=0.5,
-               custom_head:Optional[nn.Module]=None, split_on:Optional[SplitFuncOrIdxList]=None,
-               bn_final:bool=False, **learn_kwargs:Any)->Learner:
-    "Build convnet style learner."
-    meta = cnn_config(arch)
-    body = create_body(arch, pretrained, cut)
+def create_cnn(base_arch:Callable, nc:int, cut:Union[int,Callable]=None, pretrained:bool=True,
+        lin_ftrs:Optional[Collection[int]]=None, ps:Floats=0.5, custom_head:Optional[nn.Module]=None,
+        split_on:Optional[SplitFuncOrIdxList]=None, bn_final:bool=False):
+    "Create custom convnet architecture"
+    body = create_body(base_arch, pretrained, cut)
     if custom_head is None:
         nf = num_features_model(nn.Sequential(*body.children())) * 2
-        head = create_head(nf, data.c, lin_ftrs, ps=ps, bn_final=bn_final)
+        head = create_head(nf, nc, lin_ftrs, ps=ps, bn_final=bn_final)
     else: head = custom_head
-    model = nn.Sequential(body, head)
-    learn = Learner(data, model, **learn_kwargs)
-    learn.split(ifnone(split_on, meta['split']))
+    return nn.Sequential(body, head)
+
+def cnn_learner(data:DataBunch, base_arch:Callable, cut:Union[int,Callable]=None, pretrained:bool=True,
+               lin_ftrs:Optional[Collection[int]]=None, ps:Floats=0.5, custom_head:Optional[nn.Module]=None,
+               split_on:Optional[SplitFuncOrIdxList]=None, bn_final:bool=False, **kwargs:Any)->Learner:
+    "Build convnet style learner."
+    meta = cnn_config(base_arch)
+    model = create_cnn(base_arch, data.c, cut, pretrained, lin_ftrs, ps, custom_head, split_on, bn_final)
+    learn = Learner(data, model, **kwargs)
+    learn.split(split_on or meta['split'])
     if pretrained: learn.freeze()
     apply_init(model[1], nn.init.kaiming_normal_)
     return learn

--- a/tests/test_basic_train.py
+++ b/tests/test_basic_train.py
@@ -23,7 +23,7 @@ def data():
 # this is not a fixture on purpose - the memory measurement tests are very sensitive, so
 # they need to be able to get a fresh learn object and not one modified by other tests.
 def learn_large_unfit(data):
-    learn = create_cnn(data, models.resnet18, metrics=accuracy)
+    learn = cnn_learner(data, models.resnet18, metrics=accuracy)
     return learn
 
 @pytest.fixture(scope="module")

--- a/tests/test_callbacks_hooks.py
+++ b/tests/test_callbacks_hooks.py
@@ -19,7 +19,7 @@ def test_model_summary_vision(mnist_path):
     this_tests(model_summary)
     path = mnist_path
     data = ImageDataBunch.from_folder(path, ds_tfms=([], []), bs=2)
-    learn = create_cnn(data, models.resnet18, metrics=accuracy)
+    learn = cnn_learner(data, models.resnet18, metrics=accuracy)
     _ = model_summary(learn)
 
 @pytest.mark.xfail(reason = "Expected Fail, text models not supported yet.")
@@ -74,7 +74,7 @@ def test_model_summary_collab():
 def test_hook_output_basics(mnist_path):
     this_tests(hook_output)
     data = ImageDataBunch.from_folder(mnist_path, size=128, bs=2)
-    learn = create_cnn(data, models.resnet18)
+    learn = cnn_learner(data, models.resnet18)
     # need to train to get something meaningful, but for just checking shape its fine w/o it
     m = learn.model.eval()
     x,y = data.train_ds[0]

--- a/tests/test_vision_train.py
+++ b/tests/test_vision_train.py
@@ -42,7 +42,7 @@ def learn(mnist_tiny):
 def learn_large_unfit():
     path = untar_data(URLs.MNIST_TINY)
     data = ImageDataBunch.from_folder(path, ds_tfms=([], []), bs=2)
-    return create_cnn(data, models.resnet18, metrics=accuracy)
+    return cnn_learner(data, models.resnet18, metrics=accuracy)
 
 def test_accuracy(learn):
     this_tests(accuracy)
@@ -132,7 +132,7 @@ def test_model_load_mem_leak(learn_large_unfit):
 
 @pytest.mark.parametrize('arch', [models.resnet18, models.squeezenet1_1])
 def test_models_meta(mnist_tiny, arch, zero_image):
-    learn = create_cnn(mnist_tiny, arch, metrics=[accuracy, error_rate])
+    learn = cnn_learner(mnist_tiny, arch, metrics=[accuracy, error_rate])
     this_tests(learn.predict)
     pred = learn.predict(zero_image)
     assert pred is not None


### PR DESCRIPTION
This decouples creating a cnn arch from cnn learner. Also, changes arg name from `arch` to `base_arch` which improves communicating the intention and readability.

This breaks public API (don't think this is an issue at this point) and quite aggressively aligns naming (`cnn_learner` now aligned with `unet_learner`)

A second, more conservative PR to follow plus additional information.