### PR TITLE
Use barrier synchronization before torch.load() in distributed training mode. 

### DIFF
--- a/fastai/basic_data.py
+++ b/fastai/basic_data.py
@@ -277,6 +277,7 @@ def load_data(path:PathOrStr, file:PathLikeOrBinaryStream='data_save.pkl', bs:in
               no_check:bool=False, **kwargs)->DataBunch:
     "Load a saved `DataBunch` from `path/file`. `file` can be file-like (file or buffer)"
     source = Path(path)/file if is_pathlike(file) else file
+    distrib_barrier()
     ll = torch.load(source, map_location='cpu') if defaults.device == torch.device('cpu') else torch.load(source)
     return ll.databunch(path=path, bs=bs, val_bs=val_bs, num_workers=num_workers, dl_tfms=dl_tfms, device=device,
                         collate_fn=collate_fn, no_check=no_check, **kwargs)

--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -264,6 +264,7 @@ class Learner():
         if device is None: device = self.data.device
         elif isinstance(device, int): device = torch.device('cuda', device)
         source = self.path/self.model_dir/f'{file}.pth' if is_pathlike(file) else file
+        distrib_barrier()
         state = torch.load(source, map_location=device)
         if set(state.keys()) == {'model', 'opt'}:
             model_state = state['model']

--- a/fastai/callbacks/tracker.py
+++ b/fastai/callbacks/tracker.py
@@ -101,7 +101,7 @@ class SaveModelCallback(TrackerCallback):
 
     def on_train_end(self, **kwargs):
         "Load the best model."
-        if self.every=="improvement" and (self.learn.path/f'{self.learn.model_dir}/{self.name}.pth').is_file():
+        if self.every=="improvement":
             self.learn.load(f'{self.name}', purge=False)
 
 class ReduceLROnPlateauCallback(TrackerCallback):

--- a/fastai/text/learner.py
+++ b/fastai/text/learner.py
@@ -67,6 +67,7 @@ class RNNLearner(Learner):
         encoder = get_model(self.model)[0]
         if device is None: device = self.data.device
         if hasattr(encoder, 'module'): encoder = encoder.module
+        distrib_barrier()
         encoder.load_state_dict(torch.load(self.path/self.model_dir/f'{name}.pth', map_location=device))
         self.freeze()
         return self

--- a/fastai/torch_core.py
+++ b/fastai/torch_core.py
@@ -406,6 +406,10 @@ def rank_distrib():
     "Return the distributed rank of this process (if applicable)."
     return int(os.environ.get('RANK', 0))
 
+def distrib_barrier():
+    "Barrier synchronization in distributed training (if applicable).  Processes in the same process group must all arrive here before proceeding further. Example use case: avoid processes stepping on each other when saving and loading models in distributed training.  See https://pytorch.org/tutorials/intermediate/ddp_tutorial.html#save-and-load-checkpoints."
+    if num_distrib() > 1: torch.distributed.barrier()
+    
 def add_metrics(last_metrics:Collection[Rank0Tensor], mets:Union[Rank0Tensor, Collection[Rank0Tensor]]):
     "Return a dictionary for updating `last_metrics` with `mets`."
     last_metrics,mets = listify(last_metrics),listify(mets)


### PR DESCRIPTION
 Use barrier synchronization to avoid processes loading model or data file before it was written completely by the master process, when in distributed training mode.

**History**
First noticed spurious load() error when converting the lesson3-camvid Jupyter notebook to run in distributed mode in one go.  Then found discussion on SaveModelCallback error here: https://forums.fast.ai/t/to-distributed-with-savemodelcallback/41384

Experimented a fix and discussed it with @sgugger:

 https://forums.fast.ai/t/race-conditions-in-savemodelcallback-when-in-distributed-training-mode/57504

The gist to simulate the error and test the fix: https://gist.github.com/philtrade/e0ecbfd33eed7dad80642318e806a90f

**Fix**
Introduce ```fastai.torch_core.distrib_barrier()``` convenience routine.  Insert it in front of torch.load() in ```basic_data.load_data(), basic_train.load(), and text.learner.load_encoder()```.

In ```callbacks.tracker.SaveModelCallback.on_train_end()```, the ```is_file()``` check may not work: when the master process is lagging behind other processes (speed skew) noticeably, the check risks skipping over the entire load().  With barrier synchronization in place, this check can be omitted.
