### PR TITLE
ClassConfusion

### DIFF
--- a/fastai/widgets/__init__.py
+++ b/fastai/widgets/__init__.py
@@ -1,2 +1,3 @@
+from .class_confusion import *
 from .image_cleaner import *
 from .image_downloader import *

--- a/fastai/widgets/class_confusion.py
+++ b/fastai/widgets/class_confusion.py
@@ -27,6 +27,12 @@ class ClassLosses():
         self.classl = classlist
         self._show_losses(classlist)
 
+        
+    def _show_losses(self, classl:list, **kwargs):
+        "Checks if the model is for Tabular or Images and gathers top losses"
+        _, self.tl_idx = self.interp.top_losses(len(self.interp.losses))
+        self._tab_losses() if self._is_tab else self._create_tabs()
+        
     def _create_tabs(self):
         "Creates a tab for each variable"
 
@@ -54,6 +60,15 @@ class ClassLosses():
         for i in range(len(items)):
             self.tabs.set_title(i, self.tbnames[i])
         self._populate_tabs()
+        
+    def _populate_tabs(self):
+        "Adds relevant graphs to each tab"
+        with tqdm(total=len(self.tbnames)) as pbar:
+            for i, tab in enumerate(self.tbnames):
+                with self.tabs.children[i]:
+                    self._plot_tab(tab) if self._is_tab else self._plot_imgs(tab, i)
+                pbar.update(1)
+        display(self.tabs)
         
     def _plot_tab(self, tab:str):
         "Generates graphs"
@@ -92,19 +107,9 @@ class ClassLosses():
         plt.show(fig)
         plt.tight_layout()
       
-    def _populate_tabs(self):
-        "Adds relevant graphs to each tab"
-        with tqdm(total=len(self.tbnames)) as pbar:
-            for i, tab in enumerate(self.tbnames):
-                with self.tabs.children[i]:
-                    self._plot_tab(tab) if self._is_tab else self._plot_imgs(tab, i)
-                pbar.update(1)
-        display(self.tabs)
+
         
-    def _show_losses(self, classl:list, **kwargs):
-        "Checks if the model is for Tabular or Images and gathers top losses"
-        _, self.tl_idx = self.interp.top_losses(len(self.interp.losses))
-        self._tab_losses() if self._is_tab else self._create_tabs()
+
 
     def _plot_imgs(self, tab:str, i:int ,**kwargs):
         "Plots the most confused images"

--- a/fastai/widgets/class_confusion.py
+++ b/fastai/widgets/class_confusion.py
@@ -2,7 +2,6 @@ import math
 import pandas as pd
 import matplotlib.pyplot as plt
 from tqdm import tqdm
-
 from itertools import permutations
 from ..train import ClassificationInterpretation
 import ipywidgets as widgets
@@ -26,7 +25,6 @@ class ClassLosses():
         self.vars = varlist
         self.classl = classlist
         self._show_losses(classlist)
-
         
     def _show_losses(self, classl:list, **kwargs):
         "Checks if the model is for Tabular or Images and gathers top losses"
@@ -35,9 +33,7 @@ class ClassLosses():
         
     def _create_tabs(self):
         "Creates a tab for each variable"
-
         self.lis = self.classl if self.is_ordered else list(permutations(self.classl, 2))
-        
         if self._is_tab:
             self._boxes = len(self.df_list)
             self._cols = math.ceil(math.sqrt(self._boxes))
@@ -53,7 +49,6 @@ class ClassLosses():
                     if x[0:2] == self.lis[y]:
                         self._ranges.append(x[2])
                         self.tbnames.append(str(x[0] + ' | ' + x[1]))
-
         items = [widgets.Output() for i, tab in enumerate(self.tbnames)]
         self.tabs = widgets.Tab()
         self.tabs.children = items
@@ -106,20 +101,14 @@ class ClassLosses():
                     print('Less than two unique values, cannot graph the KDE')
         plt.show(fig)
         plt.tight_layout()
-      
-
-        
-
 
     def _plot_imgs(self, tab:str, i:int ,**kwargs):
         "Plots the most confused images"
         classes_gnd = self.interp.data.classes
-        
         x = 0
         if self._ranges[i] < k:
             cols = math.ceil(math.sqrt(self._ranges[i]))
             rows = math.ceil(self._ranges[i]/cols)
-            
         if self._ranges[i] < 4 or k < 4:
             cols = 2
             rows = 2
@@ -127,7 +116,6 @@ class ClassLosses():
             cols = math.ceil(math.sqrt(self._boxes))
             rows = math.ceil(self._boxes/cols)
         fig, ax = plt.subplots(rows, cols, figsize=self.figsize)
-
         [axi.set_axis_off() for axi in ax.ravel()]
         for j, idx in enumerate(self.tl_idx):
             if k < x+1 or x > self._ranges[i]:
