### PR TITLE
Optimization based on https://github.com/fastai/fastai/issues/2153

### DIFF
--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -132,7 +132,7 @@ class ItemList():
     def from_df(cls, df:DataFrame, path:PathOrStr='.', cols:IntsOrStrs=0, processor:PreProcessors=None, **kwargs)->'ItemList':
         "Create an `ItemList` in `path` from the inputs in the `cols` of `df`."
         inputs = df.iloc[:,df_names_to_idx(cols, df)]
-        assert inputs.isna().sum().sum() == 0, f"You have NaN values in column(s) {cols} of your dataframe, please fix it."
+        assert not inputs.isna().any().any(), f"You have NaN values in column(s) {cols} of your dataframe, please fix it."
         res = cls(items=_maybe_squeeze(inputs.values), path=path, inner_df=df, processor=processor, **kwargs)
         return res
 


### PR DESCRIPTION
Based on the issue (in title) we are using any() instead of sum() to check if there are any "na" values in our dataframe. This includes checks on: np.nan, np.nat, and None.