### PR TITLE
Update performance.md

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -134,8 +134,8 @@ Here are the detailed instructions, with an optional `TIFF` support:
 #### How to check whether you're running `Pillow` or `Pillow-SIMD`?
 
 ```
-python -c "from PIL import Image; print(Image.PILLOW_VERSION)"
-3.2.0.post3
+python -c "from PIL import Image; print(Image.__version__)"
+7.0.0.post3
 ```
 According to the author, if `PILLOW_VERSION` has a postfix, it is `Pillow-SIMD`. (Assuming that `Pillow` will never make a `.postX` release).
 


### PR DESCRIPTION
 version 7.0.0, Pillow has a different command.

python -c "from PIL import Image; print(Image.PILLOW_VERSION)"
3.2.0.post3
is now:

python -c "from PIL import Image; print(Image.__version__)"
7.0.0.post3

 <!-- Feel free to remove check-list items aren't relevant to your change -->
 
 - [x] Read the [contributing docs](https://github.com/fastai/fastai/blob/master/CONTRIBUTING.md)
 - [x] If you are adding new functionality, create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality.
 - [x] Include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together!
 - [x] Add details about your PR.