@@ -135,8 +123,6 @@ class ClassLosses():
             da, cl = self.interp.data.dl(self.interp.ds_type).dataset[idx]
             row = (int)(x / cols)
             col = x % cols
-
-            ix = int(cl)
             if str(cl) == tab.split(' ')[0] and str(classes_gnd[self.interp.pred_class[idx]]) == tab.split(' ')[2]:
                 img, lbl = self.interp.data.valid_ds[idx]
                 fn = self.interp.data.valid_ds.x.items[idx]
@@ -153,9 +139,7 @@ class ClassLosses():
         cat_names = self.interp.data.x.cat_names
         cont_names = self.interp.data.x.cont_names
         comb = self.classl if self.is_ordered else list(permutations(self.classl,2))
-
-        dfarr = []
-
+        self.df_list = []
         arr = []
         for i, idx in enumerate(self.tl_idx):
             da, _ = self.interp.data.dl(self.interp.ds_type).dataset[idx]
@@ -165,7 +149,6 @@ class ClassLosses():
                 if string == 'True' or string == 'False':
                     string += ';'
                     res += string
-
                 else:
                     string = string[1:]
                     res += string + ';'
@@ -176,14 +159,12 @@ class ClassLosses():
         for i, var in enumerate(self.interp.data.cont_names):
             f[var] = f[var].apply(lambda x: float(x) * self.stds[var] + self.means[var])
         f['Original'] = 'Original'
-        dfarr.append(f)
-
+        self.df_list.append(f)
         for j, x in enumerate(comb):
             arr = []
             for i, idx in enumerate(self.tl_idx):
                 da, cl = self.interp.data.dl(self.interp.ds_type).dataset[idx]
                 cl = int(cl)
-
                 if classes[self.interp.pred_class[idx]] == comb[j][0] and classes[cl] == comb[j][1]:
                     res = ''
                     for c, n in zip(da.cats, da.names[:len(da.cats)]):
@@ -201,7 +182,6 @@ class ClassLosses():
             for i, var in enumerate(self.interp.data.cont_names):
                 f[var] = f[var].apply(lambda x: float(x) * self.stds[var] + self.means[var])
             f[str(x)] = str(x)
-            dfarr.append(f)
-        self.df_list = dfarr
+            self.df_list.append(f)
         self.cat_names = cat_names
         self._create_tabs()

--- a/fastai/widgets/class_confusion.py
+++ b/fastai/widgets/class_confusion.py
@@ -1,9 +1,9 @@
 import math
 import pandas as pd
-import matplotlib.pyplot as plt
+from tqdm import tqdm
 
 from itertools import permutations
-from fastai.train import ClassificationInterpretation
+from ..train import ClassificationInterpretation
 import ipywidgets as widgets
 
 class ClassLosses():
@@ -12,7 +12,8 @@ class ClassLosses():
                is_ordered:bool=False, cut_off:int=100, varlist:list=None,
                figsize:tuple=(8,8)):
         self.interp = interp
-        if str(type(interp.learn.data)) == "<class 'fastai.tabular.data.TabularDataBunch'>":
+        self._is_tab = (str(type(interp.learn.data)) == "<class 'fastai.tabular.data.TabularDataBunch'>")
+        if self._is_tab:
             if interp.learn.data.train_ds.x.cont_names != []: 
                 for x in range(len(interp.learn.data.procs)):
                       if "Normalize" in str(interp.learn.data.procs[x]):
@@ -22,139 +23,135 @@ class ClassLosses():
         self.cut_off = cut_off
         self.figsize = figsize
         self.vars = varlist
+        self.classl = classlist
         self._show_losses(classlist)
-    
 
-    
     def _create_tabs(self):
         "Creates a tab for each variable"
-        self.boxes = len(self.df_list)
-        self.cols = math.ceil(math.sqrt(self.boxes))
-        self.rows = math.ceil(self.boxes/self.cols)
-        
-        tbnames = list(self.df_list[0].columns)[:-1]
-        items = [widgets.Output() for i, tab in enumerate(tbnames)]
-        self.tbnames = tbnames
-        self.tabs = widgets.Tab()
-        self.tabs.children = items
-        for i in range(len(items)):
-            self.tabs.set_title(i, tbnames[i])
-        self._populate_tabs()
-        
-      
-    def _populate_tabs(self):
-        "Adds relevant graphs to each tab"
-        for i, tab in enumerate(self.tbnames):
-            with self.tabs.children[i]:
-                if self.boxes is not None:
-                    fig, ax = plt.subplots(self.boxes, figsize=self.figsize)
-                else:
-                    fig, ax = plt.subplots(self.cols, self.rows, figsize=self.figsize)
-                fig.subplots_adjust(hspace=.5)
-                for j, x in enumerate(self.df_list):
-                    ttl = f'{"".join(x.columns[-1])} {tab} distribution'
-                    title = ttl if j == 0 else f'Misclassified {ttl}'
 
