### PR TITLE
Update train.py

### DIFF
--- a/fastai/train.py
+++ b/fastai/train.py
@@ -3,6 +3,8 @@ from .torch_core import *
 from .callbacks import *
 from .basic_data import *
 from .basic_train import *
+from PIL import ImageFile
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 __all__ = ['BnFreeze', 'GradientClipping', 'ShowGraph', 'Interpretation', 'ClassificationInterpretation', 'MultiLabelClassificationInterpretation',
  'fit_one_cycle', 'lr_find', 'one_cycle_scheduler', 'to_fp16', 'to_fp32', 'mixup', 'AccumulateScheduler']


### PR DESCRIPTION
There was an error raised by the function fit_one_cycle which is OSError: Image file is truncated after creating a custom dataset using Google. The problem wasn't solved by verify_images or using LOAD_TRUNCATED_IMAGES from PIL library in jupyter notebook.
![Screenshot (390)](https://user-images.githubusercontent.com/34787227/61990859-dd26be00-b065-11e9-8bc4-ebd8e580c74e.png)
![Screenshot (391)](https://user-images.githubusercontent.com/34787227/61990860-de57eb00-b065-11e9-9bdc-440a66b0c131.png)
