### PR TITLE
examples/tabular: Fixed 'split_idx' not defined

### DIFF
--- a/examples/tabular.ipynb
+++ b/examples/tabular.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -44,7 +44,7 @@
        "array(['>=50k', '<50k'], dtype=object)"
       ]
      },
-     "execution_count": 3,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -74,7 +74,7 @@
        "(0, 7812)"
       ]
      },
-     "execution_count": 5,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -254,7 +254,7 @@
        "4   Female             0             0              50   United-States   <50k  "
       ]
      },
-     "execution_count": 7,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -265,7 +265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,7 +277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,10 +286,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "scrolled": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "data = (TabularList.from_df(df, path=path, cat_names=cat_names, cont_names=cont_names, procs=procs)\n",
@@ -301,7 +299,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -471,7 +469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -520,7 +518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -529,7 +527,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -538,7 +536,7 @@
        "(Category >=50k, tensor(1), tensor([0.3581, 0.6419]))"
       ]
      },
-     "execution_count": 14,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -560,18 +558,6 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/examples/tabular.ipynb
+++ b/examples/tabular.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -44,7 +44,7 @@
        "array(['>=50k', '<50k'], dtype=object)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,16 +65,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(0, 24209)"
+       "(0, 7812)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -138,7 +138,7 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <td>0</td>\n",
+       "      <th>0</th>\n",
        "      <td>49</td>\n",
        "      <td>Private</td>\n",
        "      <td>101320</td>\n",
@@ -156,7 +156,7 @@
        "      <td>&gt;=50k</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <td>1</td>\n",
+       "      <th>1</th>\n",
        "      <td>44</td>\n",
        "      <td>Private</td>\n",
        "      <td>236746</td>\n",
@@ -174,7 +174,7 @@
        "      <td>&gt;=50k</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <td>2</td>\n",
+       "      <th>2</th>\n",
        "      <td>38</td>\n",
        "      <td>Private</td>\n",
        "      <td>96185</td>\n",
@@ -192,7 +192,7 @@
        "      <td>&lt;50k</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <td>3</td>\n",
+       "      <th>3</th>\n",
        "      <td>38</td>\n",
        "      <td>Self-emp-inc</td>\n",
        "      <td>112847</td>\n",
@@ -210,7 +210,7 @@
        "      <td>&gt;=50k</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <td>4</td>\n",
+       "      <th>4</th>\n",
        "      <td>42</td>\n",
        "      <td>Self-emp-not-inc</td>\n",
        "      <td>82297</td>\n",
@@ -254,7 +254,7 @@
        "4   Female             0             0              50   United-States   <50k  "
       ]
      },
-     "execution_count": null,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -265,7 +265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,7 +277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,12 +286,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 10,
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "data = (TabularList.from_df(df, path=path, cat_names=cat_names, cont_names=cont_names, procs=procs)\n",
-    "                           .split_by_idx(split_idx)#(list(range(800,1000)))\n",
+    "                           .split_by_idx(list(range(800,1000)))\n",
     "                           .label_from_df(cols=dep_var)\n",
     "                           .add_test(test)\n",
     "                           .databunch())"
@@ -299,7 +301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -324,132 +326,132 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>Private</td>\n",
-       "      <td>HS-grad</td>\n",
-       "      <td>Married-spouse-absent</td>\n",
-       "      <td>Sales</td>\n",
-       "      <td>Unmarried</td>\n",
+       "      <td>Bachelors</td>\n",
+       "      <td>Never-married</td>\n",
+       "      <td>Exec-managerial</td>\n",
+       "      <td>Not-in-family</td>\n",
        "      <td>White</td>\n",
        "      <td>False</td>\n",
-       "      <td>-0.6294</td>\n",
-       "      <td>-0.6110</td>\n",
+       "      <td>-1.1425</td>\n",
+       "      <td>-0.9280</td>\n",
+       "      <td>1.1422</td>\n",
+       "      <td>&lt;50k</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>Private</td>\n",
+       "      <td>HS-grad</td>\n",
+       "      <td>Never-married</td>\n",
+       "      <td>Other-service</td>\n",
+       "      <td>Not-in-family</td>\n",
+       "      <td>White</td>\n",
+       "      <td>False</td>\n",
+       "      <td>-0.5561</td>\n",
+       "      <td>0.7244</td>\n",
        "      <td>-0.4224</td>\n",
        "      <td>&lt;50k</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>Private</td>\n",
