### PR TITLE
heatmap by default is False

### DIFF
--- a/docs_src/vision.learner.ipynb
+++ b/docs_src/vision.learner.ipynb
@@ -560,7 +560,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `k` items are arranged as a square, so it will look best if `k` is a square number (4, 9, 16, etc). The title of each image shows: prediction, actual, loss, probability of actual class. When `heatmap` is True (by default it's True) , Grad-CAM heatmaps (http://openaccess.thecvf.com/content_ICCV_2017/papers/Selvaraju_Grad-CAM_Visual_Explanations_ICCV_2017_paper.pdf) are overlaid on each image. `plot_top_losses` should be used with single-labeled datasets. See `plot_multi_top_losses` below for a version capable of handling multi-labeled datasets."
+    "The `k` items are arranged as a square, so it will look best if `k` is a square number (4, 9, 16, etc). The title of each image shows: prediction, actual, loss, probability of actual class. When `heatmap` is True (by default it's False) , Grad-CAM heatmaps (http://openaccess.thecvf.com/content_ICCV_2017/papers/Selvaraju_Grad-CAM_Visual_Explanations_ICCV_2017_paper.pdf) are overlaid on each image. `plot_top_losses` should be used with single-labeled datasets. See `plot_multi_top_losses` below for a version capable of handling multi-labeled datasets."
    ]
   },
   {


### PR DESCRIPTION
Latest version of `plot_top_losses` has default value of `heatmap` will be `False` (see https://github.com/fastai/fastai/commit/9370be5c20c3e669ab08ce8d29b4aea1352decb1)

Note: prior to the above commit, default is `None` which will means value of `heatmap` will depend on `_test_cnn(self.learn.model)`
