### PR TITLE
Pass explicit strings when using torch.load

### DIFF
--- a/fastai/basic_data.py
+++ b/fastai/basic_data.py
@@ -276,7 +276,7 @@ def load_data(path:PathOrStr, file:PathLikeOrBinaryStream='data_save.pkl', bs:in
               dl_tfms:Optional[Collection[Callable]]=None, device:torch.device=None, collate_fn:Callable=data_collate,
               no_check:bool=False, **kwargs)->DataBunch:
     "Load a saved `DataBunch` from `path/file`. `file` can be file-like (file or buffer)"
-    source = Path(path)/file if is_pathlike(file) else file
+    source = str(Path(path)/file) if is_pathlike(file) else file
     distrib_barrier()
     ll = torch.load(source, map_location='cpu') if defaults.device == torch.device('cpu') else torch.load(source)
     return ll.databunch(path=path, bs=bs, val_bs=val_bs, num_workers=num_workers, dl_tfms=dl_tfms, device=device,

--- a/fastai/basic_train.py
+++ b/fastai/basic_train.py
@@ -264,7 +264,7 @@ class Learner():
         if purge: self.purge(clear_opt=ifnone(with_opt, False))
         if device is None: device = self.data.device
         elif isinstance(device, int): device = torch.device('cuda', device)
-        source = self.path/self.model_dir/f'{file}.pth' if is_pathlike(file) else file
+        source = str(self.path/self.model_dir/f'{file}.pth') if is_pathlike(file) else file
         distrib_barrier()
         state = torch.load(source, map_location=device)
         if set(state.keys()) == {'model', 'opt'}:
@@ -617,7 +617,7 @@ def load_callback(class_func, state, learn:Learner):
 
 def load_learner(path:PathOrStr, file:PathLikeOrBinaryStream='export.pkl', test:ItemList=None, tfm_y=None, **db_kwargs):
     "Load a `Learner` object saved with `export_state` in `path/file` with empty data, optionally add `test` and load on `cpu`. `file` can be file-like (file or buffer)"
-    source = Path(path)/file if is_pathlike(file) else file
+    source = str(Path(path)/file) if is_pathlike(file) else file
     state = torch.load(source, map_location='cpu') if defaults.device == torch.device('cpu') else torch.load(source)
     model = state.pop('model')
     src = LabelLists.load_state(path, state.pop('data'))


### PR DESCRIPTION
Found these were failing with the 1.6.0 release candidates for PyTorch
since torch.load no longer does a conversion of Path objects to strings.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

 <!-- Feel free to remove check-list items aren't relevant to your change -->
 
 - [x] Read the [contributing docs](https://github.com/fastai/fastai/blob/master/CONTRIBUTING.md)
 - [x] If you are adding new functionality, create a thread on [fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev) describing the functionality.
 - [x] Include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together!
 - [x] Add details about your PR.
