### PR TITLE
add docs to ItemList.process and CategoryProcessor.process

### DIFF
--- a/docs_src/data_block.ipynb
+++ b/docs_src/data_block.ipynb
@@ -6730,6 +6730,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`self` is an object of `ItemList` or its subclasses;    \n",
+    "`processor` is one or more `PreProcessors` objects;\n",
+    "\n",
+    "Behind the scenes, we put all of `processor` into a list and apply them all to the `self`."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -6859,6 +6869,17 @@
    ],
    "source": [
     "show_doc(CategoryProcessor.process)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`self` is an object of `CategoryProcessor`;    \n",
+    "`ds` is an object of `CategoryList`;    \n",
+    "`classes` is a list of unique labels;    \n",
+    "`c2i` is a dictionary from `classes` to `indexes`;    \n",
+    "It basically generates values for `ds.classes` and `ds.c2i` which previously are `None` and non-exist respectively."
    ]
   },
   {

--- a/docs_src/data_block.ipynb
+++ b/docs_src/data_block.ipynb
@@ -6287,6 +6287,76 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<h4 id=\"ItemList.process\" class=\"doc_header\"><code>process</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/data_block.py#L81\" class=\"source_link\" style=\"float:right\">[source]</a><a class=\"source_link\" data-toggle=\"collapse\" data-target=\"#ItemList-process-pytest\" style=\"float:right; padding-right:10px\">[test]</a></h4>\n",
+       "\n",
+       "> <code>process</code>(**`processor`**:`Union`\\[[`PreProcessor`](/data_block.html#PreProcessor), `Collection`\\[[`PreProcessor`](/data_block.html#PreProcessor)\\]\\]=***`None`***)\n",
+       "\n",
+       "<div class=\"collapse\" id=\"ItemList-process-pytest\"><div class=\"card card-body pytest_card\"><a type=\"button\" data-toggle=\"collapse\" data-target=\"#ItemList-process-pytest\" class=\"close\" aria-label=\"Close\"><span aria-hidden=\"true\">&times;</span></a><p>No tests found for <code>process</code>. To contribute a test please refer to <a href=\"/dev/test.html\">this guide</a> and <a href=\"https://forums.fast.ai/t/improving-expanding-functional-tests/32929\">this discussion</a>.</p></div></div>\n",
+       "\n",
+       "Apply `processor` or `self.processor` to `self`.  "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "show_doc(ItemList.process)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`processor` is one or more `PreProcessors` objects    \n",
+    "Behind the scenes, we put all of `processor` into a list and apply them all to an object of `ItemList` or its subclasses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<h4 id=\"CategoryProcessor.process\" class=\"doc_header\"><code>process</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/data_block.py#L345\" class=\"source_link\" style=\"float:right\">[source]</a><a class=\"source_link\" data-toggle=\"collapse\" data-target=\"#CategoryProcessor-process-pytest\" style=\"float:right; padding-right:10px\">[test]</a></h4>\n",
+       "\n",
+       "> <code>process</code>(**`ds`**)\n",
+       "\n",
+       "<div class=\"collapse\" id=\"CategoryProcessor-process-pytest\"><div class=\"card card-body pytest_card\"><a type=\"button\" data-toggle=\"collapse\" data-target=\"#CategoryProcessor-process-pytest\" class=\"close\" aria-label=\"Close\"><span aria-hidden=\"true\">&times;</span></a><p>No tests found for <code>process</code>. To contribute a test please refer to <a href=\"/dev/test.html\">this guide</a> and <a href=\"https://forums.fast.ai/t/improving-expanding-functional-tests/32929\">this discussion</a>.</p></div></div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "show_doc(CategoryProcessor.process)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`ds` is an object of `CategoryList`.     \n",
+    "It basically generates a list of unique labels (assigned to `ds.classes`) and a dictionary mapping `classes` to indexes (assigned to `ds.c2i`)."
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -6709,44 +6779,6 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"ItemList.process\" class=\"doc_header\"><code>process</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/data_block.py#L81\" class=\"source_link\" style=\"float:right\">[source]</a><a class=\"source_link\" data-toggle=\"collapse\" data-target=\"#ItemList-process-pytest\" style=\"float:right; padding-right:10px\">[test]</a></h4>\n",
-       "\n",
-       "> <code>process</code>(**`processor`**:`Union`\\[[`PreProcessor`](/data_block.html#PreProcessor), `Collection`\\[[`PreProcessor`](/data_block.html#PreProcessor)\\]\\]=***`None`***)\n",
-       "\n",
-       "<div class=\"collapse\" id=\"ItemList-process-pytest\"><div class=\"card card-body pytest_card\"><a type=\"button\" data-toggle=\"collapse\" data-target=\"#ItemList-process-pytest\" class=\"close\" aria-label=\"Close\"><span aria-hidden=\"true\">&times;</span></a><p>No tests found for <code>process</code>. To contribute a test please refer to <a href=\"/dev/test.html\">this guide</a> and <a href=\"https://forums.fast.ai/t/improving-expanding-functional-tests/32929\">this discussion</a>.</p></div></div>\n",
-       "\n",
-       "Apply `processor` or `self.processor` to `self`.  "
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "show_doc(ItemList.process)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`self` is an object of `ItemList` or its subclasses;    \n",
-    "`processor` is one or more `PreProcessors` objects;\n",
-    "\n",
-    "Behind the scenes, we put all of `processor` into a list and apply them all to the `self`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
        "<h4 id=\"MultiCategoryProcessor.process_one\" class=\"doc_header\"><code>process_one</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/data_block.py#L393\" class=\"source_link\" style=\"float:right\">[source]</a><a class=\"source_link\" data-toggle=\"collapse\" data-target=\"#MultiCategoryProcessor-process_one-pytest\" style=\"float:right; padding-right:10px\">[test]</a></h4>\n",
        "\n",
        "> <code>process_one</code>(**`item`**)\n",
@@ -6843,43 +6875,6 @@
    ],
    "source": [
     "show_doc(CategoryProcessor.create_classes)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "<h4 id=\"CategoryProcessor.process\" class=\"doc_header\"><code>process</code><a href=\"https://github.com/fastai/fastai/blob/master/fastai/data_block.py#L345\" class=\"source_link\" style=\"float:right\">[source]</a><a class=\"source_link\" data-toggle=\"collapse\" data-target=\"#CategoryProcessor-process-pytest\" style=\"float:right; padding-right:10px\">[test]</a></h4>\n",
-       "\n",
-       "> <code>process</code>(**`ds`**)\n",
-       "\n",
-       "<div class=\"collapse\" id=\"CategoryProcessor-process-pytest\"><div class=\"card card-body pytest_card\"><a type=\"button\" data-toggle=\"collapse\" data-target=\"#CategoryProcessor-process-pytest\" class=\"close\" aria-label=\"Close\"><span aria-hidden=\"true\">&times;</span></a><p>No tests found for <code>process</code>. To contribute a test please refer to <a href=\"/dev/test.html\">this guide</a> and <a href=\"https://forums.fast.ai/t/improving-expanding-functional-tests/32929\">this discussion</a>.</p></div></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "show_doc(CategoryProcessor.process)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`self` is an object of `CategoryProcessor`;    \n",
-    "`ds` is an object of `CategoryList`;    \n",
-    "`classes` is a list of unique labels;    \n",
-    "`c2i` is a dictionary from `classes` to `indexes`;    \n",
-    "It basically generates values for `ds.classes` and `ds.c2i` which previously are `None` and non-exist respectively."
    ]
   },
   {


### PR DESCRIPTION
<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
I noticed these two methods are intentionally hidden, I just wonder whether I can still add docs to them in case someone may find them useful, even though they are not displayed in the online docs.