### PR TITLE
fixed a bug in vision data.py

### DIFF
--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -104,7 +104,7 @@ class ImageDataBunch(DataBunch):
                     valid_pct=None, seed:int=None, classes:Collection=None, **kwargs:Any)->'ImageDataBunch':
         "Create from imagenet style dataset in `path` with `train`,`valid`,`test` subfolders (or provide `valid_pct`)."
         path=Path(path)
-        il = ImageList.from_folder(path/train, exclude=test)
+        il = ImageList.from_folder(path, include=train)
         if valid_pct is None: src = il.split_by_folder(train=train, valid=valid)
         else: src = il.split_by_rand_pct(valid_pct, seed)
         src = src.label_from_folder(classes=classes)

--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -104,7 +104,7 @@ class ImageDataBunch(DataBunch):
                     valid_pct=None, seed:int=None, classes:Collection=None, **kwargs:Any)->'ImageDataBunch':
         "Create from imagenet style dataset in `path` with `train`,`valid`,`test` subfolders (or provide `valid_pct`)."
         path=Path(path)
-        il = ImageList.from_folder(path, exclude=test)
+        il = ImageList.from_folder(path/train, exclude=test)
         if valid_pct is None: src = il.split_by_folder(train=train, valid=valid)
         else: src = il.split_by_rand_pct(valid_pct, seed)
         src = src.label_from_folder(classes=classes)


### PR DESCRIPTION
while creating dataset "from_folder", the function picks training images from folders other than train/valid, if present and assign that folder name as a class. Changed it to pick training images only from 'train'.
 <!-- Feel free to remove check-list items aren't relevant to your change -->
 
 - [x] Read the [contributing docs](https://github.com/fastai/fastai/blob/master/CONTRIBUTING.md)
 - [x] Add details about your PR.
