### PR TITLE
reconstruct x with respect to batch item x[0], return reconstructed b…

### DIFF
--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -359,7 +359,7 @@ class Learner():
                           cb_handler=CallbackHandler(self.callbacks))
         return loss
 
-    def predict(self, item:ItemBase, batch_first:bool=True, **kwargs):
+    def predict(self, item:ItemBase, return_x:bool:False, batch_first:bool=True, **kwargs):
         "Return predicted class, label and probabilities for `item`."
         batch = self.data.one_item(item)
         res = self.pred_batch(batch=batch)
@@ -372,7 +372,7 @@ class Learner():
         pred = ds.y.analyze_pred(raw_pred, **kwargs)
         x = ds.x.reconstruct(x[0])
         y = ds.y.reconstruct(pred, x) if has_arg(ds.y.reconstruct, 'x') else ds.y.reconstruct(pred)
-        return x, y, pred, raw_pred
+        return x, y, pred, raw_pred if return_x else y, pred, raw_pred
 
     def validate(self, dl=None, callbacks=None, metrics=None):
         "Validate on `dl` with potential `callbacks` and `metrics`."

--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -359,19 +359,20 @@ class Learner():
                           cb_handler=CallbackHandler(self.callbacks))
         return loss
 
-    def predict(self, item:ItemBase, **kwargs):
+    def predict(self, item:ItemBase, batch_first:bool=True, **kwargs):
         "Return predicted class, label and probabilities for `item`."
         batch = self.data.one_item(item)
         res = self.pred_batch(batch=batch)
-        pred,x = grab_idx(res,0),batch[0]
+        raw_pred,x = grab_idx(res,0,batch_first=batch_first),batch[0]
         norm = getattr(self.data,'norm',False)
         if norm:
             x = self.data.denorm(x)
             if norm.keywords.get('do_y',False): pred = self.data.denorm(pred)
         ds = self.data.single_ds
-        pred = ds.y.analyze_pred(pred, **kwargs)
-        out = ds.y.reconstruct(pred, ds.x.reconstruct(item.data)) if has_arg(ds.y.reconstruct, 'x') else ds.y.reconstruct(pred)
-        return out, pred, res[0]
+        pred = ds.y.analyze_pred(raw_pred, **kwargs)
+        x = ds.x.reconstruct(x[0])
+        y = ds.y.reconstruct(pred, x) if has_arg(ds.y.reconstruct, 'x') else ds.y.reconstruct(pred)
+        return x, y, pred, raw_pred
 
     def validate(self, dl=None, callbacks=None, metrics=None):
         "Validate on `dl` with potential `callbacks` and `metrics`."

--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -372,7 +372,7 @@ class Learner():
         pred = ds.y.analyze_pred(raw_pred, **kwargs)
         x = ds.x.reconstruct(x[0])
         y = ds.y.reconstruct(pred, x) if has_arg(ds.y.reconstruct, 'x') else ds.y.reconstruct(pred)
-        return x, y, pred, raw_pred if return_x else y, pred, raw_pred
+        return (x, y, pred, raw_pred) if return_x else (y, pred, raw_pred)
 
     def validate(self, dl=None, callbacks=None, metrics=None):
         "Validate on `dl` with potential `callbacks` and `metrics`."

--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -359,7 +359,7 @@ class Learner():
                           cb_handler=CallbackHandler(self.callbacks))
         return loss
 
-    def predict(self, item:ItemBase, return_x:bool:False, batch_first:bool=True, **kwargs):
+    def predict(self, item:ItemBase, return_x:bool=False, batch_first:bool=True, **kwargs):
         "Return predicted class, label and probabilities for `item`."
         batch = self.data.one_item(item)
         res = self.pred_batch(batch=batch)

--- a/tests/test_vision_train.py
+++ b/tests/test_vision_train.py
@@ -65,7 +65,7 @@ def test_preds(learn):
     pass_tst = False
     for i in range(3):
         img, label = learn.data.valid_ds[i]
-        pred_class,pred_idx,outputs = learn.predict(img)
+        _, pred_class,pred_idx,outputs = learn.predict(img)
         if outputs[int(label)] > outputs[1-int(label)]: return
     assert False, 'Failed to predict correct class'
 

--- a/tests/test_vision_train.py
+++ b/tests/test_vision_train.py
@@ -65,7 +65,7 @@ def test_preds(learn):
     pass_tst = False
     for i in range(3):
         img, label = learn.data.valid_ds[i]
-        _, pred_class,pred_idx,outputs = learn.predict(img)
+        pred_class,pred_idx,outputs = learn.predict(img)
         if outputs[int(label)] > outputs[1-int(label)]: return
     assert False, 'Failed to predict correct class'
 


### PR DESCRIPTION
I would like to revert back to using `x[0]` to reconstruct `x` (instead of item.data)
This is because the prediction is based on `x` and not on the `item.data` and these might be different
However it is interesting to return the reconstructed `x` to be able to perform visualization such as:
```
x, y, pred, raw_pred = learn.predict(img)
x.show(y=y)
```
if `img` and `x` are different (for example different sizes), then `img.show(y=y)` will not make sense but `x.show(y=y)` will.

However it still requires some logic to convert a prediction `y` for `x` to `img`, when resizing transformations have been applied

Also that this PR changes the api: `predict` here returns a 4-tuple

The documentation would also need to be updated with this api change.
I could also only return `y, pred, raw_pred` so that it does not change the api