### PR TITLE
Handling breaking change in pytorch grid_sample

### DIFF
--- a/fastai/vision/image.py
+++ b/fastai/vision/image.py
@@ -538,10 +538,8 @@ def _grid_sample(x:TensorImage, coords:FlowField, mode:str='bilinear', padding_m
         d = min(x.shape[1]/coords.shape[1], x.shape[2]/coords.shape[2])/2
         # If we're resizing up by >200%, and we're zooming less than that, interpolate first
         if d>1 and d>z: x = F.interpolate(x[None], scale_factor=1/d, mode='area')[0]
-    with warnings.catch_warnings():
-        #To avoid the warning that come from grid_sample.
-        warnings.simplefilter("ignore")
-        return F.grid_sample(x[None], coords, mode=mode, padding_mode=padding_mode)[0]
+        return F.grid_sample(x[None], coords, mode=mode, padding_mode=padding_mode, align_corners=True)[0] if torch.__version__ > "1.2.0"\
+            else F.grid_sample(x[None], coords, mode=mode, padding_mode=padding_mode)[0]
 
 def _affine_grid(size:TensorImageSize)->FlowField:
     size = ((1,)+size)


### PR DESCRIPTION
Disclaimer: 
I cannot create a proper test case for this fix; this, unfortunately depends on environment and pytorch version.

Backgrund:
Pytorch in 1.3.0 started to change a default behavior grid_sample from being True to False. In version 1.3.0 and 1.3.1 pytorch basically warned that this behavior will change in 1.4.0. Now, recently released Pytorch 1.4.0 indeed introduced this breaking change in grid_sample (https://pytorch.org/docs/stable/nn.functional.html?highlight=grid_sample#torch.nn.functional.grid_sample). Now, fastai,with pytorch >1.4.0 will simply have improper behavior everywhere where grid_sample is used. 

This simple PR keeps correct behavior, regardless of pytorch version.
