### PR TITLE
fix core.recurse_eq to check for length of compared arrays

### DIFF
--- a/fastai/core.py
+++ b/fastai/core.py
@@ -164,7 +164,7 @@ class ItemBase():
     def __eq__(self, other): return recurse_eq(self.data, other.data)
 
 def recurse_eq(arr1, arr2):
-    if is_listy(arr1): return np.all([recurse_eq(x,y) for x,y in zip(arr1,arr2)])
+    if is_listy(arr1): return len(arr1) == len(arr2) and np.all([recurse_eq(x,y) for x,y in zip(arr1,arr2)])
     else:              return np.all(np.atleast_1d(arr1 == arr2))
         
 def download_url(url:str, dest:str, overwrite:bool=False, pbar:ProgressBar=None,


### PR DESCRIPTION
Currently, core.py's recurse_eq method might not enumerate all elements of the array, but still consider two arrays equal

for example,

```
>>> def recurse_eq(arr1, arr2):
...     if is_listy(arr1): return np.all([recurse_eq(x,y) for x,y in zip(arr1,arr2)])
...     else:              return np.all(np.atleast_1d(arr1 == arr2))
... 
>>> 
>>> arr1 = [1,2,3]
>>> arr2 = [1,2]
>>> recurse_eq(arr1, arr2)
True
```

In order to fix this, I've added a check for length for each step of the recursion.

```
def recurse_eq(arr1, arr2):
    if len(arr1) != len(arr2): return False
    if is_listy(arr1): return np.all([recurse_eq(x,y) for x,y in zip(arr1,arr2)])
    else:              return np.all(np.atleast_1d(arr1 == arr2))

```