### PR TITLE
fix typo in tutorial.itemlist

### DIFF
--- a/docs_src/tutorial.itemlist.ipynb
+++ b/docs_src/tutorial.itemlist.ipynb
@@ -195,7 +195,7 @@
     "    def process(self, ds:ItemList):  ds.classes,ds.c = self.classes,len(self.classes)\n",
     "```\n",
     "\n",
-    "`_bunch` is the last class variable usd in the data block. When you type the final `databunch()`, the data block API calls the `_bunch.create` method with the `_bunch` of the inputs. "
+    "`_bunch` is the last class variable used in the data block. When you type the final `databunch()`, the data block API calls the `_bunch.create` method with the `_bunch` of the inputs. "
    ]
   },
   {


### PR DESCRIPTION
Just a typo no real changes
