### PR TITLE
Fix missing embedding in tensorboard callback

### DIFF
--- a/fastai/callbacks/tensorboard.py
+++ b/fastai/callbacks/tensorboard.py
@@ -78,6 +78,12 @@ class LearnerTensorboardWriter(LearnerCallback):
             scalar_value = last_metrics[i]
             self._write_scalar(name=name, scalar_value=scalar_value, iteration=iteration)
 
+    def _write_embedding(self, iteration:int)->None:
+        "Writes embedding to Tensorboard."
+        for name, emb in self.learn.model.named_children():
+            if isinstance(emb, nn.Embedding):
+                self.tbwriter.add_embedding(list(emb.parameters())[0], global_step=iteration, tag=name)
+
     def on_train_begin(self, **kwargs: Any) -> None:
         self.graph_writer.write(model=self.learn.model, tbwriter=self.tbwriter,
                                 input_to_model=next(iter(self.learn.data.dl(DatasetType.Single)))[0])
@@ -99,6 +105,7 @@ class LearnerTensorboardWriter(LearnerCallback):
     def on_epoch_end(self, last_metrics:MetricsList, iteration:int, **kwargs)->None:
         "Callback function that writes epoch end appropriate data to Tensorboard."
         self._write_metrics(iteration=iteration, last_metrics=last_metrics)
+        self._write_embedding(iteration=iteration)
 
 # TODO:  We're overriding almost everything here.  Seems like a good idea to question that ("is a" vs "has a")
 class GANTensorboardWriter(LearnerTensorboardWriter):


### PR DESCRIPTION
I've discussed in the forum (https://forums.fast.ai/t/tensorboard-integration/38023/12) 

Embedding is missing from LearnerTensorboardWriter Callback.
Can I add a few lines of code to LearnerTensorboardWriter.on_epoch_end ?

And I've made a test in (https://github.com/gnoparus/fastai_dev/blob/master/dev/42_tensorboard_callback_embedding.ipynb) but because it's tensorboard I don't know how to do assert. 

Before patch you run notebook there is no projector tab in tensorboard, after apply patch you can run notebook to see the projector tab appear.