### PR TITLE
Correct typo in text.data

### DIFF
--- a/docs_src/text.data.ipynb
+++ b/docs_src/text.data.ipynb
@@ -751,7 +751,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To use sentencepiece instead of space (requires to install sentencepiece separately) you would pass"
+    "To use sentencepiece instead of spaCy (requires to install sentencepiece separately) you would pass"
    ]
   },
   {


### PR DESCRIPTION
Fix typo for `text.data.ipnyb`
* space -> spaCy