### PR TITLE
Register `callback_fns` in `.get_preds()` if they haven't been registered previously.

### DIFF
--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -169,6 +169,7 @@ class Learner():
         self.callbacks = listify(self.callbacks)
         if self.silent is None: self.silent = defaults.silent
         self.callback_fns = [partial(Recorder, add_time=self.add_time, silent=self.silent)] + listify(self.callback_fns)
+        if defaults.extra_callbacks is not None: self.callbacks += defaults.extra_callbacks
 
     def init(self, init): apply_init(self.model, init)
 
@@ -196,7 +197,6 @@ class Learner():
         if not getattr(self, 'opt', False): self.create_opt(lr, wd)
         else: self.opt.lr,self.opt.wd = lr,wd
         callbacks = [cb(self) for cb in self.callback_fns + listify(defaults.extra_callback_fns)] + listify(callbacks)
-        if defaults.extra_callbacks is not None: callbacks += defaults.extra_callbacks
         fit(epochs, self, metrics=self.metrics, callbacks=self.callbacks+callbacks)
 
     def create_opt(self, lr:Floats, wd:Floats=0.)->None:

--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -159,6 +159,7 @@ class Learner():
     layer_groups:Collection[nn.Module]=None
     add_time:bool=True
     silent:bool=None
+    cb_fns_registered:bool=False
     def __post_init__(self)->None:
         "Setup path,metrics, callbacks and ensure model directory exists."
         self.path = Path(ifnone(self.path, self.data.path))
@@ -197,6 +198,7 @@ class Learner():
         if not getattr(self, 'opt', False): self.create_opt(lr, wd)
         else: self.opt.lr,self.opt.wd = lr,wd
         callbacks = [cb(self) for cb in self.callback_fns + listify(defaults.extra_callback_fns)] + listify(callbacks)
+        self.cb_fns_registered = True
         fit(epochs, self, metrics=self.metrics, callbacks=self.callbacks+callbacks)
 
     def create_opt(self, lr:Floats, wd:Floats=0.)->None:
@@ -333,6 +335,12 @@ class Learner():
         "Return predictions and targets on `ds_type` dataset."
         lf = self.loss_func if with_loss else None
         activ = ifnone(activ, _loss_func2activ(self.loss_func))
+        if not self.cb_fns_registered:
+            lr,wd = self.lr_range(defaults.lr),self.wd
+            if not getattr(self, 'opt', False): self.create_opt(lr, wd)
+            else: self.opt.lr,self.opt.wd = lr,wd
+            self.callbacks = [cb(self) for cb in self.callback_fns + listify(defaults.extra_callback_fns)] + listify(self.callbacks)
+            self.cb_fns_registered = True
         return get_preds(self.model, self.dl(ds_type), cb_handler=CallbackHandler(self.callbacks),
                          activ=activ, loss_func=lf, n_batch=n_batch, pbar=pbar)
 


### PR DESCRIPTION
defaults.extra_callbacks should be registered in __post_init__
in order to allow using them with Learner without training.

This is to address [this issue](https://github.com/fastai/fastai/issues/2235). It is only a small part of the problem. With this small fix, all existing tests pass.

When I tried to move registering other `callback_fns` to `__post_init__`, some problems arose, that I discussed [here](https://forums.fast.ai/t/moving-registering-callback-fns-with-learner-from-fit-to-post-init/50946).