### PR TITLE
Fixing apply(init) call for Transfrormer training

### DIFF
--- a/fastai/text/learner.py
+++ b/fastai/text/learner.py
@@ -194,9 +194,10 @@ def get_language_model(arch:Callable, vocab_sz:int, config:dict=None, drop_mult:
     init = config.pop('init') if 'init' in config else None
     encoder = arch(vocab_sz, **config)
     enc = encoder.encoder if tie_weights else None
+    if init: encoder.apply(init)
     decoder = LinearDecoder(vocab_sz, config[meta['hid_name']], output_p, tie_encoder=enc, bias=out_bias)
     model = SequentialRNN(encoder, decoder)
-    return model if init is None else model.apply(init)
+    return model
 
 def language_model_learner(data:DataBunch, arch, config:dict=None, drop_mult:float=1., pretrained:bool=True,
                            pretrained_fnames:OptStrTuple=None, **learn_kwargs) -> 'LanguageLearner':


### PR DESCRIPTION
I tried to train Transformer from scratch but was unable to make any progress in accuracy.  After researching a bunch of possible causes, it came down to the `init` method.  

Prior version would apply an `init` to the `Linear` layer that was tied to the `Embedding` layer for the inputs.  This put the mean to zero and std=0.02. Too small to learn anything.  

Two line change applies the `init` to the encoder half of the model (the Transformer part) and leaves the decoder alone.  I think this was the intention of passing in an `init` in the config for the model.  

A different decoder can train much faster for a Transformer type model (with either scaling our using attention.)  I am working on that now and will either put out as a PR or will post on forums for review first. 
