### PR TITLE
Move attempt at writing to write check

### DIFF
--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -162,7 +162,6 @@ class Learner():
     def __post_init__(self)->None:
         "Setup path,metrics, callbacks and ensure model directory exists."
         self.path = Path(ifnone(self.path, self.data.path))
-        (self.path/self.model_dir).mkdir(parents=True, exist_ok=True)
         self.model = self.model.to(self.data.device)
         self.loss_func = self.loss_func or self.data.loss_func
         self.metrics=listify(self.metrics)
@@ -175,7 +174,9 @@ class Learner():
 
     def _test_writeable_path(self):
         path = self.path/self.model_dir
-        try: tmp_file = get_tmp_file(path)
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+            tmp_file = get_tmp_file(path)
         except OSError as e:
             raise Exception(f"{e}\nCan't write to '{path}', set `learn.model_dir` attribute in Learner to a full libpath path that is writable") from None
         os.remove(tmp_file)


### PR DESCRIPTION
Same as #2034, but to the correct branch.

So it you do not have write permissions then currently creating directory for models fails. This makes it impossible to use this library even if you will never save anything. It is better to do all potentially failing operations in one place. So I moved it to where a check is done.