-                    if self.boxes is None:
-                        row = int(j / self.cols)
-                        col = j % row
-                    if tab in self.cat_names:
-                        vals = pd.value_counts(x[tab].values)
-                        if self.boxes is not None:
-                            if vals.nunique() < 10:
-                                fig = vals.plot(kind='bar', title=title,  ax=ax[j], rot=0, width=.75)
-                            else:
-                                fig = vals.plot(kind='barh', title=title,  ax=ax[j], width=.75)   
-                        else:
-                            fig = vals.plot(kind='barh', title=title,  ax=ax[row, col], width=.75)
-                    else:
-                        vals = x[tab]
-                        if self.boxes is not None:
-                            axs = vals.plot(kind='hist', ax=ax[j], title=title, y='Frequency')
-                        else:
-                            axs = vals.plot(kind='hist', ax=ax[row, col], title=title, y='Frequency')
-                        axs.set_ylabel('Frequency')
-                        if len(set(vals)) > 1:
-                            vals.plot(kind='kde', ax=axs, title=title, secondary_y=True)
-                        else:
-                            print('Less than two unique values, cannot graph the KDE')
-                plt.show(fig)
-                plt.tight_layout
-        display(self.tabs)
+        self.lis = self.classl if self.is_ordered else list(permutations(self.classl, 2))
         
-    def _show_losses(self, classl:list, **kwargs):
-        "Checks if the model is for Tabular or Images"
-        if str(type(self.interp.learn.data)) == "<class 'fastai.tabular.data.TabularDataBunch'>":
-            self._tab_losses(classl)
+        if self._is_tab:
+            self._boxes = len(self.df_list)
+            self._cols = math.ceil(math.sqrt(self._boxes))
+            self._rows = math.ceil(self._boxes/self._cols)
+            self.tbnames = list(self.df_list[0].columns)[:-1]
         else:
-            self._im_losses(classl)
+            vals = self.interp.most_confused()
+            self._ranges = []
+            self.tbnames = []
+            self._boxes = int(input('Please enter a value for `k`, or the top images you will see: '))
+            for x in iter(vals):
+                for y in range(len(self.lis)):
+                    if x[0:2] == self.lis[y]:
+                        self._ranges.append(x[2])
+                        self.tbnames.append(str(x[0] + ' | ' + x[1]))
 
-    def _im_losses(self, classl:list, **kwargs):
-        "Plots the most confused images"
-        lis = classl if self.is_ordered else list(permutations(classl, 2))
-        self.tl_val, self.tl_idx = self.interp.top_losses(len(self.interp.losses))
-        classes_gnd = self.interp.data.classes
-        vals = self.interp.most_confused()
-        self.ranges = []
-        self.tbnames = []
-        self.k = int(input('Please enter a value for `k`, or the top images you will see: '))
-        for x in iter(vals):
-            for y in range(len(lis)):
-                if x[0:2] == lis[y]:
-                    self.ranges.append(x[2])
-                    self.tbnames.append(str(x[0] + ' | ' + x[1]))
         items = [widgets.Output() for i, tab in enumerate(self.tbnames)]
         self.tabs = widgets.Tab()
         self.tabs.children = items
         for i in range(len(items)):
             self.tabs.set_title(i, self.tbnames[i])
-        for i, tab in enumerate(self.tbnames):
-            with self.tabs.children[i]:
-                x = 0
-                if self.ranges[i] < k:
-                    cols = math.ceil(math.sqrt(self.ranges[i]))
-                    rows = math.ceil(self.ranges[i]/cols)
-                    
-                if self.ranges[i] < 4 or k < 4:
-                    cols = 2
-                    rows = 2
+        self._populate_tabs()
+        
+    def _plot_tab(self, tab:str):
+        "Generates graph"
+        if self._boxes is not None:
+            fig, ax = plt.subplots(self._boxes, figsize=self.figsize)
+        else:
+            fig, ax = plt.subplots(self._cols, self._rows, figsize=self.figsize)
+        fig.subplots_adjust(hspace=.5)
+        for j, x in enumerate(self.df_list):
+            ttl = f'{"".join(x.columns[-1])} {tab} distribution'
+            title = ttl if j == 0 else f'Misclassified {ttl}'
+
+            if self._boxes is None:
+                row = int(j / self._cols)
+                col = j % row
+            if tab in self.cat_names:
+                vals = pd.value_counts(x[tab].values)
+                if self._boxes is not None:
+                    if vals.nunique() < 10:
+                        fig = vals.plot(kind='bar', title=title,  ax=ax[j], rot=0, width=.75)
+                    else:
+                        fig = vals.plot(kind='barh', title=title,  ax=ax[j], width=.75)   
                 else:
