### PR TITLE
Unet fix

### DIFF
--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -113,7 +113,11 @@ def unet_learner(data:DataBunch, arch:Callable, pretrained:bool=True, blur_final
     "Build Unet learner from `data` and `arch`."
     meta = cnn_config(arch)
     body = create_body(arch, pretrained, cut)
-    model = to_device(models.unet.DynamicUnet(body, n_classes=data.c, img_size=data.train_ds[0][0].size, blur=blur, blur_final=blur_final,
+    try:
+        size = data.train_ds[0][0].size
+    except:
+        size = next(iter(data.train_dl))[0].shape[-2:]
+    model = to_device(models.unet.DynamicUnet(body, n_classes=data.c, img_size=size, blur=blur, blur_final=blur_final,
           self_attention=self_attention, y_range=y_range, norm_type=norm_type, last_cross=last_cross,
           bottle=bottle), data.device)
     learn = Learner(data, model, **learn_kwargs)

--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -113,7 +113,7 @@ def unet_learner(data:DataBunch, arch:Callable, pretrained:bool=True, blur_final
     "Build Unet learner from `data` and `arch`."
     meta = cnn_config(arch)
     body = create_body(arch, pretrained, cut)
-    model = to_device(models.unet.DynamicUnet(body, n_classes=data.c, blur=blur, blur_final=blur_final,
+    model = to_device(models.unet.DynamicUnet(body, n_classes=data.c, img_size=data.train_ds[0][0].size, blur=blur, blur_final=blur_final,
           self_attention=self_attention, y_range=y_range, norm_type=norm_type, last_cross=last_cross,
           bottle=bottle), data.device)
     learn = Learner(data, model, **learn_kwargs)

--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -113,10 +113,8 @@ def unet_learner(data:DataBunch, arch:Callable, pretrained:bool=True, blur_final
     "Build Unet learner from `data` and `arch`."
     meta = cnn_config(arch)
     body = create_body(arch, pretrained, cut)
-    try:
-        size = data.train_ds[0][0].size
-    except:
-        size = next(iter(data.train_dl))[0].shape[-2:]
+    try:    size = data.train_ds[0][0].size
+    except: size = next(iter(data.train_dl))[0].shape[-2:]
     model = to_device(models.unet.DynamicUnet(body, n_classes=data.c, img_size=size, blur=blur, blur_final=blur_final,
           self_attention=self_attention, y_range=y_range, norm_type=norm_type, last_cross=last_cross,
           bottle=bottle), data.device)


### PR DESCRIPTION
Fix an edge case for DynamicUnet to handle input with odd sizes. The error happens when the size of the input image is an odd number. 
I added the exact input size as a parameter when creating the model. This can be fed dynamically while creating a `unet_learner` by accessing the size of the first element of the training dataset.
