### PR TITLE
Update awd_lstm.py

### DIFF
--- a/fastai/text/models/awd_lstm.py
+++ b/fastai/text/models/awd_lstm.py
@@ -97,6 +97,8 @@ class AWD_LSTM(Module):
             self.rnns = [WeightDropout(rnn, weight_p) for rnn in self.rnns]
         self.rnns = nn.ModuleList(self.rnns)
         self.encoder.weight.data.uniform_(-self.initrange, self.initrange)
+        if self.encoder.padding_idx is not None:
+                self.encoder.weight.data[self.encoder.padding_idx] = 0.
         self.input_dp = RNNDropout(input_p)
         self.hidden_dps = nn.ModuleList([RNNDropout(hidden_p) for l in range(n_layers)])
 


### PR DESCRIPTION
When the weights in an embedding layer are initialised all of the weights are updated, including those set to zero at the padding index. This means that the weights at the padding idx are now non zero, which I don't think can be desirable. The change I am proposing just reinstates the zeros at the padding index.

 <!-- Feel free to remove check-list items aren't relevant to your change -->
 
 - [ ] Read the [contributing docs](https://github.com/fastai/fastai/blob/master/CONTRIBUTING.md)
 - [ ] If you are adding new functionality, create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality.
 - [ ] Include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together!
 - [ ] Add details about your PR.
