### PR TITLE
Fix SaveModelCallback

### DIFF
--- a/fastai/callbacks/tracker.py
+++ b/fastai/callbacks/tracker.py
@@ -93,9 +93,7 @@ class SaveModelCallback(TrackerCallback):
         "Compare the value monitored to its best score and maybe save the model."
         if self.every=="epoch": self.learn.save(f'{self.name}_{epoch}')
         else: #every="improvement"
-            current = self.get_monitor_value()
-            if isinstance(current, torch.Tensor):
-                current = current.cpu()
+            current = self.get_monitor_value().cpu()
             if current is not None and self.operator(current, self.best):
                 print(f'Better model found at epoch {epoch} with {self.monitor} value: {current}.')
                 self.best = current

--- a/fastai/callbacks/tracker.py
+++ b/fastai/callbacks/tracker.py
@@ -93,7 +93,9 @@ class SaveModelCallback(TrackerCallback):
         "Compare the value monitored to its best score and maybe save the model."
         if self.every=="epoch": self.learn.save(f'{self.name}_{epoch}')
         else: #every="improvement"
-            current = self.get_monitor_value().cpu()
+            current = self.get_monitor_value()
+            if isinstance(current, torch.Tensor):
+                current = current.cpu()
             if current is not None and self.operator(current, self.best):
                 print(f'Better model found at epoch {epoch} with {self.monitor} value: {current}.')
                 self.best = current

--- a/fastai/callbacks/tracker.py
+++ b/fastai/callbacks/tracker.py
@@ -93,7 +93,7 @@ class SaveModelCallback(TrackerCallback):
         "Compare the value monitored to its best score and maybe save the model."
         if self.every=="epoch": self.learn.save(f'{self.name}_{epoch}')
         else: #every="improvement"
-            current = self.get_monitor_value()
+            current = self.get_monitor_value().cpu()
             if current is not None and self.operator(current, self.best):
                 print(f'Better model found at epoch {epoch} with {self.monitor} value: {current}.')
                 self.best = current


### PR DESCRIPTION
I added `cpu()` casting. 
When `get_monitor_value` is called in SaveModelCallback it fails since the value it returns for valid loss still sits on gpu.

I checked [valid_loss](https://github.com/fastai/fastai/blob/ed3635d17a52af7ead2805b802f20b99fa7a7b28/fastai/callbacks/tracker.py#L44) in the parent TrackerCallback but it was on gpu. Perhaps it's changed somewhere else.

**Update:**
Above was true for `language_model_learner.fit_one_cycle` after `unfreeze`. However, `text_classifier_learner` in the same situation already has `valid_loss` on cpu. So I added type check.

 <!-- Feel free to remove check-list items aren't relevant to your change -->
 
 - [x] Read the [contributing docs](https://github.com/fastai/fastai/blob/master/CONTRIBUTING.md)
 - [x] If you are adding new functionality, create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality.
 - [ ] Include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together!
 - [x] Add details about your PR.
