### PR TITLE
Fix type hints in text.learner, text.models 

### DIFF
--- a/fastai/callbacks/rnn.py
+++ b/fastai/callbacks/rnn.py
@@ -16,7 +16,7 @@ class RNNTrainer(LearnerCallback):
         "Reset the hidden state of the model."
         self.learn.model.reset()
 
-    def on_loss_begin(self, last_output:Tuple[Tensor,Tensor,Tensor], **kwargs):
+    def on_loss_begin(self, last_output:Tuple[Tensor,Sequence[Tensor],Sequence[Tensor]], **kwargs):
         "Save the extra outputs for later and only returns the true output."
         self.raw_out,self.out = last_output[1],last_output[2]
         return {'last_output': last_output[0]}

--- a/fastai/text/learner.py
+++ b/fastai/text/learner.py
@@ -93,7 +93,7 @@ class RNNLearner(Learner):
             sampler = [i for i in self.dl(ds_type).sampler]
             reverse_sampler = np.argsort(sampler)
             preds = [p[reverse_sampler] for p in preds]
-        return(preds)
+        return preds
 
 def decode_spec_tokens(tokens):
     new_toks,rule,arg = [],None,None
@@ -220,7 +220,7 @@ def language_model_learner(data:DataBunch, arch, config:dict=None, drop_mult:flo
         learn.freeze()
     return learn
 
-def masked_concat_pool(outputs, mask):
+def masked_concat_pool(outputs:List[Tensor], mask:Tensor)->Tensor:
     "Pool MultiBatchEncoder outputs into one vector [last_hidden, max_pool, avg_pool]."
     output = outputs[-1]
     avg_pool = output.masked_fill(mask[:, :, None], 0).mean(dim=1)
@@ -250,14 +250,16 @@ class MultiBatchEncoder(Module):
     def __init__(self, bptt:int, max_len:int, module:nn.Module, pad_idx:int=1):
         self.max_len,self.bptt,self.module,self.pad_idx = max_len,bptt,module,pad_idx
 
-    def concat(self, arrs:Collection[Tensor])->Tensor:
+    def concat(self, arrs:Sequence[Sequence[Tensor]])->List[Tensor]:
         "Concatenate the `arrs` along the batch dimension."
+        # arrs - outer list: sequence dimension, inner: encoder layers
+        # returned value: list of complete tensors, elements correspond to encoder layers
         return [torch.cat([l[si] for l in arrs], dim=1) for si in range_of(arrs[0])]
 
     def reset(self):
         if hasattr(self.module, 'reset'): self.module.reset()
 
-    def forward(self, input:LongTensor)->Tuple[Tensor,Tensor]:
+    def forward(self, input:LongTensor)->Tuple[List[Tensor],List[Tensor],Tensor]:
         bs,sl = input.size()
         self.reset()
         raw_outputs,outputs,masks = [],[],[]

--- a/fastai/text/learner.py
+++ b/fastai/text/learner.py
@@ -220,7 +220,7 @@ def language_model_learner(data:DataBunch, arch, config:dict=None, drop_mult:flo
         learn.freeze()
     return learn
 
-def masked_concat_pool(outputs:List[Tensor], mask:Tensor)->Tensor:
+def masked_concat_pool(outputs:Sequence[Tensor], mask:Tensor)->Tensor:
     "Pool MultiBatchEncoder outputs into one vector [last_hidden, max_pool, avg_pool]."
     output = outputs[-1]
     avg_pool = output.masked_fill(mask[:, :, None], 0).mean(dim=1)

--- a/fastai/text/learner.py
+++ b/fastai/text/learner.py
@@ -252,8 +252,6 @@ class MultiBatchEncoder(Module):
 
     def concat(self, arrs:Sequence[Sequence[Tensor]])->List[Tensor]:
         "Concatenate the `arrs` along the batch dimension."
-        # arrs - outer list: sequence dimension, inner: encoder layers
-        # returned value: list of complete tensors, elements correspond to encoder layers
         return [torch.cat([l[si] for l in arrs], dim=1) for si in range_of(arrs[0])]
 
     def reset(self):

--- a/fastai/text/models/awd_lstm.py
+++ b/fastai/text/models/awd_lstm.py
@@ -100,7 +100,7 @@ class AWD_LSTM(Module):
         self.input_dp = RNNDropout(input_p)
         self.hidden_dps = nn.ModuleList([RNNDropout(hidden_p) for l in range(n_layers)])
 
-    def forward(self, input:Tensor, from_embeddings:bool=False)->Tuple[Tensor,Tensor]:
+    def forward(self, input:Tensor, from_embeddings:bool=False)->Tuple[List[Tensor],List[Tensor]]:
         if from_embeddings: bs,sl,es = input.size()
         else: bs,sl = input.size()
         if bs!=self.bs:
@@ -156,12 +156,12 @@ class SequentialRNN(nn.Sequential):
         for c in self.children():
             if hasattr(c, 'reset'): c.reset()
 
-def awd_lstm_lm_split(model:nn.Module) -> List[nn.Module]:
+def awd_lstm_lm_split(model:nn.Module) -> List[List[nn.Module]]:
     "Split a RNN `model` in groups for differential learning rates."
     groups = [[rnn, dp] for rnn, dp in zip(model[0].rnns, model[0].hidden_dps)]
     return groups + [[model[0].encoder, model[0].encoder_dp, model[1]]]
 
-def awd_lstm_clas_split(model:nn.Module) -> List[nn.Module]:
+def awd_lstm_clas_split(model:nn.Module) -> List[List[nn.Module]]:
     "Split a RNN `model` in groups for differential learning rates."
     groups = [[model[0].module.encoder, model[0].module.encoder_dp]]
     groups += [[rnn, dp] for rnn, dp in zip(model[0].module.rnns, model[0].module.hidden_dps)]


### PR DESCRIPTION
- [x] Read the [contributing docs](https://github.com/fastai/fastai/blob/master/CONTRIBUTING.md)
 
Tinkering in text.learner, once again I had trouble figuring out (/remembering) parameter and return types in a few places. Found some outdated/erroneous type hints (+ my linter found some more) on the way.

This PR should not really break things, as it only changes type hints.

I also felt like a comment was due in `MultiBatchEncoder.concat` - I know `fast.ai ` is against comments, but I really do not think that one-liner operating on a list of lists of 3d tensors is very clear by itself. 

Maybe the comment would be better in the docstring? But then again I do not see multi-line docstings anywhere.

