### PR TITLE
fix image filename bug

### DIFF
--- a/fastai/widgets/class_confusion.py
+++ b/fastai/widgets/class_confusion.py
@@ -6,6 +6,7 @@ from itertools import permutations
 from ..tabular.data import TabularDataBunch
 from ..train import ClassificationInterpretation
 import ipywidgets as widgets
+from pathlib import Path
 
 class ClassConfusion():
     "Plot the most confused datapoints and statistics for the models misses." 
@@ -128,7 +129,7 @@ class ClassConfusion():
             if str(cl) == tab.split(' ')[0] and str(classes_gnd[self.interp.pred_class[idx]]) == tab.split(' ')[2]:
                 img, lbl = self.interp.data.valid_ds[idx]
                 fn = self.interp.data.valid_ds.x.items[idx]
-                fn = re.search('([^/*]+)_\d+.*$', str(fn)).group(0)
+                fn = Path(fn).name
                 img.show(ax=ax[row, col])
                 ax[row,col].set_title(fn)
                 x += 1


### PR DESCRIPTION
use pathlib instead of regex

`ClassConfusion(interp, data.classes, is_ordered=False, figsize=(10,10))`

Running this line gives the following error message:

---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
~/anaconda3/envs/fastai/lib/python3.7/site-packages/fastai/widgets/class_confusion.py in _populate_tabs(self)
     64             for i, tab in enumerate(self.tbnames):
     65                 with self.tabs.children[i]:
---> 66                     self._plot_tab(tab) if self._is_tab else self._plot_imgs(tab, i)
     67                 pbar.update(1)
     68         display(self.tabs)

~/anaconda3/envs/fastai/lib/python3.7/site-packages/fastai/widgets/class_confusion.py in _plot_imgs(self, tab, i, **kwargs)
    130                 img, lbl = self.interp.data.valid_ds[idx]
    131                 fn = self.interp.data.valid_ds.x.items[idx]
--> 132                 fn = re.search('([^/*]+)_\d+.*$', str(fn)).group(0)
    133                 img.show(ax=ax[row, col])
    134                 ax[row,col].set_title(fn)

AttributeError: 'NoneType' object has no attribute 'group'