### PR TITLE
pil2tensor - Only one tranpose required

### DIFF
--- a/fastai/vision/image.py
+++ b/fastai/vision/image.py
@@ -15,8 +15,7 @@ def pil2tensor(image:Union[NPImage,NPArray],dtype:np.dtype)->TensorImage:
     "Convert PIL style `image` array to torch style image tensor."
     a = np.asarray(image)
     if a.ndim==2 : a = np.expand_dims(a,2)
-    a = np.transpose(a, (1, 0, 2))
-    a = np.transpose(a, (2, 1, 0))
+    a = np.transpose(a, (2, 0, 1))
     return torch.from_numpy(a.astype(dtype, copy=False) )
 
 def image2np(image:Tensor)->np.ndarray:


### PR DESCRIPTION
The 2 transposes can be combined into one

```python
n1 = np.random.rand(2, 5, 3)

a = np.transpose(n1, (1, 0, 2))
a = np.transpose(a, (2, 1, 0))

print((n1.transpose(2,0,1) == a).all())
```