### PR TITLE
Fix typos for the whole page of data_block.ipynb

### DIFF
--- a/docs_src/data_block.ipynb
+++ b/docs_src/data_block.ipynb
@@ -965,7 +965,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The basic class to get your inputs into is the following one. It's also the same class that will contain all of your labels (hence the name [`ItemList`](/data_block.html#ItemList))."
+    "The basic class to get your inputs is the following one. It's also the same class that will contain all of your labels (hence the name [`ItemList`](/data_block.html#ItemList))."
    ]
   },
   {
@@ -1283,7 +1283,7 @@
     "\n",
     "Since all random operations use the loaded order of the dataset as the starting point, you will not be able to replicate any random operations, say randomly splitting the data into 80% train, and 20% validation, even while correctly seeding.\n",
     "\n",
-    "The solution is to use `presort=True` in the `.from_folder()` method. As can be seen below, with that argument turned on, the file return in ascending order, and this behavior will match across machines and across platforms. Now you can reproduce any random operation you perfrom on the loaded data."
+    "The solution is to use `presort=True` in the `.from_folder()` method. As can be seen below, with that argument turned on, the file is returned in ascending order, and this behavior will match across machines and across platforms. Now you can reproduce any random operation you perform on the loaded data."
    ]
   },
   {
@@ -1313,7 +1313,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "How does such output above is generated?\n",
+    "How is the output above generated?\n",
     "\n",
     "behind the scenes, executing `itemlist` calls [`ItemList.__repr__`](/data_block.html#ItemList.__repr__) which basically prints out `itemlist[0]` to `itemlist[4]`"
    ]
@@ -1482,7 +1482,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Dataframe has 2 columns. The first column is the path to the image and the second column contains label id for that image. In case you have multi-labels (i.e more than one label for a single image), you will have a space(as determined by `label_delim` argument of `label_from_df`) seperated string in the labels column.\n",
+    "Dataframe has 2 columns. The first column is the path to the image and the second column contains label id for that image. In case you have multi-labels (i.e more than one label for a single image), you will have a space (as determined by `label_delim` argument of `label_from_df`) seperated string in the labels column.\n",
     "\n",
     "`from_df` and `from_csv` can be used in a more general way. In cases you are not able to figure out how to get your ImageList, it is very easy to make a csv file with the above format.\n",
     "\n",
@@ -2541,7 +2541,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you will see below, `copy_new` allows use to borrow any argument and its value from `itemlist1`, and `itemlist1.new(itemlist1.items)` allows us to use `items` and arguments inside `copy_new` to create another [`ItemList`](/data_block.html#ItemList) by calling [`ItemList.__init__`](/data_block.html#ItemList.__init__)."
+    "As you will see below, `copy_new` allows us to borrow any argument and its value from `itemlist1`, and `itemlist1.new(itemlist1.items)` allows us to use `items` and arguments inside `copy_new` to create another [`ItemList`](/data_block.html#ItemList) by calling [`ItemList.__init__`](/data_block.html#ItemList.__init__)."
    ]
   },
   {
@@ -4465,7 +4465,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It will store list of labels in `items` belonging to `classes`. If `None` are passed, `classes` will be determined by the unique different labels. `sep` is used to split the content of `items` in a list of tags.\n",
+    "It will store a list of labels in `items` belonging to `classes`. If `None` are passed, `classes` will be determined by the different unique labels. `sep` is used to split the content of `items` in a list of tags.\n",
     "\n",
     "If `one_hot=True`, the items contain the labels one-hot encoded. In this case, it is mandatory to pass a list of `classes` (as we can't use the different labels)."
    ]
@@ -5834,7 +5834,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Even when there is just an [`ImageList`](/vision.data.html#ImageList) from a traning set folder with no split needed, we still must do `split_none()` in order to create an [`ItemLists`](/data_block.html#ItemLists), and only then we can do `ItemLists.label_from_folder()` nicely."
+    "Even when there is just an [`ImageList`](/vision.data.html#ImageList) from a training set folder with no split needed, we still must do `split_none()` in order to create an [`ItemLists`](/data_block.html#ItemLists), and only then we can do `ItemLists.label_from_folder()` nicely."
    ]
   },
   {
@@ -6195,7 +6195,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Behind the scenes, `LabelLists.get_processors()` first puts `train.x._processor` classes and `train.y._processor` classes into separate lists, and then instantiates those processors and put them into `xp` and `yp`."
+    "Behind the scenes, `LabelLists.get_processors()` first puts `train.x._processor` classes and `train.y._processor` classes into separate lists, and then instantiates those processors and puts them into `xp` and `yp`."
    ]
   },
   {
@@ -6409,7 +6409,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To to more precise, this function returns list of FilePath objects using files in `path` that must have a suffix in `extensions`, and hidden folders and files are ignored. If `recurse=True`, all files in subfolders will be applied; `include` is used to select particular folders to apply.\n",
+    "To be more precise, this function returns a list of FilePath objects using files in `path` that must have a suffix in `extensions`, and hidden folders and files are ignored. If `recurse=True`, all files in subfolders will be applied; `include` is used to select particular folders to apply.\n",
     "\n",
     "Inside [`get_files`](/data_block.html#get_files), there is [`_get_files`](/data_block.html#_get_files) which turns all filenames inside `f` from directory `parent/p` into a list of FilePath objects. All filenames must have a suffix in `extensions`. All hidden files are ignored."
    ]


### PR DESCRIPTION
Fix multiple typos for ```data_block.ipynb```.
