### PR TITLE
Filtering empty strings in download_images function

### DIFF
--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -191,7 +191,7 @@ def _download_image_inner(dest, url, i, timeout=4):
 
 def download_images(urls:Union[Path, str], dest:PathOrStr, max_pics:int=1000, max_workers:int=8, timeout=4):
     "Download images listed in text file `urls` to path `dest`, at most `max_pics`"
-    urls = list(filter(None, open('download (8).csv').read().strip().split("\n")))[:max_pics]       
+    urls = list(filter(None, open(urls).read().strip().split("\n")))[:max_pics]       
     dest = Path(dest)
     dest.mkdir(exist_ok=True)
     parallel(partial(_download_image_inner, dest, timeout=timeout), urls, max_workers=max_workers)

--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -191,7 +191,7 @@ def _download_image_inner(dest, url, i, timeout=4):
 
 def download_images(urls:Union[Path, str], dest:PathOrStr, max_pics:int=1000, max_workers:int=8, timeout=4):
     "Download images listed in text file `urls` to path `dest`, at most `max_pics`"
-    urls = open(urls).read().strip().split("\n")[:max_pics]
+    urls = list(filter(None, open('download (8).csv').read().strip().split("\n")))[:max_pics]       
     dest = Path(dest)
     dest.mkdir(exist_ok=True)
     parallel(partial(_download_image_inner, dest, timeout=timeout), urls, max_workers=max_workers)


### PR DESCRIPTION
Using the script below in Chome Dev Tools to download images from Google Images may include empty strings that resulted in errors for the download_images method. It might be solved in this script but I wanted to filter these empty strings in download_images method. This PR is fixing the [issue](https://github.com/fastai/fastai/issues/2490).

```
urls=Array.from(document.querySelectorAll('.rg_i')).map(el=> el.hasAttribute('data-src')?el.getAttribute('data-src'):el.getAttribute('data-iurl'));
window.open('data:text/csv;charset=utf-8,' + escape(urls.join('\n')));

```
You can see the error [here](https://forums.fast.ai/t/problems-fetching-urls-from-google-images/62933/12?u=ozgur) 

It seems download_images method reads CSV file, splits it with “\n” to read line by line, but does not filter empty strings in the string array.

`urls = open(urls).read().strip().split("\n")[:max_pics]
`
Changing this line as below will fix this issue.
`urls = list(filter(None, open(urls).read().strip().split("\n")))[:max_pics]
`