### PR TITLE
WIP: Add support for training sampler

### DIFF
--- a/fastai/basic_data.py
+++ b/fastai/basic_data.py
@@ -111,11 +111,14 @@ class DataBunch():
     @classmethod
     def create(cls, train_ds:Dataset, valid_ds:Dataset, test_ds:Optional[Dataset]=None, path:PathOrStr='.', bs:int=64,
                val_bs:int=None, num_workers:int=defaults.cpus, dl_tfms:Optional[Collection[Callable]]=None,
-               device:torch.device=None, collate_fn:Callable=data_collate, no_check:bool=False, **dl_kwargs)->'DataBunch':
+               device:torch.device=None, collate_fn:Callable=data_collate, no_check:bool=False,
+               train_sampler:torch.utils.data.Sampler=None, **dl_kwargs)->'DataBunch':
         "Create a `DataBunch` from `train_ds`, `valid_ds` and maybe `test_ds` with a batch size of `bs`. Passes `**dl_kwargs` to `DataLoader()`"
         datasets = cls._init_ds(train_ds, valid_ds, test_ds)
         val_bs = ifnone(val_bs, bs)
-        dls = [DataLoader(d, b, shuffle=s, drop_last=s, num_workers=num_workers, **dl_kwargs) for d,b,s in
+        dls = [DataLoader(d, b, shuffle=(s and not (d == train_ds and train_sampler)),
+                          drop_last=s, num_workers=num_workers,
+                          sampler=(train_sampler if d == train_ds else None), **dl_kwargs) for d,b,s in
                zip(datasets, (bs,val_bs,val_bs,val_bs), (True,False,False,False)) if d is not None]
         return cls(*dls, path=path, device=device, dl_tfms=dl_tfms, collate_fn=collate_fn, no_check=no_check)
 

--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -540,11 +540,12 @@ class LabelLists(ItemLists):
 
     def databunch(self, path:PathOrStr=None, bs:int=64, val_bs:int=None, num_workers:int=defaults.cpus,
                   dl_tfms:Optional[Collection[Callable]]=None, device:torch.device=None, collate_fn:Callable=data_collate,
-                  no_check:bool=False, **kwargs)->'DataBunch':
+                  no_check:bool=False, train_sampler:torch.utils.data.Sampler=None, **kwargs)->'DataBunch':
         "Create an `DataBunch` from self, `path` will override `self.path`, `kwargs` are passed to `DataBunch.create`."
         path = Path(ifnone(path, self.path))
         data = self.x._bunch.create(self.train, self.valid, test_ds=self.test, path=path, bs=bs, val_bs=val_bs,
-                                    num_workers=num_workers, dl_tfms=dl_tfms, device=device, collate_fn=collate_fn, no_check=no_check, **kwargs)
+                                    num_workers=num_workers, dl_tfms=dl_tfms, device=device, collate_fn=collate_fn, no_check=no_check,
+                                    train_sampler=train_sampler, **kwargs)
         if getattr(self, 'normalize', False):#In case a normalization was serialized
             norm = self.normalize
             data.normalize((norm['mean'], norm['std']), do_x=norm['do_x'], do_y=norm['do_y'])


### PR DESCRIPTION
This PR adds support for a sampler to use for the training set `DataLoader`. This was motivated by wanting to use a `WeightedRandomSampler` to support oversampling of rare classes. The sampler can't simply be passed in as a `kwarg` to `databunch()` because we only want to pass it to the `train_dl`. Also, when specifying a sampler, we need to turn off shuffle for the `train_dl` because that option is not compatible with setting a sampler -- PyTorch won't allow it.

### TODO
- [ ] Add unit tests