### PR TITLE
Include Optuna integration badge on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Anaconda-Server Badge](https://anaconda.org/fastai/fastai/badges/platforms.svg)](https://anaconda.org/fastai/fastai)
 [![fastai python compatibility](https://img.shields.io/pypi/pyversions/fastai.svg)](https://pypi.python.org/pypi/fastai)
 [![fastai license](https://img.shields.io/pypi/l/fastai.svg)](https://pypi.python.org/pypi/fastai)
+[![Optuna](https://img.shields.io/badge/Optuna-integrated-blue)](https://optuna.org)
 
 # fastai
 


### PR DESCRIPTION
Hi!

Optuna is a new hyperparameter optimization library, and we’ve written an Optuna integration module for fast.ai to make it easy to search for good hyperparameter settings and prune unpromising trials. We’re looking for ways to let fast.ai users know this is available and thought a badge to show Optuna integration is available would be helpful.

Here’s our example of using the pruning integration with fast.ai: https://github.com/optuna/optuna/blob/master/examples/pruning/keras_integration.py

If there are other ways you would recommend reaching out to fast.ai users to let them know about Optuna, please let us know.

Thanks!