### PR TITLE
Fix AttributeError in ImageCleaner (duplicates=False case)

### DIFF
--- a/fastai/test_registry.json
+++ b/fastai/test_registry.json
@@ -1898,14 +1898,14 @@
         },
         {
             "file": "tests/test_widgets_image_cleaner.py",
-            "line": 36,
+            "line": 37,
             "test": "test_image_cleaner_with_data_from_csv"
         }
     ],
     "fastai.widgets.image_downloader.ImageDownloader": [
         {
             "file": "tests/test_widgets_image_cleaner.py",
-            "line": 44,
+            "line": 45,
             "test": "test_image_downloader_with_path"
         }
     ]

--- a/fastai/widgets/image_cleaner.py
+++ b/fastai/widgets/image_cleaner.py
@@ -167,7 +167,7 @@ class BasicImageWidget(ABC):
     def create_image_list(self, fns_idxs:Collection[int], drop_batch_on_nonfile=False) -> Iterator[ImgData]:
         "Create a list of images, filenames and labels but first removing files that are not supposed to be displayed."
         items = self._dataset.x.items
-        idxs = ((i for i in fns_idxs if items[i].is_file())
+        idxs = ((i for i in fns_idxs if Path(items[i]).is_file())
                 if not drop_batch_on_nonfile
                 else chain.from_iterable(c for c in chunks(fns_idxs, self.batch_size)
                                            if all(Path(items[i]).is_file() for i in c)))

--- a/tests/test_widgets_image_cleaner.py
+++ b/tests/test_widgets_image_cleaner.py
@@ -33,13 +33,14 @@ def test_image_cleaner_wrong_input_type(data):
     n = len(data.valid_ds)
     ImageCleaner(data, np.arange(n), path)
 
-def test_image_cleaner_with_data_from_csv():
+@pytest.mark.parametrize('duplicates', [True, False])
+def test_image_cleaner_with_data_from_csv(duplicates: bool):
     this_tests(ImageCleaner)
     path = untar_data(URLs.MNIST_TINY)
     data_from_csv = ImageList.from_csv(path, csv_name='labels.csv').split_none().label_from_df().transform(get_transforms(), size=224).databunch()
     learn_cln = cnn_learner(data_from_csv, models.resnet34, metrics=error_rate)
     ds, idxs = DatasetFormatter().from_similars(learn_cln)
-    ImageCleaner(ds, idxs, path=path, duplicates=True)
+    ImageCleaner(ds, idxs, path=path, duplicates=duplicates)
 
 def test_image_downloader_with_path():
     this_tests(ImageDownloader)


### PR DESCRIPTION
When refactoring `ImageCleaner` (https://github.com/fastai/fastai/pull/2335), I removed `Path(items[i])` conversions, since in cases I checked, `items[i]` was already a `Path`, and conversion seemed superfluous. Turns out it's not: https://github.com/fastai/fastai/issues/2344.

https://github.com/fastai/fastai/pull/2347 fixed duplicates finder, this PR fixes plain `ImageCleaner`.