### PR TITLE
variable `do_blur` unused when creating `UnetBlock` in DynamicUnet Module

### DIFF
--- a/fastai/vision/models/unet.py
+++ b/fastai/vision/models/unet.py
@@ -56,7 +56,7 @@ class DynamicUnet(SequentialEx):
             up_in_c, x_in_c = int(x.shape[1]), int(sfs_szs[idx][1])
             do_blur = blur and (not_final or blur_final)
             sa = self_attention and (i==len(sfs_idxs)-3)
-            unet_block = UnetBlock(up_in_c, x_in_c, self.sfs[i], final_div=not_final, blur=blur, self_attention=sa,
+            unet_block = UnetBlock(up_in_c, x_in_c, self.sfs[i], final_div=not_final, blur=do_blur, self_attention=sa,
                                    **kwargs).eval()
             layers.append(unet_block)
             x = unet_block(x)


### PR DESCRIPTION
In the `DynamicUnet` Class, while creating the decoder part of the unet network, we created a `do_blur` variable that checks if we want to apply the blur (via the `blur` parameter) and also, if the layer is a final layer or not, but it is **not used** in instantiating the `UnetBlock`, and instead, the `blur' parameter is used !