### PR TITLE
correct typos in text docs

### DIFF
--- a/docs_src/text.data.ipynb
+++ b/docs_src/text.data.ipynb
@@ -163,7 +163,7 @@
        "\n",
        "<div class=\"collapse\" id=\"TextClasDataBunch-create-pytest\"><div class=\"card card-body pytest_card\"><a type=\"button\" data-toggle=\"collapse\" data-target=\"#TextClasDataBunch-create-pytest\" class=\"close\" aria-label=\"Close\"><span aria-hidden=\"true\">&times;</span></a><p>No tests found for <code>create</code>. To contribute a test please refer to <a href=\"/dev/test.html\">this guide</a> and <a href=\"https://forums.fast.ai/t/improving-expanding-functional-tests/32929\">this discussion</a>.</p></div></div>\n",
        "\n",
-       "Function that transform the `datasets` in a [`DataBunch`](/basic_data.html#DataBunch) for classification. Passes `**dl_kwargs` on to `DataLoader()`  "
+       "Function that transforms the `datasets` in a [`DataBunch`](/basic_data.html#DataBunch) for classification. Passes `**dl_kwargs` on to `DataLoader()`  "
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -552,7 +552,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since it comes in the form of csv files, we will use the corresponding `text_data` method. Here is an overview of what your file you should look like:"
+    "Since it comes in the form of csv files, we will use the corresponding `text_data` method. Here is an overview of what your file should look like:"
    ]
   },
   {
@@ -1561,9 +1561,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "LanguageModelPreLoader is an internal class uses for training a language model. It takes the sentences passed as a jagged array of numericalised sentences in `dataset` and returns contiguous batches to the pytorch dataloader with batch size `bs` and a sequence length `bptt`. \n",
+    "LanguageModelPreLoader is an internal class used for training a language model. It takes the sentences passed as a jagged array of numericalised sentences in `dataset` and returns contiguous batches to the pytorch dataloader with batch size `bs` and a sequence length `bptt`. \n",
     "- `lengths` can be provided for the jagged training data else lengths is calculated internally \n",
-    "- `backwards=True` will reverses the sentences. \n",
+    "- `backwards=True` will reverse the sentences. \n",
     "- `shuffle=True`, will shuffle the order of the sentences, at the start of each epoch - except the first\n",
     "\n",
     "The following description is usefull for understanding the implementation of [`LanguageModelPreLoader`](/text.data.html#LanguageModelPreLoader):\n",

--- a/docs_src/text.interpret.ipynb
+++ b/docs_src/text.interpret.ipynb
@@ -163,7 +163,7 @@
        "\n",
        "<div class=\"collapse\" id=\"TextClassificationInterpretation-show_top_losses-pytest\"><div class=\"card card-body pytest_card\"><a type=\"button\" data-toggle=\"collapse\" data-target=\"#TextClassificationInterpretation-show_top_losses-pytest\" class=\"close\" aria-label=\"Close\"><span aria-hidden=\"true\">&times;</span></a><p>No tests found for <code>show_top_losses</code>. To contribute a test please refer to <a href=\"/dev/test.html\">this guide</a> and <a href=\"https://forums.fast.ai/t/improving-expanding-functional-tests/32929\">this discussion</a>.</p></div></div>\n",
        "\n",
-       "Create a tabulation showing the first `k` texts in top_losses along with their prediction, actual,loss, and probability of actual class. `max_len` is the maximum number of tokens displayed. "
+       "Create a tabulation showing the first `k` texts in top_losses along with their prediction, actual, loss, and probability of actual class. `max_len` is the maximum number of tokens displayed. "
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -435,7 +435,7 @@
   "jekyll": {
    "keywords": "fastai",
    "summary": "Easy access of language models and ULMFiT",
-   "title": "text.learner"
+   "title": "text.interpret"
   },
   "kernelspec": {
    "display_name": "Python 3",

--- a/docs_src/text.ipynb
+++ b/docs_src/text.ipynb
@@ -24,10 +24,10 @@
    "source": [
     "The [`text`](/text.html#text) module of the fastai library contains all the necessary functions to define a Dataset suitable for the various NLP (Natural Language Processing) tasks and quickly generate models you can use for them. Specifically:\n",
     "- [`text.transform`](/text.transform.html#text.transform) contains all the scripts to preprocess your data, from raw text to token ids,\n",
-    "- [`text.data`](/text.data.html#text.data) contains the definition of [`TextDataBunch`](/text.data.html#TextDataBunch), which the main class you'll need in NLP,\n",
+    "- [`text.data`](/text.data.html#text.data) contains the definition of [`TextDataBunch`](/text.data.html#TextDataBunch), which is the main class you'll need in NLP,\n",
     "- [`text.learner`](/text.learner.html#text.learner) contains helper functions to quickly create a language model or an RNN classifier.\n",
     "\n",
-    "Have a look at the links above for full details of the API of each module, of read on for a quick overview."
+    "Have a look at the links above for full details of the API of each module, or read on for a quick overview."
    ]
   },
   {
@@ -115,10 +115,10 @@
    "metadata": {},
    "source": [
     "Creating a dataset from your raw texts is very simple if you have it in one of those ways\n",
-    "- organized it in folders in an ImageNet style\n",
-    "- organized in a csv file with labels columns and a text columns\n",
+    "- organized in folders in an ImageNet style\n",
+    "- organized in a csv file with labels columns and a text column\n",
     "\n",
-    "Here, the sample from imdb is in a texts csv files that looks like this:"
+    "Here, the sample from imdb is in a texts csv file that looks like this:"
    ]
   },
   {

--- a/docs_src/text.learner.ipynb
+++ b/docs_src/text.learner.ipynb
@@ -75,7 +75,7 @@
     "\n",
     "They each have a default config for language modelling that is in <code>{lower_case_class_name}\\_lm\\_config</code> if you want to change the default parameter. At this stage, only the AWD LSTM and Tranformer support `pretrained=True` but we hope to add more pretrained models soon. `drop_mult` is applied to all the dropouts weights of the `config`, `learn_kwargs` are passed to the [`Learner`](/basic_train.html#Learner) initialization.\n",
     "\n",
-    "If your [`data`](/text.data.html#text.data) is backward, the pretrained model downloaded will also be a backard one (only available for [`AWD_LSTM`](/text.models.awd_lstm.html#AWD_LSTM))."
+    "If your [`data`](/text.data.html#text.data) is backward, the pretrained model downloaded will also be a backward one (only available for [`AWD_LSTM`](/text.models.awd_lstm.html#AWD_LSTM))."
    ]
   },
   {
@@ -151,7 +151,7 @@
     "- a layer that concatenates the final outputs of the RNN with the maximum and average of all the intermediate outputs (on the sequence length dimension),\n",
     "- blocks of ([`nn.BatchNorm1d`](https://pytorch.org/docs/stable/nn.html#torch.nn.BatchNorm1d), [`nn.Dropout`](https://pytorch.org/docs/stable/nn.html#torch.nn.Dropout), [`nn.Linear`](https://pytorch.org/docs/stable/nn.html#torch.nn.Linear), [`nn.ReLU`](https://pytorch.org/docs/stable/nn.html#torch.nn.ReLU)) layers.\n",
     "\n",
-    "The blocks are defined by the `lin_ftrs` and `drops` arguments. Specifically, the first block will have a number of inputs inferred from the backbone arch and the last one will have a number of outputs equal to data.c (which contains the number of classes of the data) and the intermediate blocks have a number of inputs/outputs determined by `lin_ftrs` (of course a block has a number of inputs equal to the number of outputs of the previous block). The dropouts all have a the same value ps if you pass a float, or the corresponding values if you pass a list. Default is to have an intermediate hidden size of 50 (which makes two blocks model_activation -> 50 -> n_classes) with a dropout of 0.1."
+    "The blocks are defined by the `lin_ftrs` and `drops` arguments. Specifically, the first block will have a number of inputs inferred from the backbone arch and the last one will have a number of outputs equal to data.c (which contains the number of classes of the data) and the intermediate blocks have a number of inputs/outputs determined by `lin_ftrs` (of course a block has a number of inputs equal to the number of outputs of the previous block). The dropouts all have the same value ps if you pass a float, or the corresponding values if you pass a list. Default is to have an intermediate hidden size of 50 (which makes two blocks model_activation -> 50 -> n_classes) with a dropout of 0.1."
    ]
   },
   {
@@ -236,7 +236,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If `ordered=True`, returns the predictions in the order of the dataset, otherwise they will be ordered by the sampler (from the longest text to the shortest). The other arguments are passed [`Learner.get_preds`](/basic_train.html#Learner.get_preds)."
+    "If `ordered=True`, returns the predictions in the order of the dataset, otherwise they will be ordered by the sampler (from the longest text to the shortest). The other arguments are passed to [`Learner.get_preds`](/basic_train.html#Learner.get_preds)."
    ]
   },
   {

--- a/docs_src/text.models.ipynb
+++ b/docs_src/text.models.ipynb
@@ -24,7 +24,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[`text.models`](/text.models.html#text.models) module fully implements the encoder for an [AWD-LSTM](https://arxiv.org/pdf/1708.02182.pdf), the [transformer model](https://arxiv.org/abs/1706.03762) and the [transformer XL model](https://arxiv.org/abs/1901.02860). They can then plugged in with a decoder to make a language model, or some classifying layers to make a text classifier."
+    "[`text.models`](/text.models.html#text.models) module fully implements the encoder for an [AWD-LSTM](https://arxiv.org/pdf/1708.02182.pdf), the [transformer model](https://arxiv.org/abs/1706.03762) and the [transformer XL model](https://arxiv.org/abs/1901.02860). They can then be plugged in with a decoder to make a language model, or some classifying layers to make a text classifier."
    ]
   },
   {


### PR DESCRIPTION
- [x] Read the [contributing docs](https://github.com/fastai/fastai/blob/master/CONTRIBUTING.md)
- [x] Add details about your PR.

I corrected a few typos I found in the text docs : `text`, `text.learner`, `text.interpret`, `text.data` and `text.models`.

 Thanks for the library!