### PR TITLE
fix __all__ in vision.learner

### DIFF
--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -9,7 +9,7 @@ from ..layers import *
 from ..callbacks.hooks import *
 from ..train import ClassificationInterpretation
 
-__all__ = ['cnn_learner', 'create_cnn', 'create_body', 'create_head', 'unet_learner']
+__all__ = ['cnn_learner', 'create_cnn_model', 'create_body', 'create_head', 'unet_learner']
 # By default split models between first and second layer
 def _default_split(m:nn.Module): return (m[1],)
 # Split a resnet style model


### PR DESCRIPTION
When `create_cnn` got changed to `create_cnn_model`, the name was not changed in `__all__` and cannot be imported now.

Would love a quick post1 release or something like that to be able to use this when installing a specific version :slightly_smiling_face: 