### PR TITLE
Update mnist stats

### DIFF
--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -76,7 +76,7 @@ def normalize_funcs(mean:FloatTensor, std:FloatTensor, do_x:bool=True, do_y:bool
 
 cifar_stats = ([0.491, 0.482, 0.447], [0.247, 0.243, 0.261])
 imagenet_stats = ([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])
-mnist_stats = ([0.15]*3, [0.15]*3)
+mnist_stats = ([0.131], [0.308])
 
 def channel_view(x:Tensor)->Tensor:
     "Make channel the first axis of `x` and flatten remaining axes"


### PR DESCRIPTION
Updates MNIST stats as discussed on [forum](https://forums.fast.ai/t/mnist-stats-look-wrong/55407/4). I've also changed them to be 1D as otherwise they broadcast 1 channel images up to 3 channel. I put up the [notebook ](https://nbviewer.jupyter.org/gist/thomasbrandon/2e8e365086ed20cef655dac11cd8c365) with the code to calculate which shows the issue with broadcasting.
