### PR TITLE
made centering optionnal in pca

### DIFF
--- a/fastai/torch_core.py
+++ b/fastai/torch_core.py
@@ -303,9 +303,9 @@ def np2model_tensor(a):
     if not dtype: return res
     return res.type(dtype)
 
-def _pca(x, k=2):
+def _pca(x, k=2, center=True):
     "Compute PCA of `x` with `k` dimensions."
-    x = x-torch.mean(x,0)
+    if center: x = x-torch.mean(x,0)
     U,S,V = torch.svd(x.t())
     return torch.mm(x,U[:,:k])
 torch.Tensor.pca = _pca


### PR DESCRIPTION
Added a parameter to the pca method to make centering optional (useful when the position of the origin is meaningful).

