### PR TITLE
Enhance the dynamicUnet to support efficientnet

### DIFF
--- a/fastai/torch_core.py
+++ b/fastai/torch_core.py
@@ -258,7 +258,7 @@ def apply_init(m, init_func:LayerFunc):
 
 def in_channels(m:nn.Module) -> List[int]:
     "Return the shape of the first weight layer in `m`."
-    for l in m.children():
+    for l in m.modules():
         if hasattr(l, 'weight'): return l.weight.shape[1]
     raise Exception('No weight layer')
 

--- a/fastai/torch_core.py
+++ b/fastai/torch_core.py
@@ -258,7 +258,7 @@ def apply_init(m, init_func:LayerFunc):
 
 def in_channels(m:nn.Module) -> List[int]:
     "Return the shape of the first weight layer in `m`."
-    for l in flatten_model(m):
+    for l in m.children():
         if hasattr(l, 'weight'): return l.weight.shape[1]
     raise Exception('No weight layer')
 

--- a/fastai/vision/models/unet.py
+++ b/fastai/vision/models/unet.py
@@ -46,7 +46,7 @@ def get_unet_config(model, img_size=(512, 512))->Tuple[List[Tuple], List[nn.Modu
     img_size = [x.shape[-1] // (2 ** i) for i in range(8)]
     img_size = [size for size in img_size if size >= 7]
     layer_mata = pd.DataFrame(layer_mata, columns=['sn', 'layer_name', 'c', 'w', 'h', 'size'])
-    layer_mata = layer_mata.loc[(layer_mata.w.isin(img_size))].drop_duplicates(['w'], keep='last')
+    layer_mata = layer_mata.loc[(layer_mata.h.isin(img_size))].drop_duplicates(['h'], keep='last')
 
     layer_size = list(layer_mata['size'])
     layers = [layers[i] for i in layer_mata.sn]

--- a/fastai/vision/models/unet.py
+++ b/fastai/vision/models/unet.py
@@ -11,6 +11,47 @@ def _get_sfs_idxs(sizes:Sizes) -> List[int]:
     if feature_szs[0] != feature_szs[1]: sfs_idxs = [0] + sfs_idxs
     return sfs_idxs
 
+def get_unet_config(model, img_size=(512, 512))->Tuple[List[Tuple], List[nn.Module]]:
+    "Cut the network to several blocks, the width and high of the image are reduced by half. And the image W and H >= 7"
+    x = torch.rand(1, in_channels(model), *img_size)
+    hooks = []
+    count = 0
+    layer_mata = []
+    layers = []
+
+    def flatten_moduleList(module: nn.Module) -> List[nn.Module]:
+        "If the ModuleList can be found in children, flatten it. Which is important to take efficientnet as decoder of unet"
+        res_list = []
+        for item in module.children():
+            if isinstance(item, nn.ModuleList):
+                res_list.extend(flatten_moduleList(item))
+            else:
+                res_list.append(item)
+        return res_list
+
+    def hook(module, input, output):
+        "To get the metadata of the layer"
+        nonlocal count
+        if len(output.shape) == 4:
+            b, c, w, h = output.shape
+            layer_mata.append((count, type(module).__name__, c, w, h, output.shape))
+        layers.append(module)
+        count += 1
+
+    for module in flatten_moduleList(model):
+        hooks.append(module.register_forward_hook(hook))
+    model(x)
+    for h in hooks: h.remove()
+
+    img_size = [x.shape[-1] // (2 ** i) for i in range(8)]
+    img_size = [size for size in img_size if size >= 7]
+    layer_mata = pd.DataFrame(layer_mata, columns=['sn', 'layer_name', 'c', 'w', 'h', 'size'])
+    layer_mata = layer_mata.loc[(layer_mata.w.isin(img_size))].drop_duplicates(['w'], keep='last')
+
+    layer_size = list(layer_mata['size'])
+    layers = [layers[i] for i in layer_mata.sn]
+    return layer_size, layers
+
 class UnetBlock(Module):
     "A quasi-UNet block, using `PixelShuffle_ICNR upsampling`."
     def __init__(self, up_in_c:int, x_in_c:int, hook:Hook, final_div:bool=True, blur:bool=False, leaky:float=None,
@@ -36,26 +77,30 @@ class UnetBlock(Module):
 
 class DynamicUnet(SequentialEx):
     "Create a U-Net from a given architecture."
-    def __init__(self, encoder:nn.Module, n_classes:int, img_size:Tuple[int,int]=(256,256), blur:bool=False, blur_final=True, self_attention:bool=False,
-                 y_range:Optional[Tuple[float,float]]=None,
-                 last_cross:bool=True, bottle:bool=False, **kwargs):
-        imsize = img_size
-        sfs_szs = model_sizes(encoder, size=imsize)
-        sfs_idxs = list(reversed(_get_sfs_idxs(sfs_szs)))
-        self.sfs = hook_outputs([encoder[i] for i in sfs_idxs], detach=False)
+
+    def __init__(self, encoder: nn.Module, n_classes: int, img_size: Tuple[int, int] = (256, 256),
+                 blur: bool = False,
+                 blur_final=True, self_attention: bool = False,
+                 y_range: Optional[Tuple[float, float]] = None,
+                 last_cross: bool = True, bottle: bool = False, **kwargs):
+        imsize = tuple(img_size)
+        sfs_szs, select_layer = get_unet_config(encoder, img_size)
+        ni = sfs_szs[-1][1]
+        sfs_szs = list(reversed(sfs_szs[:-1]))
+        select_layer = list(reversed(select_layer[:-1]))
+        self.sfs = hook_outputs(select_layer, detach=False)
         x = dummy_eval(encoder, imsize).detach()
 
-        ni = sfs_szs[-1][1]
-        middle_conv = nn.Sequential(conv_layer(ni, ni*2, **kwargs),
-                                    conv_layer(ni*2, ni, **kwargs)).eval()
+        middle_conv = nn.Sequential(conv_layer(ni, ni * 2, **kwargs),
+                                    conv_layer(ni * 2, ni, **kwargs)).eval()
         x = middle_conv(x)
         layers = [encoder, batchnorm_2d(ni), nn.ReLU(), middle_conv]
 
-        for i,idx in enumerate(sfs_idxs):
-            not_final = i!=len(sfs_idxs)-1
-            up_in_c, x_in_c = int(x.shape[1]), int(sfs_szs[idx][1])
+        for i, x_size in enumerate(sfs_szs):
+            not_final = i != len(sfs_szs) - 1
+            up_in_c, x_in_c = int(x.shape[1]), int(x_size[1])
             do_blur = blur and (not_final or blur_final)
-            sa = self_attention and (i==len(sfs_idxs)-3)
+            sa = self_attention and (i==len(sfs_szs) - 3)
             unet_block = UnetBlock(up_in_c, x_in_c, self.sfs[i], final_div=not_final, blur=do_blur, self_attention=sa,
                                    **kwargs).eval()
             layers.append(unet_block)

--- a/tests/test_torch_core.py
+++ b/tests/test_torch_core.py
@@ -56,6 +56,26 @@ def test_apply_init():
     assert conv1_w.equal(m[0][0].weight), "Expected first colvulition layer's weights to be %r" % conv1_w
     assert bn1_w.equal(m[0][2].weight), "Expected first batch norm layers weights to be %r" % bn1_w
 
+
+def test_in_channels_withchildren():
+    class Conv2dStaticSamePadding(nn.Conv2d):
+        "It is a mini class for first layer of Efficientnet:"
+        #https://github.com/lukemelas/EfficientNet-PyTorch/blob/master/efficientnet_pytorch/utils.py
+        def __init__(self, in_channels, out_channels, kernel_size, stride=1, **kwargs):
+            super().__init__(in_channels, out_channels, kernel_size, stride, **kwargs)
+            self.stride = self.stride if len(self.stride) == 2 else [self.stride[0]] * 2
+            self.static_padding = nn.ZeroPad2d((0, 1, 0, 1))
+
+    class dummy_efficientnet(nn.Module):
+        "It is a dummy class for efficientNet, which is only used for testing in_channels"
+        def __init__(self):
+            super().__init__()
+            self.conv_head = Conv2dStaticSamePadding(3, 48, kernel_size=1)
+
+    this_tests(in_channels)
+    m = dummy_efficientnet()
+    assert in_channels(m) == 3
+
 def test_in_channels():
     this_tests(in_channels)
     m = simple_cnn(b)


### PR DESCRIPTION
 <!-- Feel free to remove check-list items aren't relevant to your change -->
 
 - [X] Read the [contributing docs](https://github.com/fastai/fastai/blob/master/CONTRIBUTING.md)
 - [ ] If you are adding new functionality, create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality.
 - [X] Include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together!
 - [X] Add details about your PR.

DynamicUnet design is very cool, but it is not support EfficientNet as decoder, even it can get better score in most of the scenarios. 

The reason is the structure of EfficientNet is diff from normal structure.
- EfficientNet has ModuleList block, which can not forward.
- in_channels can not calculate the input channel for EfficientNet

Here is one of the simple test case to validate it

`
import torch
from torch import nn
from fastai.vision import models
from efficientnet_pytorch import EfficientNet

def eff():
    class EfficientNet_(EfficientNet):
        def __init__(self, *args, **kwargs):
            super().__init__(*args, **kwargs)
        def forward(self, inputs):
            x = self.extract_features(inputs)
            return x
    return EfficientNet_.from_pretrained(f'efficientnet-b0', in_channels=3)

for encoder in [eff(), 
                nn.Sequential(*list(models.resnet34().children())[:-3])]:
    unet =  models.unet.DynamicUnet(encoder, n_classes=5, img_size=(224, 224)) 
    print(type(encoder), unet(torch.rand(1,3,224,224)).shape)

`