### PR TITLE
Add activ to pred_batch

### DIFF
--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -338,16 +338,18 @@ class Learner():
         return get_preds(self.model, self.dl(ds_type), cb_handler=CallbackHandler(callbacks),
                          activ=activ, loss_func=lf, n_batch=n_batch, pbar=pbar)
 
-    def pred_batch(self, ds_type:DatasetType=DatasetType.Valid, batch:Tuple=None, reconstruct:bool=False, with_dropout:bool=False) -> List[Tensor]:
+    def pred_batch(self, ds_type:DatasetType=DatasetType.Valid, batch:Tuple=None, reconstruct:bool=False,
+                   with_dropout:bool=False, activ:nn.Module=None) -> List[Tensor]:
         "Return output of the model on one batch from `ds_type` dataset."
         if batch is not None: xb,yb = batch
         else: xb,yb = self.data.one_batch(ds_type, detach=False, denorm=False)
         cb_handler = CallbackHandler(self.callbacks)
         xb,yb = cb_handler.on_batch_begin(xb,yb, train=False)
+        activ = ifnone(activ, _loss_func2activ(self.loss_func))
         with torch.no_grad():
             if not with_dropout: preds = loss_batch(self.model.eval(), xb, yb, cb_handler=cb_handler)
             else: preds = loss_batch(self.model.eval().apply(self.apply_dropout), xb, yb, cb_handler=cb_handler)
-            res = _loss_func2activ(self.loss_func)(preds[0])
+            res = activ(preds[0])
         if not reconstruct: return res
         res = res.detach().cpu()
         ds = self.dl(ds_type).dataset
@@ -585,7 +587,7 @@ class Recorder(LearnerCallback):
             values = self._split_list_val(values, skip_start, skip_end)
             ax.plot(val_iter, values)
             ax.set_ylabel(str(self.metrics_names[i]))
-            ax.set_xlabel('Batches processed')             
+            ax.set_xlabel('Batches processed')
         if ifnone(return_fig, defaults.return_fig): return fig
         if not IN_NOTEBOOK: plot_sixel(fig)
 


### PR DESCRIPTION
Added `activ` parameter in case we want a custom activation instead of the [predefined one from the loss function.](https://github.com/fastai/fastai/blob/85dca5af46e62c48f9574d79d3de46b409707453/fastai/basic_train.py#L350).