### PR TITLE
Make heatmap work with rectangular images

### DIFF
--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -153,8 +153,8 @@ def _cl_int_plot_top_losses(self, k, largest=True, figsize=(12,12), heatmap:bool
                 grad = hook_g.stored[0][0].cpu()
                 grad_chan = grad.mean(1).mean(1)
                 mult = F.relu(((acts*grad_chan[...,None,None])).sum(0))
-                sz = im.shape[-1]
-                axes.flat[i].imshow(mult, alpha=0.6, extent=(0,sz,sz,0), interpolation='bilinear', cmap='magma')
+                sz = list(im.shape[-2:])
+                axes.flat[i].imshow(mult, alpha=0.6, extent=(0,*sz[::-1],0), interpolation='bilinear', cmap='magma')                
     if ifnone(return_fig, defaults.return_fig): return fig
 
 def _cl_int_plot_multi_top_losses(self, samples:int=3, figsize:Tuple[int,int]=(8,8), save_misclassified:bool=False):


### PR DESCRIPTION
Training a model on rectangular images and afterwards using the ClassificationInterpretation and plot_top_losses resulted in heatmaps that were quadratic on top of rectangular images. With this little change it now works for quadratic and rectangular images.

**Before** (heatmap not well aligned and reaches down below the image boundaries):
<img width="643" alt="Screenshot 2019-03-10 at 16 11 30" src="https://user-images.githubusercontent.com/1515904/54082352-3b6d3180-434f-11e9-85fc-df3e1446cd74.png">

**After**:
<img width="882" alt="Screenshot 2019-03-10 at 16 11 43" src="https://user-images.githubusercontent.com/1515904/54082355-52138880-434f-11e9-88bd-b3192ac5ec0d.png">

PS: I had first used a conditional (if) statement but then found that the _im.shape[-2:]_ in combination with reversing using _*sz[::-1]_ works both for quadratic and rectangular images.

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
