### PR TITLE
Remove auto_update kwarg from progress_bar call

### DIFF
--- a/fastai/core.py
+++ b/fastai/core.py
@@ -208,8 +208,9 @@ def download_url(url:str, dest:str, overwrite:bool=False, pbar:ProgressBar=None,
 
     with open(dest, 'wb') as f:
         nbytes = 0
-        if show_progress: pbar = progress_bar(range(file_size), auto_update=False, leave=False, parent=pbar)
+        if show_progress: pbar = progress_bar(range(file_size), leave=False, parent=pbar)
         try:
+            if show_progress: pbar.update(0)
             for chunk in u.iter_content(chunk_size=chunk_size):
                 nbytes += len(chunk)
                 if show_progress: pbar.update(nbytes)


### PR DESCRIPTION
The kwarg was removed in the November release of progressbar ( https://github.com/fastai/fastprogress/commit/c7c91a1b410a2381a8901e40021aa538ee2a8ec2 ). 
This then breaks for fresh `fastai` installs (e.g. https://forums.fast.ai/t/fastprogress-auto-update/58830/6).

Also call `pbar.update(0)` because the `progress_bar.update()` requires it atm -- it assumes `progress_bar.wait_for` exists.
It would probably be better if the `progress_bar.__init__` set this to 1 or for `update` to handle this gracefully but I'm new to the libraries and don't have the time for a larger PR :)

 <!-- Feel free to remove check-list items aren't relevant to your change -->
 
 - [x] Read the [contributing docs](https://github.com/fastai/fastai/blob/master/CONTRIBUTING.md)
 - [ ] If you are adding new functionality, create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality.
 - [ ] Include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together!
 - [x] Add details about your PR.
