### PR TITLE
 Fix for the type mismatch error that occurs at the call to _th_addmm_out.

### DIFF
--- a/fastai/vision/image.py
+++ b/fastai/vision/image.py
@@ -252,7 +252,7 @@ class ImagePoints(Image):
     "Support applying transforms to a `flow` of points."
     def __init__(self, flow:FlowField, scale:bool=True, y_first:bool=True):
         if scale: flow = scale_flow(flow)
-        if y_first: flow.flow = flow.flow.flip(1)
+        if y_first: flow.flow = flow.flow.flip(1).float()
         self._flow = flow
         self._affine_mat = None
         self.flow_func = []


### PR DESCRIPTION
The error, " RuntimeError: Expected object of scalar type Double but got scalar type Float for argument #3 'mat2' in call to _th_addmm_out" occurs in the fasatai dl1 notebook: lesson3-head-pose.ipynb.
![image](https://user-images.githubusercontent.com/62723901/81604850-2c8c6f80-9396-11ea-91c0-f6d71cd76637.png)

This occurs when c.flow is a tensor of type Double, m[:2,2] and a are tensors of type Float. 
So defining **flow.flow**  as Float ( in the file: https://github.com/fastai/fastai/blob/master/fastai/vision/image.py) as in the below picture helps to resolve this error.
![image](https://user-images.githubusercontent.com/62723901/81605770-98bba300-9397-11ea-89f5-81fcbf960502.png)

