### PR TITLE
added apply_tfms to EmptyLabel

### DIFF
--- a/fastai/core.py
+++ b/fastai/core.py
@@ -303,6 +303,7 @@ class EmptyLabel(ItemBase):
     def __init__(self): self.obj,self.data = 0,0
     def __str__(self):  return ''
     def __hash__(self): return hash(str(self))
+    def apply_tfms(self, tfms:Collection, **kwargs): return self
 
 class Category(ItemBase):
     "Basic class for single classification labels."


### PR DESCRIPTION
This PR aims to fix applying transforms to `EmptyLabelLists`.
```
from fastai import *
from fastai.datasets import *
from fastai.vision import *

path = untar_data(URLs.MNIST)

bs=64

src = (ImageImageList.from_folder(path)
       .split_by_folder('training', 'testing')
       .label_from_func(lambda x: x)
       .add_test_folder(path)
       .transform(get_transforms(), tfm_y=True)
       .databunch(bs=bs).normalize(imagenet_stats, do_y=True)
      )
```
this code fails because it tries to apply transforms to the labels that are `EmptyLabelLists`. My solution is probably not the best way to solve this. @sgugger  probably a more elegant solution would be to modify `transform` method from `LabelList` or the `_check_kwargs`.