### PR TITLE
Fix Imputer Import

### DIFF
--- a/courses/dl1/rossman_exp.py
+++ b/courses/dl1/rossman_exp.py
@@ -9,7 +9,8 @@ samp_size = 100000
 import math, keras, datetime, pandas as pd, numpy as np, keras.backend as K
 import matplotlib.pyplot as plt, xgboost, operator, random, pickle, os
 from sklearn_pandas import DataFrameMapper
-from sklearn.preprocessing import LabelEncoder, Imputer, StandardScaler
+from sklearn.impute import SimpleImputer
+from sklearn.preprocessing import LabelEncoder, StandardScaler
 from keras.models import Model
 from keras.layers import merge, Input
 from keras.layers.core import Dense, Activation, Reshape, Flatten, Dropout

--- a/old/fastai/structured.py
+++ b/old/fastai/structured.py
@@ -1,7 +1,8 @@
 from .imports import *
 
 from sklearn_pandas import DataFrameMapper
-from sklearn.preprocessing import LabelEncoder, Imputer, StandardScaler
+from sklearn.impute import SimpleImputer
+from sklearn.preprocessing import LabelEncoder, StandardScaler
 from pandas.api.types import is_string_dtype, is_numeric_dtype, is_categorical_dtype
 from sklearn.ensemble import forest
 from sklearn.tree import export_graphviz


### PR DESCRIPTION
 - [x] Read the [contributing docs](https://github.com/fastai/fastai/blob/master/CONTRIBUTING.md)
 - [x] Add details about your PR.

from sklearn.impute import SimpleImputer will work because of the following

DeprecationWarning: Class Imputer is deprecated; Imputer was deprecated in version 0.20 and will be removed in 0.22. Import impute.SimpleImputer from sklearn instead.

https://github.com/mindsdb/lightwood/issues/75#issuecomment-565657292