### PR TITLE
add solution to bug caused by old version

### DIFF
--- a/docs/troubleshoot.md
+++ b/docs/troubleshoot.md
@@ -418,13 +418,7 @@ Incidentally, we want you to include its output in any bug reports you may submi
 
 One more situation this may happen is where you accidentally try to run fastai-1.0-based code from under `courses/*/` in the git repo, which includes a symlink to fastai-0.7 code base and then all the hell breaks loose. Just move your notebook away from those folders and all will be good.
 
-If `import fastai` works, but not `import fastai.vision`, do:
-```
-import sys
-import fastai
-print(sys.modules['fastai'])
-```
-and see which fastai got loaded - that will help you to untangle the conflict.
+If `import fastai` works, but not `import fastai.vision`, that may caused by the old version(maybe 0.7) of fastai you've installed. Try `pip list` in the terminal to see the version if you installed fastai by pip previously. To solve the problem, upgrade the fastai version to 1.0 or higher: `pip install --upgrade fastai`. 
 
 
 ## Conda environments not showing up in Jupyter Notebook


### PR DESCRIPTION
add solution to the problem: "ModuleNotFoundError: No module named ‘fastai.vision’"

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