+       "      <td>Some-college</td>\n",
+       "      <td>Never-married</td>\n",
+       "      <td>Other-service</td>\n",
+       "      <td>Own-child</td>\n",
+       "      <td>White</td>\n",
+       "      <td>False</td>\n",
+       "      <td>-1.5090</td>\n",
+       "      <td>-0.1673</td>\n",
+       "      <td>-0.0312</td>\n",
+       "      <td>&lt;50k</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>Private</td>\n",
+       "      <td>HS-grad</td>\n",
+       "      <td>Divorced</td>\n",
+       "      <td>Adm-clerical</td>\n",
+       "      <td>Other-relative</td>\n",
+       "      <td>Amer-Indian-Eskimo</td>\n",
+       "      <td>False</td>\n",
+       "      <td>1.2763</td>\n",
+       "      <td>-0.8370</td>\n",
+       "      <td>-0.4224</td>\n",
+       "      <td>&lt;50k</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>Local-gov</td>\n",
        "      <td>Bachelors</td>\n",
+       "      <td>Divorced</td>\n",
+       "      <td>Transport-moving</td>\n",
+       "      <td>Not-in-family</td>\n",
+       "      <td>White</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0.2502</td>\n",
+       "      <td>-1.3617</td>\n",
+       "      <td>1.1422</td>\n",
+       "      <td>&lt;50k</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>Private</td>\n",
+       "      <td>Some-college</td>\n",
+       "      <td>Married-civ-spouse</td>\n",
+       "      <td>Prof-specialty</td>\n",
+       "      <td>Husband</td>\n",
+       "      <td>White</td>\n",
+       "      <td>False</td>\n",
+       "      <td>-0.8493</td>\n",
+       "      <td>-0.3286</td>\n",
+       "      <td>-0.0312</td>\n",
+       "      <td>&gt;=50k</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>Private</td>\n",
+       "      <td>11th</td>\n",
        "      <td>Never-married</td>\n",
        "      <td>Prof-specialty</td>\n",
        "      <td>Own-child</td>\n",
        "      <td>White</td>\n",
        "      <td>False</td>\n",
-       "      <td>-0.6294</td>\n",
-       "      <td>-0.0009</td>\n",
-       "      <td>1.1422</td>\n",
+       "      <td>-1.5090</td>\n",
+       "      <td>0.8521</td>\n",
+       "      <td>-1.2046</td>\n",
        "      <td>&lt;50k</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>Private</td>\n",
-       "      <td>Some-college</td>\n",
+       "      <td>7th-8th</td>\n",
        "      <td>Married-civ-spouse</td>\n",
-       "      <td>Craft-repair</td>\n",
+       "      <td>Tech-support</td>\n",
        "      <td>Husband</td>\n",
        "      <td>White</td>\n",
        "      <td>False</td>\n",
-       "      <td>-0.0430</td>\n",
-       "      <td>-0.2710</td>\n",
-       "      <td>-0.0312</td>\n",
-       "      <td>&gt;=50k</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>Private</td>\n",
-       "      <td>HS-grad</td>\n",
-       "      <td>Married-civ-spouse</td>\n",
-       "      <td>Craft-repair</td>\n",
-       "      <td>Husband</td>\n",
-       "      <td>White</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0.1769</td>\n",
-       "      <td>-1.1414</td>\n",
-       "      <td>-0.4224</td>\n",
-       "      <td>&gt;=50k</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>Private</td>\n",
-       "      <td>HS-grad</td>\n",
-       "      <td>Married-civ-spouse</td>\n",
-       "      <td>Machine-op-inspct</td>\n",
-       "      <td>Husband</td>\n",
-       "      <td>White</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0.8365</td>\n",
-       "      <td>5.4769</td>\n",
-       "      <td>-0.4224</td>\n",
-       "      <td>&gt;=50k</td>\n",
+       "      <td>-0.2629</td>\n",
+       "      <td>0.0550</td>\n",
+       "      <td>-2.3781</td>\n",
+       "      <td>&lt;50k</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>Private</td>\n",
        "      <td>HS-grad</td>\n",
        "      <td>Never-married</td>\n",
