### PR TITLE
Inconsistency in comment spacing on line 6 fixed

### DIFF
--- a/docs/js/customscripts.js
+++ b/docs/js/customscripts.js
@@ -3,7 +3,7 @@ $('#mysidebar').height($(".nav").height());
 
 $( document ).ready(function() {
 
-    //this script says, if the height of the viewport is greater than 800px, then insert affix class, which makes the nav bar float in a fixed
+    // this script says, if the height of the viewport is greater than 800px, then insert affix class, which makes the nav bar float in a fixed
     // position as your scroll. if you have a lot of nav items, this height may not work for you.
     var h = $(window).height();
     //console.log (h);


### PR DESCRIPTION
There was a lack of space between the comment tag the actual comment, which is inconsistent with the rest of the file, so I fixed it.

<!-- If you are adding new functionality, please first create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality. Generally it's best to discuss changes to functionality there first, so we can all agree on an approach. Please include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together! When creating your PR, please remove all the text in this template, and add details about your PR. -->
