### PR TITLE
Update docstring with learning rate suggestions

### DIFF
--- a/courses/dl2/imdb_scripts/README.md
+++ b/courses/dl2/imdb_scripts/README.md
@@ -152,7 +152,7 @@ train_clas.py --dir-path DIR_PATH --cuda-id CUDA_ID [--lm-id LM_ID] [--clas-id C
 - `FROM_SCRATCH`: whether to train the model from scratch (without loading a pretrained model)
 - `TRAIN_FILE_ID`: can be used to indicate different training files (e.g. to test training sizes)
 
-For fine-tuning the classifier on IMDb, we set `--cl`, the number of epochs to `50`.
+For fine-tuning the classifier on IMDb, we set `--cl`, the number of epochs to `50`. `--lr .005`, works well if `--backwards` is set to True, otherwise the default .01 is fine.
 
 ### 5. Evaluate the classifier
 


### PR DESCRIPTION
With --backwards True, IMDB classifier achieves 93.9% accuracy with lr=.005, vs. 92.6% with lr=.01,the default. 
This tripped me up so I figured it should be documented. I have only run half of same experiments for the forward model, scoring 94.5% with the default lr=.01.