### PR TITLE
Failed to export classes for TextClasDataBunch.from_ids

### DIFF
--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -158,6 +158,7 @@ class TextDataBunch(DataBunch):
         if not is1d(train_lbls): src.train.y.one_hot,src.valid.y.one_hot = True,True
         if test_ids is not None: src.add_test(TextList(test_ids, vocab, path=path), label=train_lbls[0])
         src.valid.x.processor = ifnone(processor, [TokenizeProcessor(), NumericalizeProcessor(vocab=vocab)])
+        src.valid.y.processor = ifnone(processor, [CategoryProcessor(src.valid.y)])
         return src.databunch(**kwargs)
 
     @classmethod

--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -158,7 +158,7 @@ class TextDataBunch(DataBunch):
         if not is1d(train_lbls): src.train.y.one_hot,src.valid.y.one_hot = True,True
         if test_ids is not None: src.add_test(TextList(test_ids, vocab, path=path), label=train_lbls[0])
         src.valid.x.processor = ifnone(processor, [TokenizeProcessor(), NumericalizeProcessor(vocab=vocab)])
-        src.valid.y.processor = ifnone(processor, [CategoryProcessor(src.valid.y)])
+        if classes is not None: src.valid.y.processor = ifnone(processor, [CategoryProcessor(src.valid.y)])
         return src.databunch(**kwargs)
 
     @classmethod

--- a/tests/test_text_data.py
+++ b/tests/test_text_data.py
@@ -188,14 +188,13 @@ def test_from_ids_works_for_variable_length_sentences():
 
 def test_from_ids_exports_classes():
     this_tests(TextClasDataBunch.from_ids)
-    ids = [np.array([0]),np.array([0,1])]*5 # notice diffrent number of elements in arrays
+    ids = [np.array([0])]*10
     lbl = [0]*10
     data = TextClasDataBunch.from_ids('/tmp', vocab=Vocab({0: BOS, 1:PAD}),
                                       train_ids=ids, train_lbls=lbl,
                                       valid_ids=ids, valid_lbls=lbl, classes={0:0}, bs=8)
     data.export('/tmp')
-    empty_data = TextClasDataBunch.load_empty('/tmp')
-    assert empty_data.classes is not None
+    TextClasDataBunch.load_empty('/tmp').classes
 
 def test_regression():
     this_tests('na')

--- a/tests/test_text_data.py
+++ b/tests/test_text_data.py
@@ -196,7 +196,7 @@ def test_from_ids_exports_classes():
                                       classes=['a', 'b', 'c'], bs=8)
     data.export('/tmp/export.pkl')
     empty_data = TextClasDataBunch.load_empty('/tmp')
-    assert hasattr(empty_data, 'classese')
+    assert hasattr(empty_data, 'classes')
     assert empty_data.classes == ['a', 'b', 'c'] 
 
 def test_regression():

--- a/tests/test_text_data.py
+++ b/tests/test_text_data.py
@@ -193,7 +193,7 @@ def test_from_ids_exports_classes():
     data = TextClasDataBunch.from_ids('/tmp', vocab=Vocab({0: BOS, 1:PAD}),
                                       train_ids=ids, train_lbls=lbl,
                                       valid_ids=ids, valid_lbls=lbl, classes={0:0}, bs=8)
-    data.export('/tmp')
+    data.export('/tmp/export.pkl')
     TextClasDataBunch.load_empty('/tmp').classes
 
 def test_regression():

--- a/tests/test_text_data.py
+++ b/tests/test_text_data.py
@@ -192,9 +192,12 @@ def test_from_ids_exports_classes():
     lbl = [0]*10
     data = TextClasDataBunch.from_ids('/tmp', vocab=Vocab({0: BOS, 1:PAD}),
                                       train_ids=ids, train_lbls=lbl,
-                                      valid_ids=ids, valid_lbls=lbl, classes={0:0}, bs=8)
+                                      valid_ids=ids, valid_lbls=lbl,
+                                      classes=['a', 'b', 'c'], bs=8)
     data.export('/tmp/export.pkl')
-    TextClasDataBunch.load_empty('/tmp').classes
+    empty_data = TextClasDataBunch.load_empty('/tmp')
+    assert hasattr(empty_data, 'classese')
+    assert empty_data.classes == ['a', 'b', 'c'] 
 
 def test_regression():
     this_tests('na')

--- a/tests/test_text_data.py
+++ b/tests/test_text_data.py
@@ -186,6 +186,17 @@ def test_from_ids_works_for_variable_length_sentences():
                                       train_ids=ids, train_lbls=lbl,
                                       valid_ids=ids, valid_lbls=lbl, classes={0:0}, bs=8)
 
+def test_from_ids_exports_classes():
+    this_tests(TextClasDataBunch.from_ids)
+    ids = [np.array([0]),np.array([0,1])]*5 # notice diffrent number of elements in arrays
+    lbl = [0]*10
+    data = TextClasDataBunch.from_ids('/tmp', vocab=Vocab({0: BOS, 1:PAD}),
+                                      train_ids=ids, train_lbls=lbl,
+                                      valid_ids=ids, valid_lbls=lbl, classes={0:0}, bs=8)
+    data.export('/tmp')
+    empty_data = TextClasDataBunch.load_empty('/tmp')
+    assert empty_data.classes is not None
+
 def test_regression():
     this_tests('na')
     path = untar_data(URLs.IMDB_SAMPLE)


### PR DESCRIPTION
TextClasDataBunch generated by `TextClasDataBunch.from_ids` has not set up the CategoryProcessor, so the info of classes get lost when export and load it again.

Let me know what needs to be adjusted or changed (My first pull request, so I assume there will a lot.).