### PR TITLE
Fix some API renames

### DIFF
--- a/docs/dev/test.md
+++ b/docs/dev/test.md
@@ -561,7 +561,7 @@ def path():
 @pytest.fixture(scope="module")
 def learn(path):
     data = ImageDataBunch.from_folder(path, ds_tfms=([], []), bs=2)
-    learn = create_cnn(data, models.resnet18, metrics=accuracy)
+    learn = cnn_learner(data, models.resnet18, metrics=accuracy)
     return learn
 
 def test_val_loss(learn):

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -39,7 +39,7 @@ What we do here is that we import the necessary stuff from fastai (for later), w
 
 You then have to add one thing to your learner before fitting it to tell it it's going to execute a distributed training:
 ``` python
-learn = learn.distributed(arg.local_rank)
+learn = learn.to_distributed(arg.local_rank)
 ```
 This will add the additional callbacks that will make sure your model and your data loaders are properly setups.
 
@@ -59,7 +59,7 @@ torch.distributed.init_process_group(backend='nccl', init_method='env://')
 path = untar_data(URLs.CIFAR)
 ds_tfms = ([*rand_pad(4, 32), flip_lr(p=0.5)], [])
 data = ImageDataBunch.from_folder(path, valid='test', ds_tfms=ds_tfms, bs=128).normalize(cifar_stats)
-learn = Learner(data, wrn_22(), metrics=accuracy).distributed(arg.local_rank)
+learn = Learner(data, wrn_22(), metrics=accuracy).to_distributed(arg.local_rank)
 learn.fit_one_cycle(10, 3e-3, wd=0.4, div_factor=10, pct_start=0.5)
 ```
 

--- a/docs/tutorial.resources.md
+++ b/docs/tutorial.resources.md
@@ -166,7 +166,7 @@ learn.freeze()
 learn.export(destroy=True) # or learn.export() + learn.destroy()
 
 # beginning of inference
-learn = load_learner(path, test=ImageItemList.from_folder(path/'test'))
+learn = load_learner(path, test=ImageList.from_folder(path/'test'))
 preds = learn.get_preds(ds_type=DatasetType.Test)
 ```
 

--- a/docs/tutorial.resources.md
+++ b/docs/tutorial.resources.md
@@ -25,7 +25,7 @@ import ...
 # init main objects
 model = ... # custom or pretrained
 data = ...  # create databunch
-learn = create_cnn(data, model, metrics)
+learn = cnn_learner(data, model, metrics)
 
 # train
 learn.fit_one_cycle(epochs)

--- a/examples/dogs_cats.ipynb
+++ b/examples/dogs_cats.ipynb
@@ -102,7 +102,7 @@
     }
    ],
    "source": [
-    "learn = create_cnn(data, models.resnet34, metrics=accuracy)\n",
+    "learn = cnn_learner(data, models.resnet34, metrics=accuracy)\n",
     "learn.fit_one_cycle(1)"
    ]
   },
@@ -243,7 +243,7 @@
     }
    ],
    "source": [
-    "learn = create_cnn(data, models.resnet50, metrics=accuracy)\n",
+    "learn = cnn_learner(data, models.resnet50, metrics=accuracy)\n",
     "learn.fit_one_cycle(1)"
    ]
   },

--- a/examples/train_cifar.py
+++ b/examples/train_cifar.py
@@ -18,7 +18,7 @@ def main( gpu:Param("GPU to run on", str)=None ):
                                       num_workers=workers).normalize(cifar_stats)
     learn = Learner(data, wrn_22(), metrics=accuracy)
     if gpu is None: learn.model = nn.DataParallel(learn.model)
-    else: learn.distributed(gpu)
+    else: learn.to_distributed(gpu)
     learn.to_fp16()
     learn.fit_one_cycle(35, 3e-3, wd=0.4)
 

--- a/examples/train_imagenet.py
+++ b/examples/train_imagenet.py
@@ -42,7 +42,7 @@ def main( gpu:Param("GPU to run on", str)=None ):
     ]
     learn.split(lambda m: (children(m)[-2],))
     if gpu is None: learn.model = nn.DataParallel(learn.model)
-    else:           learn.distributed(gpu)
+    else:           learn.to_distributed(gpu)
     learn.to_fp16(dynamic=True)
 
     # Using bs 256 on single GPU as baseline, scale the LR linearly

--- a/examples/train_mnist.py
+++ b/examples/train_mnist.py
@@ -7,6 +7,6 @@ def main():
     path = url2path(URLs.MNIST_SAMPLE)
     tfms = (rand_pad(2, 28), [])
     data = ImageDataBunch.from_folder(path, ds_tfms=tfms, bs=64).normalize(imagenet_stats)
-    learn = create_cnn(data, models.resnet18, metrics=accuracy)
+    learn = cnn_learner(data, models.resnet18, metrics=accuracy)
     learn.fit_one_cycle(1, 0.02)
 


### PR DESCRIPTION
This PR complete some renames in docs, notebooks or tests. These are leftover renames needed due to recent API changes.

Renames (where sensible):

- `ImageItemList` -> `ImageList`
- `create_cnn()` -> `cnn_learner()`
- `Learner.distributed()` -> `Learner.to_distributed()`

**EDIT**: the 2 test failures seems unrelated connection timeout errors while getting data for tests