### PR TITLE
Make classes to labels consistent

### DIFF
--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -287,7 +287,8 @@ class ItemList():
 
     def label_from_folder(self, label_cls:Callable=None, **kwargs)->'LabelList':
         "Give a label to each filename depending on its folder."
-        return self.label_from_func(func=lambda o: o.parts[-2], label_cls=label_cls, **kwargs)
+        labels_func = lambda o: int(o.parts[-2]) if o.parts[-2].isdigit() else o.parts[-2]
+        return self.label_from_func(func=labels_func, label_cls=label_cls, **kwargs)
 
     def label_from_re(self, pat:str, full_path:bool=False, label_cls:Callable=None, **kwargs)->'LabelList':
         "Apply the re in `pat` to determine the label of every filename.  If `full_path`, search in the full name."


### PR DESCRIPTION
Right now when you get labels from_csv or df it infers the type meaning if I get the labels from a CSV file and the labels are all numeric values it will assume they are an integer if not it will assume they are strings. However, label_from_df always assume the labels are string even if all the folder names are numeric. In isolation, this those not cause any problem but if I try to create a DataBunch where I read the train is from a csv file and the validation is from folder there will be an inconsistency between the mapping of classes names and labels. That is because sorting numeric string is different than sorting integers. 

I know my case is very unique but I experienced this and others might 2. The idea is that both labels_from_df and label_from_folder provide the same mapping which they currently don't mainly because string sorted not the same as int sorting when creating the label name to label dictionary.

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
