### PR TITLE
Fix gan to adapt callback API changes

### DIFF
--- a/fastai/vision/gan.py
+++ b/fastai/vision/gan.py
@@ -99,7 +99,7 @@ class GANTrainer(LearnerCallback):
         self.switch(self.gen_mode)
         self.closses,self.glosses = [],[]
         self.smoothenerG,self.smoothenerC = SmoothenValue(self.beta),SmoothenValue(self.beta)
-        self.recorder.no_val=True
+        #self.recorder.no_val=True
         self.recorder.add_metric_names(['gen_loss', 'disc_loss'])
         self.imgs,self.titles = [],[]
 
@@ -111,7 +111,7 @@ class GANTrainer(LearnerCallback):
         "Clamp the weights with `self.clip` if it's not None, return the correct input."
         if self.clip is not None:
             for p in self.critic.parameters(): p.data.clamp_(-self.clip, self.clip)
-        return (last_input,last_target) if self.gen_mode else (last_target, last_input)
+        return {'last_input':last_input,'last_target':last_target} if self.gen_mode else {'last_input':last_target,'last_target':last_input}
 
     def on_backward_begin(self, last_loss, last_output, **kwargs):
         "Record `last_loss` in the proper list."
@@ -128,9 +128,9 @@ class GANTrainer(LearnerCallback):
         "Put the critic or the generator back to eval if necessary."
         self.switch(self.gen_mode)
 
-    def on_epoch_end(self, pbar, epoch, **kwargs):
+    def on_epoch_end(self, pbar, epoch, last_metrics, **kwargs):
         "Put the various losses in the recorder and show a sample image."
-        self.recorder.add_metrics([getattr(self.smoothenerG,'smooth',None),getattr(self.smoothenerC,'smooth',None)])
+        if last_metrics is not None: last_metrics += [getattr(self.smoothenerG,'smooth',None),getattr(self.smoothenerC,'smooth',None)]
         if not hasattr(self, 'last_gen') or not self.show_img: return
         data = self.learn.data
         img = self.last_gen[0]


### PR DESCRIPTION
Fix GAN to adapt the changes in commit "Change in the Callback API". Works fine if validation set is not empty. 

If the validation set is empty, although training works fine, the `gen_loss` and `disc_loss` still won't be added to `last_metrics` and won't show in the progress bar. The `gen_loss` and `disc_loss` are added in `on_epoch_end` of `GANTrainer`, if `last_metrics` is not `None`, (with my changes here) the two losses will be added to it and recorded (the `Recorder` is called after `GANTrainer`); But when the validation set is empty, `self.state_dict['last_metrics']` is set to None in `on_epoch_end` of `CallbackHandler`, then I'm not sure how to add the GAN metrics to it. 
Perhapse we shouldn't set `self.state_dict['last_metrics']` to `None` (but set to an empty list instead), so all callbacks can still share and modify it? 