### PR TITLE
fix Image.resize() not returning self on same size

### DIFF
--- a/fastai/vision/image.py
+++ b/fastai/vision/image.py
@@ -187,7 +187,7 @@ class Image(ItemBase):
         "Resize the image to `size`, size can be a single int."
         assert self._flow is None
         if isinstance(size, int): size=(self.shape[0], size, size)
-        if tuple(size)==tuple(self.shape): return
+        if tuple(size)==tuple(self.shape): return self
         self.flow = _affine_grid(size)
         return self
 

--- a/tests/test_vision_image.py
+++ b/tests/test_vision_image.py
@@ -45,3 +45,11 @@ def test_tis2hw_str_raises_an_error():
     this_tests(tis2hw)
     with pytest.raises(RuntimeError) as e:
         tis2hw("224")
+
+def test_image_resize_same_size_shortcut():
+    this_tests(Image.resize)
+    px = torch.Tensor([[[1, 2,], [3, 4]]])
+    image = Image(px)
+    old_size = image.size
+    image = image.resize(px.size()) 
+    assert(image is not None and (old_size == image.size))


### PR DESCRIPTION
Image.resize() was not returning `self` if the requested size is the same as the current size.
Also adds test for this.

I did not add a test for for the general resize behavior, because there appears to be a bug with a target size of 1, which I can currently not look into and I don't want to add a test which does not cover this.