### PR TITLE
OverSamplingCallback not working on inference time

### DIFF
--- a/fastai/callbacks/oversampling.py
+++ b/fastai/callbacks/oversampling.py
@@ -16,7 +16,7 @@ class OverSamplingCallback(LearnerCallback):
     def on_train_begin(self, **kwargs):
         self.labels = self.learn.data.train_dl.dataset.y.items
         _, counts = np.unique(self.labels,return_counts=True)
-        self.weights = (torch.DoubleTensor((1/counts)[self.labels]) if weights is None)
+        if self.weights is None: self.weights = torch.DoubleTensor((1/counts)[self.labels]) 
         self.label_counts = np.bincount([self.learn.data.train_dl.dataset.y[i].data for i in range(len(self.learn.data.train_dl.dataset))])
         self.total_len_oversample = int(self.learn.data.c*np.max(self.label_counts))
         self.learn.data.train_dl.dl.batch_sampler = BatchSampler(WeightedRandomSampler(self.weights,self.total_len_oversample), self.learn.data.train_dl.batch_size,False)

--- a/fastai/callbacks/oversampling.py
+++ b/fastai/callbacks/oversampling.py
@@ -11,12 +11,12 @@ __all__ = ['OverSamplingCallback']
 class OverSamplingCallback(LearnerCallback):
     def __init__(self,learn:Learner,weights:torch.Tensor=None):
         super().__init__(learn)
+        self.weights = weights
+
+    def on_train_begin(self, **kwargs):
         self.labels = self.learn.data.train_dl.dataset.y.items
         _, counts = np.unique(self.labels,return_counts=True)
-        self.weights = (weights if weights is not None else
-                        torch.DoubleTensor((1/counts)[self.labels]))
+        self.weights = (torch.DoubleTensor((1/counts)[self.labels]) if weights is None)
         self.label_counts = np.bincount([self.learn.data.train_dl.dataset.y[i].data for i in range(len(self.learn.data.train_dl.dataset))])
         self.total_len_oversample = int(self.learn.data.c*np.max(self.label_counts))
-        
-    def on_train_begin(self, **kwargs):
         self.learn.data.train_dl.dl.batch_sampler = BatchSampler(WeightedRandomSampler(self.weights,self.total_len_oversample), self.learn.data.train_dl.batch_size,False)


### PR DESCRIPTION
The OverSamplingCallback initializes the weights inside the constructor using train data.
On inference time it crashes when there is only test data available.

Gist with inference crash before fix;
https://gist.github.com/mmauri/eb538d330f0cd7dad6881c4fde4eef00#file-test_oversamplingcallback_inference-ipynb

Gist after fix:
https://gist.github.com/mmauri/0ae954b0ab09d0314e5042e48bf14280