### PR TITLE
Removing duplicate code in transformer.py

### DIFF
--- a/fastai/text/models/transformer.py
+++ b/fastai/text/models/transformer.py
@@ -105,7 +105,7 @@ class MultiHeadRelativeAttention(MultiHeadAttention):
         context = x if mem is None else torch.cat([mem, x], dim=1)
         wq,wk,wv = torch.chunk(self.attention(context), 3, dim=-1)
         wq = wq[:,-x_len:]
-        wq,wk,wv = map(lambda x:x.view(bs, x.size(1), self.n_heads, self.d_head), (wq,wk,wv))
+        wq,wk,wv = map(lambda x:x.view(bs, x_len, self.n_heads, self.d_head), (wq,wk,wv))
         wq,wk,wv = wq.permute(0, 2, 1, 3),wk.permute(0, 2, 3, 1),wv.permute(0, 2, 1, 3)
         wkr = self.r_attn(r)
         wkr = wkr.view(seq_len, self.n_heads, self.d_head)
@@ -127,7 +127,7 @@ class MultiHeadRelativeAttention(MultiHeadAttention):
         wq,wk,wv = torch.chunk(self.attention(context), 3, dim=-1)
         wq = wq[:,-x_len:]
         wkr = self.r_attn(r)
-        wq,wk,wv = map(lambda x:x.view(bs, x.size(1), self.n_heads, self.d_head), (wq,wk,wv))
+        wq,wk,wv = map(lambda x:x.view(bs, x_len, self.n_heads, self.d_head), (wq,wk,wv))
         wkr = wkr.view(seq_len, self.n_heads, self.d_head)     
         #### compute attention score (AC is (a) + (c) and BS is (b) + (d) in the paper)
         AC = torch.einsum('bind,bjnd->bijn', (wq+u, wk))

--- a/fastai/text/models/transformer.py
+++ b/fastai/text/models/transformer.py
@@ -51,10 +51,10 @@ class MultiHeadAttention(nn.Module):
     def _apply_attention(self, x:Tensor, mask:Tensor=None):
         bs,x_len = x.size(0),x.size(1)
         wq,wk,wv = torch.chunk(self.attention(x), 3, dim=-1)
-        wq,wk,wv = map(lambda x:x.view(bs, x.size(1), self.n_heads, self.d_head), (wq,wk,wv))
+        wq,wk,wv = map(lambda x:x.view(bs, x_len, self.n_heads, self.d_head), (wq,wk,wv))
         wq,wk,wv = wq.permute(0, 2, 1, 3),wk.permute(0, 2, 3, 1),wv.permute(0, 2, 1, 3)
         attn_score = torch.matmul(wq, wk)
-        if self.scale: attn_score = attn_score.div_(self.d_head ** 0.5)
+        if self.scale: attn_score.div_(self.d_head ** 0.5)
         if mask is not None: 
             attn_score = attn_score.float().masked_fill(mask, -float('inf')).type_as(attn_score)
         attn_prob = self.drop_att(F.softmax(attn_score, dim=-1))
@@ -65,9 +65,9 @@ class MultiHeadAttention(nn.Module):
         # Permute and matmul is a little bit faster but this implementation is more readable
         bs,x_len = x.size(0),x.size(1)
         wq,wk,wv = torch.chunk(self.attention(x), 3, dim=-1)
-        wq,wk,wv = map(lambda x:x.view(bs, x.size(1), self.n_heads, self.d_head), (wq,wk,wv))
+        wq,wk,wv = map(lambda x:x.view(bs, x_len, self.n_heads, self.d_head), (wq,wk,wv))
         attn_score = torch.einsum('bind,bjnd->bijn', (wq, wk))
-        if self.scale: attn_score = attn_score.mul_(1/(self.d_head ** 0.5))
+        if self.scale: attn_score.mul_(1/(self.d_head ** 0.5))
         if mask is not None: 
             attn_score = attn_score.float().masked_fill(mask, -float('inf')).type_as(attn_score)
         attn_prob = self.drop_att(F.softmax(attn_score, dim=2))


### PR DESCRIPTION
The changes are for `fastai/text/models/transformer.py`.

The changes are for `MultiHeadAttention` and `MultiHeadRelativeAttention` classes, more specifically in the `_apply_attention` and `_attention_einsem` functions of these classes.

The changes include changing `x.size(1)` to `x_len` for all the above functions in the following line
`wq,wk,wv = map(lambda x:x.view(bs, x.size(1), self.n_heads, self.d_head), (wq,wk,wv))`

And the second change, is in the if statement
```
if self.scale: attn_score = attn_score.div_(self.d_head ** 0.5)

if self.scale: attn_score.div_(self.d_head ** 0.5)
```