-                    cols = math.ceil(math.sqrt(self.k))
-                    rows = math.ceil(self.k/cols)
-                fig, ax = plt.subplots(rows, cols, figsize=self.figsize)
-
-                [axi.set_axis_off() for axi in ax.ravel()]
-                for j, idx in enumerate(self.tl_idx):
-                    if k < x+1 or x > self.ranges[i]:
-                        break
-                    da, cl = self.interp.data.dl(self.interp.ds_type).dataset[idx]
-                    row = (int)(x / cols)
-                    col = x % cols
-
-                    ix = int(cl)
-                    if str(cl) == tab.split(' ')[0] and str(classes_gnd[self.interp.pred_class[idx]]) == tab.split(' ')[2]:
-                        img, lbl = self.interp.data.valid_ds[idx]
-                        fn = self.interp.data.valid_ds.x.items[idx]
-                        fn = re.search('([^/*]+)_\d+.*$', str(fn)).group(0)
-                        img.show(ax=ax[row, col])
-                        ax[row,col].set_title(fn)
-                        x += 1
-                plt.show(fig)
-                plt.tight_layout()
+                    fig = vals.plot(kind='barh', title=title,  ax=ax[row, col], width=.75)
+            else:
+                vals = x[tab]
+                if self._boxes is not None:
+                    axs = vals.plot(kind='hist', ax=ax[j], title=title, y='Frequency')
+                else:
+                    axs = vals.plot(kind='hist', ax=ax[row, col], title=title, y='Frequency')
+                axs.set_ylabel('Frequency')
+                if len(set(vals)) > 1:
+                    vals.plot(kind='kde', ax=axs, title=title, secondary_y=True)
+                else:
+                    print('Less than two unique values, cannot graph the KDE')
+        plt.show(fig)
+        plt.tight_layout()
+      
+    def _populate_tabs(self):
+        "Adds relevant graphs to each tab"
+        with tqdm(total=len(self.tbnames)) as pbar:
+            for i, tab in enumerate(self.tbnames):
+                with self.tabs.children[i]:
+                    self._plot_tab(tab) if self._is_tab else self._plot_imgs(tab, i)
+                pbar.update(1)
         display(self.tabs)
+        
+    def _show_losses(self, classl:list, **kwargs):
+        "Checks if the model is for Tabular or Images and gathers top losses"
+        _, self.tl_idx = self.interp.top_losses(len(self.interp.losses))
+        self._tab_losses() if self._is_tab else self._create_tabs()
 
-    def _tab_losses(self, classl:list, **kwargs):
+    def _plot_imgs(self, tab:str, i:int ,**kwargs):
+        "Plots the most confused images"
+        classes_gnd = self.interp.data.classes
+        
+        x = 0
+        if self._ranges[i] < k:
+            cols = math.ceil(math.sqrt(self._ranges[i]))
+            rows = math.ceil(self._ranges[i]/cols)
+            
+        if self._ranges[i] < 4 or k < 4:
+            cols = 2
+            rows = 2
+        else:
+            cols = math.ceil(math.sqrt(self._boxes))
+            rows = math.ceil(self._boxes/cols)
+        fig, ax = plt.subplots(rows, cols, figsize=self.figsize)
+
+        [axi.set_axis_off() for axi in ax.ravel()]
+        for j, idx in enumerate(self.tl_idx):
+            if k < x+1 or x > self._ranges[i]:
+                break
+            da, cl = self.interp.data.dl(self.interp.ds_type).dataset[idx]
+            row = (int)(x / cols)
+            col = x % cols
+
+            ix = int(cl)
+            if str(cl) == tab.split(' ')[0] and str(classes_gnd[self.interp.pred_class[idx]]) == tab.split(' ')[2]:
+                img, lbl = self.interp.data.valid_ds[idx]
+                fn = self.interp.data.valid_ds.x.items[idx]
+                fn = re.search('([^/*]+)_\d+.*$', str(fn)).group(0)
+                img.show(ax=ax[row, col])
+                ax[row,col].set_title(fn)
+                x += 1
+        plt.show(fig)
+        plt.tight_layout()
+
+    def _tab_losses(self, **kwargs):
         "Gathers dataframes of the combinations data"
-        tl_val, tl_idx = self.interp.top_losses(len(self.interp.losses))
         classes = self.interp.data.classes
         cat_names = self.interp.data.x.cat_names
         cont_names = self.interp.data.x.cont_names
-        comb = classl if self.is_ordered else list(permutations(classl,2))
+        comb = self.classl if self.is_ordered else list(permutations(self.classl,2))
 
         dfarr = []
 
         arr = []
