### PR TITLE
bug fix to WideResNet. Change to input for flex channel input

### DIFF
--- a/fastai/vision/models/wrn.py
+++ b/fastai/vision/models/wrn.py
@@ -37,17 +37,17 @@ def _make_group(N, ni, nf, block, stride, drop_p):
 
 class WideResNet(nn.Module):
     "Wide ResNet with `num_groups` and a width of `k`."
-    def __init__(self, num_groups:int, N:int, num_classes:int, k:int=1, drop_p:float=0.0, start_nf:int=16):
+    def __init__(self, num_groups:int, N:int, num_classes:int, k:int=1, drop_p:float=0.0, start_nf:int=16, n_in_channels:int=3):
         super().__init__()
         n_channels = [start_nf]
         for i in range(num_groups): n_channels.append(start_nf*(2**i)*k)
 
-        layers = [conv2d(3, n_channels[0], 3, 1)]  # conv1
+        layers = [conv2d(n_in_channels, n_channels[0], 3, 1)]  # conv1
         for i in range(num_groups):
             layers += _make_group(N, n_channels[i], n_channels[i+1], BasicBlock, (1 if i==0 else 2), drop_p)
 
-        layers += [nn.BatchNorm2d(n_channels[3]), nn.ReLU(inplace=True), nn.AdaptiveAvgPool2d(1),
-                   Flatten(), nn.Linear(n_channels[3], num_classes)]
+        layers += [nn.BatchNorm2d(n_channels[num_groups]), nn.ReLU(inplace=True), nn.AdaptiveAvgPool2d(1),
+                   Flatten(), nn.Linear(n_channels[num_groups], num_classes)]
         self.features = nn.Sequential(*layers)
 
     def forward(self, x): return self.features(x)


### PR DESCRIPTION
In WideRestNet the input values for the last BatchNorm and Linear Layers has the same value as the 4th value in n_channels. This will lead to failure _unless_ the `num_groups` = 3. 
Also added an extra input of the number of channels at input `n_in_channels`. Set the default to 3 channels.
Brought this chnge up in forum...  https://forums.fast.ai/t/developer-chat/22363/868?u=aarons
