### PR TITLE
fix Image.resize() missing return for equal sizes

### DIFF
--- a/fastai/vision/image.py
+++ b/fastai/vision/image.py
@@ -187,7 +187,7 @@ class Image(ItemBase):
         "Resize the image to `size`, size can be a single int."
         assert self._flow is None
         if isinstance(size, int): size=(self.shape[0], size, size)
-        if tuple(size)==tuple(self.shape): return
+        if tuple(size)==tuple(self.shape): return self
         self.flow = _affine_grid(size)
         return self
 


### PR DESCRIPTION
<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