-        for i, idx in enumerate(tl_idx):
+        for i, idx in enumerate(self.tl_idx):
             da, _ = self.interp.data.dl(self.interp.ds_type).dataset[idx]
             res = ''
             for c, n in zip(da.cats, da.names[:len(da.cats)]):
@@ -177,7 +174,7 @@ class ClassLosses():
 
         for j, x in enumerate(comb):
             arr = []
-            for i, idx in enumerate(tl_idx):
+            for i, idx in enumerate(self.tl_idx):
                 da, cl = self.interp.data.dl(self.interp.ds_type).dataset[idx]
                 cl = int(cl)
 

--- a/fastai/widgets/class_confusion.py
+++ b/fastai/widgets/class_confusion.py
@@ -55,7 +55,7 @@ class ClassLosses():
         self._populate_tabs()
         
     def _plot_tab(self, tab:str):
-        "Generates graph"
+        "Generates graphs"
         if self._boxes is not None:
             fig, ax = plt.subplots(self._boxes, figsize=self.figsize)
         else:

--- a/fastai/widgets/class_confusion.py
+++ b/fastai/widgets/class_confusion.py
@@ -12,7 +12,7 @@ class ClassConfusion():
                is_ordered:bool=False, cut_off:int=100, varlist:list=None,
                figsize:tuple=(8,8)):
         self.interp = interp
-        self._is_tab = (str(type(interp.learn.data)) == "<class 'fastai.tabular.data.TabularDataBunch'>")
+        self._is_tab = isinstance(interp.learn.data, TabularDataBunch)
         if self._is_tab:
             if interp.learn.data.train_ds.x.cont_names != []: 
                 for x in range(len(interp.learn.data.procs)):

--- a/fastai/widgets/class_confusion.py
+++ b/fastai/widgets/class_confusion.py
@@ -1,5 +1,6 @@
 import math
 import pandas as pd
+import matplotlib as plt
 from tqdm import tqdm
 
 from itertools import permutations

--- a/fastai/widgets/class_confusion.py
+++ b/fastai/widgets/class_confusion.py
@@ -1,6 +1,6 @@
 import math
 import pandas as pd
-import matplotlib as plt
+import matplotlib.pyplot as plt
 from tqdm import tqdm
 
 from itertools import permutations

--- a/fastai/widgets/class_confusion.py
+++ b/fastai/widgets/class_confusion.py
@@ -22,7 +22,7 @@ class ClassConfusion():
         self.is_ordered = is_ordered
         self.cut_off = cut_off
         self.figsize = figsize
-        self.vars = varlist
+        self.varlist = varlist
         self.classl = classlist
         self._show_losses(classlist)
         
@@ -38,7 +38,7 @@ class ClassConfusion():
             self._boxes = len(self.df_list)
             self._cols = math.ceil(math.sqrt(self._boxes))
             self._rows = math.ceil(self._boxes/self._cols)
-            self.tbnames = list(self.df_list[0].columns)[:-1]
+            self.tbnames = list(self.df_list[0].columns)[:-1] if self.varlist is None else self.varlist
         else:
             vals = self.interp.most_confused()
             self._ranges = []

--- a/fastai/widgets/class_confusion.py
+++ b/fastai/widgets/class_confusion.py
@@ -26,24 +26,23 @@ class ClassLosses():
     
 
     
-    def _create_tabs(self, df_list:list, cat_names:list):
+    def _create_tabs(self):
         "Creates a tab for each variable"
-        self.boxes = len(df_list)
+        self.boxes = len(self.df_list)
         self.cols = math.ceil(math.sqrt(self.boxes))
         self.rows = math.ceil(self.boxes/self.cols)
         
-        df_list[0].columns = df_list[0].columns.get_level_values(0)
-        tbnames = list(df_list[0].columns)[:-1]
+        tbnames = list(self.df_list[0].columns)[:-1]
         items = [widgets.Output() for i, tab in enumerate(tbnames)]
         self.tbnames = tbnames
         self.tabs = widgets.Tab()
         self.tabs.children = items
         for i in range(len(items)):
             self.tabs.set_title(i, tbnames[i])
-        self._populate_tabs(self.classl)
+        self._populate_tabs()
         
       
-    def _populate_tabs(self, classl:list):
+    def _populate_tabs(self):
         "Adds relevant graphs to each tab"
         for i, tab in enumerate(self.tbnames):
             with self.tabs.children[i]:
@@ -52,7 +51,7 @@ class ClassLosses():
                 else:
                     fig, ax = plt.subplots(self.cols, self.rows, figsize=self.figsize)
                 fig.subplots_adjust(hspace=.5)
-                for j, x in enumerate(self.dfs):
+                for j, x in enumerate(self.df_list):
                     ttl = f'{"".join(x.columns[-1])} {tab} distribution'
                     title = ttl if j == 0 else f'Misclassified {ttl}'
 
