### PR TITLE
Fix off-by-one error in LanguageLearner show_results

### DIFF
--- a/fastai/text/learner.py
+++ b/fastai/text/learner.py
@@ -176,8 +176,8 @@ class LanguageLearner(RNNLearner):
         items,names = [],['text', 'target', 'pred']
         for i, (x,y,z) in enumerate(zip(xs,ys,zs)):
             txt_x = ' '.join(x.text.split(' ')[:max_len])
-            txt_y = ' '.join(y.text.split(' ')[max_len:2*max_len])
-            txt_z = ' '.join(z.text.split(' ')[max_len:2*max_len])
+            txt_y = ' '.join(y.text.split(' ')[max_len-1:2*max_len-1])
+            txt_z = ' '.join(z.text.split(' ')[max_len-1:2*max_len-1])
             items.append([txt_x, txt_y, txt_z])
         items = np.array(items)
         df = pd.DataFrame({n:items[:,i] for i,n in enumerate(names)}, columns=names)


### PR DESCRIPTION
As pointed out [on the forums here](https://forums.fast.ai/t/1-word-skipped-language-model-learner-show-results/42589), `LanguageLearner.show_results` is off by one word when displaying the `target` and `pred`. This happens because x and y are one word offset from each other coming from `one_batch` (which is ultimately pulling from `LanguageModelPreLoader.__getitem__`).

**Before (missing "1")**
![image](https://user-images.githubusercontent.com/870796/55371937-f52e6c80-54cd-11e9-9824-2263960db5e3.png)

**After (fixed)**
![image](https://user-images.githubusercontent.com/870796/55372004-227b1a80-54ce-11e9-852f-d3599330a6fd.png)
