### PR TITLE
Specify Which torchvision models are included in vision.models docs

### DIFF
--- a/docs_src/vision.models.ipynb
+++ b/docs_src/vision.models.ipynb
@@ -24,7 +24,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "On top of the models offered by [torchvision](https://pytorch.org/docs/stable/torchvision/models.html), the fastai library has implementations for the following models:\n",
+    "The fastai library includes several pretrained models from
+    [torchvision](https://pytorch.org/docs/stable/torchvision/models.html),
+    namely:\n",
+    "\n",
+    "- resnet18, resnet34, resnet50, resnet50, resnet101, resnet151\n",
+    "- squeezenet1_0, squeezenet1_1\n",
+    "- densenet121, densenet169, densenet201, densenet161\n",
+    "- vgg16_bn, vgg19_bn\n",
+    "- alexnet\n"
+    "On top of the models offered by torchvision, fastai has implementations for the following models:\n",
     "\n",
     "- Darknet architecture, which is the base of [Yolo v3](https://pjreddie.com/media/files/papers/YOLOv3.pdf)\n",
     "- Unet architecture based on a pretrained model. The original unet is described [here](https://arxiv.org/abs/1505.04597), the model implementation is detailed in [`models.unet`](/vision.models.unet.html#vision.models.unet)\n",


### PR DESCRIPTION
The current vision.models [docs](https://docs.fast.ai/vision.models.html#Computer-Vision-models-zoo) do not specify which models are included from the torchvision model zoo. 

This is problematic, since some of torchvision's models are *not* imported by fastai e.g. inception_v3, vgg16 (no batch norm).

Currently the only reference for which models are imported is the direct source: 
https://github.com/fastai/fastai/blob/master/fastai/vision/models/__init__.py

This PR gives a comprehensive list of all models that can be imported via `models.<model_name>` directly in the docs.