### PR TITLE
added flush and fsync to on_epoch_end()

### DIFF
--- a/fastai/callbacks/csv_logger.py
+++ b/fastai/callbacks/csv_logger.py
@@ -37,6 +37,8 @@ class CSVLogger(LearnerCallback):
         if self.add_time: stats.append(format_time(time() - self.start_epoch))
         str_stats = ','.join(stats)
         self.file.write(str_stats + '\n')
+        self.file.flush()
+        os.fsync(self.file.fileno())
 
     def on_train_end(self, **kwargs: Any) -> None:  
         "Close the file."


### PR DESCRIPTION
CSVLogger writes (closes) the log file at the end of training (on_train_end()). To get frequent updates on the training status, I've added file.flush() and os.fsync() to on_epoch_end() as discussed on the CSVLogger thread  https://forums.fast.ai/t/csv-logger-callback/26971/19 .