### PR TITLE
Disable progress context manager

### DIFF
--- a/docs_src/utils.mod_display.ipynb
+++ b/docs_src/utils.mod_display.ipynb
@@ -1,0 +1,172 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Modify Display Utils"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Utilities for collecting/checking `fastai` user environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastai.utils.mod_display import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hide_input": true
+   },
+   "outputs": [],
+   "source": [
+    "from fastai.gen_doc.nbdoc import *\n",
+    "from fastai.utils.collect_env import * "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hide_input": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<h2 id=\"progress_disabled\" class=\"doc_header\"><code>class</code> <code>progress_disabled</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/utils/mod_display.py#L13\" class=\"source_link\" style=\"float:right\">[source]</a><a class=\"source_link\" data-toggle=\"collapse\" data-target=\"#progress_disabled-pytest\" style=\"float:right; padding-right:10px\">[test]</a></h2>\n",
+       "\n",
+       "> <code>progress_disabled</code>(**`learner`**:[`Learner`](/basic_train.html#Learner))\n",
+       "\n",
+       "<div class=\"collapse\" id=\"progress_disabled-pytest\"><div class=\"card card-body pytest_card\"><a type=\"button\" data-toggle=\"collapse\" data-target=\"#progress_disabled-pytest\" class=\"close\" aria-label=\"Close\"><span aria-hidden=\"true\">&times;</span></a><p>No tests found for <code>progress_disabled</code>. To contribute a test please refer to <a href=\"/dev/test.html\">this guide</a> and <a href=\"https://forums.fast.ai/t/improving-expanding-functional-tests/32929\">this discussion</a>.</p></div></div>\n",
+       "\n",
+       "Context manager to disable the progress update bar and Recorder print  "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "show_doc(progress_disabled)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hide_input": true
+   },
+   "outputs": [],
+   "source": [
+    "from fastai.vision import *\n",
+    "path = untar_data(URLs.MNIST_SAMPLE)\n",
+    "data = ImageDataBunch.from_folder(path)\n",
+    "learn = cnn_learner(data, models.resnet18, metrics=accuracy)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`learn.fit()` will display a progress bar and give the final results once completed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "Total time: 00:06 <p><table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: left;\">\n",
+       "      <th>epoch</th>\n",
+       "      <th>train_loss</th>\n",
+       "      <th>valid_loss</th>\n",
+       "      <th>accuracy</th>\n",
+       "      <th>time</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>0</td>\n",
+       "      <td>0.139825</td>\n",
+       "      <td>0.081791</td>\n",
+       "      <td>0.974975</td>\n",
+       "      <td>00:06</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "learn.fit(1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`progress_disabled(learn)` will remove all that update and only show the total time once completed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total time: 00:05\n"
+     ]
+    }
+   ],
+   "source": [
+    "with progress_disabled(learn) as learn:\n",
+    "    learn.fit(1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Undocumented Methods - Methods moved below this line will intentionally be hidden"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/fastai/utils/mod_display.py
+++ b/fastai/utils/mod_display.py
@@ -1,10 +1,7 @@
-" Utils for modifying what is displayed in notbooks and command line"
+" Utils for modifying what is displayed in notebooks and command line"
 import fastai
 import fastprogress
 
-#from fastai.basic_train import Learner,Recorder
-#from fastai.core import copy,partial
-from fastai import *
 from ..basic_train import *
 from ..core import *
 
@@ -12,14 +9,17 @@ __all__ = ['progress_disabled']
 
 class progress_disabled():
     ''' Context manager to disable the progress update bar and Recorder print'''
-    def __init__(self,learner:Learner):
-        self.learn = learner
-        self.orig_callback_fns = copy(learner.callback_fns)
+    def __init__(self,learn:Learner):
+        self.learn = learn
+
     def __enter__(self):
         #silence progress bar
         fastprogress.fastprogress.NO_BAR = True
         fastai.basic_train.master_bar, fastai.basic_train.progress_bar = fastprogress.force_console_behavior()
-        self.learn.callback_fns[0] = partial(Recorder,add_time=True,silent=True) #silence recorder
+        self.orig_callback_fns = copy(self.learn.callback_fns)
+        rec_name = [x for x in self.learn.callback_fns if x.func == Recorder][0]
+        rec_idx = self.learn.callback_fns.index(rec_name)
+        self.learn.callback_fns[rec_idx] = partial(Recorder,add_time=True,silent=True) #silence recorder
 
         return self.learn
 

--- a/fastai/utils/mod_display.py
+++ b/fastai/utils/mod_display.py
@@ -1,0 +1,19 @@
+" Utils for modifying what is displayed in notbooks and command line"
+import fastai
+import fastprogress
+
+class progress_diabled():
+    ''' Context manager to disable the progress update bar and Recorder print'''
+    def __init__(self,learner:Learner):
+        self.learn = learner
+        self.orig_callback_fns = copy(learner.callback_fns)
+        def __enter__(self):
+            #silence progress bar
+            fastprogress.fastprogress.NO_BAR = True
+            fastai.basic_train.master_bar, fastai.basic_train.progress_bar = fastprogress.force_console_behavior()
+            self.learn.callback_fns[0] = partial(Recorder,add_time=True,silent=True) #silence recorder
+            return self.learn
+
+        def __exit__(self,type,value,traceback):
+            fastai.basic_train.master_bar, fastai.basic_train.progress_bar = master_bar,progress_bar
+            self.learn.callback_fns = self.orig_callback_fns

--- a/fastai/utils/mod_display.py
+++ b/fastai/utils/mod_display.py
@@ -5,9 +5,9 @@ import fastprogress
 from ..basic_train import *
 from ..core import *
 
-__all__ = ['progress_disabled']
+__all__ = ['progress_disabled_ctx']
 
-class progress_disabled():
+class progress_disabled_ctx():
     ''' Context manager to disable the progress update bar and Recorder print'''
     def __init__(self,learn:Learner):
         self.learn = learn

--- a/fastai/utils/mod_display.py
+++ b/fastai/utils/mod_display.py
@@ -2,18 +2,27 @@
 import fastai
 import fastprogress
 
-class progress_diabled():
+#from fastai.basic_train import Learner,Recorder
+#from fastai.core import copy,partial
+from fastai import *
+from ..basic_train import *
+from ..core import *
+
+__all__ = ['progress_disabled']
+
+class progress_disabled():
     ''' Context manager to disable the progress update bar and Recorder print'''
     def __init__(self,learner:Learner):
         self.learn = learner
         self.orig_callback_fns = copy(learner.callback_fns)
-        def __enter__(self):
-            #silence progress bar
-            fastprogress.fastprogress.NO_BAR = True
-            fastai.basic_train.master_bar, fastai.basic_train.progress_bar = fastprogress.force_console_behavior()
-            self.learn.callback_fns[0] = partial(Recorder,add_time=True,silent=True) #silence recorder
-            return self.learn
+    def __enter__(self):
+        #silence progress bar
+        fastprogress.fastprogress.NO_BAR = True
+        fastai.basic_train.master_bar, fastai.basic_train.progress_bar = fastprogress.force_console_behavior()
+        self.learn.callback_fns[0] = partial(Recorder,add_time=True,silent=True) #silence recorder
 
-        def __exit__(self,type,value,traceback):
-            fastai.basic_train.master_bar, fastai.basic_train.progress_bar = master_bar,progress_bar
-            self.learn.callback_fns = self.orig_callback_fns
+        return self.learn
+
+    def __exit__(self,type,value,traceback):
+        fastai.basic_train.master_bar, fastai.basic_train.progress_bar = master_bar,progress_bar
+        self.learn.callback_fns = self.orig_callback_fns


### PR DESCRIPTION
Adding a context manager in `fastai.utils` to disable display of the context bar in jupyter notebooks.  

When you are searching for a batchsize or trying to fit across several parameter sets this can suppress the updates so that you have a clean notebook.  In particular when you use `StopAfterNBatches` you can get red bars that can be alarming but are expected.

I also tried to add a notebook that shows usage.  

I was unsure where to put the code for this.  Happy to move to another location or combine in another file if that is a better fit.

Feedback always appreciated!

