### PR TITLE
fbeta metric: last + current with "add_metrics" fun

### DIFF
--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -213,7 +213,7 @@ class FBeta(CMScores):
         rec = self._recall()
         metric = (1 + self.beta2) * prec * rec / (prec * self.beta2 + rec + self.eps)
         if self.avg: metric = (self._weights(avg=self.avg) * self.metric).sum()
-        return {'last_metrics': last_metrics + metric}
+        return add_metrics(last_metrics, metric)
 
     def on_train_end(self, **kwargs): self.average = self.avg
 


### PR DESCRIPTION
in FBeta metrics in case of a set `average` (i.e. to `'macro'`) final `metrics` will be a tensor while `last_metrics` will be a list, hence can't be just `+`ed.
https://github.com/fastai/fastai/blob/99044b6fbf2774e83de6cf8a910b30c375738db8/fastai/metrics.py#L214-L216
this change would call `add_metrics` instead, also makes it consistent with all other metrics classes
