### PR TITLE
add_datepart function to accept multiple field names to work on 

### DIFF
--- a/old/fastai/structured.py
+++ b/old/fastai/structured.py
@@ -67,13 +67,13 @@ def get_sample(df,n):
     idxs = sorted(np.random.permutation(len(df))[:n])
     return df.iloc[idxs].copy()
 
-def add_datepart(df, fldname, drop=True, time=False, errors="raise"):	
+def add_datepart(df, fldnames, drop=True, time=False, errors="raise"):	
     """add_datepart converts a column of df from a datetime64 to many columns containing
     the information from the date. This applies changes inplace.
     Parameters:
     -----------
     df: A pandas data frame. df gain several new columns.
-    fldname: A string that is the name of the date column you wish to expand.
+    fldname: A string or list of strings that is the name of the date column you wish to expand.
         If it is not a datetime64 series, it will be converted to one with pd.to_datetime.
     drop: If true then the original date column will be removed.
     time: If true time features: Hour, Minute, Second will be added.
@@ -91,21 +91,35 @@ def add_datepart(df, fldname, drop=True, time=False, errors="raise"):
     0   2000  3      10    11   5          71         False         False           False           False             False        False          952732800
     1   2000  3      10    12   6          72         False         False           False           False             False        False          952819200
     2   2000  3      11    13   0          73         False         False           False           False             False        False          952905600
+    >>>df2 = pd.DataFrame({'start_date' : pd.to_datetime(['3/11/2000','3/13/2000','3/15/2000']),
+                            'end_date':pd.to_datetime(['3/17/2000','3/18/2000','4/1/2000'],infer_datetime_format=True)})
+    >>>df2
+        start_date	end_date    
+    0	2000-03-11	2000-03-17
+    1	2000-03-13	2000-03-18
+    2	2000-03-15	2000-04-01
+    >>>add_datepart(df2,['start_date','end_date'])
+    >>>df2
+    	start_Year	start_Month	start_Week	start_Day	start_Dayofweek	start_Dayofyear	start_Is_month_end	start_Is_month_start	start_Is_quarter_end	start_Is_quarter_start	start_Is_year_end	start_Is_year_start	start_Elapsed	end_Year	end_Month	end_Week	end_Day	end_Dayofweek	end_Dayofyear	end_Is_month_end	end_Is_month_start	end_Is_quarter_end	end_Is_quarter_start	end_Is_year_end	end_Is_year_start	end_Elapsed
+    0	2000	    3	        10	        11	        5	            71	            False	            False	                False	                False	                False	            False	            952732800	    2000	    3	        11	        17	    4	            77	            False	            False	            False	            False	                False	        False	            953251200
+    1	2000	    3	        11	        13	        0	            73	            False	            False	                False	                False               	False           	False           	952905600     	2000       	3	        11      	18  	5           	78          	False	            False           	False           	False               	False          	False           	953337600
+    2	2000	    3	        11	        15	        2           	75          	False           	False               	False               	False               	False               False           	953078400      	2000    	4          	13      	1   	5           	92          	False           	True            	False           	True                	False          	False           	954547200
     """
-    fld = df[fldname]
-    fld_dtype = fld.dtype
-    if isinstance(fld_dtype, pd.core.dtypes.dtypes.DatetimeTZDtype):
-        fld_dtype = np.datetime64
+    for fldname in fldnames:
+        fld = df[fldname]
+        fld_dtype = fld.dtype
+        if isinstance(fld_dtype, pd.core.dtypes.dtypes.DatetimeTZDtype):
+            fld_dtype = np.datetime64
 
-    if not np.issubdtype(fld_dtype, np.datetime64):
-        df[fldname] = fld = pd.to_datetime(fld, infer_datetime_format=True, errors=errors)
-    targ_pre = re.sub('[Dd]ate$', '', fldname)
-    attr = ['Year', 'Month', 'Week', 'Day', 'Dayofweek', 'Dayofyear',
-            'Is_month_end', 'Is_month_start', 'Is_quarter_end', 'Is_quarter_start', 'Is_year_end', 'Is_year_start']
-    if time: attr = attr + ['Hour', 'Minute', 'Second']
-    for n in attr: df[targ_pre + n] = getattr(fld.dt, n.lower())
-    df[targ_pre + 'Elapsed'] = fld.astype(np.int64) // 10 ** 9
-    if drop: df.drop(fldname, axis=1, inplace=True)
+        if not np.issubdtype(fld_dtype, np.datetime64):
+            df[fldname] = fld = pd.to_datetime(fld, infer_datetime_format=True, errors=errors)
+        targ_pre = re.sub('[Dd]ate$', '', fldname)
+        attr = ['Year', 'Month', 'Week', 'Day', 'Dayofweek', 'Dayofyear',
+                'Is_month_end', 'Is_month_start', 'Is_quarter_end', 'Is_quarter_start', 'Is_year_end', 'Is_year_start']
+        if time: attr = attr + ['Hour', 'Minute', 'Second']
+        for n in attr: df[targ_pre + n] = getattr(fld.dt, n.lower())
+        df[targ_pre + 'Elapsed'] = fld.astype(np.int64) // 10 ** 9
+        if drop: df.drop(fldname, axis=1, inplace=True)
 
 def is_date(x): return np.issubdtype(x.dtype, np.datetime64)
 

--- a/old/fastai/structured.py
+++ b/old/fastai/structured.py
@@ -105,6 +105,8 @@ def add_datepart(df, fldnames, drop=True, time=False, errors="raise"):
     1	2000	    3	        11	        13	        0	            73	            False	            False	                False	                False               	False           	False           	952905600     	2000       	3	        11      	18  	5           	78          	False	            False           	False           	False               	False          	False           	953337600
     2	2000	    3	        11	        15	        2           	75          	False           	False               	False               	False               	False               False           	953078400      	2000    	4          	13      	1   	5           	92          	False           	True            	False           	True                	False          	False           	954547200
     """
+    if isinstance(fldnames,str): 
+        fldnames = [fldnames]
     for fldname in fldnames:
         fld = df[fldname]
         fld_dtype = fld.dtype


### PR DESCRIPTION
Functionality to accept multiple field names to which the add_datepart function can be applied.

**Before :**
The add_datepart function was able to accept only one field name(a single string) on which it could perform the function .

**After:**
Now the add_datepart function can accept a single string or a list of strings (field names)  from which it could extract different datetime information.

