### PR TITLE
edited the computation of ConfusionMatrix for large speedup

### DIFF
--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -155,10 +155,8 @@ class ConfusionMatrix(Callback):
         targs = last_target.cpu()
         if self.n_classes == 0:
             self.n_classes = last_output.shape[-1]
-            self.x = torch.arange(0, self.n_classes)
-        cm = ((preds==self.x[:, None]) & (targs==self.x[:, None, None])).sum(dim=2, dtype=torch.float32)
-        if self.cm is None: self.cm =  cm
-        else:               self.cm += cm
+        if self.cm is None: self.cm = torch.zeros((n_classes, n_classes))
+        self.cm[targs, preds] += 1
 
     def on_epoch_end(self, **kwargs):
         self.metric = self.cm

--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -155,8 +155,10 @@ class ConfusionMatrix(Callback):
         targs = last_target.cpu()
         if self.n_classes == 0:
             self.n_classes = last_output.shape[-1]
-        if self.cm is None: self.cm = torch.zeros((n_classes, n_classes))
-        self.cm[targs, preds] += 1
+        if self.cm is None: self.cm = torch.zeros((n_classes, n_classes), device=torch.device('cpu'), dtype=torch.int32)
+        cm_temp_numpy = self.cm.numpy()
+        np.add.at(cm_temp_numpy, (targs ,preds), 1)
+        self.cm = torch.from_numpy(cm_temp_numpy)
 
     def on_epoch_end(self, **kwargs):
         self.metric = self.cm

--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -155,7 +155,7 @@ class ConfusionMatrix(Callback):
         targs = last_target.cpu()
         if self.n_classes == 0:
             self.n_classes = last_output.shape[-1]
-        if self.cm is None: self.cm = torch.zeros((n_classes, n_classes), device=torch.device('cpu'), dtype=torch.int32)
+        if self.cm is None: self.cm = torch.zeros((n_classes, n_classes), device=torch.device('cpu'))
         cm_temp_numpy = self.cm.numpy()
         np.add.at(cm_temp_numpy, (targs ,preds), 1)
         self.cm = torch.from_numpy(cm_temp_numpy)


### PR DESCRIPTION
### Describe the change
The method `on_batch_end()` of class `ConfusionMatrix` is very slow when the data has a large number of target classes.

The line that causes the computation to be slow is the following :
```cm = ((preds==self.x[:, None]) & (targs==self.x[:, None, None])).sum(dim=2, dtype=torch.float32)```
This is because we initialize an MxM matrix at each call (where M is the number of labels). We propose to initialize this matrix only once at the start of the Confusion Matrix computation and to leverage the indexing capabilities offered by PyTorch (seen in the line `self.cm[targs, preds] += 1`)

### Context
I stumbled over this issue when when doing a single label text classification task on WordNet definitions with over 10,000 target classes. The training was working well but the validation was tremendously slow. I opened a thread on the fastai forums describing my problem here :
[https://forums.fast.ai/t/learner-uses-gpu-with-training-set-but-not-validation/64698/6](url)

After doing some memory profiling, I pinpointed that the source of the problem came from the `on_batch_end()` method.

I was using an OpenStack VM of 16GB of RAM and 4 cores when this issue arose. A colleague and I reproduced the problem and proposed the above change in a Google Colab environment to make sure that the issue wasn't hardware related.

### Testing and Reproducing
In an interactive python environment (we used Google Colab for this), initialize a sample output:
```
in_batch = torch.rand((12, 10000)).to(torch.device('cpu'))
b = torch.tensor([254]).repeat(12)
b[5] = 128

in_batch[5, 128] = np.inf
```
`in_batch` represents a model output (e.g. softmax). `b`  is a vector of predictions that we consider to be the ground truth. We set the 5th element of B to 128 and the 128th element of the 5th batch of the output to `np.inf` so that this predictions matches it's ground truth.
```
def on_batch_end_original(last_output, last_target, cm=None, n_classes=0, **kwargs):
        preds = last_output.argmax(-1).view(-1).cpu()
        targs = last_target.cpu()
        if n_classes == 0:
            n_classes = last_output.shape[-1]
            x = torch.arange(0, n_classes)
        cm_tmp = ((preds==x[:, None]) & (targs==x[:, None, None])).sum(dim=2, dtype=torch.float32)
        if cm is None: cm = cm_tmp
        else:               cm += cm
        return cm

  def on_batch_end(last_output, last_target, cm=None, n_classes=0, **kwargs):
        preds = last_output.argmax(-1).view(-1).cpu()
        targs = last_target.cpu()
        if n_classes == 0:
            n_classes = last_output.shape[-1]
            #x = torch.arange(0, n_classes)
        if cm is None: cm = torch.zeros((n_classes, n_classes))
        #cm = ((preds==self.x[:, None]) & (targs==self.x[:, None, None])).sum(dim=2, dtype=torch.float32)
        cm[targs, preds] += 1
        return cm
```
The function `on_batch_end_original()` mimics the original method found in the `Confusionmatrix` class. `on_batch_end()` mimics the behavior of our change.
We time each functions with:
```
%%timeit
cm = None
for i in range(1):
  cm = on_batch_end_original(in_batch, b, cm)
```
`[output] 1 loop, best of 3: 5.46 s per loop`

```
%%timeit
cm2 = None
for i in range(100):
  cm2 = on_batch_end(in_batch, b, cm2)
```
`[output] 10 loops, best of 3: 102 ms per loop`

As we can see, our propose change is able to compute a 100 times the confusion matrix  in a fraction of the time it takes the original function to compute it once.
We make sure our confusion matrices are equal:
```(cm == cm2).all()```
`[output] tensor(True)`

Finally,
```cm.diag().argmax()```
`[output] tensor(128)`
verifies that the confusion matrices recorded a correct prediction for label 128.

#### Note:
It is possible that this change is slower on tasks with only few target classes but it seems to us that the large speedup benefits of this change outweigh a small change of compute time. This might need further testing if our change does not seem convincing to you.

**Co-authored-by: Martin Sotir <martinsotir@gmail.com>**