### PR TITLE
add PooledSelfAttention

### DIFF
--- a/fastai/layers.py
+++ b/fastai/layers.py
@@ -5,7 +5,7 @@ __all__ = ['AdaptiveConcatPool2d', 'BCEWithLogitsFlat', 'BCEFlat', 'MSELossFlat'
            'Flatten', 'Lambda', 'PoolFlatten', 'View', 'ResizeBatch', 'bn_drop_lin', 'conv2d', 'conv2d_trans', 'conv_layer',
            'embedding', 'simple_cnn', 'NormType', 'relu', 'batchnorm_2d', 'trunc_normal_', 'PixelShuffle_ICNR', 'icnr',
            'NoopLoss', 'WassersteinLoss', 'SelfAttention', 'SequentialEx', 'MergeLayer', 'res_block', 'sigmoid_range',
-           'SigmoidRange', 'PartialLayer', 'FlattenedLoss', 'BatchNorm1dFlat', 'LabelSmoothingCrossEntropy']
+           'SigmoidRange', 'PartialLayer', 'FlattenedLoss', 'BatchNorm1dFlat', 'LabelSmoothingCrossEntropy', 'PooledSelfAttention2d']
 
 class Lambda(nn.Module):
     "An easy way to create a pytorch layer for a simple `func`."
@@ -66,14 +66,14 @@ def bn_drop_lin(n_in:int, n_out:int, bn:bool=True, p:float=0., actn:Optional[nn.
     return layers
 
 def conv1d(ni:int, no:int, ks:int=1, stride:int=1, padding:int=0, bias:bool=False):
-    "Create and iniialize `nn.Conv1d` layer."
+    "Create and initialize a `nn.Conv1d` layer with spectral normalization."
     conv = nn.Conv1d(ni, no, ks, stride=stride, padding=padding, bias=bias)
     nn.init.kaiming_normal_(conv.weight)
     if bias: conv.bias.data.zero_()
     return spectral_norm(conv)
 
-class SelfAttention(nn.Module):
-    "Self attention layer for 2d."
+class PooledSelfAttention2d(nn.Module):
+    "Pooled self attention layer for 2d."
     def __init__(self, n_channels:int):
         super().__init__()
         self.theta = spectral_norm(conv2d(n_channels, n_channels//8, 1))
@@ -81,13 +81,8 @@ class SelfAttention(nn.Module):
         self.g     = spectral_norm(conv2d(n_channels, n_channels//2, 1))
         self.o     = spectral_norm(conv2d(n_channels//2, n_channels, 1))
         self.gamma = nn.Parameter(tensor([0.]))
-        # backward compatibility
-        self.query = self.theta
-        self.key   = self.phi
-        self.value = self.g
 
     def forward(self, x):
-        #Notation from https://arxiv.org/pdf/1805.08318.pdf
         # code borrowed from https://github.com/ajbrock/BigGAN-PyTorch/blob/7b65e82d058bfe035fc4e299f322a1f83993e04c/layers.py#L156
         theta = self.theta(x)
         phi = F.max_pool2d(self.phi(x), [2,2])
@@ -98,6 +93,24 @@ class SelfAttention(nn.Module):
         beta = F.softmax(torch.bmm(theta.transpose(1, 2), phi), -1)
         o = self.o(torch.bmm(g, beta.transpose(1,2)).view(-1, self.ch // 2, x.shape[2], x.shape[3]))
         return self.gamma * o + x
+
+class SelfAttention(nn.Module):
+    "Self attention layer for nd."
+    def __init__(self, n_channels:int):
+        super().__init__()
+        self.query = conv1d(n_channels, n_channels//8)
+        self.key   = conv1d(n_channels, n_channels//8)
+        self.value = conv1d(n_channels, n_channels)
+        self.gamma = nn.Parameter(tensor([0.]))
+
+    def forward(self, x):
+        #Notation from https://arxiv.org/pdf/1805.08318.pdf
+        size = x.size()
+        x = x.view(*size[:2],-1)
+        f,g,h = self.query(x),self.key(x),self.value(x)
+        beta = F.softmax(torch.bmm(f.permute(0,2,1).contiguous(), g), dim=1)
+        o = self.gamma * torch.bmm(h, beta) + x
+        return o.view(*size).contiguous()
 
 def conv2d(ni:int, nf:int, ks:int=3, stride:int=1, padding:int=None, bias=False, init:LayerFunc=nn.init.kaiming_normal_) -> nn.Conv2d:
     "Create and initialize `nn.Conv2d` layer. `padding` defaults to `ks//2`."


### PR DESCRIPTION
The previous implementation was based on [Self-Attention Generative Adversarial Networks](https://arxiv.org/abs/1805.08318) and the authors didn't mention max_pooling and the output_convolution in the paper but [their code](https://github.com/brain-research/self-attention-gan/blob/master/non_local.py) has them.

note that [BigGAN's unofficial implementation from the official authors](https://github.com/ajbrock/BigGAN-PyTorch/blob/master/layers.py#L144) and [compare_gan](https://github.com/google/compare_gan/blob/master/compare_gan/architectures/arch_ops.py)(from google) both have the same architecture
