### PR TITLE
Special handling of MixedItemList on add_test

### DIFF
--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -558,7 +558,8 @@ class LabelLists(ItemLists):
         # if no label passed, use label of first training item
         if label is None: labels = EmptyLabelList([0] * len(items))
         else: labels = self.valid.y.new([label] * len(items)).process()
-        if isinstance(items, ItemList): items = self.valid.x.new(items.items, inner_df=items.inner_df).process()
+        if isinstance(items, MixedItemList): items = self.valid.x.new(items.item_lists, inner_df=items.inner_df).process()
+        elif isinstance(items, ItemList): items = self.valid.x.new(items.items, inner_df=items.inner_df).process()
         else: items = self.valid.x.new(items).process()
         self.test = self.valid.new(items, labels)
         return self


### PR DESCRIPTION
When a `MixedItemList` is `add_test`ed, the current code creates the new instance using its `items`, but this list contains only the indexes. The right attribute in this case would be `item_lists`, which contains the list of `ItemList`s. The patch adds another type check to the method.

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
