### PR TITLE
Data block minor fixes

### DIFF
--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -152,7 +152,7 @@ class ItemList():
         "Only keep filenames in `include` folder or reject the ones in `exclude`."
         include,exclude = listify(include),listify(exclude)
         def _inner(o):
-            if isintance(o, Path): n = o.relative_to(self.path).parts[0]
+            if isinstance(o, Path): n = o.relative_to(self.path).parts[0]
             else: o.split(os.path.sep)[len(str(self.path).split(os.path.sep))]
             if include and not n in include: return False
             if exclude and     n in exclude: return False

--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -153,7 +153,7 @@ class ItemList():
         include,exclude = listify(include),listify(exclude)
         def _inner(o):
             if isinstance(o, Path): n = o.relative_to(self.path).parts[0]
-            else: o.split(os.path.sep)[len(str(self.path).split(os.path.sep))]
+            else: n = o.split(os.path.sep)[len(str(self.path).split(os.path.sep))]
             if include and not n in include: return False
             if exclude and     n in exclude: return False
             return True

--- a/tests/test_data_block.py
+++ b/tests/test_data_block.py
@@ -1,6 +1,8 @@
 import pytest
 from fastai.gen_doc.doctest import this_tests
 from fastai.basics import *
+from fastai.vision import ImageList
+
 
 def chk(a,b): assert np.array_equal(a,b)
 
@@ -130,8 +132,8 @@ def test_regression():
 def test_wrong_order():
     this_tests('na')
     path = untar_data(URLs.MNIST_TINY)
-    with pytest.raises(Exception):
-        src = ImageList.from_folder(path).label_from_folder().split_by_folder()
+    with pytest.raises(Exception, match="Your data isn't split*"):
+        ImageList.from_folder(path).label_from_folder().split_by_folder()
 
 class CustomDataset(Dataset):
     def __init__(self, data_list): self.data = copy(data_list)

--- a/tests/test_data_block.py
+++ b/tests/test_data_block.py
@@ -150,12 +150,12 @@ def test_custom_dataset():
     assert data.loss_func == F.nll_loss
 
 def test_filter_by_folder():
-    items = ["in", "out", "unspecified_means_out"]
+    items = ["parent/in", "parent/out", "parent/unspecified_means_out"]
 
-    res = ItemList.filter_by_folder(ItemList(items = [Path(p) for p in items]),
+    res = ItemList.filter_by_folder(ItemList(items = [Path(p) for p in items], path="parent"),
                                     include=["in", "and_in"], exclude=["out", "also_out"])
-    assert res.items == [Path("in")]
+    assert res.items == [Path("parent/in")]
 
     res = ItemList.filter_by_folder(ItemList(items = items),
                                     include=["in", "and_in"], exclude=["out", "also_out"])
-    assert res.items == ["in"]
+    assert res.items == ["parent/in"]

--- a/tests/test_data_block.py
+++ b/tests/test_data_block.py
@@ -148,3 +148,14 @@ def test_custom_dataset():
 
     # test property fallback
     assert data.loss_func == F.nll_loss
+
+def test_filter_by_folder():
+    items = ["in", "out", "unspecified_means_out"]
+
+    res = ItemList.filter_by_folder(ItemList(items = [Path(p) for p in items]),
+                                    include=["in", "and_in"], exclude=["out", "also_out"])
+    assert res.items == [Path("in")]
+
+    res = ItemList.filter_by_folder(ItemList(items = items),
+                                    include=["in", "and_in"], exclude=["out", "also_out"])
+    assert res.items == ["in"]


### PR DESCRIPTION
-fix test_wrong_order by adding missing import and making test more strict
-fix typo in filter_by_folder and add unit test for the metohd. The method is still broken for string items