### PR TITLE
Fix label smoothing.

### DIFF
--- a/fastai/layers.py
+++ b/fastai/layers.py
@@ -307,7 +307,6 @@ class LabelSmoothingCrossEntropy(nn.Module):
     def forward(self, output, target):
         c = output.size()[-1]
         log_preds = F.log_softmax(output, dim=-1)
-        eps = self.eps / c
-        losses = -log_preds.sum(dim=-1) * eps # deviation of predicted label distribution p from the prior uniform
-        losses += (1 - eps) * F.nll_loss(log_preds, target)
+        losses = -log_preds.sum(dim=-1) * self.eps/c # deviation of predicted label distribution p from the prior uniform
+        losses += (1 - self.eps) * F.nll_loss(log_preds, target)
         return losses.mean()

--- a/fastai/layers.py
+++ b/fastai/layers.py
@@ -307,10 +307,7 @@ class LabelSmoothingCrossEntropy(nn.Module):
     def forward(self, output, target):
         c = output.size()[-1]
         log_preds = F.log_softmax(output, dim=-1)
-        # losses =  -log_preds.sum(dim=-1) * self.eps / (c-1)
-        # losses += (1-self.eps*c/(c-1)) * F.nll_loss(log_preds, target)
         eps = self.eps / c
-
-        losses = -log_preds.sum(dim=-1) * eps / c  # deviation of predicted label distribution p from the prior uniform
+        losses = -log_preds.sum(dim=-1) * eps # deviation of predicted label distribution p from the prior uniform
         losses += (1 - eps) * F.nll_loss(log_preds, target)
         return losses.mean()

--- a/fastai/layers.py
+++ b/fastai/layers.py
@@ -307,6 +307,10 @@ class LabelSmoothingCrossEntropy(nn.Module):
     def forward(self, output, target):
         c = output.size()[-1]
         log_preds = F.log_softmax(output, dim=-1)
-        losses =  -log_preds.sum(dim=-1) * self.eps / (c-1) 
-        losses += (1-self.eps*c/(c-1)) * F.nll_loss(log_preds, target)
+        # losses =  -log_preds.sum(dim=-1) * self.eps / (c-1)
+        # losses += (1-self.eps*c/(c-1)) * F.nll_loss(log_preds, target)
+        eps = self.eps / c
+
+        losses = -log_preds.sum(dim=-1) * eps / c  # deviation of predicted label distribution p from the prior uniform
+        losses += (1 - eps) * F.nll_loss(log_preds, target)
         return losses.mean()


### PR DESCRIPTION
Hi Sylvain,
When I was going through the label smoothing code I've noticed a small issue in the code. Basically for a small number of categories `c`  your loss differs from original label smoothing. Once I've fixed the issue I've got slightly better results on classifying MLDoc with ulmfit.

Here is a bit of rationale as per: Rethinking the Inception Architecture for Computer Vision

The Smoothing looks like that:
`(1−eps)H(q, p)+eps*H(u, p)`
where `H` is cross entropy, `q` is label distribution, `p` is the calculated distribution returned from the network, `u` is the uniform distribution, and `eps` is epsilon hyper param scaled by a number of labels.

If you look at the current code in fastai you get roughly the following equation:

```(1−eps*(c/(c-1)))H(q, p)+eps*H(u, p)```

Here is why. The cross entropy with uniform distribution is written as follows:
```H(u,p) = -log_preds.sum(dim=-1) / c ```
which is almost the same as your previous code the, the `1/(c-1)` vs `1/c` shouldn't matter that much.

The issue is with the term `(1−eps)H(q, p)` as it should be:
`(1-eps) * F.nll_loss(log_preds, target)` and the current code is multiplying eps by (c/(c-1))
It doesn't do much harm if the number of categories is large (like in case of image net), but if you have only a few labels then this difference is larger.
