### PR TITLE
Add fix_ds to fix missing attribute error

### DIFF
--- a/fastai/basic_data.py
+++ b/fastai/basic_data.py
@@ -192,7 +192,7 @@ class DataBunch():
             ys = [self.train_ds.y.reconstruct(grab_idx(y, i), x=x) for i,x in enumerate(xs)]
         else : ys = [self.train_ds.y.reconstruct(grab_idx(y, i)) for i in range(n_items)]
         self.train_ds.x.show_xys(xs, ys, **kwargs)
- 
+
     def export(self, file:PathLikeOrBinaryStream='export.pkl'):
         "Export the minimal state of `self` for inference in `self.path/file`. `file` can be file-like (file or buffer)"
         xtra = dict(normalize=self.norm.keywords) if getattr(self, 'norm', False) else {}
@@ -205,6 +205,8 @@ class DataBunch():
 
     @property
     def train_ds(self)->Dataset: return self._grab_dataset(self.train_dl)
+    @property
+    def fix_ds(self)->Dataset: return self._grab_dataset(self.fix_dl)
     @property
     def valid_ds(self)->Dataset: return self._grab_dataset(self.valid_dl)
     @property
@@ -225,10 +227,10 @@ class DataBunch():
 
     @property
     def is_empty(self)->bool:
-        return not ((self.train_dl and len(self.train_ds.items) != 0) or 
-                    (self.valid_dl and len(self.valid_ds.items) != 0) or 
+        return not ((self.train_dl and len(self.train_ds.items) != 0) or
+                    (self.valid_dl and len(self.valid_ds.items) != 0) or
                     (self.test_dl  and len(self.test_ds.items)  != 0))
-    
+
     @property
     def batch_size(self):   return self.train_dl.batch_size
     @batch_size.setter

--- a/fastai/test_registry.json
+++ b/fastai/test_registry.json
@@ -14,14 +14,14 @@
         },
         {
             "file": "tests/test_basic_data.py",
-            "line": 44,
+            "line": 45,
             "test": "test_DataBunch_no_valid_dl"
         }
     ],
     "fastai.basic_data.DataBunch.one_batch": [
         {
             "file": "tests/test_basic_data.py",
-            "line": 58,
+            "line": 60,
             "test": "test_DataBunch_onebatch"
         },
         {
@@ -41,28 +41,28 @@
         },
         {
             "file": "tests/test_basic_data.py",
-            "line": 83,
+            "line": 85,
             "test": "test_DataBunch_save_load"
         }
     ],
     "fastai.basic_data.DataBunch.one_item": [
         {
             "file": "tests/test_basic_data.py",
-            "line": 67,
+            "line": 69,
             "test": "test_DataBunch_oneitem"
         }
     ],
     "fastai.basic_data.DataBunch.save": [
         {
             "file": "tests/test_basic_data.py",
-            "line": 83,
+            "line": 85,
             "test": "test_DataBunch_save_load"
         }
     ],
     "fastai.basic_data.DataBunch.show_batch": [
         {
             "file": "tests/test_basic_data.py",
-            "line": 75,
+            "line": 77,
             "test": "test_DataBunch_show_batch"
         }
     ],
@@ -81,7 +81,7 @@
         },
         {
             "file": "tests/test_basic_data.py",
-            "line": 83,
+            "line": 85,
             "test": "test_DataBunch_save_load"
         }
     ],

--- a/tests/test_basic_data.py
+++ b/tests/test_basic_data.py
@@ -38,6 +38,7 @@ def test_DataBunch_Create():
     assert 4 == len(data.dls)
     assert 3 == len(data.train_dl)
     assert 18 == len(data.train_ds)
+    assert 18 == len(data.fix_ds)
     assert 2 == len(data.valid_dl)
     assert 9 == len(data.valid_ds)
 
@@ -52,6 +53,7 @@ def test_DataBunch_no_valid_dl():
     assert 3 == len(data.dls)
     assert 3 == len(data.train_dl)
     assert 18 == len(data.train_ds)
+    assert 18 == len(data.fix_ds)
     assert None == data.valid_dl
 
 ## TO DO (?)ideally, call one_batch with type dataloader


### PR DESCRIPTION
Previously, `interp = learn_cln.interpret(DatasetType.Fix)` would throw an attribute error, saying that fix_ds does not exist.  This is important when looking at top_losses or plot_confusion_matrix.
 `learn_cln.interpret(DatasetType.Train)` gives a ClassificationInterpretation which is not meaningful because of the lack of ordering in DatasetType.Train.  This change allows users to meaningfully interpret the training dataset.  