### PR TITLE
DOC: add from fastai.vision import * to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 The fastai library simplifies training fast and accurate neural nets using modern best practices. See the [fastai website](https://docs.fast.ai) to get started. The library is based on research into deep learning best practices undertaken at [fast.ai](http://www.fast.ai), and includes \"out of the box\" support for [`vision`](https://docs.fast.ai/vision.html#vision), [`text`](https://docs.fast.ai/text.html#text), [`tabular`](https://docs.fast.ai/tabular.html#tabular), and [`collab`](https://docs.fast.ai/collab.html#collab) (collaborative filtering) models. For brief examples, see the [examples](https://github.com/fastai/fastai/tree/master/examples) folder; detailed examples are provided in the full [documentation](https://docs.fast.ai/). For instance, here's how to train an MNIST model using [resnet18](https://arxiv.org/abs/1512.03385) (from the [vision example](https://github.com/fastai/fastai/blob/master/examples/vision.ipynb)):
 
 ```python
+from fastai.vision import *
 path = untar_data(MNIST_PATH)
 data = image_data_from_folder(path)
 learn = cnn_learner(data, models.resnet18, metrics=accuracy)


### PR DESCRIPTION
As I am first time visitor of https://docs.fast.ai/index.html

I quickly installed the package using the conda example (https://docs.fast.ai/index.html#Installation-and-updating)

I then wanted to try the example at the top. I had to look at https://github.com/fastai/fastai/blob/master/examples/vision.ipynb

to get the line ```from fastai.vision import * ```.

Added this line before the example will help newbies run an example by only looking at the README
