### PR TITLE
Fixed has_pool_type bug reported by fastai forum user TomB. Added a t…

### DIFF
--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -48,7 +48,7 @@ def cnn_config(arch):
 def has_pool_type(m):
     if is_pool_type(m): return True
     for l in m.children():
-		if has_pool_type(l): return True
+        if has_pool_type(l): return True
     return False
 
 def create_body(arch:Callable, pretrained:bool=True, cut:Optional[Union[int, Callable]]=None):

--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -47,7 +47,8 @@ def cnn_config(arch):
 
 def has_pool_type(m):
     if is_pool_type(m): return True
-    for l in m.children(): return has_pool_type(l)
+    for l in m.children():
+		if has_pool_type(l): return True
     return False
 
 def create_body(arch:Callable, pretrained:bool=True, cut:Optional[Union[int, Callable]]=None):

--- a/tests/test_vision_learner.py
+++ b/tests/test_vision_learner.py
@@ -45,5 +45,5 @@ def test_create_head(image):
 def test_has_pool_type():
 	this_tests(has_pool_type)
 	nc = 5 # dummy number of output classes
-	rn34m = create_cnn_model(models.resnet34, nc=nc)
-	assert has_pool_type(rn34m) # rn34 has pool type
+	rn18m = create_cnn_model(resnet18, nc=nc)
+	assert has_pool_type(rn18m) # rn34 has pool type

--- a/tests/test_vision_learner.py
+++ b/tests/test_vision_learner.py
@@ -40,3 +40,9 @@ def test_create_head(image):
     nc = 4 # number of output classes
     head = create_head(nf=image.shape[1]*2,nc=nc)
     assert list(head(image).shape) == [image.shape[0],nc]
+
+def test_has_pool_type():
+	this_tests(has_pool_type)
+	nc = 5 # dummy number of output classes
+	rn34m = create_cnn_model(models.resnet34, nc=nc)
+	assert has_pool_type(rn34m) # rn34 has pool type

--- a/tests/test_vision_learner.py
+++ b/tests/test_vision_learner.py
@@ -6,6 +6,7 @@ from fastai.vision.learner import *
 from fastai.callbacks.hooks import *
 from torchvision.models import resnet18
 from torchvision.models.resnet import BasicBlock
+from fastai.vision.learner import has_pool_type
 
 @pytest.fixture
 def image():


### PR DESCRIPTION
…est that should return True when has_pool_type checks a ResNet34 model (which does have pool!)

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
