### PR TITLE
fixes exception before model save

### DIFF
--- a/fastai/callbacks/tracker.py
+++ b/fastai/callbacks/tracker.py
@@ -101,7 +101,7 @@ class SaveModelCallback(TrackerCallback):
 
     def on_train_end(self, **kwargs):
         "Load the best model."
-        if self.every=="improvement":
+        if self.every=="improvement" and os.path.isfile(self.path/self.model_dir/f'{self.name}.pth'):
             self.learn.load(f'{self.name}', purge=False)
 
 class ReduceLROnPlateauCallback(TrackerCallback):


### PR DESCRIPTION
If an exception happens before the model is saved, then this raised an FileNotFoundError which is overriding the previous error, see e.g. https://forums.fast.ai/t/to-distributed-with-savemodelcallback/41384/46

 
