### PR TITLE
Add the extension to the download url to make it correct

### DIFF
--- a/fastai/datasets.py
+++ b/fastai/datasets.py
@@ -211,7 +211,7 @@ def download_data(url:str, fname:PathOrStr=None, data:bool=True, ext:str='.tgz')
     fname = Path(ifnone(fname, _url2tgz(url, data, ext=ext)))
     os.makedirs(fname.parent, exist_ok=True)
     if not fname.exists():
-        print(f'Downloading {url}')
+        print(f'Downloading {url}{ext}')
         download_url(f'{url}{ext}', fname)
     return fname
 


### PR DESCRIPTION
 Currently, the piece that prints out the download URL omits the file extension which causes the URL link in the notebook to be incorrect
![example_interactive-Copy1 - Jupyter Notebook - Google Chrome 2020-04-22 11 32 23](https://user-images.githubusercontent.com/806458/80001936-fa6da900-848c-11ea-9070-fef3b38c2dc4.png)
 
 
 - [x ] Read the [contributing docs](https://github.com/fastai/fastai/blob/master/CONTRIBUTING.md)
 - [x ] Add details about your PR.
