### PR TITLE
fixed return value for parallel for the case max_workers = 1

### DIFF
--- a/fastai/core.py
+++ b/fastai/core.py
@@ -320,7 +320,7 @@ def text2html_table(items:Collection[Collection[str]])->str:
 def parallel(func, arr:Collection, max_workers:int=None):
     "Call `func` on every element of `arr` in parallel using `max_workers`."
     max_workers = ifnone(max_workers, defaults.cpus)
-    if max_workers<2: _ = [func(o,i) for i,o in enumerate(arr)]
+    if max_workers<2: results = [func(o,i) for i,o in enumerate(arr)]
     else:
         with ProcessPoolExecutor(max_workers=max_workers) as ex:
             futures = [ex.submit(func,o,i) for i,o in enumerate(arr)]


### PR DESCRIPTION
Nearly forgot it!

For the case max_workers = 1, the result is thrown away. This PR fixes that.