### PR TITLE
Allow to override defaults of special case in Tokenizer with an empty list.

### DIFF
--- a/fastai/text/transform.py
+++ b/fastai/text/transform.py
@@ -91,7 +91,7 @@ class Tokenizer():
         self.tok_func,self.lang,self.special_cases = tok_func,lang,special_cases
         self.pre_rules  = ifnone(pre_rules,  defaults.text_pre_rules )
         self.post_rules = ifnone(post_rules, defaults.text_post_rules)
-        self.special_cases = special_cases if special_cases else defaults.text_spec_tok
+        self.special_cases = special_cases if special_cases is not None else defaults.text_spec_tok
         self.n_cpus = ifnone(n_cpus, defaults.cpus)
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Following : https://forums.fast.ai/t/tokenizer-with-no-special-cases/51627

At the moment calling `Tokenizer(special_cases=[])` will create a Tokenizer whose `special_cases` attribute will be overriden by defaults, this PR changes that by using default only if special_cases is set to `None` (its default value).