### PR TITLE
Test Registry merge new with existing

### DIFF
--- a/fastai/gen_doc/doctest.py
+++ b/fastai/gen_doc/doctest.py
@@ -70,7 +70,7 @@ class TestAPIRegistry:
         if path.exists() == False: return 
         with open(path, 'r') as f: old_api_tests_map = json.load(f)   
         if old_api_tests_map == False: return
-        print(f"\n*** Saving test registry @ {path}")
+        print(f"\n*** Merging test registry @ {path}")
         for func_fq_key, new_entries in TestAPIRegistry.api_tests_map.items():
             if func_fq_key in old_api_tests_map: 
                 for new_entry in new_entries:

--- a/fastai/gen_doc/doctest.py
+++ b/fastai/gen_doc/doctest.py
@@ -1,7 +1,6 @@
 import sys, re, json, pprint
 from pathlib import Path
 from collections import defaultdict
-from itertools import chain
 from inspect import currentframe, getframeinfo, ismodule
 
 __all__ = ['this_tests']


### PR DESCRIPTION
wrt https://forums.fast.ai/t/test-registry-project/38344/216

@stas00 If there is value & a way to make merge_with_old_registry even more compact (e.g. the loops, if then) happy to look at it. 

For the rest, functionally: passed the local tests I was able to come up with ;-)