### PR TITLE
Adding Ability To Sponsor / Donate to Fastai via GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# This is an example:to get you started
+tidelift: pypi/fastai


### PR DESCRIPTION
I'm making this PR to start a discussion about a new feature that GitHub announced earlier this morning called [GitHub Sponsors](https://help.github.com/en/articles/about-github-sponsors#about-github-sponsors).  My motivation is I would like to support Fastai and even sponsor fellows etc, and I think the community would too!

At the moment you can accept donations via any number of platforms.   You just have to edit the yaml file in this PR appropriately directing people to your preferred platform of choice.   After completing the necessary steps, your repo(s) will get a button that looks like this:
![image](https://user-images.githubusercontent.com/1483922/58267700-027f0f00-7d39-11e9-9ed4-f36a6bf39222.png)

In order for this to work, you have to [enable sponsorships in your repository settings](https://github.com/fastai/fastai/settings)

![image](https://user-images.githubusercontent.com/1483922/58267916-512ca900-7d39-11e9-8049-1d082d70298c.png)

**Also you do not have to do this for each repository,** you can just have one yaml file for the whole fastai orginization.  [see this article on how to do this](https://help.github.com/en/articles/creating-a-default-community-health-file-for-your-organization).


For illustrative purposes, I have started this PR with [tidelift](https://tidelift.com/subscription/) but you do not have to use tidelift - see [this help document](https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository#about-funding-files) on the different options.  Also you can completely ignore this PR and start fresh if that is helpful.   I just wanted to get the discussion started.  


I'm happy to open a different PR or help in any other way that is useful.  Thanks!