### PR TITLE
Fix mixup to work with 3D CNNs

### DIFF
--- a/fastai/callbacks/mixup.py
+++ b/fastai/callbacks/mixup.py
@@ -23,7 +23,8 @@ class MixUpCallback(LearnerCallback):
         if self.stack_x:
             new_input = [last_input, last_input[shuffle], lambd]
         else: 
-            new_input = (last_input * lambd.view(lambd.size(0),1,1,1) + x1 * (1-lambd).view(lambd.size(0),1,1,1))
+            outshape = [lambd.size(0)] + [1 for _ in range(len(x1.shape) - 1)]
+            new_input = (last_input * lambd.view(outshape) + x1 * (1-lambd).view(outshape))
         if self.stack_y:
             new_target = torch.cat([last_target[:,None].float(), y1[:,None].float(), lambd[:,None].float()], 1)
         else:

--- a/fastai/callbacks/mixup.py
+++ b/fastai/callbacks/mixup.py
@@ -23,8 +23,8 @@ class MixUpCallback(LearnerCallback):
         if self.stack_x:
             new_input = [last_input, last_input[shuffle], lambd]
         else: 
-            outshape = [lambd.size(0)] + [1 for _ in range(len(x1.shape) - 1)]
-            new_input = (last_input * lambd.view(outshape) + x1 * (1-lambd).view(outshape))
+            out_shape = [lambd.size(0)] + [1 for _ in range(len(x1.shape) - 1)]
+            new_input = (last_input * lambd.view(out_shape) + x1 * (1-lambd).view(out_shape))
         if self.stack_y:
             new_target = torch.cat([last_target[:,None].float(), y1[:,None].float(), lambd[:,None].float()], 1)
         else:


### PR DESCRIPTION
Current implementation of `MixUpCallBack`assumes that input data has shape of (N, C, H, W) and new input is always calculated to match this. However, this means that for 3d data with shape of (N, C, D, H, W) the output has shape of (N, N, D, H, W), not (N, C, D, H, W). 

Example error: 
```
Given groups=1, weight of size 8 1 3 3 3, expected input[32, 32, 461, 17, 17] to have 1 channels, but got 32 channels instead
```

This is fixed by replacing 
```
new_input = (last_input * lambd.view(lambd.size(0),1,1,1) + x1 * (1-lambd).view(lambd.size(0),1,1,1))
```
with 
```
outshape = [lambd.size(0)] + [1 for _ in range(len(x1.shape) - 1)]
new_input = (last_input * lambd.view(outshape) + x1 * (1-lambd).view(outshape))
```
This way output shape is always same as input shape.


I've also slightly modified and added some layers for 3D-CNNs to layers.py, so if they would be useful i can also add them. 3D-CNNs are used to process hyperspectral images(more than 100 channels, not 8) or volumetric data.