### PR TITLE
change max_colwidth to None instead of -1 as Pandas 1.0.0 does not su…

### DIFF
--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -357,7 +357,8 @@ class TextList(ItemList):
             items.append([i, txt_x] if self._is_lm else [txt_x, y])
         items = np.array(items)
         df = pd.DataFrame({n:items[:,i] for i,n in enumerate(names)}, columns=names)
-        with pd.option_context('display.max_colwidth', None):
+        max_colwidth = None if pd.__version__ >= "1.0.0" else -1
+        with pd.option_context('display.max_colwidth', max_colwidth):
             display(HTML(df.to_html(index=False)))
 
     def show_xyzs(self, xs, ys, zs, max_len:int=70):

--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -357,7 +357,7 @@ class TextList(ItemList):
             items.append([i, txt_x] if self._is_lm else [txt_x, y])
         items = np.array(items)
         df = pd.DataFrame({n:items[:,i] for i,n in enumerate(names)}, columns=names)
-        with pd.option_context('display.max_colwidth', -1):
+        with pd.option_context('display.max_colwidth', None):
             display(HTML(df.to_html(index=False)))
 
     def show_xyzs(self, xs, ys, zs, max_len:int=70):


### PR DESCRIPTION
Simply changing the display.max_colwidth from `-1` to `None` as pandas 1.0.0 no longer supports -1 and throws an error.  

 <!-- Feel free to remove check-list items aren't relevant to your change -->
 
 - [ x] Read the [contributing docs](https://github.com/fastai/fastai/blob/master/CONTRIBUTING.md)
 - [x ] Add details about your PR.

With pandas 1.0.0 -1 is no longer a valid option for display.max_colwidth

It results in the following error:

> ~\Anaconda3\envs\spam\lib\site-packages\fastai\text\data.py in show_xys(self, xs, ys, max_len)
>     358         items = np.array(items)
>     359         df = pd.DataFrame({n:items[:,i] for i,n in enumerate(names)}, columns=names)
> --> 360         with pd.option_context('display.max_colwidth', -1):
>     361             display(HTML(df.to_html(index=False)))
>     362 
> 
> ~\Anaconda3\envs\spam\lib\site-packages\pandas\_config\config.py in __enter__(self)
>     405 
>     406         for pat, val in self.ops:
> --> 407             _set_option(pat, val, silent=True)
>     408 
>     409     def __exit__(self, *args):
> 
> ~\Anaconda3\envs\spam\lib\site-packages\pandas\_config\config.py in _set_option(*args, **kwargs)
>     125         o = _get_registered_option(key)
>     126         if o and o.validator:
> --> 127             o.validator(v)
>     128 
>     129         # walk the nested dict
> 
> ~\Anaconda3\envs\spam\lib\site-packages\pandas\_config\config.py in is_nonnegative_int(value)
>     842 
>     843     msg = "Value must be a nonnegative integer or None"
> --> 844     raise ValueError(msg)
>     845 
>     846 
> 
> ValueError: Value must be a nonnegative integer or None


