### PR TITLE
Serialization / Deserialization of Fastai objects to byte streams

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@ of that change.
 ### New:
 
 ### Changed:
+- Loading and saving. Added option to save/load from streams (buffers or file pointers). 
+**Note** In all save/load related functions (`Learn.save`, `Learn.export`, `load_learner`, `DataBunch.save`, `load_data`), the parameter name `fname` has changes to `file`.
 
 ### Fixed:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,11 +12,13 @@ of that change.
 
 ## 1.0.51.dev0 (Work In Progress)
 
+### Breaking changed:
+- Loading and saving. Added option to save/load from streams (buffers or file pointers). 
+**Note** In all save/load related functions (`Learn.save`, `Learn.export`, `load_learner`, `DataBunch.save`, `load_data`), the parameter name `fname` was renamed to `file`.
+
 ### New:
 
 ### Changed:
-- Loading and saving. Added option to save/load from streams (buffers or file pointers). 
-**Note** In all save/load related functions (`Learn.save`, `Learn.export`, `load_learner`, `DataBunch.save`, `load_data`), the parameter name `fname` has changes to `file`.
 
 ### Fixed:
 

--- a/docs_src/basic_train.ipynb
+++ b/docs_src/basic_train.ipynb
@@ -2265,7 +2265,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "learn = load_learner(path, fname='trained_model.pkl')"
+    "learn = load_learner(path, 'trained_model.pkl')"
    ]
   },
   {

--- a/docs_src/text.ipynb
+++ b/docs_src/text.ipynb
@@ -276,8 +276,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_lm = load_data(path, fname='data_lm_export.pkl')\n",
-    "data_clas = load_data(path, fname='data_clas_export.pkl', bs=16)"
+    "data_lm = load_data(path, 'data_lm_export.pkl')\n",
+    "data_clas = load_data(path, 'data_clas_export.pkl', bs=16)"
    ]
   },
   {

--- a/fastai/basic_data.py
+++ b/fastai/basic_data.py
@@ -146,12 +146,12 @@ class DataBunch():
     def remove_tfm(self,tfm:Callable)->None:
         for dl in self.dls: dl.remove_tfm(tfm)
 
-    def save(self, fname:PathOrStr='data_save.pkl', buffer:io.BytesIO=None)->None:
-        "Save the `DataBunch` in `self.path/fname`. If buffer is specified, save to buffer"
+    def save(self, file:PathLikeOrBinaryStream= 'data_save.pkl')->None:
+        "Save the `DataBunch` in `self.path/file`. If `file` is a binary stream, save to it."
         if not getattr(self, 'label_list', False):
             warn("Serializing the `DataBunch` only works when you created it using the data block API.")
             return
-        try_save(self.label_list, self.path, fname, buffer)
+        try_save(self.label_list, self.path, file)
 
     def add_test(self, items:Iterator, label:Any=None)->None:
         "Add the `items` as a test set. Pass along `label` otherwise label them with `EmptyLabel`."
@@ -269,12 +269,12 @@ class DataBunch():
             warn(message)
             print(final_message)
 
-def load_data(path:PathOrStr, fname:str='data_save.pkl', bs:int=64, val_bs:int=None, num_workers:int=defaults.cpus,
-                  dl_tfms:Optional[Collection[Callable]]=None, device:torch.device=None, collate_fn:Callable=data_collate,
-                  no_check:bool=False, buffer:io.BytesIO=None, **kwargs)->DataBunch:
-    """Load from `path/fname` a saved `DataBunch`.
-    If `buffer` is specified, load from it (`path` is still required to set the working directory)"""
-    target = buffer if buffer else Path(path)/fname
-    ll = torch.load(target, map_location='cpu') if defaults.device == torch.device('cpu') else torch.load(target)
+def load_data(path:PathOrStr, file:PathLikeOrBinaryStream= 'data_save.pkl', bs:int=64, val_bs:int=None, num_workers:int=defaults.cpus,
+              dl_tfms:Optional[Collection[Callable]]=None, device:torch.device=None, collate_fn:Callable=data_collate,
+              no_check:bool=False, **kwargs)->DataBunch:
+    """Load from `path/file` a saved `DataBunch`.
+    If `file` is a binary stream (file or buffer), read from it (`path` is still required to set the working directory)."""
+    source = Path(path)/file if is_pathlike(file) else file
+    ll = torch.load(source, map_location='cpu') if defaults.device == torch.device('cpu') else torch.load(source)
     return ll.databunch(path=path, bs=bs, val_bs=val_bs, num_workers=num_workers, dl_tfms=dl_tfms, device=device,
                         collate_fn=collate_fn, no_check=no_check, **kwargs)

--- a/fastai/basic_data.py
+++ b/fastai/basic_data.py
@@ -147,7 +147,7 @@ class DataBunch():
         for dl in self.dls: dl.remove_tfm(tfm)
 
     def save(self, file:PathLikeOrBinaryStream= 'data_save.pkl')->None:
-        "Save the `DataBunch` in `self.path/file`. If `file` is a binary stream, save to it."
+        "Save the `DataBunch` in `self.path/file`. `file` can be file-like (file or buffer)"
         if not getattr(self, 'label_list', False):
             warn("Serializing the `DataBunch` only works when you created it using the data block API.")
             return
@@ -193,10 +193,10 @@ class DataBunch():
         else : ys = [self.train_ds.y.reconstruct(grab_idx(y, i)) for i in range(n_items)]
         self.train_ds.x.show_xys(xs, ys, **kwargs)
  
-    def export(self, fname:str='export.pkl'):
-        "Export the minimal state of `self` for inference in `self.path/fname`."
+    def export(self, file:PathLikeOrBinaryStream='export.pkl'):
+        "Export the minimal state of `self` for inference in `self.path/file`. `file` can be file-like (file or buffer)"
         xtra = dict(normalize=self.norm.keywords) if getattr(self, 'norm', False) else {}
-        try_save(self.valid_ds.get_state(**xtra), self.path, fname)
+        try_save(self.valid_ds.get_state(**xtra), self.path, file)
 
     def _grab_dataset(self, dl:DataLoader):
         ds = dl.dl.dataset
@@ -269,11 +269,10 @@ class DataBunch():
             warn(message)
             print(final_message)
 
-def load_data(path:PathOrStr, file:PathLikeOrBinaryStream= 'data_save.pkl', bs:int=64, val_bs:int=None, num_workers:int=defaults.cpus,
+def load_data(path:PathOrStr, file:PathLikeOrBinaryStream='data_save.pkl', bs:int=64, val_bs:int=None, num_workers:int=defaults.cpus,
               dl_tfms:Optional[Collection[Callable]]=None, device:torch.device=None, collate_fn:Callable=data_collate,
               no_check:bool=False, **kwargs)->DataBunch:
-    """Load from `path/file` a saved `DataBunch`.
-    If `file` is a binary stream (file or buffer), read from it (`path` is still required to set the working directory)."""
+    "Load a saved `DataBunch` from `path/file`. `file` can be file-like (file or buffer)"
     source = Path(path)/file if is_pathlike(file) else file
     ll = torch.load(source, map_location='cpu') if defaults.device == torch.device('cpu') else torch.load(source)
     return ll.databunch(path=path, bs=bs, val_bs=val_bs, num_workers=num_workers, dl_tfms=dl_tfms, device=device,

--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -225,8 +225,7 @@ class Learner():
         self.create_opt(defaults.lr)
 
     def export(self, file:PathLikeOrBinaryStream='export.pkl', destroy=False):
-        """Export the state of the `Learner` in `self.path/file`.
-        If `file` is a binary stream (buffer or file), write to it."""
+        "Export the state of the `Learner` in `self.path/file`. `file` can be file-like (file or buffer)"
         if rank_distrib(): return # don't save if slave proc
         args = ['opt_func', 'loss_func', 'metrics', 'true_wd', 'bn_wd', 'wd', 'train_bn', 'model_dir', 'callback_fns']
         state = {a:getattr(self,a) for a in args}
@@ -242,8 +241,7 @@ class Learner():
         if destroy: self.destroy()
 
     def save(self, file:PathLikeOrBinaryStream=None, return_path:bool=False, with_opt:bool=True):
-        """Save model and optimizer state (if `with_opt`) with `file` to `self.model_dir`.
-        If `file` is a binary stream (buffer or file), write to it."""
+        "Save model and optimizer state (if `with_opt`) with `file` to `self.model_dir`. `file` can be file-like (file or buffer)"
         if is_pathlike(file): self._test_writeable_path()
         if rank_distrib(): return # don't save if slave proc
         target = self.path/self.model_dir/f'{file}.pth' if is_pathlike(file) else file
@@ -259,8 +257,7 @@ class Learner():
 
     def load(self, file:PathLikeOrBinaryStream=None, device:torch.device=None, strict:bool=True,
              with_opt:bool=None, purge:bool=True, remove_module:bool=False):
-        """Load model and optimizer state (if `with_opt`) `file` from `self.model_dir` using `device`.
-        If `file` is a binary stream (buffer or file), read from it."""
+        "Load model and optimizer state (if `with_opt`) `file` from `self.model_dir` using `device`. `file` can be file-like (file or buffer)"
         if purge: self.purge(clear_opt=ifnone(with_opt, False))
         if device is None: device = self.data.device
         elif isinstance(device, int): device = torch.device('cuda', device)
@@ -590,8 +587,7 @@ def load_callback(class_func, state, learn:Learner):
     return res
 
 def load_learner(path:PathOrStr, file:PathLikeOrBinaryStream='export.pkl', test:ItemList=None, **db_kwargs):
-    """Load a `Learner` object saved with `export_state` in `path/file` with empty data, optionally add `test` and load on `cpu`.
-    If `file` is a binary stream (buffer or file), read from it."""
+    "Load a `Learner` object saved with `export_state` in `path/file` with empty data, optionally add `test` and load on `cpu`. `file` can be file-like (file or buffer)"
     source = Path(path)/file if is_pathlike(file) else file
     state = torch.load(source, map_location='cpu') if defaults.device == torch.device('cpu') else torch.load(source)
     model = state.pop('model')

--- a/fastai/core.py
+++ b/fastai/core.py
@@ -1,4 +1,6 @@
 "`fastai.core` contains essential util functions to format and split data"
+from io import BufferedWriter, BytesIO
+
 from .imports.core import *
 
 warnings.filterwarnings("ignore", message="numpy.dtype size changed")
@@ -28,6 +30,7 @@ OptRange = Optional[Tuple[float,float]]
 OptStrTuple = Optional[Tuple[str,str]]
 OptStats = Optional[Tuple[np.ndarray, np.ndarray]]
 PathOrStr = Union[Path,str]
+PathLikeOrBinaryStream = Union[PathOrStr, BufferedWriter, BytesIO]
 PBar = Union[MasterBar, ProgressBar]
 Point=Tuple[float,float]
 Points=Collection[Point]
@@ -37,7 +40,6 @@ StartOptEnd=Union[float,Tuple[float,float]]
 StrList = Collection[str]
 Tokens = Collection[Collection[str]]
 OptStrList = Optional[StrList]
-
 np.set_printoptions(precision=6, threshold=50, edgeitems=4, linewidth=120)
 
 def num_cpus()->int:
@@ -51,6 +53,7 @@ defaults = SimpleNamespace(cpus=_default_cpus, cmap='viridis', return_fig=False)
 def is_listy(x:Any)->bool: return isinstance(x, (tuple,list))
 def is_tuple(x:Any)->bool: return isinstance(x, tuple)
 def is_dict(x:Any)->bool: return isinstance(x, dict)
+def is_pathlike(x:Any)->bool: return isinstance(x, (str,Path))
 def noop(x): return x
 
 def chunks(l:Collection, n:int)->Iterable:

--- a/fastai/test_registry.json
+++ b/fastai/test_registry.json
@@ -38,6 +38,11 @@
             "file": "tests/test_text_data.py",
             "line": 110,
             "test": "test_backwards_cls_databunch"
+        },
+        {
+            "file": "tests/test_basic_data.py",
+            "line": 72,
+            "test": "test_DataBunch_save_load"
         }
     ],
     "fastai.basic_data.DataBunch.one_item": [
@@ -45,6 +50,13 @@
             "file": "tests/test_basic_data.py",
             "line": 56,
             "test": "test_DataBunch_oneitem"
+        }
+    ],
+    "fastai.basic_data.DataBunch.save": [
+        {
+            "file": "tests/test_basic_data.py",
+            "line": 72,
+            "test": "test_DataBunch_save_load"
         }
     ],
     "fastai.basic_data.DataBunch.show_batch": [
@@ -59,6 +71,11 @@
             "file": "tests/test_text_data.py",
             "line": 129,
             "test": "test_load_and_save_test"
+        },
+        {
+            "file": "tests/test_basic_data.py",
+            "line": 72,
+            "test": "test_DataBunch_save_load"
         }
     ],
     "fastai.basic_train.Learner.destroy": [

--- a/fastai/test_registry.json
+++ b/fastai/test_registry.json
@@ -93,7 +93,7 @@
     "fastai.basic_train.Learner.export": [
         {
             "file": "tests/test_basic_train.py",
-            "line": 218,
+            "line": 226,
             "test": "test_export_load_learner"
         }
     ],
@@ -212,7 +212,7 @@
     "fastai.basic_train.load_learner": [
         {
             "file": "tests/test_basic_train.py",
-            "line": 218,
+            "line": 226,
             "test": "test_export_load_learner"
         }
     ],
@@ -272,7 +272,7 @@
         },
         {
             "file": "tests/test_basic_train.py",
-            "line": 218,
+            "line": 226,
             "test": "test_export_load_learner"
         }
     ],