@@ -109,15 +108,14 @@ class ClassLosses():
         self.tabs.children = items
         for i in range(len(items)):
             self.tabs.set_title(i, self.tbnames[i])
-        self.classl = classl
         for i, tab in enumerate(self.tbnames):
             with self.tabs.children[i]:
                 x = 0
-                if self.ranges[i] < self.k:
+                if self.ranges[i] < k:
                     cols = math.ceil(math.sqrt(self.ranges[i]))
                     rows = math.ceil(self.ranges[i]/cols)
                     
-                if self.ranges[i] or self.k < 4:
+                if self.ranges[i] < 4 or k < 4:
                     cols = 2
                     rows = 2
                 else:
@@ -127,7 +125,7 @@ class ClassLosses():
 
                 [axi.set_axis_off() for axi in ax.ravel()]
                 for j, idx in enumerate(self.tl_idx):
-                    if self.k < x+1 or x > self.ranges[i]:
+                    if k < x+1 or x > self.ranges[i]:
                         break
                     da, cl = self.interp.data.dl(self.interp.ds_type).dataset[idx]
                     row = (int)(x / cols)
@@ -201,7 +199,6 @@ class ClassLosses():
                 f[var] = f[var].apply(lambda x: float(x) * self.stds[var] + self.means[var])
             f[str(x)] = str(x)
             dfarr.append(f)
-        self.dfs = dfarr
+        self.df_list = dfarr
         self.cat_names = cat_names
-        self.classl = classl
-        self._create_tabs(dfarr, cat_names)
+        self._create_tabs()

--- a/fastai/widgets/class_confusion.py
+++ b/fastai/widgets/class_confusion.py
@@ -3,6 +3,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 from tqdm import tqdm
 from itertools import permutations
+from ..tabular import TabularDataBunch
 from ..train import ClassificationInterpretation
 import ipywidgets as widgets
 

