### PR TITLE
Added progress bar for parallel with 1 worker

### DIFF
--- a/fastai/core.py
+++ b/fastai/core.py
@@ -320,7 +320,7 @@ def text2html_table(items:Collection[Collection[str]])->str:
 def parallel(func, arr:Collection, max_workers:int=None):
     "Call `func` on every element of `arr` in parallel using `max_workers`."
     max_workers = ifnone(max_workers, defaults.cpus)
-    if max_workers<2: results = [func(o,i) for i,o in enumerate(arr)]
+    if max_workers<2: results = [func(o,i) for i,o in progress_bar(enumerate(arr), total=len(arr))]
     else:
         with ProcessPoolExecutor(max_workers=max_workers) as ex:
             futures = [ex.submit(func,o,i) for i,o in enumerate(arr)]


### PR DESCRIPTION
I suggest the following change to show the nice progress bar when calling the `parallel` function with `max_workers = 1`

Example:
![image](https://user-images.githubusercontent.com/16240134/56189068-5bb39e80-6027-11e9-8495-8087ad3e158d.png)

