### PR TITLE
fix core.is1d to handle cases where Collection doesn't have attr 'shape'

### DIFF
--- a/fastai/core.py
+++ b/fastai/core.py
@@ -79,7 +79,7 @@ def ifnone(a:Any,b:Any)->Any:
 
 def is1d(a:Collection)->bool:
     "Return `True` if `a` is one-dimensional"
-    return len(a.shape) == 1 if hasattr(a, 'shape') else True
+    return len(a.shape) == 1 if hasattr(a, 'shape') else len(np.array(a).shape) == 1
 
 def uniqueify(x:Series, sort:bool=False)->List:
     "Return sorted unique values of `x`."

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -231,6 +231,12 @@ def test_subplots_single():
     assert (len(axs) == 1)
     assert (len(axs[0]) == 1)
 
+def test_is1d():
+    assert is1d([1, 2, 3, 4])
+    assert is1d((1, 2, 3, 4))
+    assert not is1d([[1, 2], [3, 4]])
+    assert not is1d(np.array(((1,2), (3,4))))
+
 def test_itembase_eq():
     this_tests(ItemBase.__eq__, Category, FloatItem, MultiCategory)
     c1 = Category(0, 'cat')


### PR DESCRIPTION
I been shaky about is1d for some time now, but decided to make this PR to fix cases where the Collection argument passed in might actually be multi-dimensional, but returns as 1d.

See the code below  

```
>>> def test_is1d():
...     assert is1d([1, 2, 3, 4])
...     assert is1d((1, 2, 3, 4))
...     assert not is1d([[1, 2], [3, 4]])
...     assert not is1d(np.array(((1,2), (3,4))))
... 
>>> def is1d(a:Collection):
...     return len(a.shape) == 1 if hasattr(a, 'shape') else True
... 
>>> test_is1d()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 4, in test_is1d
AssertionError
>>> 
>>> def is1d(a:Collection):
...     return len(a.shape) == 1 if hasattr(a, 'shape') else len(np.array(a).shape) == 1
... 
>>> test_is1d()
>>> 

```

Essentially this fixes cases where a tuple might be multi-d or a list might be multi-d

for example with the old code it returns

```
>>> def is1d(a:Collection):
...     return len(a.shape) == 1 if hasattr(a, 'shape') else True
... 
>>> is1d([[1,2], [3,4]])
True
>>> is1d(((1,2), (3,4)))
True
>>> 

```

However 

```
>>> np.array([[1,2], [3,4]]).shape
(2, 2)
>>> np.array(((1,2), (3,4))).shape
(2, 2)
```