-       "      <td>Machine-op-inspct</td>\n",
-       "      <td>Unmarried</td>\n",
-       "      <td>White</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0.4701</td>\n",
-       "      <td>-0.8623</td>\n",
-       "      <td>-0.4224</td>\n",
-       "      <td>&lt;50k</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>Private</td>\n",
-       "      <td>HS-grad</td>\n",
-       "      <td>Widowed</td>\n",
-       "      <td>Machine-op-inspct</td>\n",
-       "      <td>Unmarried</td>\n",
-       "      <td>White</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0.8365</td>\n",
-       "      <td>0.2641</td>\n",
-       "      <td>-0.4224</td>\n",
-       "      <td>&lt;50k</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>Self-emp-not-inc</td>\n",
-       "      <td>Some-college</td>\n",
-       "      <td>Never-married</td>\n",
-       "      <td>Farming-fishing</td>\n",
+       "      <td>Transport-moving</td>\n",
        "      <td>Not-in-family</td>\n",
        "      <td>White</td>\n",
        "      <td>False</td>\n",
-       "      <td>-0.4095</td>\n",
-       "      <td>-1.4829</td>\n",
-       "      <td>-0.0312</td>\n",
+       "      <td>-0.8493</td>\n",
+       "      <td>-0.3286</td>\n",
+       "      <td>-0.4224</td>\n",
        "      <td>&lt;50k</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>Private</td>\n",
        "      <td>Bachelors</td>\n",
-       "      <td>Married-civ-spouse</td>\n",
-       "      <td>Exec-managerial</td>\n",
-       "      <td>Husband</td>\n",
+       "      <td>Never-married</td>\n",
+       "      <td>Adm-clerical</td>\n",
+       "      <td>Not-in-family</td>\n",
        "      <td>White</td>\n",
        "      <td>False</td>\n",
-       "      <td>-0.3362</td>\n",
-       "      <td>-0.2967</td>\n",
+       "      <td>-0.7760</td>\n",
+       "      <td>1.3159</td>\n",
        "      <td>1.1422</td>\n",
-       "      <td>&lt;50k</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>Private</td>\n",
-       "      <td>Some-college</td>\n",
-       "      <td>Married-civ-spouse</td>\n",
-       "      <td>Exec-managerial</td>\n",
-       "      <td>Own-child</td>\n",
-       "      <td>Black</td>\n",
-       "      <td>False</td>\n",
-       "      <td>-0.7027</td>\n",
-       "      <td>-0.4258</td>\n",
-       "      <td>-0.0312</td>\n",
        "      <td>&lt;50k</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -469,13 +471,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<table border=\"1\" class=\"dataframe\">\n",
+       "Total time: 00:02 <p><table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: left;\">\n",
        "      <th>epoch</th>\n",
@@ -488,10 +490,10 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>0</td>\n",
-       "      <td>0.371339</td>\n",
-       "      <td>0.382887</td>\n",
-       "      <td>0.810000</td>\n",
-       "      <td>00:06</td>\n",
+       "      <td>0.357122</td>\n",
+       "      <td>0.381649</td>\n",
+       "      <td>0.790000</td>\n",
+       "      <td>00:02</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>"
@@ -518,7 +520,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -527,16 +529,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(Category <50k, tensor(0), tensor([0.5185, 0.4815]))"
+       "(Category >=50k, tensor(1), tensor([0.3581, 0.6419]))"
       ]
      },
-     "execution_count": null,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -544,6 +546,13 @@
    "source": [
     "learn.predict(row)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -551,6 +560,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
As per forum post https://forums.fast.ai/t/examples-tabular-ipynb-split-idx-is-not-defined/62459/4, reverting back by un-commenting necessary code.

 <!-- Feel free to remove check-list items aren't relevant to your change -->
 
 - [x ] Read the [contributing docs](https://github.com/fastai/fastai/blob/master/CONTRIBUTING.md)
 - [x ] Add details about your PR.

The variable 'split_idx' was being used without being defined.  
I posted to the forum first, where Zachary Mueller suggested the fix, and pointed toward a similar code in course-v3 where it's corrected: https://github.com/fastai/course-v3/blob/master/nbs/dl1/lesson4-tabular.ipynb

So this submission is simply reverting to where the `list(range())` syntax is uncommented and replacing the `split_idx`. 