--- a/fastai/widgets/class_confusion.py
+++ b/fastai/widgets/class_confusion.py
@@ -1,0 +1,226 @@
+import math
+import pandas as pd
+import matplotlib.pyplot as plt
+
+from itertools import permutations, combinations
+from fastai.train import ClassificationInterpretation
+import ipywidgets as widgets
+
+class ClassLosses():
+    
+    """Plot the most confused datapoints and statistics for your misses. 
+    \nPass in a `interp` object and a list of classes to look at. 
+    Optionally you can include an odered list in the form of [[class_1, class_2]],
+    \n a figure size, and a cut_off limit for the maximum categorical categories to use on a variable"""
+    def __init__(self, interp:ClassificationInterpretation, classlist:list, 
+               is_ordered:bool=False, cut_off:int=100, varlist:list=None,
+               figsize:tuple=(8,8)):
+        self.interp = interp
+        if str(type(interp.learn.data)) == "<class 'fastai.tabular.data.TabularDataBunch'>":
+            if interp.learn.data.train_ds.x.cont_names != []: 
+                for x in range(len(interp.learn.data.procs)):
+                      if "Normalize" in str(interp.learn.data.procs[x]):
+                            self.means = interp.learn.data.train_ds.x.processor[0].procs[x].means
+                            self.stds = interp.learn.data.train_ds.x.processor[0].procs[x].stds
+        self.is_ordered = is_ordered
+        self.cut_off = cut_off
+        self.figsize = figsize
+        self.vars = varlist
+        self.show_losses(classlist)
+    
+
+    
+    def create_tabs(self, df_list:list, cat_names:list):
+        self.cols = math.ceil(math.sqrt(len(df_list)))
+        self.rows = math.ceil(len(df_list)/self.cols)
+        self.boxes = len(df_list)
+        df_list[0].columns = df_list[0].columns.get_level_values(0)
+        tbnames = list(df_list[0].columns)
+        tbnames = tbnames[:-1]
+        items = [widgets.Output() for i, tab in enumerate(tbnames)]
+        self.tbnames = tbnames
+        self.tabs = widgets.Tab()
+        self.tabs.children = items
+        for i in range(len(items)):
+            self.tabs.set_title(i, tbnames[i])
+        self.populate_tabs(self.classl)
+      
+    def populate_tabs(self, classl:list):
+        for i, tab in enumerate(self.tbnames):
+            with self.tabs.children[i]:
+                if self.boxes is not None:
+                    fig, ax = plt.subplots(self.boxes, figsize=self.figsize)
+                    fig.subplots_adjust(hspace=.5)
+                else:
+                    fig, ax = plt.subplots(self.cols, self.rows, figsize=self.figsize)
+                    fig.subplots_adjust(hspace=.5)
+                for j, x in enumerate(self.dfs):
+                    if self.boxes is None:
+                        row = int(j / self.cols)
+                        col = j % row
+                    if tab in self.cat_names:
+                        vals = pd.value_counts(x[tab].values)
+                        ttl = str.join('', x.columns[-1])
+                        if j == 0:
+                            title = ttl + ' ' + tab + ' distribution'
+                        else:
+                            title = 'Misclassified ' + ttl + ' ' + tab + ' distribution'
+                        if self.boxes is not None:
+                            if vals.nunique() < 10:
+                                fig = vals.plot(kind='bar', title=title,  ax=ax[j], rot=0, width=.75)
+                            else:
+                                fig = vals.plot(kind='barh', title=title,  ax=ax[j], width=.75)   
+                        else:
+                            fig = vals.plot(kind='barh', title=title,  ax=ax[row, col], width=.75)
+                    else:
+                        vals = x[tab]
+                        ttl = str.join('', x.columns[-1])
+                        if j == 0:
+                            title = ttl + ' ' + tab + ' distribution'
+                        else:
+                            title = 'Misclassified ' + ttl + ' ' + tab + ' distrobution'
+                        if self.boxes is not None:
+                            axs = vals.plot(kind='hist', ax=ax[j], title=title, y='Frequency')
+                        else:
+                            axs = vals.plot(kind='hist', ax=ax[row, col], title=title, y='Frequency')
+                        axs.set_ylabel('Frequency')
+                        if len(set(vals)) > 1:
+                            vals.plot(kind='kde', ax=axs, title=title, secondary_y=True)
+                        else:
+                            print('Less than two unique values, cannot graph the KDE')
+                plt.show(fig)
+                plt.tight_layout
+        display(self.tabs)
+        
+    def show_losses(self, classl:list, **kwargs):
+        if str(type(self.interp.learn.data)) == "<class 'fastai.tabular.data.TabularDataBunch'>":
+            self.tab_losses(classl)
+        else:
+            self.im_losses(classl)
+
+    def im_losses(self, classl:list, **kwargs):
+        if self.is_ordered == True:
+            lis = classl
+        else: 
+            lis = list(permutations(classl, 2))
+        self.tl_val, self.tl_idx = self.interp.top_losses(len(self.interp.losses))
+        classes_gnd = self.interp.data.classes
+        vals = self.interp.most_confused()
+        ranges = []
+        tbnames = []
+        k = input('Please enter a value for `k`, or the top images you will see: ')
+        k = int(k)
+        self.k = k
+        for x in iter(vals):
+            for y in range(len(lis)):
+                if x[0:2] == lis[y]:
+                    ranges.append(x[2])
+                    tbnames.append(str(x[0] + ' | ' + x[1]))
+        items = [widgets.Output() for i, tab in enumerate(tbnames)]
+        self.tbnames = tbnames
+        self.tabs = widgets.Tab()
+        self.tabs.children = items
+        for i in range(len(items)):
+            self.tabs.set_title(i, tbnames[i])
+        self.ranges = ranges
+        self.classl = classl
+        for i, tab in enumerate(self.tbnames):
+            with self.tabs.children[i]:
+                x = 0
+                if self.ranges[i] < k:
+                    cols = math.ceil(math.sqrt(self.k))
+                    rows = math.ceil(self.ranges[i]/cols)
+                    fig, ax = plt.subplots(rows, cols, figsize=self.figsize)
+
+                if self.ranges[i] < 4:
+                    cols = 2
+                    rows = 2
+                    fig, ax = plt.subplots(rows, cols, figsize=self.figsize)
+                else:
+                    cols = math.ceil(math.sqrt(self.k))
+                    rows = math.ceil(self.k/cols)
+                    fig, ax = plt.subplots(rows, cols, figsize=self.figsize)
+
+                [axi.set_axis_off() for axi in ax.ravel()]
+                for j, idx in enumerate(self.tl_idx):
+                    if k < x+1 or x > self.ranges[i]:
+                        break
+                    da, cl = self.interp.data.dl(self.interp.ds_type).dataset[idx]
+                    row = (int)(x / cols)
+                    col = x % cols
+
+                    ix = int(cl)
+                    if str(cl) == tab.split(' ')[0] and str(classes_gnd[self.interp.pred_class[idx]]) == tab.split(' ')[2]:
+                        img, lbl = self.interp.data.valid_ds[idx]
+                        fn = self.interp.data.valid_ds.x.items[idx]
+                        fn = re.search('([^/*]+)_\d+.*$', str(fn)).group(0)
+                        img.show(ax=ax[row, col])
+                        ax[row,col].set_title(fn)
+                        x += 1
+                plt.show(fig)
+                plt.tight_layout()
+        display(self.tabs)
+
+    def tab_losses(self, classl:list, **kwargs):
+        tl_val, tl_idx = self.interp.top_losses(len(self.interp.losses))
+        classes = self.interp.data.classes
+        cat_names = self.interp.data.x.cat_names
+        cont_names = self.interp.data.x.cont_names
+        if self.is_ordered == False:
+            comb = list(permutations(classl,2))
+        else:
+            comb = classl
+
+        dfarr = []
+
+        arr = []
+        for i, idx in enumerate(tl_idx):
+            da, _ = self.interp.data.dl(self.interp.ds_type).dataset[idx]
+            res = ''
+            for c, n in zip(da.cats, da.names[:len(da.cats)]):
+                string = f'{da.classes[n][c]}'
+                if string == 'True' or string == 'False':
+                    string += ';'
+                    res += string
+
+                else:
+                    string = string[1:]
+                    res += string + ';'
+            for c, n in zip(da.conts, da.names[len(da.cats):]):
+                res += f'{c:.4f};'
+            arr.append(res)
+        f = pd.DataFrame([ x.split(';')[:-1] for x in arr], columns=da.names)
+        for i, var in enumerate(self.interp.data.cont_names):
+            f[var] = f[var].apply(lambda x: float(x) * self.stds[var] + self.means[var])
+        f['Original'] = 'Original'
+        dfarr.append(f)
+
+
+        for j, x in enumerate(comb):
+            arr = []
+            for i, idx in enumerate(tl_idx):
+                da, cl = self.interp.data.dl(self.interp.ds_type).dataset[idx]
+                cl = int(cl)
+
+                if classes[self.interp.pred_class[idx]] == comb[j][0] and classes[cl] == comb[j][1]:
+                    res = ''
+                    for c, n in zip(da.cats, da.names[:len(da.cats)]):
+                        string = f'{da.classes[n][c]}'
+                        if string == 'True' or string == 'False':
+                            string += ';'
+                            res += string
+                        else:
+                            string = string[1:]
+                            res += string + ';'
+                    for c, n in zip(da.conts, da.names[len(da.cats):]):
+                        res += f'{c:.4f};'
+                    arr.append(res)      
+            f = pd.DataFrame([ x.split(';')[:-1] for x in arr], columns=da.names)
+            for i, var in enumerate(self.interp.data.cont_names):
+                f[var] = f[var].apply(lambda x: float(x) * self.stds[var] + self.means[var])
+            f[str(x)] = str(x)
+            dfarr.append(f)
+        self.dfs = dfarr
+        self.cat_names = cat_names
+        self.classl = classl
+        self.create_tabs(dfarr, cat_names)

