### PR TITLE
core function parallel returns results of processes if any

### DIFF
--- a/fastai/core.py
+++ b/fastai/core.py
@@ -324,7 +324,11 @@ def parallel(func, arr:Collection, max_workers:int=None):
     else:
         with ProcessPoolExecutor(max_workers=max_workers) as ex:
             futures = [ex.submit(func,o,i) for i,o in enumerate(arr)]
-            for f in progress_bar(concurrent.futures.as_completed(futures), total=len(arr)): pass
+            results = []
+            for f in progress_bar(concurrent.futures.as_completed(futures), total=len(arr)): 
+                results.append(f.result())
+    if any([o is not None for o in results]):
+        return results
 
 def subplots(rows:int, cols:int, imgsize:int=4, figsize:Optional[Tuple[int,int]]=None, title=None, **kwargs):
     "Like `plt.subplots` but with consistent axs shape, `kwargs` passed to `fig.suptitle` with `title`"

--- a/fastai/core.py
+++ b/fastai/core.py
@@ -325,10 +325,8 @@ def parallel(func, arr:Collection, max_workers:int=None):
         with ProcessPoolExecutor(max_workers=max_workers) as ex:
             futures = [ex.submit(func,o,i) for i,o in enumerate(arr)]
             results = []
-            for f in progress_bar(concurrent.futures.as_completed(futures), total=len(arr)): 
-                results.append(f.result())
-    if any([o is not None for o in results]):
-        return results
+            for f in progress_bar(concurrent.futures.as_completed(futures), total=len(arr)): results.append(f.result())
+    if any([o is not None for o in results]): return results
 
 def subplots(rows:int, cols:int, imgsize:int=4, figsize:Optional[Tuple[int,int]]=None, title=None, **kwargs):
     "Like `plt.subplots` but with consistent axs shape, `kwargs` passed to `fig.suptitle` with `title`"


### PR DESCRIPTION
Hi,

In this PR I propose a minor change to the function parallel. Currently the function does not return the results of the parallel processes. This is a problem for the cases where such return values are required. 

Currently:
![image](https://user-images.githubusercontent.com/16240134/55403031-2bfb9580-5555-11e9-856a-9967796ba953.png)


With the change:
![image](https://user-images.githubusercontent.com/16240134/55402982-07072280-5555-11e9-9a87-ae05d5aff3c8.png)

I added a check so that the function parallel returns the results only if at least one process has returned a value.
