### PR TITLE
fix(load): fix load_empty unsupported operand type(s) for /: 'str' an…

### DIFF
--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -557,6 +557,7 @@ class LabelLists(ItemLists):
     @classmethod
     def load_empty(cls, path:PathOrStr, fn:PathOrStr='export.pkl'):
         "Create a `LabelLists` with empty sets from the serialized file in `path/fn`."
+        path = Path(path)
         state = torch.load(open(path/fn, 'rb'))
         return LabelLists.load_state(path, state)
 


### PR DESCRIPTION
The same bug like #1480 with code style like **load_state** method.
