### PR TITLE
Adding a new __get_files function

### DIFF
--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -26,6 +26,18 @@ def _get_files(parent, p, f, extensions):
     res = [p/o for o in f if not o.startswith('.')
            and (extensions is None or f'.{o.split(".")[-1].lower()}' in low_extensions)]
     return res
+                
+def __get_files(p:PathOrStr, extensions:Collection[str]=None):
+    p = Path(p)
+    res = [] # result list    
+    if (not extensions):  return p.glob("**/*") # all files
+    if extensions.__class__==str: extensions = [extensions]
+    for _ in extensions:
+        if(_.__class__==str):
+            res.extend(p.glob("**/*"+_))
+        else:            
+            raise ValueError(f"Extensions must be strings, not {_}")
+    return res
 
 def get_files(path:PathOrStr, extensions:Collection[str]=None, recurse:bool=False,
               include:Optional[Collection[str]]=None, presort:bool=False)->FilePathList:


### PR DESCRIPTION
Takes two parameters and uses pathlib Path glob function that searches Windows or Linux path recursively.
The function returns the generator object, should be easy to read, and memory efficient.
You can provide 0, 1 or multiple extension in a list.
In case no extension provided all files will be inside generator function.
I assume the most frequent use case will be setting the single extension like '.jpg' or ['.jpg'], but frequent like ['.jpg', '.jpeg']

Pathlib is aware of Linux and Windows specifics and this work on both systems. 
I am providing here a simple test case:
```

def __get_files(p:PathOrStr, extensions:Collection[str]=None):
    p = Path(p)
    res = [] # result list    
    if (not extensions):  return p.glob("**/*") # all the files
    if extensions.__class__==str: extensions = [extensions] #single string promote to list  
    for _ in extensions:
        if(_.__class__==str):
            res.extend(p.glob("**/*"+_))
        else:            
            raise ValueError(f"Extensions must be strings, not {_}")
    return res
                
gen = __get_files(p=r"C:\Users\dj\Artificial-Intelligence-with-Python", extensions=['.a',...])

for _ in gen:
     print(_)
```
This returns ``ValueError: Extensions must be strings, not Ellipsis``.

_Note: This pull request doesn't alter any existing functionality, just set some base for the future improvements._

Ref: https://stackoverflow.com/questions/2186525/how-to-use-glob-to-find-files-recursively/2186565#2186565

