### PR TITLE
"open on GCP" button has been added to 3 more notebooks

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,4 +18,22 @@ steps:
   entrypoint: '/bin/bash'
   id: 'basic_data.ipynb'
   waitFor: ['checkout']
+- name: 'gcr.io/deeplearning-platform-release/pytorch-cpu'
+  args: ['-c', 'papermill training.ipynb gs://dl-platform-fastai/${COMMIT_SHA}/docs_src/training.ipynb --log-output']
+  dir: 'fastai-src/docs_src'
+  entrypoint: '/bin/bash'
+  id: 'training.ipynb'
+  waitFor: ['checkout']
+- name: 'gcr.io/deeplearning-platform-release/pytorch-cpu'
+  args: ['-c', 'papermill basic_train.ipynb gs://dl-platform-fastai/${COMMIT_SHA}/docs_src/basic_train.ipynb --log-output']
+  dir: 'fastai-src/docs_src'
+  entrypoint: '/bin/bash'
+  id: 'basic_train.ipynb'
+  waitFor: ['checkout']
+- name: 'gcr.io/deeplearning-platform-release/pytorch-cpu'
+  args: ['-c', 'papermill train.ipynb gs://dl-platform-fastai/${COMMIT_SHA}/docs_src/train.ipynb --log-output']
+  dir: 'fastai-src/docs_src'
+  entrypoint: '/bin/bash'
+  id: 'train.ipynb'
+  waitFor: ['checkout']
 timeout: 90m

--- a/docs_src/basic_data.ipynb
+++ b/docs_src/basic_data.ipynb
@@ -929,6 +929,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Open This Notebook\n",
+    "\n",
+    "<button style=\"display: flex; align-item: center; padding: 4px 8px; font-size: 14px; font-weight: 700; color: #1976d2; cursor: pointer;\" onclick=\"window.location.href = 'https://console.cloud.google.com/mlengine/notebooks/deploy-notebook?q=download_url%3Dhttps%253A%252F%252Fraw.githubusercontent.com%252Ffastai%252Ffastai%252Fmaster%252Fdocs_src%252Fbasic_data.ipynb';\"><img src=\"https://www.gstatic.com/images/branding/product/1x/cloud_24dp.png\" /><span style=\"line-height: 24px; margin-left: 10px;\">Open in GCP Notebooks</span></button>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Undocumented Methods - Methods moved below this line will intentionally be hidden"
    ]
   },
@@ -965,15 +974,6 @@
    "metadata": {},
    "source": [
     "## New Methods - Please document or move to the undocumented section"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Open This Notebook\n",
-    "\n",
-    "<button style=\"display: flex; align-item: center; padding: 4px 8px; font-size: 14px; font-weight: 700; color: #1976d2; cursor: pointer;\" onclick=\"window.location.href = 'https://console.cloud.google.com/mlengine/notebooks/deploy-notebook?q=download_url%3Dhttps%253A%252F%252Fraw.githubusercontent.com%252Ffastai%252Ffastai%252Fmaster%252Fdocs_src%252Fbasic_data.ipynb';\"><img src=\"https://www.gstatic.com/images/branding/product/1x/cloud_24dp.png\" /><span style=\"line-height: 24px; margin-left: 10px;\">Open in GCP Notebooks</span></button>"
    ]
   }
  ],

--- a/docs_src/basic_train.ipynb
+++ b/docs_src/basic_train.ipynb
@@ -3437,6 +3437,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Open This Notebook\n",
+    "\n",
+    "<button style=\"display: flex; align-item: center; padding: 4px 8px; font-size: 14px; font-weight: 700; color: #1976d2; cursor: pointer;\" onclick=\"window.location.href = 'https://console.cloud.google.com/mlengine/notebooks/deploy-notebook?q=download_url%3Dhttps%253A%252F%252Fraw.githubusercontent.com%252Ffastai%252Ffastai%252Fmaster%252Fdocs_src%252Fbasic_train.ipynb';\"><img src=\"https://www.gstatic.com/images/branding/product/1x/cloud_24dp.png\" /><span style=\"line-height: 24px; margin-left: 10px;\">Open in GCP Notebooks</span></button>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Undocumented Methods - Methods moved below this line will intentionally be hidden"
    ]
   },

--- a/docs_src/train.ipynb
+++ b/docs_src/train.ipynb
@@ -1356,6 +1356,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Open This Notebook\n",
+    "\n",
+    "<button style=\"display: flex; align-item: center; padding: 4px 8px; font-size: 14px; font-weight: 700; color: #1976d2; cursor: pointer;\" onclick=\"window.location.href = 'https://console.cloud.google.com/mlengine/notebooks/deploy-notebook?q=download_url%3Dhttps%253A%252F%252Fraw.githubusercontent.com%252Ffastai%252Ffastai%252Fmaster%252Fdocs_src%252Ftrain.ipynb';\"><img src=\"https://www.gstatic.com/images/branding/product/1x/cloud_24dp.png\" /><span style=\"line-height: 24px; margin-left: 10px;\">Open in GCP Notebooks</span></button>"
+   ]
   }
  ],
  "metadata": {

--- a/docs_src/training.ipynb
+++ b/docs_src/training.ipynb
@@ -386,6 +386,15 @@
     "learn = cnn_learner(data, models.resnet18, metrics=accuracy)\n",
     "learn.fit_one_cycle(1)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Open This Notebook\n",
+    "\n",
+    "<button style=\"display: flex; align-item: center; padding: 4px 8px; font-size: 14px; font-weight: 700; color: #1976d2; cursor: pointer;\" onclick=\"window.location.href = 'https://console.cloud.google.com/mlengine/notebooks/deploy-notebook?q=download_url%3Dhttps%253A%252F%252Fraw.githubusercontent.com%252Ffastai%252Ffastai%252Fmaster%252Fdocs_src%252Ftraining.ipynb';\"><img src=\"https://www.gstatic.com/images/branding/product/1x/cloud_24dp.png\" /><span style=\"line-height: 24px; margin-left: 10px;\">Open in GCP Notebooks</span></button>"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
This is follow up work on the https://github.com/fastai/fastai/pull/2069 and https://github.com/fastai/fastai/pull/2214

This PR include:
* fix for the button on the basic_data.ipynb (it was not displayed on the site)
* three new, more complex (basic_data.ipynb, train.ipynb, training.ipynb ), notebooks are now covered with CI tests to make sure they are fully compatible with GCP AI Platform Notebooks
* "open on GCP" button has been added to the same three Notebooks

All changes been tested on the Cloud Build CI and are green.

After this PR is merge we probably will wait for ~1 week before covering more Notebooks, just to collect some metrics.