### PR TITLE
Support list of labels in LabelLists.add_test

### DIFF
--- a/fastai/data_block.py
+++ b/fastai/data_block.py
@@ -562,7 +562,9 @@ class LabelLists(ItemLists):
         "Add test set containing `items` with an arbitrary `label`."
         # if no label passed, use label of first training item
         if label is None: labels = EmptyLabelList([0] * len(items))
-        else: labels = self.valid.y.new([label] * len(items)).process()
+        else:
+          labels = label if hasattr(label, '__len__') else [label] * len(items)
+          labels = self.valid.y.new(labels).process()
         if isinstance(items, MixedItemList): items = self.valid.x.new(items.item_lists, inner_df=items.inner_df).process()
         elif isinstance(items, ItemList): items = self.valid.x.new(items.items, inner_df=items.inner_df).process()
         else: items = self.valid.x.new(items).process()

--- a/fastai/test_registry.json
+++ b/fastai/test_registry.json
@@ -2,7 +2,7 @@
     "fastai.basic_data.DataBunch": [
         {
             "file": "tests/test_data_block.py",
-            "line": 152,
+            "line": 153,
             "test": "test_custom_dataset"
         }
     ],
@@ -555,33 +555,33 @@
     "fastai.data_block.CategoryProcessor.process_one": [
         {
             "file": "tests/test_data_block.py",
-            "line": 80,
+            "line": 81,
             "test": "test_category_processor_existing_class"
         },
         {
             "file": "tests/test_data_block.py",
-            "line": 91,
+            "line": 92,
             "test": "test_category_processor_non_existing_class"
         }
     ],
     "fastai.data_block.ItemList.filter_by_folder": [
         {
             "file": "tests/test_data_block.py",
-            "line": 161,
+            "line": 162,
             "test": "test_filter_by_folder"
         }
     ],
     "fastai.data_block.ItemList.filter_by_rand": [
         {
             "file": "tests/test_data_block.py",
-            "line": 112,
+            "line": 113,
             "test": "test_filter_by_rand"
         }
     ],
     "fastai.data_block.ItemList.from_df": [
         {
             "file": "tests/test_data_block.py",
-            "line": 175,
+            "line": 176,
             "test": "test_from_df"
         }
     ],
@@ -600,15 +600,22 @@
     "fastai.data_block.ItemList.split_by_rand_pct": [
         {
             "file": "tests/test_data_block.py",
-            "line": 103,
+            "line": 104,
             "test": "test_splitdata_datasets"
         }
     ],
     "fastai.data_block.ItemList.split_subsets": [
         {
             "file": "tests/test_data_block.py",
-            "line": 121,
+            "line": 122,
             "test": "test_split_subsets"
+        }
+    ],
+    "fastai.data_block.LabelLists.add_test": [
+        {
+            "file": "tests/test_data_block.py",
+            "line": 184,
+            "test": "test_add_test"
         }
     ],
     "fastai.data_block.LabelLists.databunch": [

--- a/tests/test_data_block.py
+++ b/tests/test_data_block.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 from fastai.gen_doc.doctest import this_tests
 from fastai.basics import *
 from fastai.vision import ImageList
@@ -179,3 +180,23 @@ def test_from_df():
         ImageList.from_df(path="dummy_path", df=df)
     except Exception as ex:
         assert not isinstance(ex, TypeError)
+
+def test_add_test():
+    this_tests(LabelLists.add_test)
+    label_lists = LabelLists('.',
+      LabelList(ItemList([1, 2]), ItemList([True, False])),
+      LabelList(ItemList([2, 3]), ItemList([True, False])))
+
+    checks = [
+      ([ 7,  8,  9], None,                [False, False, False]),
+      ([10, 11, 12], True,                [True, True, True]),
+      ([13, 14, 15], [True, False, True], [True, False, True])
+    ]
+
+    for check in checks:
+      items, label, final_labels = check
+
+      label_lists.add_test(ItemList(items), label)
+
+      np.testing.assert_array_equal(label_lists.test.items, items)
+      np.testing.assert_array_equal(label_lists.test.y.items, final_labels)


### PR DESCRIPTION
 <!-- Feel free to remove check-list items aren't relevant to your change -->
 
 - [x] Read the [contributing docs](https://github.com/fastai/fastai/blob/master/CONTRIBUTING.md)
 - [x] Include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together!
 - [x] Add details about your PR.

Currently, `LabelLists.add_test` only supports using the same label for all the test set items

This PR adds support for using a list of labels in the test set