### PR TITLE
Documentation for ROC-related metrics

### DIFF
--- a/docs_src/metrics.ipynb
+++ b/docs_src/metrics.ipynb
@@ -1033,7 +1033,73 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[`MultiLabelFbeta`](/metrics.html#MultiLabelFbeta) implements mutlilabel classification fbeta score similar to [scikit-learn's](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html) as a [`LearnerCallback`](/basic_train.html#LearnerCallback). Average options: [\"micro\", \"macro\", \"weighted\", \"none\"]. Intended to use with one-hot encoded targets with 1s and 0s. "
+    "[`MultiLabelFbeta`](/metrics.html#MultiLabelFbeta) implements mutlilabel classification fbeta score similar to [scikit-learn's](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html) as a [`LearnerCallback`](/basic_train.html#LearnerCallback). Average options: [\"micro\", \"macro\", \"weighted\", \"none\"]. Intended to use with one-hot encoded targets with 1s and 0s."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_doc(auc_roc_score, title_level=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[`auc_roc_score`](/metrics.html#auc_roc_score) computes the AUC score for the ROC curve similarly to [scikit-learn](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.roc_auc_score.html) using the trapezoid method, effectively summarizing the curve information in a single number. See [Wikipedia's page](https://en.wikipedia.org/wiki/Receiver_operating_characteristic#Area_under_the_curve) for more information on this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jekyll_note(\"Instead of passing this method to the learner's metrics directly, make use of the AUROC() class.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_doc(roc_curve, title_level=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[`roc_curve`](/metrics.html#roc_curve) generates the ROC curve similarly to [scikit-learn](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.roc_curve.html). See [Wikipedia's page](https://en.wikipedia.org/wiki/Receiver_operating_characteristic) for more information on the ROC curve."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jekyll_note(\"Instead of passing this method to the learner's metrics directly, make use of the AUROC() class.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_doc(AUROC, title_level=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[`AUROC`](/metrics.html#AUROC) creates a `Callback` for computing the AUC score for the ROC curve with [`auc_roc_score`](/metrics.html#auc_roc_score) at the end of each epoch, given that averaging over batches is incorrect in case of the AUROC. See [Wikipedia's page](https://en.wikipedia.org/wiki/Receiver_operating_characteristic#Area_under_the_curve) for more information on the AUROC."
    ]
   },
   {
@@ -1882,6 +1948,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/docs_src/metrics.ipynb
+++ b/docs_src/metrics.ipynb
@@ -1948,18 +1948,6 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -271,7 +271,7 @@ class Perplexity(Callback):
         return add_metrics(last_metrics, torch.exp(self.loss / self.len))
 
 def auc_roc_score(input:Tensor, targ:Tensor):
-    "Using trapezoid method to calculate the area under roc curve"
+    "Computes the area under the receiver operator characteristic (ROC) curve using the trapezoid method. Restricted binary classification tasks."
     fpr, tpr = roc_curve(input, targ)
     d = fpr[1:] - fpr[:-1]
     sl1, sl2 = [slice(None)], [slice(None)]
@@ -279,7 +279,7 @@ def auc_roc_score(input:Tensor, targ:Tensor):
     return (d * (tpr[tuple(sl1)] + tpr[tuple(sl2)]) / 2.).sum(-1)
 
 def roc_curve(input:Tensor, targ:Tensor):
-    "Returns the false positive and true positive rates"
+    "Computes the receiver operator characteristic (ROC) curve by determining the true positive ratio (TPR) and false positive ratio (FPR) for various classification thresholds. Restricted binary classification tasks."
     targ = (targ == 1)
     desc_score_indices = torch.flip(input.argsort(-1), [-1])
     input = input[desc_score_indices]
@@ -297,7 +297,7 @@ def roc_curve(input:Tensor, targ:Tensor):
 
 @dataclass
 class AUROC(Callback):
-    "Calculates the auc score based on the roc curve. Restricted to the binary classification task."
+    "Computes the area under the curve (AUC) score based on the receiver operator characteristic (ROC) curve. Restricted to binary classification tasks."
     def on_epoch_begin(self, **kwargs):
         self.targs, self.preds = LongTensor([]), Tensor([])
         


### PR DESCRIPTION
Added documentation for metric methods/classes introduced by #1881, referring to sklearn and Wikipedia. I was wondering whether it might be a better idea to have `roc_curve` and `auc_roc_score` as methods to the `AUROC` class, given that they are not meant to be passed directly to the `metrics` argument of your learner?