### PR TITLE
added some clarity to what label_cls is and multi-regression usage

### DIFF
--- a/docs_src/data_block.ipynb
+++ b/docs_src/data_block.ipynb
@@ -2449,6 +2449,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "If no `label_cls` argument is passed, the correct labeling type can usually be inferred based on the data (for classification or regression). If you have multiple regression targets (e.g. predict 5 different numbers from a single image/text), be aware that arrays of floats are by default considered to be targets for one-hot encoded classification. If your task is regression, be sure the pass `label_cls = FloatList` so that learners created from your databunch initialize correctly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The first example in these docs created labels as follows:"
    ]
   },


### PR DESCRIPTION
Added some documentation to the datablock api explaining more about `label_cls` usage and how to get correct labeling for multi-regression. See [here](https://forums.fast.ai/t/nlp-multi-regression-with-datablock-api/40950)
