### PR TITLE
ImageSegment save fix

### DIFF
--- a/fastai/vision/image.py
+++ b/fastai/vision/image.py
@@ -241,6 +241,11 @@ class ImageSegment(Image):
                         interpolation='nearest', alpha=alpha, vmin=0, **kwargs)
         if title: ax.set_title(title)
 
+    def save(self, fn:PathOrStr):
+        "Save the mask to `fn`."
+        x = image2np(self.data).astype(np.uint8)
+        PIL.Image.fromarray(x).save(fn)
+
     def reconstruct(self, t:Tensor): return ImageSegment(t)
 
 class ImagePoints(Image):

--- a/fastai/vision/image.py
+++ b/fastai/vision/image.py
@@ -242,7 +242,7 @@ class ImageSegment(Image):
         if title: ax.set_title(title)
 
     def save(self, fn:PathOrStr):
-        "Save the mask to `fn`."
+        "Save the image segment to `fn`."
         x = image2np(self.data).astype(np.uint8)
         PIL.Image.fromarray(x).save(fn)
 


### PR DESCRIPTION
Issue discussed on the Fast AI Forums: https://forums.fast.ai/t/imagesegment-save-method-saves-masks-incorrectly/52459/2

This fix allows the saving of masks properly. Since the current `ImageSegment` `save()` method is inherited from `Image`.