### PR TITLE
Changed tvm to models in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The fastai library simplifies training fast and accurate neural nets using moder
 ```python
 path = untar_data(MNIST_PATH)
 data = image_data_from_folder(path)
-learn = cnn_learner(data, tvm.resnet18, metrics=accuracy)
+learn = cnn_learner(data, models.resnet18, metrics=accuracy)
 learn.fit(1)
 ```
 


### PR DESCRIPTION
The example used tvm from the older versions. Changed it to models  
