### PR TITLE
Open On GCP Button has been added to the applications.ipynb and basic_data.ipynb

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,4 +12,10 @@ steps:
   entrypoint: '/bin/bash'
   id: 'applications.ipynb'
   waitFor: ['checkout']
+- name: 'gcr.io/deeplearning-platform-release/pytorch-cpu'
+  args: ['-c', 'papermill basic_data.ipynb gs://dl-platform-fastai/${COMMIT_SHA}/docs_src/basic_data.ipynb --log-output']
+  dir: 'fastai-src/docs_src'
+  entrypoint: '/bin/bash'
+  id: 'basic_data.ipynb'
+  waitFor: ['checkout']
 timeout: 90m

--- a/docs_src/applications.ipynb
+++ b/docs_src/applications.ipynb
@@ -106,6 +106,15 @@
    "source": [
     "*For more information on [imports](/index.html#imports)*"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Open This Notebook\n",
+    "\n",
+    "<button style=\"display: flex; align-item: center; padding: 4px 8px; font-size: 14px; font-weight: 700; color: #1976d2; cursor: pointer;\" onclick=\"window.location.href = 'https://console.cloud.google.com/mlengine/notebooks/deploy-notebook?q=download_url%3Dhttps%253A%252F%252Fraw.githubusercontent.com%252Ffastai%252Ffastai%252Fmaster%252Fdocs_src%252Fapplications.ipynb';\"><img src=\"https://www.gstatic.com/images/branding/product/1x/cloud_24dp.png\" /><span style=\"line-height: 24px; margin-left: 10px;\">Open in GCP Notebooks</span></button>"
+   ]
   }
  ],
  "metadata": {

--- a/docs_src/basic_data.ipynb
+++ b/docs_src/basic_data.ipynb
@@ -966,6 +966,15 @@
    "source": [
     "## New Methods - Please document or move to the undocumented section"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Open This Notebook\n",
+    "\n",
+    "<button style=\"display: flex; align-item: center; padding: 4px 8px; font-size: 14px; font-weight: 700; color: #1976d2; cursor: pointer;\" onclick=\"window.location.href = 'https://console.cloud.google.com/mlengine/notebooks/deploy-notebook?q=download_url%3Dhttps%253A%252F%252Fraw.githubusercontent.com%252Ffastai%252Ffastai%252Fmaster%252Fdocs_src%252Fbasic_data.ipynb';\"><img src=\"https://www.gstatic.com/images/branding/product/1x/cloud_24dp.png\" /><span style=\"line-height: 24px; margin-left: 10px;\">Open in GCP Notebooks</span></button>"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
This is follow up work on the https://github.com/fastai/fastai/pull/2069

This PR introducing two changes:
* covers additional Notebook with AI Platform Notebooks compatibility tests
* adds "open on GCP" button to the two Notebooks that are covered with the tests

Both changes are testes with the CI. Example of how these two notebooks will look like after converting them to the HTML can be found here: 

basic_data.ipynb: https://storage.googleapis.com/public-content/misc/fastai-pr/basic_data.html
applications.ipynb: https://storage.googleapis.com/public-content/misc/fastai-pr/applications.html

as soon as this PR is merged we will monitor how people using this button and in case of small (ideally zero) rate of failed actions of opening notebooks to GCP we can proceed with covering with button (and tests) other notebooks.