### PR TITLE
Enable followlinks on os.walk for recursive walk

### DIFF
--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -28,11 +28,11 @@ def _get_files(parent, p, f, extensions):
     return res
 
 def get_files(path:PathOrStr, extensions:Collection[str]=None, recurse:bool=False,
-              include:Optional[Collection[str]]=None, presort:bool=False)->FilePathList:
+              include:Optional[Collection[str]]=None, presort:bool=False, followlinks:bool=False)->FilePathList:
     "Return list of files in `path` that have a suffix in `extensions`; optionally `recurse`."
     if recurse:
         res = []
-        for i,(p,d,f) in enumerate(os.walk(path, followlinks=True)):
+        for i,(p,d,f) in enumerate(os.walk(path, followlinks=followlinks)):
             # skip hidden dirs
             if include is not None and i==0:  d[:] = [o for o in d if o in include]
             else:                             d[:] = [o for o in d if not o.startswith('.')]

--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -32,7 +32,7 @@ def get_files(path:PathOrStr, extensions:Collection[str]=None, recurse:bool=Fals
     "Return list of files in `path` that have a suffix in `extensions`; optionally `recurse`."
     if recurse:
         res = []
-        for i,(p,d,f) in enumerate(os.walk(path)):
+        for i,(p,d,f) in enumerate(os.walk(path, followlinks=True)):
             # skip hidden dirs
             if include is not None and i==0:  d[:] = [o for o in d if o in include]
             else:                             d[:] = [o for o in d if not o.startswith('.')]


### PR DESCRIPTION
I am loading several ImageDataBunch.from_folder having the same validation set, but experimenting with different training sets.
In order not to have to copy-paste the validation images to each dataset, I have created a symlink (ln -s ../valid ./valid) in each dataset, pointing to the common validation set, but fastai did not use this folder without having set the followlinks param to true.