### PR TITLE
Adding collab_learner and from_df to this_tests

### DIFF
--- a/tests/test_collab_train.py
+++ b/tests/test_collab_train.py
@@ -14,5 +14,5 @@ def learn():
     return learn
 
 def test_val_loss(learn):
-    this_tests(learn.validate)
+    this_tests(learn.validate, CollabDataBunch.from_df, collab_learner)
     assert learn.validate()[0] < 0.8


### PR DESCRIPTION
I noticed these weren't showing up in the test doc links [here](https://docs.fast.ai/collab.html#CollabLearner). So this is just supposed to expose that link.
