### PR TITLE
Update imdb.ipynb, Redundant Parameters.

### DIFF
--- a/courses/dl2/imdb.ipynb
+++ b/courses/dl2/imdb.ipynb
@@ -737,7 +737,7 @@
    "source": [
     "trn_dl = LanguageModelLoader(np.concatenate(trn_lm), bs, bptt)\n",
     "val_dl = LanguageModelLoader(np.concatenate(val_lm), bs, bptt)\n",
-    "md = LanguageModelData(PATH, 1, vs, trn_dl, val_dl, bs=bs, bptt=bptt)"
+    "md = LanguageModelData(PATH, 1, vs, trn_dl, val_dl)"
    ]
   },
   {


### PR DESCRIPTION
bs and bptt are not used in LanguageModelData.