### PR TITLE
Fix typo in docs `StopAfterNBatches`

### DIFF
--- a/docs_src/callbacks.misc.ipynb
+++ b/docs_src/callbacks.misc.ipynb
@@ -79,7 +79,7 @@
     "from fastai.callbacks.misc import StopAfterNBatches\n",
     "[...]\n",
     "learn = cnn_learner([...])\n",
-    "learn.callbacks.append(StopAfterNBatches(learn, n_batches=2))\n",
+    "learn.callbacks.append(StopAfterNBatches(n_batches=2))\n",
     "learn.fit_one_cycle(3, max_lr=1e-2)\n",
     "```\n",
     "and it'll either fit into the existing memory or it'll immediately fail with OOM error. You may want to add [ipyexperiments](https://github.com/stas00/ipyexperiments/) to show you the memory usage, including the peak usage.\n",


### PR DESCRIPTION
The callback does not take `Learner` as an argument to the constructor.