### PR TITLE
MultiLabelFbeta Metric

### DIFF
--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -2,6 +2,7 @@
 from .torch_core import *
 from .callback import *
 from .layers import *
+from .basic_train import LearnerCallback
 
 __all__ = ['error_rate', 'accuracy', 'accuracy_thresh', 'dice', 'exp_rmspe', 'fbeta','FBeta', 'mse', 'mean_squared_error',
             'mae', 'mean_absolute_error', 'rmse', 'root_mean_squared_error', 'msle', 'mean_squared_logarithmic_error',

--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -301,3 +301,50 @@ class AUROC(Callback):
     
     def on_epoch_end(self, last_metrics, **kwargs):
         return add_metrics(last_metrics, auc_roc_score(self.preds, self.targs))
+
+class MultiLabelFbeta(LearnerCallback):
+    "Computes the fbeta score for multilabel classification"
+    # https://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html
+    _order = -20 
+    def __init__(self, learn, beta=2, eps=1e-15, thresh=0.3, sigmoid=True, average="micro"):
+        super().__init__(learn)
+        self.eps, self.thresh, self.sigmoid, self.average, self.beta2 = \
+            eps, thresh, sigmoid, average, beta**2
+
+    def on_train_begin(self, **kwargs):
+        self.c = self.learn.data.c
+        if self.average != "none": self.learn.recorder.add_metric_names([f'{self.average}_fbeta'])
+        else: self.learn.recorder.add_metric_names([f"fbeta_{c}" for c in self.learn.data.classes])
+
+    def on_epoch_begin(self, **kwargs):
+        dvc = self.learn.data.device
+        self.tp = torch.zeros(self.c).to(dvc)
+        self.total_pred = torch.zeros(self.c).to(dvc)
+        self.total_targ = torch.zeros(self.c).to(dvc)
+    
+    def on_batch_end(self, last_output, last_target, **kwargs):
+        pred, targ = (last_output.sigmoid() if self.sigmoid else last_output) > self.thresh, last_target.byte()
+        m = pred*targ
+        self.tp += m.sum(0).float()
+        self.total_pred += pred.sum(0).float()
+        self.total_targ += targ.sum(0).float()
+    
+    def fbeta_score(self, precision, recall):
+        return (1 + self.beta2)*(precision*recall)/((self.beta2*precision + recall) + self.eps)
+
+    def on_epoch_end(self, last_metrics, **kwargs):
+        self.total_pred += self.eps
+        if self.average == "micro":
+            precision, recall = self.tp.sum() / self.total_pred.sum(), self.tp.sum() / self.total_targ.sum()
+            res = self.fbeta_score(precision, recall)
+        elif self.average == "macro":
+            res = self.fbeta_score((self.tp / self.total_pred), (self.tp / self.total_targ)).mean()
+        elif self.average == "weighted":
+            scores = self.fbeta_score((self.tp / self.total_pred), (self.tp / self.total_targ))
+            res = (scores*self.total_targ).sum() / self.total_targ.sum()
+        elif self.average == "none":
+            res = listify(self.fbeta_score((self.tp / self.total_pred), (self.tp / self.total_targ)))
+        else:
+            raise Exception("Choose one of the average types: [micro, macro, weighted, none]")
+        
+        return add_metrics(last_metrics, res)

--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -7,7 +7,7 @@ __all__ = ['error_rate', 'accuracy', 'accuracy_thresh', 'dice', 'exp_rmspe', 'fb
             'mae', 'mean_absolute_error', 'rmse', 'root_mean_squared_error', 'msle', 'mean_squared_logarithmic_error',
             'explained_variance', 'r2_score', 'top_k_accuracy', 'KappaScore', 'ConfusionMatrix', 'MatthewsCorreff',
             'Precision', 'Recall', 'R2Score', 'ExplainedVariance', 'ExpRMSPE', 'RMSE', 'Perplexity', 'AUROC', 'auc_roc_score', 
-            'roc_curve']
+            'roc_curve', 'MultiLabelFbeta']
 
 def fbeta(y_pred:Tensor, y_true:Tensor, thresh:float=0.2, beta:float=2, eps:float=1e-9, sigmoid:bool=True)->Rank0Tensor:
     "Computes the f_beta between `preds` and `targets`"


### PR DESCRIPTION
<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->

This is an implementation of fbeta score metric using `LearnerCallback` for multilabel targets. There is already [FBeta(CMScores)](https://github.com/fastai/fastai/blob/master/fastai/metrics.py#L202) but it uses confusion matrix, hence `argmax` which doesn't allow multilabel output.

As a solution there is also [fbeta()](https://github.com/fastai/fastai/blob/master/fastai/metrics.py#L12) which is intended for mutlilabel use case but lacks the average metric properties, only calculated per batch and doesn't give the average options: [micro, macro, weighted, none]. 

Implementation is tested and compared with [sckit-learn fbeta](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html). Here is a [notebook](https://github.com/KeremTurgutlu/experimental/blob/master/Multiclass%20Fbeta%20.ipynb) using planet dataset.

