### PR TITLE
Add FASTAI_HOME as optional location of config file

### DIFF
--- a/docs_src/datasets.ipynb
+++ b/docs_src/datasets.ipynb
@@ -100,8 +100,11 @@
    "source": [
     "For the rest of the datasets you will need to download them with [`untar_data`](/datasets.html#untar_data) or [`download_data`](/datasets.html#download_data). [`untar_data`](/datasets.html#untar_data) will decompress the data file and download it while [`download_data`](/datasets.html#download_data) will just download and save the compressed file in `.tgz` format. \n",
     "\n",
-    "By default, data will be downloaded to `~/.fastai/data` folder.  \n",
-    "Configure the default `data_path` by editing `~/.fastai/config.yml`.  "
+    "The locations where the data and models are downloaded are set in `config.yml`, which by default is located in `~/.fastai`. This directory can be changed via the optional environment variable `FASTAI_HOME` (e.g FASTAI_HOME=/home/.fastai).\n",
+    "\n",
+    "If no `config.yml` is present in the specified directory, a default one will be created with `data_path` and `models_path` entries pointing to respectively `data` folder and `models` folder in the same directory as `config.yml`.\n",
+    "\n",
+    "Configure those download locations by editing `data_path` and `models_path` in `config.yml`."
    ]
   },
   {
@@ -188,7 +191,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note: If the data file already exists in a <code>data</code> directory inside the notebook, that data file will be used instead of <code>~/.fasta/data</code>. Paths are resolved by calling the function [`datapath4file`](/datasets.html#datapath4file) - which checks if data exists locally (`data/`) first, before downloading to `~/.fastai/data` home directory.\n",
+    "Note: If the data file already exists in a <code>data</code> directory inside the notebook, that data file will be used instead of the one present in the folder specified in `config.yml`. `config.yml` is located in the directory specified in optional environment variable `FASTAI_HOME` (defaults to `~/.fastai/`). Paths are resolved by calling the function [`datapath4file`](/datasets.html#datapath4file) - which checks if data exists locally (`data/`) first, before downloading to the folder specified in `config.yml`.\n",
     "\n",
     "Example:"
    ]
@@ -247,9 +250,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "All the downloading functions use this to decide where to put the tgz and expanded folder. If `filename` already exists in a <code>data</code> directory in the same place as the calling notebook/script, that is used as the parent directly, otherwise `~/.fastai/config.yml` is read to see what path to use, which defaults to <code>~/.fastai/data</code> is used. To override this default, simply modify the value in your `~/.fastai/config.yml`:\n",
+    "All the downloading functions use this to decide where to put the tgz and expanded folder. If `filename` already exists in a <code>data</code> directory in the same place as the calling notebook/script, that is used as the parent directly, otherwise `config.yml` is read to see what path to use, which defaults to <code>~/.fastai/data</code> is used. To override this default, simply modify the value in your `config.yml`:\n",
     "\n",
-    "    data_path: ~/.fastai/data"
+    "    data_path: ~/.fastai/data\n",
+    "\n",
+    "`config.yml` is located in the directory specified in optional environment variable `FASTAI_HOME` (defaults to `~/.fastai/`)."
    ]
   },
   {

--- a/fastai/datasets.py
+++ b/fastai/datasets.py
@@ -127,11 +127,12 @@ _checks = {
 
 #TODO: This can probably be coded more shortly and nicely.
 class Config():
-    "Creates a default config file at `~/.fastai/config.yml`"
-    DEFAULT_CONFIG_PATH = '~/.fastai/config.yml'
+    "Creates a default config file 'config.yml' in $FASTAI_HOME (default `~/.fastai/`)"
+    DEFAULT_CONFIG_LOCATION = os.path.expanduser(os.getenv('FASTAI_HOME', '~/.fastai'))
+    DEFAULT_CONFIG_PATH = DEFAULT_CONFIG_LOCATION + '/config.yml'
     DEFAULT_CONFIG = {
-        'data_path': '~/.fastai/data',
-        'model_path': '~/.fastai/models'
+        'data_path': DEFAULT_CONFIG_LOCATION + '/data',
+        'model_path': DEFAULT_CONFIG_LOCATION + '/models'
     }
 
     @classmethod


### PR DESCRIPTION
[I didn't create a thread on the fastai forums as this code change seems tangential to the actual functionality of fastai]

This pr adds FASTAI_HOME environment var which works similar to TORCH_HOME (in [pytorch]/torch/utils/model_zoo.py).

I run fastai in a docker container and ~ points to /root inside the container, which means that any downloads go inside the container and consequently are lost when the container is stopped unless I copy them from the container (and copy them back in when the container is started).

Setting FASTAI_HOME to an external VOLUME (e.g. 'VOLUME /home' and 'ENV FASTAI_HOME=/home/.fastai') in the dockerfile saves all downloads outside the container (via the config.yml which also has /home/.. as for data_path and model_path).