### PR TITLE
fix for dice

### DIFF
--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -55,10 +55,12 @@ def dice(input:Tensor, targs:Tensor, iou:bool=False, eps:float=1e-8)->Rank0Tenso
     n = targs.shape[0]
     input = input.argmax(dim=1).view(n,-1)
     targs = targs.view(n,-1)
-    intersect = (input * targs).sum().float()
-    union = (input+targs).sum().float()
-    if not iou: return (2. * intersect / union if union > 0 else union.new([1.]).squeeze())
-    else: return (intersect / (union-intersect+eps) if union > 0 else union.new([1.]).squeeze())
+    intersect = (input * targs).sum(dim=1).float()
+    union = (input+targs).sum(dim=1).float()
+    if not iou: l = 2. * intersect / union
+    else: l = intersect / (union-intersect+eps)
+    l[union == 0.] = 1.
+    return l.mean()
 
 def psnr(input:Tensor, targs:Tensor)->Rank0Tensor:
     return 10 * (1. / mean_squared_error(input, targs)).log10()

--- a/fastai/test_registry.json
+++ b/fastai/test_registry.json
@@ -233,7 +233,7 @@
     "fastai.callback.AverageMetric": [
         {
             "file": "tests/test_metrics.py",
-            "line": 213,
+            "line": 232,
             "test": "test_average_metric_naming"
         }
     ],
@@ -769,12 +769,12 @@
     "fastai.metrics.dice": [
         {
             "file": "tests/test_metrics.py",
-            "line": 108,
+            "line": 127,
             "test": "test_dice"
         },
         {
             "file": "tests/test_metrics.py",
-            "line": 118,
+            "line": 137,
             "test": "test_dice_iou"
         }
     ],
@@ -805,14 +805,14 @@
     "fastai.metrics.explained_variance": [
         {
             "file": "tests/test_metrics.py",
-            "line": 174,
+            "line": 193,
             "test": "test_explained_variance"
         }
     ],
     "fastai.metrics.fbeta": [
         {
             "file": "tests/test_metrics.py",
-            "line": 126,
+            "line": 145,
             "test": "test_fbeta"
         }
     ],
@@ -826,35 +826,35 @@
     "fastai.metrics.mean_absolute_error": [
         {
             "file": "tests/test_metrics.py",
-            "line": 135,
+            "line": 154,
             "test": "test_mae"
         }
     ],
     "fastai.metrics.mean_squared_error": [
         {
             "file": "tests/test_metrics.py",
-            "line": 144,
+            "line": 163,
             "test": "test_mse"
         }
     ],
     "fastai.metrics.mean_squared_logarithmic_error": [
         {
             "file": "tests/test_metrics.py",
-            "line": 163,
+            "line": 182,
             "test": "test_msle"
         }
     ],
     "fastai.metrics.r2_score": [
         {
             "file": "tests/test_metrics.py",
-            "line": 185,
+            "line": 204,
             "test": "test_r2_score"
         }
     ],
     "fastai.metrics.root_mean_squared_error": [
         {
             "file": "tests/test_metrics.py",
-            "line": 153,
+            "line": 172,
             "test": "test_rmse"
         }
     ],

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -104,6 +104,25 @@ def test_accuracy_thresh():
     (p2, t2, 0.4),
     (torch.zeros(5,2,5), torch.eye(5,5), 1/3),
     (torch.zeros(5,2,5), torch.zeros(5,5), 0),
+    (tensor([[[[1., 1.],
+               [1., 1.]],
+              [[0., 0.],
+               [0., 0.]]],
+             [[[1., 1.],
+               [1., 1.]],
+              [[1., 0.],
+               [0., 0.]]],
+             [[[1., 1.],
+               [1., 1.]],
+              [[0., 0.],
+               [1., 0.]]]]),
+     tensor([[[[0, 0],
+               [0, 0]]],
+             [[[0, 0],
+               [0, 1]]],
+             [[[0, 0],
+               [1, 0]]]]),
+     2/3)
 ])
 def test_dice(p, t, expect):
     this_tests(dice)
@@ -112,7 +131,7 @@ def test_dice(p, t, expect):
 @pytest.mark.parametrize("p, t, expect, atol", [
     (p2, t2, 0.25, 0.),
     (p3, t3, 1.0, 0.),
-    (p2, torch.eye(5,5), 0.111, 1e-3),
+    (p2, torch.eye(5,5), 0.200, 1e-3),
     (p2, torch.zeros(5,5), 0, 0.),
 ])
 def test_dice_iou(p, t, expect, atol):


### PR DESCRIPTION
This should compute dice batch-wise and then return the mean. I believe the previous implementation was computing dice over the entire batch. I found this while trying to use fastai for the pneumothorax kaggle challenge. 

The added test for dice should fail for the previous implementation and work the new one. 