### PR TITLE
fix "FBeta" score calc on precision with "nan"s

### DIFF
--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -212,6 +212,7 @@ class FBeta(CMScores):
         prec = self._precision()
         rec = self._recall()
         metric = (1 + self.beta2) * prec * rec / (prec * self.beta2 + rec + self.eps)
+        metric[metric != metric] = 0  # removing potential "nan"s
         if self.avg: metric = (self._weights(avg=self.avg) * metric).sum()
         return add_metrics(last_metrics, metric)
 


### PR DESCRIPTION
following the [conversation](https://forums.fast.ai/t/fbeta-formula-for-averages-references-non-existing-metric/40965) on the dev forum:

Whenever the precision does not go over all the classes it returns `nan`s in some of it's elements, hence the end `*` and `sum()` result in the overall `nan`:

https://github.com/fastai/fastai/blob/bc093a9de9c9d6c3d2c7e5ad6d7a427face1ca9a/fastai/metrics.py#L215

This happens in the beginning of training. Given enough epochs, and/or once `precision` saw all the classes, `fbeta` has a number to show.

Added `metric[metric != metric] = 0` before multiplying it by weights. It ensures "`nan`"s are converted to "`0`"s and the resulting fbeta is never "`nan`":

| epoch | train_loss | valid_loss | accuracy | precision | recall | fbeta | time
|---|---|---|---|---|---|---|---|
| 0 | 1.847709 | 1.456625 | 0.537861 | nan | 0.309992 | **nan** | 01:15

becomes:

| epoch | train_loss | valid_loss | accuracy | precision | recall | fbeta | time
|---|---|---|---|---|---|---|---|
| 0 | 1.847709 | 1.456625 | 0.537861 | nan | 0.309992 | **0.303910** | 01:15

with an actual number for `fbeta`