--- a/fastai/widgets/class_confusion.py
+++ b/fastai/widgets/class_confusion.py
@@ -6,7 +6,7 @@ from itertools import permutations
 from ..train import ClassificationInterpretation
 import ipywidgets as widgets
 
-class ClassLosses():
+class ClassConfusion():
     "Plot the most confused datapoints and statistics for the models misses." 
     def __init__(self, interp:ClassificationInterpretation, classlist:list, 
                is_ordered:bool=False, cut_off:int=100, varlist:list=None,

--- a/fastai/widgets/class_confusion.py
+++ b/fastai/widgets/class_confusion.py
@@ -7,7 +7,7 @@ from fastai.train import ClassificationInterpretation
 import ipywidgets as widgets
 
 class ClassLosses():
-    "Plot the most confused datapoints and statistics for your misses." 
+    "Plot the most confused datapoints and statistics for the models misses." 
     def __init__(self, interp:ClassificationInterpretation, classlist:list, 
                is_ordered:bool=False, cut_off:int=100, varlist:list=None,
                figsize:tuple=(8,8)):
@@ -44,7 +44,7 @@ class ClassLosses():
         
       
     def _populate_tabs(self, classl:list):
-        "Adds relevent graphs to each tab"
+        "Adds relevant graphs to each tab"
         for i, tab in enumerate(self.tbnames):
             with self.tabs.children[i]:
                 if self.boxes is not None:


### PR DESCRIPTION
ClassConfusion is a widget for further analyzing how both tabular and image models perform and operate, and to scientifically assess their behavior. For tabular models we analyze the trends in the outliers of the data, looking at the relative distributions between two confused classes and the original distribution. This let's us paint a picture to how our data is being used. If we are worried about how many unique names we have in a categorical dataset, `cut_off` is there to make sure we do not exceed our limit.

For images, we can pass in a set of classes and see what the worst-performing or most-confused images were, and we can also see their filenames if we want a quick deletion. I will be working on the documentation later tonight. But here are some images of the results. If we have an ordered set of pairs to look at, we adjust the `is_ordered` value to True on the constructor. 

![Tabular](https://user-images.githubusercontent.com/7831895/61332095-07b48380-a7e9-11e9-95aa-63c10c03f7db.png)
![Pets](https://user-images.githubusercontent.com/7831895/61332098-08e5b080-a7e9-11e9-9c72-8e3a199f4185.png)

Let me know what needs to be adjusted or changed.