### PR TITLE
Include ability to log more items that were not in training set

### DIFF
--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -692,7 +692,7 @@ class LabelList(Dataset):
         if state.get('normalize', False): res.normalize = state['normalize']
         return res
 
-    def process(self, xp:PreProcessor=None, yp:PreProcessor=None, name:str=None):
+    def process(self, xp:PreProcessor=None, yp:PreProcessor=None, name:str=None, max_warn_items:int=5):
         "Launch the processing on `self.x` and `self.y` with `xp` and `yp`."
         self.y.process(yp)
         if getattr(self.y, 'filter_missing_y', False):
@@ -704,8 +704,8 @@ class LabelList(Dataset):
                 for p in self.y.processor:
                     if len(getattr(p, 'warns', [])) > 0:
                         warnings = list(set(p.warns))
-                        self.warn += ', '.join(warnings[:5])
-                        if len(warnings) > 5: self.warn += "..."
+                        self.warn += ', '.join(warnings[:max_warn_items])
+                        if len(warnings) > max_warn_items: self.warn += "..."
                     p.warns = []
                 self.x,self.y = self.x[~filt],self.y[~filt]
         self.x.process(xp)


### PR DESCRIPTION
Log more (or fewer) items when warning about labels not existing in the training set, but existing in the validation set.