### PR TITLE
Fix typo in distributed.md

### DIFF
--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -29,7 +29,7 @@ import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument("--local_rank", type=int)
 args = parser.parse_args()
-torch.cuda.set_device(arg.local_rank)
+torch.cuda.set_device(args.local_rank)
 torch.distributed.init_process_group(backend='nccl', init_method='env://')
 ```
 
@@ -39,7 +39,7 @@ What we do here is that we import the necessary stuff from fastai (for later), w
 
 You then have to add one thing to your learner before fitting it to tell it it's going to execute a distributed training:
 ``` python
-learn = learn.to_distributed(arg.local_rank)
+learn = learn.to_distributed(args.local_rank)
 ```
 This will add the additional callbacks that will make sure your model and your data loaders are properly setups.
 
@@ -53,13 +53,13 @@ import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument("--local_rank", type=int)
 args = parser.parse_args()
-torch.cuda.set_device(arg.local_rank)
+torch.cuda.set_device(args.local_rank)
 torch.distributed.init_process_group(backend='nccl', init_method='env://')
 
 path = untar_data(URLs.CIFAR)
 ds_tfms = ([*rand_pad(4, 32), flip_lr(p=0.5)], [])
 data = ImageDataBunch.from_folder(path, valid='test', ds_tfms=ds_tfms, bs=128).normalize(cifar_stats)
-learn = Learner(data, wrn_22(), metrics=accuracy).to_distributed(arg.local_rank)
+learn = Learner(data, wrn_22(), metrics=accuracy).to_distributed(args.local_rank)
 learn.fit_one_cycle(10, 3e-3, wd=0.4, div_factor=10, pct_start=0.5)
 ```
 


### PR DESCRIPTION
The docs were setting `args = parser.parse_args()` (plural) but trying to read it back as `arg.local_rank` (not plural).
