### PR TITLE
Only reset loss function when using stack_y=True

### DIFF
--- a/fastai/callbacks/mixup.py
+++ b/fastai/callbacks/mixup.py
@@ -33,7 +33,7 @@ class MixUpCallback(LearnerCallback):
         return {'last_input': new_input, 'last_target': new_target}  
     
     def on_train_end(self, **kwargs):
-        self.learn.loss_func = self.learn.loss_func.get_old()
+        if self.stack_y: self.learn.loss_func = self.learn.loss_func.get_old()
         
 
 class MixUpLoss(nn.Module):


### PR DESCRIPTION
Currently if a user creates a mixup learner with `stack_y=False` they receive an error after training ends.   This error occurs because we haven't replaced the normal loss function with `MixUpLoss` and therefore there is no `.get_old()` method on our loss function.

I can make a test for this issue if you would like, just let me know where I should put it.

The error this prevents is:
```
Traceback (most recent call last):
  File "trainAll.py", line 84, in <module>
    learn.fit_one_cycle(10, 1e-2)
  File "/home/josh/git/fastai/fastai/train.py", line 22, in fit_one_cycle
    learn.fit(cyc_len, max_lr, wd=wd, callbacks=callbacks)
  File "/home/josh/git/fastai/fastai/basic_train.py", line 199, in fit
    fit(epochs, self, metrics=self.metrics, callbacks=self.callbacks+callbacks)
  File "/home/josh/git/fastai/fastai/basic_train.py", line 112, in fit
    finally: cb_handler.on_train_end(exception)
  File "/home/josh/git/fastai/fastai/callback.py", line 323, in on_train_end
    self('train_end', exception=exception)
  File "/home/josh/git/fastai/fastai/callback.py", line 251, in __call__
    for cb in self.callbacks: self._call_and_update(cb, cb_name, **kwargs)
  File "/home/josh/git/fastai/fastai/callback.py", line 241, in _call_and_update
    new = ifnone(getattr(cb, f'on_{cb_name}')(**self.state_dict, **kwargs), dict())
  File "/home/josh/git/fastai/fastai/callbacks/mixup.py", line 42, in on_train_end
    self.learn.loss_func = self.learn.loss_func.get_old()
AttributeError: 'FlattenedLoss' object has no attribute 'get_old'
```