--- a/fastai/torch_core.py
+++ b/fastai/torch_core.py
@@ -404,7 +404,7 @@ def add_metrics(last_metrics:Collection[Rank0Tensor], mets:Union[Rank0Tensor, Co
     return {'last_metrics': last_metrics + mets}
 
 def try_save(state:Dict, path:Path=None, fname:PathOrStr=None, buffer:io.BytesIO=None):
-    if (path is None or fname is None) or buffer is None:
+    if (path is None or fname is None) and buffer is None:
         raise ValueError("Please specify either path/fname or buffer")
     target = buffer if buffer else open(path/fname, 'wb')
     try: torch.save(state, target)

--- a/fastai/torch_core.py
+++ b/fastai/torch_core.py
@@ -403,11 +403,9 @@ def add_metrics(last_metrics:Collection[Rank0Tensor], mets:Union[Rank0Tensor, Co
     last_metrics,mets = listify(last_metrics),listify(mets)
     return {'last_metrics': last_metrics + mets}
 
-def try_save(state:Dict, path:Path=None, fname:PathOrStr=None, buffer:io.BytesIO=None):
-    if (path is None or fname is None) and buffer is None:
-        raise ValueError("Please specify either path/fname or buffer")
-    target = buffer if buffer else open(path/fname, 'wb')
+def try_save(state:Dict, path:Path=None, file:PathLikeOrBinaryStream=None):
+    target = open(path / file, 'wb') if is_pathlike(file) else file
     try: torch.save(state, target)
     except OSError as e:
-        raise Exception(f"{e}\n Can't write {path/fname}. Pass an absolute writable pathlib obj `fname`.")
+        raise Exception(f"{e}\n Can't write {path / file}. Pass an absolute writable pathlib obj `fname`.")
 

--- a/fastai/torch_core.py
+++ b/fastai/torch_core.py
@@ -404,8 +404,8 @@ def add_metrics(last_metrics:Collection[Rank0Tensor], mets:Union[Rank0Tensor, Co
     return {'last_metrics': last_metrics + mets}
 
 def try_save(state:Dict, path:Path=None, file:PathLikeOrBinaryStream=None):
-    target = open(path / file, 'wb') if is_pathlike(file) else file
+    target = open(path/file, 'wb') if is_pathlike(file) else file
     try: torch.save(state, target)
     except OSError as e:
-        raise Exception(f"{e}\n Can't write {path / file}. Pass an absolute writable pathlib obj `fname`.")
+        raise Exception(f"{e}\n Can't write {path/file}. Pass an absolute writable pathlib obj `fname`.")
 

--- a/fastai/torch_core.py
+++ b/fastai/torch_core.py
@@ -403,8 +403,11 @@ def add_metrics(last_metrics:Collection[Rank0Tensor], mets:Union[Rank0Tensor, Co
     last_metrics,mets = listify(last_metrics),listify(mets)
     return {'last_metrics': last_metrics + mets}
 
-def try_save(state:Dict, path:Path, fname:PathOrStr):
-    try: torch.save(state, open(path/fname, 'wb'))
+def try_save(state:Dict, path:Path=None, fname:PathOrStr=None, buffer:io.BytesIO=None):
+    if (path is None or fname is None) or buffer is None:
+        raise ValueError("Please specify either path/fname or buffer")
+    target = buffer if buffer else open(path/fname, 'wb')
+    try: torch.save(state, target)
     except OSError as e:
         raise Exception(f"{e}\n Can't write {path/fname}. Pass an absolute writable pathlib obj `fname`.")
 

--- a/tests/test_basic_data.py
+++ b/tests/test_basic_data.py
@@ -17,8 +17,8 @@ from fastai.gen_doc.doctest import this_tests
 ## Class DataBunch
 
 def test_DataBunch_Create():
-    x_train,y_train =  fake_basedata(n_in=3, batch_size=6),fake_basedata(n_in=3, batch_size=6)
-    x_valid,y_valid =  fake_basedata(n_in=3, batch_size=3),fake_basedata(n_in=3, batch_size=3)
+    x_train,y_train = fake_basedata(n_in=3, batch_size=6),fake_basedata(n_in=3, batch_size=6)
+    x_valid,y_valid = fake_basedata(n_in=3, batch_size=3),fake_basedata(n_in=3, batch_size=3)
     bs=5
     train_ds,valid_ds = TensorDataset(x_train, y_train),TensorDataset(x_valid, y_valid)
     data = DataBunch.create(train_ds, valid_ds, bs=bs)
@@ -31,7 +31,7 @@ def test_DataBunch_Create():
     assert 9 == len(data.valid_ds)
 
 def test_DataBunch_no_valid_dl():
-    x_train,y_train =  fake_basedata(n_in=3, batch_size=6),fake_basedata(n_in=3, batch_size=6)
+    x_train,y_train = fake_basedata(n_in=3, batch_size=6),fake_basedata(n_in=3, batch_size=6)
     bs=5
     train_ds = TensorDataset(x_train, y_train)
     data = DataBunch.create(train_ds, None, bs=bs)
@@ -69,10 +69,29 @@ def test_DataBunch_show_batch(capsys):
     match = re.findall(r'tensor', captured.out)
     assert match
 
-## TO DO: check over file created ?
-##def test_DataBunch_export():
-##     data = fake_data()
-##     data.export()
+def test_DataBunch_save_load():
+    save_name = 'data_save.pkl'
+    this_tests(DataBunch.save, load_data)
+
+    data = fake_data(n_in=4, n_out=5, batch_size=6)
+    data.save(fname=save_name)
+    loaded_data = load_data(data.path, fname=save_name, bs=6)
+    this_tests(loaded_data.one_batch)
+    x,y = loaded_data.one_batch()
+    assert 4 == x[0].shape[0]
+    assert 6 == x.shape[0]
+    assert 6 == y.shape[0]
+
+    # save/load using buffer
+    output_buffer = io.BytesIO()
+    data.save(buffer=output_buffer)
+    input_buffer = io.BytesIO(output_buffer.getvalue())
+    loaded_data = load_data(data.path, buffer=input_buffer, bs=6)
+    this_tests(loaded_data.one_batch)
+    x,y = loaded_data.one_batch()
+    assert 4 == x[0].shape[0]
+    assert 6 == x.shape[0]
+    assert 6 == y.shape[0]
 
 def test_DeviceDataLoader_getitem():
     this_tests('na')

--- a/tests/test_basic_data.py
+++ b/tests/test_basic_data.py
@@ -74,8 +74,8 @@ def test_DataBunch_save_load():
     this_tests(DataBunch.save, load_data)
 
     data = fake_data(n_in=4, n_out=5, batch_size=6)
-    data.save(fname=save_name)
-    loaded_data = load_data(data.path, fname=save_name, bs=6)
+    data.save(save_name)
+    loaded_data = load_data(data.path, save_name, bs=6)
     this_tests(loaded_data.one_batch)
     x,y = loaded_data.one_batch()
     assert 4 == x[0].shape[0]
@@ -84,9 +84,9 @@ def test_DataBunch_save_load():
 
     # save/load using buffer
     output_buffer = io.BytesIO()
-    data.save(buffer=output_buffer)
+    data.save(output_buffer)
     input_buffer = io.BytesIO(output_buffer.getvalue())
-    loaded_data = load_data(data.path, buffer=input_buffer, bs=6)
+    loaded_data = load_data(data.path, input_buffer, bs=6)
     this_tests(loaded_data.one_batch)
     x,y = loaded_data.one_batch()
     assert 4 == x[0].shape[0]

--- a/tests/test_basic_train.py
+++ b/tests/test_basic_train.py
@@ -275,7 +275,7 @@ def test_model_load_mem_leak():
     used_before = gpu_mem_get_used()
 
     name = 'mnist-tiny-test-load-mem-leak'
-    model_path = learn.save(name=name, return_path=True)
+    model_path = learn.save(name, return_path=True)
     _ = learn.load(name)
     if os.path.exists(model_path): os.remove(model_path)
     used_after = gpu_mem_get_used()

--- a/tests/test_basic_train.py
+++ b/tests/test_basic_train.py
@@ -116,6 +116,14 @@ def test_save_load(learn):
     _ = learn.load(name, purge=True)
     check_learner(learn, model_summary_before, train_items_before)
 
+    # Test save/load using bytes streams
+    output_buffer = io.BytesIO()
+    learn.save(buffer=output_buffer)
+    learn.purge()
+    input_buffer = io.BytesIO(output_buffer.getvalue())
+    _ = learn.load(buffer=input_buffer)
+    check_learner(learn, model_summary_before, train_items_before)
+
     # cleanup
     if os.path.exists(model_path): os.remove(model_path)
 

--- a/tests/utils/fakes.py
+++ b/tests/utils/fakes.py
@@ -57,7 +57,7 @@ def fake_basedata(n_in:int=5,batch_size:int=5, train_length:int=None, valid_leng
     return torch.empty([train_length+valid_length, n_in]).random_(-10, 10)
 
 
-def fake_data(n_in:int=5, n_out:int=4, batch_size:int=5, train_length:int=None, valid_length:int=None):
+def fake_data(n_in:int=5, n_out:int=4, batch_size:int=5, train_length:int=None, valid_length:int=None) -> DataBunch:
     if train_length is None: train_length = 2 * batch_size
     if valid_length is None: valid_length = batch_size
     return (RandomItemList([0] * (train_length+valid_length), sizes=[n_in])
@@ -65,7 +65,7 @@ def fake_data(n_in:int=5, n_out:int=4, batch_size:int=5, train_length:int=None, 
                 .label_const(0., y_range=[0,n_out])
                 .databunch(bs=batch_size))
 
-def fake_learner(n_in:int=5, n_out:int=4, batch_size:int=5, train_length:int=None, valid_length:int=None, layer_group_count:int=1):
+def fake_learner(n_in:int=5, n_out:int=4, batch_size:int=5, train_length:int=None, valid_length:int=None, layer_group_count:int=1) -> Learner:
     data = fake_data(n_in=n_in, n_out=n_out, batch_size=batch_size, train_length=train_length, valid_length=valid_length)
     additional = [nn.Sequential(nn.Linear(n_in, n_in)) for _ in range(layer_group_count - 1)]
     final = [nn.Sequential(nn.Linear(n_in, n_out))]


### PR DESCRIPTION
Added options to save/export/load using `BytesIO` streams to the following functions: `Learn.save`, `Learn.export`, `load_learner`, `DataBunch.save`, `load_data`.

Following a discussion with @sgugger [here](https://forums.fast.ai/t/serialize-learner-to-string/40848).