### PR TITLE
Bug Fix: `plot_top_losses`

### DIFF
--- a/fastai/tabular/models.py
+++ b/fastai/tabular/models.py
@@ -48,7 +48,7 @@ def _cl_int_from_learner(cls, learn:Learner, ds_type=DatasetType.Valid, activ:nn
     preds = learn.get_preds(ds_type=ds_type, activ=activ, with_loss=True)
     return cls(learn, *preds, ds_type=ds_type)
 
-def _cl_int_plot_top_losses(self, k, largest:bool=True, return_table:bool=False)->Optional[plt.Figure]:
+def _cl_int_plot_tab_top_losses(self, k, largest:bool=True, return_table:bool=False)->Optional[plt.Figure]:
     "Generates a dataframe of 'top_losses' along with their prediction, actual, loss, and probability of the actual class."
     tl_val, tl_idx = self.top_losses(k, largest)
     classes = self.data.classes
@@ -73,7 +73,7 @@ def _cl_int_plot_top_losses(self, k, largest:bool=True, return_table:bool=False)
 
 
 ClassificationInterpretation.from_learner = _cl_int_from_learner
-ClassificationInterpretation.plot_top_losses = _cl_int_plot_top_losses
+ClassificationInterpretation.plot_tab_top_losses = _cl_int_plot_tab_top_losses
 
 def _learner_interpret(learn:Learner, ds_type:DatasetType = DatasetType.Valid):
     "Create a 'ClassificationInterpretation' object from 'learner' on 'ds_type'."


### PR DESCRIPTION
There was a bug happening where since they had the same name, tabular plot_top_losses was taking priority to vision's plot_top_losses. To adjust for this I mimicked how it is for the `plot_multi_top_losses` and just renamed the function to `plot_tab_top_losses`. I had originally thought that this would not have been an issue at the time of making the original PR but since they all have the same super interp class I think the functions were at conflict of which to use sometimes. This resolves the issue by just including a third plot option for tabular.

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
