### PR TITLE
Fix for Issue 2359: Update core Imports to Prevent pytest Warning

### DIFF
--- a/fastai/imports/core.py
+++ b/fastai/imports/core.py
@@ -6,7 +6,8 @@ import mimetypes, inspect, typing, functools, importlib, weakref
 import html, re, requests, tarfile, numbers, tempfile, bz2
 
 from abc import abstractmethod, abstractproperty
-from collections import abc,  Counter, defaultdict, Iterable, namedtuple, OrderedDict
+from collections import Counter, defaultdict, namedtuple, OrderedDict
+from collections.abc import Iterable
 import concurrent
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from copy import copy, deepcopy


### PR DESCRIPTION
Updated core imports so Iterable is imported from collections.abc. Removed superfluous abc import

