### PR TITLE
Added Verbose

### DIFF
--- a/fastai/datasets.py
+++ b/fastai/datasets.py
@@ -233,7 +233,7 @@ def untar_data(url:str, fname:PathOrStr=None, dest:PathOrStr=None, data=True, fo
         fname = download_data(url, fname=fname, data=data)
         if url in _checks:
             assert _check_file(fname) == _checks[url], f"Downloaded file {fname} does not match checksum expected! Remove that file from {Config().data_archive_path()} and try your code again."
-        if verbose: print('.tgz file downloaded. Extracting the contents...)
+        if verbose: print('.tgz file downloaded. Extracting the contents...')
         tarfile.open(fname, 'r:gz').extractall(dest.parent)
         if verbose: print('File extracted successfully.')
     return dest

--- a/fastai/datasets.py
+++ b/fastai/datasets.py
@@ -221,7 +221,7 @@ def _check_file(fname):
         hash_nb = hashlib.md5(f.read(2**20)).hexdigest()
     return size,hash_nb
 
-def untar_data(url:str, fname:PathOrStr=None, dest:PathOrStr=None, data=True, force_download=False) -> Path:
+def untar_data(url:str, fname:PathOrStr=None, dest:PathOrStr=None, data=True, force_download=False, verbose=False) -> Path:
     "Download `url` to `fname` if `dest` doesn't exist, and un-tgz to folder `dest`."
     dest = url2path(url, data) if dest is None else Path(dest)/url2name(url)
     fname = Path(ifnone(fname, _url2tgz(url, data)))
@@ -233,5 +233,7 @@ def untar_data(url:str, fname:PathOrStr=None, dest:PathOrStr=None, data=True, fo
         fname = download_data(url, fname=fname, data=data)
         if url in _checks:
             assert _check_file(fname) == _checks[url], f"Downloaded file {fname} does not match checksum expected! Remove that file from {Config().data_archive_path()} and try your code again."
+        if verbose: print('.tgz file downloaded. Extracting the contents...)
         tarfile.open(fname, 'r:gz').extractall(dest.parent)
+        if verbose: print('File extracted successfully.')
     return dest


### PR DESCRIPTION
While downloading URLs.IMDB (which is a huge data-set), I didn't knew that it was being extracted after being downloaded, because no such information was printed to console of file being extracted. And as I was using Google Colab (which I think most of the students prefer), it takes a lot of time to extract the file contents. And I cancelled the process 4 times before acknowledging what's going on.

I think it's better that we just print the the on-going process for everyone's benefit.
(I added a flag just not to surprise anyone, though I don't think it's necessary)

 <!-- Feel free to remove check-list items aren't relevant to your change -->
 
 - [x] Read the [contributing docs](https://github.com/fastai/fastai/blob/master/CONTRIBUTING.md)
 - [x] Include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together!
 - [x] Add details about your PR.
