### PR TITLE
fix model summary output format

### DIFF
--- a/fastai/callbacks/hooks.py
+++ b/fastai/callbacks/hooks.py
@@ -176,6 +176,6 @@ def model_summary(m:Learner, n:int=70):
     res += f"\nTotal params: {total_params:,}\n"
     res += f"Total trainable params: {total_trainable_params:,}\n"
     res += f"Total non-trainable params: {total_params - total_trainable_params:,}\n"
-    return res
+    return print(res)
 
 Learner.summary = model_summary


### PR DESCRIPTION
Current code returns summary as string and notebook renders it as such without treating `\n` as newline char. Code need to call `print()` and return its output to be rendered by notebook to correctly format. 

Before

<img width="715" alt="image" src="https://user-images.githubusercontent.com/186077/53875213-5153bd00-4004-11e9-9e0f-859e063fabe4.png">

After

<img width="589" alt="image" src="https://user-images.githubusercontent.com/186077/53875233-603a6f80-4004-11e9-86e9-ebc3c3ddc489.png">
