### PR TITLE
Scale default value is too low, 0.08 instead of 0.8 in _presize funct…

### DIFF
--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -445,7 +445,7 @@ def _db_pre_transform(self, train_tfm:List[Callable], valid_tfm:List[Callable]):
     self.valid_ds.x.after_open = compose(valid_tfm)
     return self
 
-def _presize(self, size:int, val_xtra_size:int=32, scale:Tuple[float]=(0.08, 1.0), ratio:Tuple[float]=(0.75, 4./3.),
+def _presize(self, size:int, val_xtra_size:int=32, scale:Tuple[float]=(0.8, 1.0), ratio:Tuple[float]=(0.75, 4./3.),
              interpolation:int=2):
     "Resize images to `size` using `RandomResizedCrop`, passing along `kwargs` to train transform"
     return self.pre_transform(


### PR DESCRIPTION
…ion.

Having a little object in the photo, the object often wasn't even present in the transformed data with the default 0.08 value.
0.8 gives reasonable augmentation, I think that the original intent also was 0.8, but an extra zero was typed in mistakenly or something.

 <!-- Feel free to remove check-list items aren't relevant to your change -->
 
 - [x] Read the [contributing docs](https://github.com/fastai/fastai/blob/master/CONTRIBUTING.md)
 - [ ] If you are adding new functionality, create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality.
 - [ ] Include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together!
 - [x] Add details about your PR.
