### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ dep_groups = {
         typing
 """),
     'text':   to_list("""
-        spacy>=2.0.18
+        spacy>=2.0.18; python_version<'3.8'
 """),
     'vision': to_list("""
         torchvision


### PR DESCRIPTION
Spacy dependency is turned off by default when installing fastai on Python 3.8 since Python 3.8 is not currently supported by Spacy.
This is the only dependency that prohibits installing fastai on Python 3.8.