### PR TITLE
Expose tfm_y argument in load_learner

### DIFF
--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -608,13 +608,13 @@ def load_callback(class_func, state, learn:Learner):
     for k,v in others.items(): setattr(res, k, v)
     return res
 
-def load_learner(path:PathOrStr, file:PathLikeOrBinaryStream='export.pkl', test:ItemList=None, **db_kwargs):
+def load_learner(path:PathOrStr, file:PathLikeOrBinaryStream='export.pkl', test:ItemList=None, tfm_y=None, **db_kwargs):
     "Load a `Learner` object saved with `export_state` in `path/file` with empty data, optionally add `test` and load on `cpu`. `file` can be file-like (file or buffer)"
     source = Path(path)/file if is_pathlike(file) else file
     state = torch.load(source, map_location='cpu') if defaults.device == torch.device('cpu') else torch.load(source)
     model = state.pop('model')
     src = LabelLists.load_state(path, state.pop('data'))
-    if test is not None: src.add_test(test)
+    if test is not None: src.add_test(test, tfm_y=tfm_y)
     data = src.databunch(**db_kwargs)
     cb_state = state.pop('cb_state')
     clas_func = state.pop('cls')


### PR DESCRIPTION
As discussed [here](https://forums.fast.ai/t/inference-using-load-learner/38694/28?u=joshvarty) currently there is no way to specify `tfm_y` when loading a learner with `load_learner()`. This can cause an exception when the learner tries to apply transforms against an `EmptyLabel`.

When loading an exported learner, we want callers to be able to choose whether or not to apply transforms against y.

