### PR TITLE
Test for cont_cat_split

### DIFF
--- a/fastai/tabular/transform.py
+++ b/fastai/tabular/transform.py
@@ -102,8 +102,8 @@ def add_elapsed_times(df:DataFrame, field_names:Collection[str], date_field:str,
         work_df = work_df.merge(tmp, 'left', [date_field, base_field], suffixes=['', s])
     work_df.drop(field_names,1,inplace=True)
     return df.merge(work_df, 'left', [date_field, base_field])
-        
-def cont_cat_split(df, max_card=20, dep_var=None):
+
+def cont_cat_split(df, max_card=20, dep_var=None)->Tuple[List,List]:
     "Helper function that returns column names of cont and cat variables from given df."
     cont_names, cat_names = [], []
     for label in df:
@@ -181,7 +181,7 @@ class FillMissing(TabularProc):
 class Normalize(TabularProc):
     "Normalize the continuous variables."
     def apply_train(self, df:DataFrame):
-        "Comput the means and stds of `self.cont_names` columns to normalize them."
+        "Compute the means and stds of `self.cont_names` columns to normalize them."
         self.means,self.stds = {},{}
         for n in self.cont_names:
             assert is_numeric_dtype(df[n]), (f"""Cannot normalize '{n}' column as it isn't numerical.

--- a/tests/test_tabular_transform.py
+++ b/tests/test_tabular_transform.py
@@ -60,3 +60,22 @@ def test_fill_missing_returns_correct_medians():
     # Make sure the train median is used in both cases
     assert train_df.equals(expected_filled_train_df)
     assert valid_df.equals(expected_filled_valid_df)
+
+def test_cont_cat_split():
+    this_tests(cont_cat_split)
+    cat_names = ['A']
+    cont_names = ['F','I']
+    df = pd.DataFrame({'A': ['a', 'b'], 'F': [0., 1.], 'I': [0, 1]})
+
+    # Make sure the list and number of columns is correct
+    res_cont, res_cat = cont_cat_split(df, max_card=0)
+    assert res_cont == cont_names
+    assert res_cat  == cat_names
+    assert len(res_cont) == len(cont_names)
+    assert len(res_cat)  == len(cat_names)
+    # Make sure `max_card` is correctly used to differentiate int as categorical
+    res_cont, res_cat = cont_cat_split(df)
+    assert res_cont == ['F']
+    assert res_cat  == ['A','I']
+
+


### PR DESCRIPTION
This patch:

1. Adds a test for cont_cat_split() in tabular/transforms.py

1. Adds return value to cont_cat_split()

1. Corrects a minor typo.

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
