### PR TITLE
Fix oversampling

### DIFF
--- a/fastai/callbacks/oversampling.py
+++ b/fastai/callbacks/oversampling.py
@@ -9,12 +9,13 @@ __all__ = ['OverSamplingCallback']
 
 
 class OverSamplingCallback(LearnerCallback):
-    def __init__(self,learn:Learner, weights:torch.Tensor=None):
+    def __init__(self,learn:Learner):
         super().__init__(learn)
         self.labels = self.learn.data.train_dl.dataset.y.items
         _, counts = np.unique(self.labels,return_counts=True)
-        self.weights = (weights if weights is not None else
-                        torch.DoubleTensor((1/counts)[self.labels]))
-
+        self.weights = torch.DoubleTensor((1/counts)[self.labels])
+        self.label_counts = np.bincount([self.learn.data.train_dl.dataset.y[i].data for i in range(len(self.learn.data.train_dl.dataset))])
+        self.total_len_oversample = int(self.learn.data.c*np.max(self.label_counts))
+        
     def on_train_begin(self, **kwargs):
-        self.learn.data.train_dl.dl.batch_sampler = BatchSampler(WeightedRandomSampler(self.weights,len(self.learn.data.train_dl.dataset)), self.learn.data.train_dl.batch_size,False)        
+        self.learn.data.train_dl.dl.batch_sampler = BatchSampler(WeightedRandomSampler(weights,self.total_len_oversample), self.learn.data.train_dl.batch_size,False)

--- a/fastai/callbacks/oversampling.py
+++ b/fastai/callbacks/oversampling.py
@@ -9,11 +9,12 @@ __all__ = ['OverSamplingCallback']
 
 
 class OverSamplingCallback(LearnerCallback):
-    def __init__(self,learn:Learner):
+    def __init__(self,learn:Learner,weights:torch.Tensor=None):
         super().__init__(learn)
         self.labels = self.learn.data.train_dl.dataset.y.items
         _, counts = np.unique(self.labels,return_counts=True)
-        self.weights = torch.DoubleTensor((1/counts)[self.labels])
+        self.weights = (weights if weights is not None else
+                        torch.DoubleTensor((1/counts)[self.labels]))
         self.label_counts = np.bincount([self.learn.data.train_dl.dataset.y[i].data for i in range(len(self.learn.data.train_dl.dataset))])
         self.total_len_oversample = int(self.learn.data.c*np.max(self.label_counts))
         

--- a/fastai/callbacks/oversampling.py
+++ b/fastai/callbacks/oversampling.py
@@ -19,4 +19,4 @@ class OverSamplingCallback(LearnerCallback):
         self.total_len_oversample = int(self.learn.data.c*np.max(self.label_counts))
         
     def on_train_begin(self, **kwargs):
-        self.learn.data.train_dl.dl.batch_sampler = BatchSampler(WeightedRandomSampler(weights,self.total_len_oversample), self.learn.data.train_dl.batch_size,False)
+        self.learn.data.train_dl.dl.batch_sampler = BatchSampler(WeightedRandomSampler(self.weights,self.total_len_oversample), self.learn.data.train_dl.batch_size,False)


### PR DESCRIPTION
There was an error with the oversampling callback, and did not perform as I originally intended. 
It currently redistributed the dataset so that all classes have same frequencies but the size of the dataset is the same. So some samples were omitted from the final dataset.

This version now duplicates the samples so that all classes have the same number of samples as the class with the highest frequency.