### PR TITLE
Adding VGG11 and VGG13 with batch normalization

### DIFF
--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -37,7 +37,7 @@ model_meta = {
 
     models.densenet121:{**_densenet_meta}, models.densenet169:{**_densenet_meta},
     models.densenet201:{**_densenet_meta}, models.densenet161:{**_densenet_meta},
-    models.vgg16_bn:{**_vgg_meta}, models.vgg19_bn:{**_vgg_meta},
+    models.vgg11_bn:{**_vgg_meta}, models.vgg13_bn:{**_vgg_meta}, models.vgg16_bn:{**_vgg_meta}, models.vgg19_bn:{**_vgg_meta},
     models.alexnet:{**_alexnet_meta}}
 
 def cnn_config(arch):

--- a/fastai/vision/models/__init__.py
+++ b/fastai/vision/models/__init__.py
@@ -2,7 +2,7 @@ from .xresnet import *
 from torchvision.models import ResNet,resnet18,resnet34,resnet50,resnet101,resnet152
 from torchvision.models import SqueezeNet,squeezenet1_0,squeezenet1_1
 from torchvision.models import densenet121,densenet169,densenet201,densenet161
-from torchvision.models import vgg16_bn,vgg19_bn,alexnet
+from torchvision.models import vgg11_bn,vgg13_bn,vgg16_bn,vgg19_bn,alexnet
 from .darknet import *
 from .unet import *
 from .wrn import *

--- a/fastai/vision/models/__init__.py
+++ b/fastai/vision/models/__init__.py
@@ -7,3 +7,4 @@ from .darknet import *
 from .unet import *
 from .wrn import *
 from .xception import *
+from .efficientnet import *

--- a/fastai/vision/models/__init__.py
+++ b/fastai/vision/models/__init__.py
@@ -7,4 +7,3 @@ from .darknet import *
 from .unet import *
 from .wrn import *
 from .xception import *
-from .efficientnet import *


### PR DESCRIPTION
I noticed that fast ai currently has VGG16 and VGG19 with batch normalization. Why not complete the family of VGG neural networks with the addition of VGG11 and VGG13?