### PR TITLE
fix roc_curve cuda vs cpu error

### DIFF
--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -295,8 +295,9 @@ def roc_curve(input:Tensor, targ:Tensor):
     tps = torch.cumsum(targ * 1, dim=-1)[threshold_idxs]
     fps = (1 + threshold_idxs - tps)
     if tps[0] != 0 or fps[0] != 0:
-        fps = torch.cat((LongTensor([0]), fps))
-        tps = torch.cat((LongTensor([0]), tps))
+        zer = torch.zeros(1, dtype=fps.dtype, device=fps.device)
+        fps = torch.cat((zer, fps))
+        tps = torch.cat((zer, tps))
     fpr, tpr = fps.float() / fps[-1], tps.float() / tps[-1]
     return fpr, tpr
 

--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -295,7 +295,7 @@ def roc_curve(input:Tensor, targ:Tensor):
     tps = torch.cumsum(targ * 1, dim=-1)[threshold_idxs]
     fps = (1 + threshold_idxs - tps)
     if tps[0] != 0 or fps[0] != 0:
-        zer = torch.zeros(1, dtype=fps.dtype, device=fps.device)
+        zer = fps.new_zeros(1)
         fps = torch.cat((zer, fps))
         tps = torch.cat((zer, tps))
     fpr, tpr = fps.float() / fps[-1], tps.float() / tps[-1]


### PR DESCRIPTION
Minor change to roc_curve. 

Previously it was always using the default cpu device type. This causes an error when trying to add a cuda and cpu array.

