### PR TITLE
Fix #2524

### DIFF
--- a/fastai/vision/gan.py
+++ b/fastai/vision/gan.py
@@ -138,7 +138,7 @@ class GANTrainer(LearnerCallback):
         data = self.learn.data
         img = self.last_gen[0]
         norm = getattr(data,'norm',False)
-        if norm and norm.keywords.get('do_y',False): img = data.denorm(img)
+        if norm and norm.keywords.get('do_y',False): img = data.denorm(img, do_x=True)
         img = data.train_ds.y.reconstruct(img)
         self.imgs.append(img)
         self.titles.append(f'Epoch {epoch}')


### PR DESCRIPTION
 <!-- Feel free to remove check-list items aren't relevant to your change -->
 
 - [x] Read the [contributing docs](https://github.com/fastai/fastai/blob/master/CONTRIBUTING.md)
 - [ ] Include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together!

It's not easily testable as it depends on an intermediate result used in `GANTrainer.on_epoch_end`. It would require caching the intermediate result given by `data.denorm` just for the purpose of testing or coding some kind of heuristic about the pixel distribution of GANTrainer.imgs; probably not worth it.

 - [x] Add details about your PR.

It just enforces denormalization of the generated image shown at the end of any training epoch by `GANTrainer.on_epoch_end`. The call to `data.denorm()` was doing nothing. More details are given in the linked issue.
This is my first PR, hope it's ok! Let me know otherwise.