### PR TITLE
Typo in documentation for Learner.save() argument: name -> file

### DIFF
--- a/docs_src/basic_train.ipynb
+++ b/docs_src/basic_train.ipynb
@@ -2030,7 +2030,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If argument `name` is a pathlib object that's an absolute path, it'll override the default base directory (`learn.path`), otherwise the model will be saved in a file relative to `learn.path`."
+    "If argument `file` is a pathlib object that's an absolute path, it'll override the default base directory (`learn.path`), otherwise the model will be saved in a file relative to `learn.path`."
    ]
   },
   {


### PR DESCRIPTION
"If argument `name` is a pathlib object that's an absolute path" 
to
"If argument `file` is a pathlib object that's an absolute path"
 
 - [x] Read the [contributing docs](https://github.com/fastai/fastai/blob/master/CONTRIBUTING.md)
 - [x] Add details about your PR.
