### PR TITLE
Use UTF-8 for notebooks even on Windows

### DIFF
--- a/fastai/gen_doc/gen_notebooks.py
+++ b/fastai/gen_doc/gen_notebooks.py
@@ -85,7 +85,7 @@ def execute_nb(fname, metadata=None, save=True, show_doc_only=False):
     metadata = metadata or {}
     ep.preprocess(nb, metadata)
     if save:
-        with open(fname, 'wt') as f: nbformat.write(nb, f)
+        with open(fname, 'wt', encoding='utf-8') as f: nbformat.write(nb, f)
         NotebookNotary().sign(nb)
 
 def _symbol_skeleton(name): return [get_doc_cell(name), get_md_cell(f"`{name}`")]


### PR DESCRIPTION
```cmd
python.exe tools\build-docs --update-nb-links docs_src\widgets.image_cleaner.ipynb
```
results in
```
Updating notebook docs_src\widgets.image_cleaner.ipynb. Please wait...
Traceback (most recent call last):
  File ".\tools\build-docs", line 57, in <module>
    update_notebooks(file, **vars(args))
  File "D:\Projects\fastai\fastai\gen_doc\gen_notebooks.py", line 326, in update_notebooks
    execute_nb(doc_path, {'metadata': {'path': doc_path.parent}}, show_doc_only=True)
  File "D:\Projects\fastai\fastai\gen_doc\gen_notebooks.py", line 88, in execute_nb
    with open(fname, 'wt') as f: nbformat.write(nb, f)
  File "C:\Users\user\Miniconda3\envs\test\lib\site-packages\nbformat\__init__.py", line 169, in write
    fp.write(s)
  File "C:\Users\user\Miniconda3\envs\test\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\u2192' in position 25299: character maps to <undefined>
```

`\u2192` is an arrow in:
```
<code>download_google_images</code>(**`path`**:`PathOrStr`, ...) → `FilePathList`
```