### PR TITLE
Add segmentation acc

### DIFF
--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -8,7 +8,7 @@ __all__ = ['error_rate', 'accuracy', 'accuracy_thresh', 'dice', 'exp_rmspe', 'fb
             'mae', 'mean_absolute_error', 'rmse', 'root_mean_squared_error', 'msle', 'mean_squared_logarithmic_error',
             'explained_variance', 'r2_score', 'top_k_accuracy', 'KappaScore', 'ConfusionMatrix', 'MatthewsCorreff',
             'Precision', 'Recall', 'R2Score', 'ExplainedVariance', 'ExpRMSPE', 'RMSE', 'Perplexity', 'AUROC', 'auc_roc_score', 
-            'roc_curve', 'MultiLabelFbeta']
+            'roc_curve', 'MultiLabelFbeta', 'nonvoid_accuracy']
 
 def fbeta(y_pred:Tensor, y_true:Tensor, thresh:float=0.2, beta:float=2, eps:float=1e-9, sigmoid:bool=True)->Rank0Tensor:
     "Computes the f_beta between `preds` and `targets`"
@@ -39,6 +39,12 @@ def top_k_accuracy(input:Tensor, targs:Tensor, k:int=5)->Rank0Tensor:
     input = input.topk(k=k, dim=-1)[1]
     targs = targs.unsqueeze(dim=-1).expand_as(input)
     return (input == targs).max(dim=-1)[0].float().mean()
+
+def nonvoid_accuracy(input, target, void_code):
+    "Computes non-void accuracy, e.g. camvid for multiclass segmentation"
+    target = target.squeeze(1)
+    mask = target != void_code
+    return (input.argmax(dim=1)[mask]==target[mask]).float().mean()
 
 def error_rate(input:Tensor, targs:Tensor)->Rank0Tensor:
     "1 - `accuracy`"

--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -8,7 +8,7 @@ __all__ = ['error_rate', 'accuracy', 'accuracy_thresh', 'dice', 'exp_rmspe', 'fb
             'mae', 'mean_absolute_error', 'rmse', 'root_mean_squared_error', 'msle', 'mean_squared_logarithmic_error',
             'explained_variance', 'r2_score', 'top_k_accuracy', 'KappaScore', 'ConfusionMatrix', 'MatthewsCorreff',
             'Precision', 'Recall', 'R2Score', 'ExplainedVariance', 'ExpRMSPE', 'RMSE', 'Perplexity', 'AUROC', 'auc_roc_score', 
-            'roc_curve', 'MultiLabelFbeta', 'nonvoid_accuracy']
+            'roc_curve', 'MultiLabelFbeta', 'foreground_acc']
 
 def fbeta(y_pred:Tensor, y_true:Tensor, thresh:float=0.2, beta:float=2, eps:float=1e-9, sigmoid:bool=True)->Rank0Tensor:
     "Computes the f_beta between `preds` and `targets`"
@@ -40,8 +40,8 @@ def top_k_accuracy(input:Tensor, targs:Tensor, k:int=5)->Rank0Tensor:
     targs = targs.unsqueeze(dim=-1).expand_as(input)
     return (input == targs).max(dim=-1)[0].float().mean()
 
-def nonvoid_accuracy(input, target, void_code):
-    "Computes non-void accuracy, e.g. camvid for multiclass segmentation"
+def foreground_acc(input, target, void_code):
+    "Computes non-background accuracy, e.g. camvid for multiclass segmentation"
     target = target.squeeze(1)
     mask = target != void_code
     return (input.argmax(dim=1)[mask]==target[mask]).float().mean()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -81,9 +81,9 @@ def test_top_k_accuracy(p, t, k, expect):
     (torch.randn((128, 8, 224, 224)),  torch.randint(0, 8, (128, 1, 224, 224)), 1/8, 1e-3),
     (torch.randn((128, 16, 224, 224)),  torch.randint(0, 16, (128, 1, 224, 224)), 1/16, 1e-3),
 ])
-def test_nonvoid_accuracy(p, t, expect, atol):
-    this_tests(nonvoid_accuracy)
-    assert np.isclose(partial(nonvoid_accuracy, void_code=0)(p, t).item(), expect, atol=atol)
+def test_foreground_acc(p, t, expect, atol):
+    this_tests(foreground_acc)
+    assert np.isclose(partial(foreground_acc, void_code=0)(p, t).item(), expect, atol=atol)
 
 @pytest.mark.parametrize("p, t, expect", [
     (p1, t1, 0.8),

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -32,6 +32,14 @@ seq_preds = torch.Tensor([
     [0.6, 0.3, 0.08, 0.02],
 ]).expand(5,4,-1)
 
+# Test data for multi-class single-label segmentation models
+# classes: 6, nonvoid_classes: 5
+segment_targ = torch.LongTensor([[[
+    [0,1,2,3,4,5],
+    [0,1,2,3,4,5],
+    [0,1,2,3,4,5],    
+]]])
+
 @pytest.mark.parametrize("p, t, expect", [
     (p1, t1, 0.2),
     (torch.eye(5), t1, 1),
@@ -67,6 +75,15 @@ def test_accuracy(p, t, expect):
 def test_top_k_accuracy(p, t, k, expect):
     this_tests(top_k_accuracy)
     assert np.isclose(top_k_accuracy(p, t, k).item(), expect)
+
+@pytest.mark.parametrize("p, t, expect, atol", [
+    (torch.randn((128, 2, 224, 224)),  torch.randint(0, 2, (128, 1, 224, 224)), 1/2, 1e-3),
+    (torch.randn((128, 8, 224, 224)),  torch.randint(0, 8, (128, 1, 224, 224)), 1/8, 1e-3),
+    (torch.randn((128, 16, 224, 224)),  torch.randint(0, 16, (128, 1, 224, 224)), 1/16, 1e-3),
+])
+def test_nonvoid_accuracy(p, t, expect, atol):
+    this_tests(nonvoid_accuracy)
+    assert np.isclose(partial(nonvoid_accuracy, void_code=0)(p, t).item(), expect, atol=atol)
 
 @pytest.mark.parametrize("p, t, expect", [
     (p1, t1, 0.8),

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -32,14 +32,6 @@ seq_preds = torch.Tensor([
     [0.6, 0.3, 0.08, 0.02],
 ]).expand(5,4,-1)
 
-# Test data for multi-class single-label segmentation models
-# classes: 6, nonvoid_classes: 5
-segment_targ = torch.LongTensor([[[
-    [0,1,2,3,4,5],
-    [0,1,2,3,4,5],
-    [0,1,2,3,4,5],    
-]]])
-
 @pytest.mark.parametrize("p, t, expect", [
     (p1, t1, 0.2),
     (torch.eye(5), t1, 1),


### PR DESCRIPTION
Added non foreground accuracy metric from camvid notebook and 3 random (p,t) paired test for it., which passed.

I wrote random tests using the expect == expected values (which is 1/n_classes) with large batch size for three different number of classes (2, 8, 16) since it would be very space consuming to hard code segmentation predictions.
