### PR TITLE
Added the sep attribute to the copy_new attribute of TextList

### DIFF
--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -322,7 +322,7 @@ class TextList(ItemList):
     def __init__(self, items:Iterator, vocab:Vocab=None, pad_idx:int=1, sep=' ', **kwargs):
         super().__init__(items, **kwargs)
         self.vocab,self.pad_idx,self.sep = vocab,pad_idx,sep
-        self.copy_new += ['vocab', 'pad_idx']
+        self.copy_new += ['vocab', 'pad_idx', 'sep']
 
     def get(self, i):
         o = super().get(i)


### PR DESCRIPTION
Following the PR https://github.com/fastai/fastai/pull/2195
The `sep` attribute was not passed to copy_new, as a result, when new was called (as for example in show_batch), the default separator would be used. Adding `'sep'` to the copy_new attributes fixes this. 