### PR TITLE
Tweak `_maybe_squeeze` helper to behave properly with single-row dataframes too

### DIFF
--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -10,7 +10,10 @@ __all__ = ['ItemList', 'CategoryList', 'MultiCategoryList', 'MultiCategoryProces
 def _decode(df):
     return np.array([[df.columns[i] for i,t in enumerate(x) if t==1] for x in df.values], dtype=np.object)
 
-def _maybe_squeeze(arr): return (arr if is1d(arr) else np.array(arr).ravel())
+def _maybe_squeeze(arr):
+    if is1d(arr): return arr
+    if np.array(arr).shape == (): return np.array(arr).ravel()
+    return np.squeeze(arr)
 
 def _path_to_same_str(p_fn):
     "path -> str, but same on nt+posix, for alpha-sort only"

--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -10,10 +10,7 @@ __all__ = ['ItemList', 'CategoryList', 'MultiCategoryList', 'MultiCategoryProces
 def _decode(df):
     return np.array([[df.columns[i] for i,t in enumerate(x) if t==1] for x in df.values], dtype=np.object)
 
-def _maybe_squeeze(arr):
-    if is1d(arr): return arr
-    if np.array(arr).shape == (): return np.array(arr).ravel()
-    return np.squeeze(arr)
+def _maybe_squeeze(arr): return arr if is1d(arr) else (np.array(arr).ravel() if np.array(arr).shape == () else np.squeeze(arr))
 
 def _path_to_same_str(p_fn):
     "path -> str, but same on nt+posix, for alpha-sort only"

--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -10,7 +10,7 @@ __all__ = ['ItemList', 'CategoryList', 'MultiCategoryList', 'MultiCategoryProces
 def _decode(df):
     return np.array([[df.columns[i] for i,t in enumerate(x) if t==1] for x in df.values], dtype=np.object)
 
-def _maybe_squeeze(arr): return (arr if is1d(arr) else np.squeeze(arr))
+def _maybe_squeeze(arr): return (arr if is1d(arr) else np.array(arr).ravel())
 
 def _path_to_same_str(p_fn):
     "path -> str, but same on nt+posix, for alpha-sort only"


### PR DESCRIPTION
Hello all,

When calling `learner.get_preds` on a `tabular.Learner` there is currently a failure case for single-row dataframes (the `basic_data.DataBunch` for said learner is a single-row DF).

This PR makes a minor tweak to the one-line utility fn `_maybe_squeeze`. After this tweak, the previous functionality is preserved while single-row DFs in the data bunch are also supported.

The edge-case boils down to zero-dim array semantics in numpy:
```
np.array(0).shape
Out[19]: ()
np.array(0).ravel().shape
Out[20]: (1,)
np.squeeze(np.array(0)).shape
Out[21]: ()
```

Note that ravel properly translates shape `() -> (1,)` while squeeze does not. 

Thank you for the great library. Feedback appreciated; I'm happy to add a test case too as desired.