### PR TITLE
Oversampling Callback

### DIFF
--- a/fastai/callbacks/__init__.py
+++ b/fastai/callbacks/__init__.py
@@ -8,3 +8,4 @@ from .rnn import *
 from .tracker import *
 from .csv_logger import *
 from .loss_metrics import *
+from .oversampling import *

--- a/fastai/callbacks/oversampling.py
+++ b/fastai/callbacks/oversampling.py
@@ -1,17 +1,16 @@
 from ..torch_core import *
 from ..basic_data import DataBunch
 from ..callback import *
-from ..basic_train import Learner
+from ..basic_train import Learner,LearnerCallback
 from torch.utils.data.sampler import WeightedRandomSampler
 
 __all__ = ['OverSamplingCallback']
 
 
 
-class OverSamplingCallback(Callback):
+class OverSamplingCallback(LearnerCallback):
     def __init__(self,learn:Learner):
-        #super().__init__(learn)
-        self.learn = learn
+        super().__init__(learn)
         self.labels = self.learn.data.train_dl.dataset.y.items
         _, counts = np.unique(self.labels,return_counts=True)
         self.weights = torch.DoubleTensor((1/counts)[self.labels])

--- a/fastai/callbacks/oversampling.py
+++ b/fastai/callbacks/oversampling.py
@@ -1,0 +1,20 @@
+from ..torch_core import *
+from ..basic_data import DataBunch
+from ..callback import *
+from ..basic_train import Learner
+from torch.utils.data.sampler import WeightedRandomSampler
+
+__all__ = ['OverSamplingCallback']
+
+
+
+class OverSamplingCallback(Callback):
+    def __init__(self,learn:Learner):
+        #super().__init__(learn)
+        self.learn = learn
+        self.labels = self.learn.data.train_dl.dataset.y.items
+        _, counts = np.unique(self.labels,return_counts=True)
+        self.weights = torch.DoubleTensor((1/counts)[self.labels])
+        
+    def on_train_begin(self, **kwargs):
+        self.learn.data.train_dl.dl.batch_sampler = BatchSampler(WeightedRandomSampler(self.weights,len(self.learn.data.train_dl.dataset)), self.learn.data.train_dl.batch_size,False)        


### PR DESCRIPTION
Adding a callback for oversampling. Currently does this by changing the sampler to be a weighted random sampler with weights corresponding to 1/counts of the classes. Previously tested on MNIST dataset.