### PR TITLE
Fix the get_preds(DatasetType.Train, ordered=True)

### DIFF
--- a/fastai/text/learner.py
+++ b/fastai/text/learner.py
@@ -80,8 +80,10 @@ class RNNLearner(Learner):
                   ordered:bool=False) -> List[Tensor]:
         "Return predictions and targets on the valid, train, or test set, depending on `ds_type`."
         self.model.reset()
+        if ordered: np.random.seed(42)
         preds = super().get_preds(ds_type=ds_type, with_loss=with_loss, n_batch=n_batch, pbar=pbar)
         if ordered and hasattr(self.dl(ds_type), 'sampler'):
+            np.random.seed(42)
             sampler = [i for i in self.dl(ds_type).sampler]
             reverse_sampler = np.argsort(sampler)
             preds = [p[reverse_sampler] for p in preds] 


### PR DESCRIPTION
The code currently tries to resort the predictions after it  receives it from the super().get_preds unfortunately it fails to do so as it twice takes the order from the sampler which in case of randomized samplers is different each time.

A bit of dirty fix is to use the same random seed during get_pred and when getting the order from  random sampler.
But it would be much better to make it possible to introduce an intereface to the sampler that let us disable the randomization.