### PR TITLE
Add LMTextList to __all__

### DIFF
--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -8,7 +8,7 @@ from ..callback import Callback
 
 __all__ = ['LanguageModelPreLoader', 'SortSampler', 'SortishSampler', 'TextList', 'pad_collate', 'TextDataBunch',
            'TextLMDataBunch', 'TextClasDataBunch', 'Text', 'open_text', 'TokenizeProcessor', 'NumericalizeProcessor',
-           'OpenFileProcessor', 'LMLabelList']
+           'OpenFileProcessor', 'LMLabelList', 'LMTextList']
 
 TextMtd = IntEnum('TextMtd', 'DF TOK IDS')
 text_extensions = {'.txt'}


### PR DESCRIPTION
Add LMTextList so it pulls in with from fastai.text import * 

This will allow LMLabelList to be called similar to how LMLabelList can be at the moment.  I ran into an issue where I was trying to debug label_for_lm and that caused an issue for me. Pretty sure this won't break anything.

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
