### PR TITLE
Typo in URL path

### DIFF
--- a/tools/fastai-make-pr-branch-py
+++ b/tools/fastai-make-pr-branch-py
@@ -96,7 +96,7 @@ def parse_args():
     #     args.prefix = f'https://{args.token}@github.com/'
 
     args.path = f'{args.repo_name}-{args.new_branch_name}'
-    args.url = f'{args.prefix}/{args.user_name}/{args.repo_name}.git'
+    args.url = f'{args.prefix}{args.user_name}/{args.repo_name}.git'
     args.orig_repo_url = f'{args.prefix}{args.orig_user_name}/{args.repo_name}.git'
 
     return args

--- a/tools/fastai-make-pr-branch-py
+++ b/tools/fastai-make-pr-branch-py
@@ -87,7 +87,7 @@ def parse_args():
 
     args = parser.parse_args()
     args.token = os.environ[ENV_VAR]
-    args.prefix = f'https://{args.token}@github.com'
+    args.prefix = f'https://{args.token}@github.com/'
 
     # support token access only
     # if args.auth == 'ssh':
@@ -96,7 +96,7 @@ def parse_args():
     #     args.prefix = f'https://{args.token}@github.com/'
 
     args.path = f'{args.repo_name}-{args.new_branch_name}'
-    args.url = f'{args.prefix}{args.user_name}/{args.repo_name}.git'
+    args.url = f'{args.prefix}/{args.user_name}/{args.repo_name}.git'
     args.orig_repo_url = f'{args.prefix}{args.orig_user_name}/{args.repo_name}.git'
 
     return args


### PR DESCRIPTION
I have spotted an issue in the string interpolation when tried to fork `git-tool` to port this PR. It seems I've made this last change without verifying how it works. A good lesson to perform backtesting even when the introduced change seems to be obvious.
