### PR TITLE
Favor the metric function's direct __name__

### DIFF
--- a/fastai/callback.py
+++ b/fastai/callback.py
@@ -328,8 +328,8 @@ class CallbackHandler():
 class AverageMetric(Callback):
     "Wrap a `func` in a callback for metrics computation."
     def __init__(self, func):
-        # If it's a partial, use func.func
-        name = getattr(func,'func', func).__name__
+        # If func has a __name__ use this one else it should be a partial
+        name = func.__name__ if hasattr(func, '__name__') else func.func.__name__
         self.func, self.name = func, name
         self.world = num_distrib()
 

--- a/fastai/test_registry.json
+++ b/fastai/test_registry.json
@@ -230,6 +230,13 @@
             "test": "test_accuracy"
         }
     ],
+    "fastai.callback.AverageMetric": [
+        {
+            "file": "tests/test_metrics.py",
+            "line": 190,
+            "test": "test_average_metric_naming"
+        }
+    ],
     "fastai.callback.Callback": [
         {
             "file": "tests/test_callback.py",

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -186,3 +186,18 @@ def test_custom_metric_class():
     # expecting column header 'dummy', and the metrics per class definition
     for s in ['dummy', f'{dummy_base_val}.00', f'{dummy_base_val**2}.00']:
         assert s in cs.out, f"{s} is in the output:\n{cs.out}"
+
+def test_average_metric_naming():
+    this_tests(AverageMetric)
+    top2_accuracy = partial(top_k_accuracy, k=2)
+    top3_accuracy = partial(top_k_accuracy, k=3)
+    top4_accuracy = partial(top_k_accuracy, k=4)
+    # give top2_accuracy and top4_accuracy a custom name
+    top2_accuracy.__name__ = "top2_accuracy"
+    top4_accuracy.__name__ = "top4_accuracy"
+    # prewrap top4_accuracy
+    top4_accuracy = AverageMetric(top4_accuracy)
+    learn = fake_learner()
+    learn.metrics = [accuracy, top2_accuracy, top3_accuracy, top4_accuracy]
+    learn.fit(1)
+    assert learn.recorder.names[3:7] == ["accuracy", "top2_accuracy", "top_k_accuracy", "top4_accuracy"]


### PR DESCRIPTION
Enables custom names for partially applied metrics => closes #2032

I was not really sure where to locate the tests, as `AverageMetric` is a `Callback` but test_metrics seemed to me intuitively to be the better place.