### PR TITLE
Separate creating cnn arch from cnn learner

### DIFF
--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -9,7 +9,7 @@ from ..layers import *
 from ..callbacks.hooks import *
 from ..train import ClassificationInterpretation
 
-__all__ = ['create_cnn', 'create_body', 'create_head', 'unet_learner']
+__all__ = ['create_cnn_learner', 'create_cnn', 'create_body', 'create_head', 'unet_learner']
 # By default split models between first and second layer
 def _default_split(m:nn.Module): return (m[1],)
 # Split a resnet style model
@@ -66,20 +66,25 @@ def create_head(nf:int, nc:int, lin_ftrs:Optional[Collection[int]]=None, ps:Floa
     if bn_final: layers.append(nn.BatchNorm1d(lin_ftrs[-1], momentum=0.01))
     return nn.Sequential(*layers)
 
-def create_cnn(data:DataBunch, arch:Callable, cut:Union[int,Callable]=None, pretrained:bool=True,
-               lin_ftrs:Optional[Collection[int]]=None, ps:Floats=0.5,
-               custom_head:Optional[nn.Module]=None, split_on:Optional[SplitFuncOrIdxList]=None,
-               bn_final:bool=False, **learn_kwargs:Any)->Learner:
-    "Build convnet style learner."
-    meta = cnn_config(arch)
-    body = create_body(arch, pretrained, cut)
+def create_cnn_arch(base_arch:Callable, nc:int, cut:Union[int,Callable]=None, pretrained:bool=True,
+        lin_ftrs:Optional[Collection[int]]=None, ps:Floats=0.5, custom_head:Optional[nn.Module]=None,
+        split_on:Optional[SplitFuncOrIdxList]=None, bn_final:bool=False):
+    "Create custom convnet architecture"
+    body = create_body(base_arch, pretrained, cut)
     if custom_head is None:
         nf = num_features_model(nn.Sequential(*body.children())) * 2
-        head = create_head(nf, data.c, lin_ftrs, ps=ps, bn_final=bn_final)
+        head = create_head(nf, nc, lin_ftrs, ps=ps, bn_final=bn_final)
     else: head = custom_head
-    model = nn.Sequential(body, head)
-    learn = Learner(data, model, **learn_kwargs)
-    learn.split(ifnone(split_on, meta['split']))
+    return nn.Sequential(body, head)
+
+def create_cnn(data:DataBunch, base_arch:Callable, cut:Union[int,Callable]=None, pretrained:bool=True,
+               lin_ftrs:Optional[Collection[int]]=None, ps:Floats=0.5, custom_head:Optional[nn.Module]=None,
+               split_on:Optional[SplitFuncOrIdxList]=None, bn_final:bool=False, **kwargs:Any)->Learner:
+    "Build convnet style learner."
+    meta = cnn_config(base_arch)
+    model = create_cnn_arch(base_arch, data.c, cut, pretrained, lin_ftrs, ps, custom_head, split_on, bn_final)
+    learn = Learner(data, model, **kwargs)
+    learn.split(split_on or meta['split'])
     if pretrained: learn.freeze()
     apply_init(model[1], nn.init.kaiming_normal_)
     return learn


### PR DESCRIPTION
This is a more conservative version of https://github.com/fastai/fastai/pull/1759.

I do not think the naming works as well though as in the other PR, I would be in support of making a more aggressive change. Not fixing the tests for now but if you chose to go with this PR, will gladly do so (like I did for the other PR)

I have seen some conversation on the forum and I think the library is in too early of a state to maintain a stable public API, but those are just my two Polish groszes. 