### PR TITLE
Bugfix/default drops text learner

### DIFF
--- a/fastai/text/learner.py
+++ b/fastai/text/learner.py
@@ -273,7 +273,7 @@ def get_text_classifier(arch:Callable, vocab_sz:int, n_class:int, bptt:int=70, m
     for k in config.keys(): 
         if k.endswith('_p'): config[k] *= drop_mult
     if lin_ftrs is None: lin_ftrs = [50]
-    if ps is None:  ps = [0.1]
+    if ps is None:  ps = [0.1]*len(lin_ftrs)
     layers = [config[meta['hid_name']] * 3] + lin_ftrs + [n_class]
     ps = [config.pop('output_p')] + ps
     init = config.pop('init') if 'init' in config else None

--- a/fastai/text/learner.py
+++ b/fastai/text/learner.py
@@ -224,6 +224,8 @@ class PoolingLinearClassifier(nn.Module):
     def __init__(self, layers:Collection[int], drops:Collection[float]):
         super().__init__()
         mod_layers = []
+        if len(layers) != len(drops)-1:
+            raise ValueError("Number of layers and dropout values do not match.")
         activs = [nn.ReLU(inplace=True)] * (len(layers) - 2) + [None]
         for n_in,n_out,p,actn in zip(layers[:-1],layers[1:], drops, activs):
             mod_layers += bn_drop_lin(n_in, n_out, p=p, actn=actn)

--- a/fastai/text/learner.py
+++ b/fastai/text/learner.py
@@ -224,10 +224,10 @@ class PoolingLinearClassifier(nn.Module):
     def __init__(self, layers:Collection[int], drops:Collection[float]):
         super().__init__()
         mod_layers = []
-        if len(layers) != len(drops)-1:
+        if len(drops) != len(layers)-1:
             raise ValueError("Number of layers and dropout values do not match.")
         activs = [nn.ReLU(inplace=True)] * (len(layers) - 2) + [None]
-        for n_in,n_out,p,actn in zip(layers[:-1],layers[1:], drops, activs):
+        for n_in, n_out, p, actn in zip(layers[:-1], layers[1:], drops, activs):
             mod_layers += bn_drop_lin(n_in, n_out, p=p, actn=actn)
         self.layers = nn.Sequential(*mod_layers)
 


### PR DESCRIPTION
When setting more than one hidden layer using `lin_ftrs` in `get_text_classifier` without setting `ps`, a wrong architecture is created. This PR fixes is and also issues an error when trying to init the internal `PoolingLinearClassifier` improperly.
