### PR TITLE
Modify init to pull the collect_env libraries

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -8,7 +8,7 @@ This document will show you how to speed things up and get more out of your GPU/
 
 To check your setup for recommended performance improvements, run:
 ```
-python -c "import fastai.utils.collect_env; fastai.utils.collect_env.check_perf()"
+python -c "import fastai.utils; fastai.utils.check_perf()"
 ```
 
 ## Mixed Precision Training

--- a/docs/support.md
+++ b/docs/support.md
@@ -52,7 +52,7 @@ When you make a post, make sure to include in your post:
    ```
    git clone https://github.com/fastai/fastai
    cd fastai
-   python -c 'import fastai.utils.collect_env; fastai.utils.collect_env.show_install(1)'
+   python -c 'import fastai.utils; fastai.utils.show_install(1)'
    ```
 
    The reporting script won't work if `pytorch` wasn't installed, so if that's the case, then send in the following details:

--- a/docs/troubleshoot.md
+++ b/docs/troubleshoot.md
@@ -85,7 +85,7 @@ If you have `nvidia-smi` working and `pytorch` still can't recognize your NVIDIA
 Also note that `pytorch` will **silently fallback to CPU** if it reports `torch.cuda.is_available()` as `False`, so the only indicator of something being wrong will be that your notebooks will be running very slowly and you will hear your CPU revving up (if you are using a local system). Run:
 
 ```
-python -c 'import fastai.utils.collect_env; fastai.utils.collect_env.show_install(1)'
+python -c 'import fastai.utils; fastai.utils.show_install(1)'
 ```
 to detect such issues. If you have this problem it'll say that your torch cuda is not available.
 
@@ -306,7 +306,7 @@ It's possible that your system is misconfigured and while you think you're using
 You can check that by checking the output of `import torch; print(torch.cuda.is_available())` - it should return `True` if `pytorch` sees your GPU(s). You can also see the state of your setup with:
 
 ```
-python -c 'import fastai.utils.collect_env; fastai.utils.collect_env.show_install(1)'
+python -c 'import fastai.utils; fastai.utils.show_install(1)'
 ```
 which will include that check in its report.
 
@@ -406,7 +406,7 @@ and checking whether it shows the correct paths. That is compare these paths wit
 Alternatively, you can use the `fastai` helper that will show you that and other important details about your environment:
 
 ```
-from fastai.utils.show_install import *
+from fastai.utils import *
 show_install()
 ```
 

--- a/docs_src/utils.collect_env.ipynb
+++ b/docs_src/utils.collect_env.ipynb
@@ -20,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fastai.utils.collect_env import *"
+    "from fastai.utils import *"
    ]
   },
   {
@@ -32,7 +32,7 @@
    "outputs": [],
    "source": [
     "from fastai.gen_doc.nbdoc import *\n",
-    "from fastai.utils.collect_env import * "
+    "from fastai.utils import * "
    ]
   },
   {

--- a/fastai/utils/__init__.py
+++ b/fastai/utils/__init__.py
@@ -1,1 +1,3 @@
+from .collect_env import *
 
+__all__ = [*collect_env.__all__]


### PR DESCRIPTION
This will allow somebody to the show_install function with `from fastai.utils import *` instead of needing to remember that it is in collect_env

Here is the forum thread discussing this change: https://forums.fast.ai/t/show-install-modification-suggestion/44214

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
