### PR TITLE
adding time column to CSVLogger

### DIFF
--- a/fastai/callbacks/csv_logger.py
+++ b/fastai/callbacks/csv_logger.py
@@ -4,6 +4,8 @@ from ..torch_core import *
 from ..basic_data import DataBunch
 from ..callback import *
 from ..basic_train import Learner, LearnerCallback
+from time import time
+from fastprogress.fastprogress import format_time
 
 __all__ = ['CSVLogger']
 
@@ -12,6 +14,7 @@ class CSVLogger(LearnerCallback):
     def __init__(self, learn:Learner, filename: str = 'history', append: bool = False): 
         super().__init__(learn)
         self.filename,self.path,self.append = filename,self.learn.path/f'{filename}.csv',append
+        self.add_time = True
 
     def read_logged_file(self):  
         "Read the content of saved file"
@@ -21,13 +24,17 @@ class CSVLogger(LearnerCallback):
         "Prepare file with metric names."
         self.path.parent.mkdir(parents=True, exist_ok=True)      
         self.file = self.path.open('a') if self.append else self.path.open('w')
-        self.file.write(','.join(self.learn.recorder.names[:-1]) + '\n')
+        self.file.write(','.join(self.learn.recorder.names[:(None if self.add_time else -1)]) + '\n')
+    
+    def on_epoch_begin(self, **kwargs:Any)->None:
+        if self.add_time: self.start_epoch = time()
         
     def on_epoch_end(self, epoch: int, smooth_loss: Tensor, last_metrics: MetricsList, **kwargs: Any) -> bool:
         "Add a line with `epoch` number, `smooth_loss` and `last_metrics`."
         last_metrics = ifnone(last_metrics, [])
         stats = [str(stat) if isinstance(stat, int) else '#na#' if stat is None else f'{stat:.6f}'
                  for name, stat in zip(self.learn.recorder.names, [epoch, smooth_loss] + last_metrics)]
+        if self.add_time: stats.append(format_time(time() - self.start_epoch))
         str_stats = ','.join(stats)
         self.file.write(str_stats + '\n')
 

--- a/fastai/test_registry.json
+++ b/fastai/test_registry.json
@@ -245,7 +245,7 @@
     "fastai.callbacks.csv_logger.CSVLogger": [
         {
             "file": "tests/test_callbacks_csv_logger.py",
-            "line": 37,
+            "line": 42,
             "test": "test_logger"
         }
     ],

--- a/tests/test_callbacks_csv_logger.py
+++ b/tests/test_callbacks_csv_logger.py
@@ -14,12 +14,17 @@ def create_metrics_dataframe(learn):
             learn.recorder.metrics))]
     return pd.DataFrame(records, columns=learn.recorder.names[:-1])
 
+def float_or_x(x):
+    "Tries to convert to float, returns x if it can't"
+    try:return float(x)
+    except:return x
+
 def convert_into_dataframe(buffer):
     "Converts data captured from `fastprogress.ConsoleProgressBar` into dataframe."
     lines = buffer.split('\n')
     header, *lines = [l.strip() for l in lines if l and not l.startswith('Total')]
-    header = header.split()[:-1]
-    floats = [[float(x) for x in line.split()[:-1]] for line in lines]
+    header = header.split()[:]
+    floats = [[float_or_x(x) for x in line.split()[:]] for line in lines]
     records = [dict(zip(header, metrics_list)) for metrics_list in floats]
     df = pd.DataFrame(records, columns=header)
     df['epoch'] = df['epoch'].astype(int)
@@ -48,7 +53,8 @@ def test_logger():
     # https://github.com/pandas-dev/pandas/issues/25068#issuecomment-460014120
     # which quite often fails on CI.
     # once it's resolved can change the setting back to check_less_precise=True (or better =3), until then using =2 as it works, but this check is less good.
-    pd.testing.assert_frame_equal(csv_df, recorder_df, check_exact=False, check_less_precise=2)
+    csv_df_notime = csv_df.drop(['time'], axis=1)
+    pd.testing.assert_frame_equal(csv_df_notime, recorder_df, check_exact=False, check_less_precise=2)
 
 @pytest.fixture(scope="module", autouse=True)
 def cleanup(request):


### PR DESCRIPTION
**Discussion + Context**
Request originated by @stas [on forum](https://forums.fast.ai/t/expand-recorder-to-deal-with-non-int-float-data/41534d)

>  ...so for example CSVLogger can’t save the time column of per-epoch training....

**Feature Description:**
The added functionality simply ports the same logic that is used in `Recorder` to record epoch time in `CSVLogger`: the time between `on_epoch_begin` and 'on_epoch_end' is returned as a formatted string of format 'MM:SS'.  

The only issue I see is that dataframe interprets the time value as strings / object-type. (There does appear to be pandas type to handle “timedeltas” but they seem more obscure and troublesome than helpful). 

Overall, I think this is helpful for people who want to review past training protocols and notice discrepancies in training time, especially when the recorder's output in a notebook get's erased with an overwrite or kernel interrupt.

**Testing Impact**
Both [panda] asserts in the tests had to be changed slightly to accommodate the extra column in this table. When comparing `CSVLogger` dataframe against `Recorder` dataframe, we can not include the time field as Recorder does not store (only prints) this information data.
