### PR TITLE
TypeError: new() argument after * must be an iterable, not int

### DIFF
--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -116,7 +116,7 @@ def unet_learner(data:DataBunch, arch:Callable, pretrained:bool=True, blur_final
     "Build Unet learner from `data` and `arch`."
     meta = cnn_config(arch)
     body = create_body(arch, pretrained, cut)
-    try:    size = data.train_ds[0][0].size
+    try:    size = data.train_ds[0][0].size()
     except: size = next(iter(data.train_dl))[0].shape[-2:]
     model = to_device(models.unet.DynamicUnet(body, n_classes=data.c, img_size=size, blur=blur, blur_final=blur_final,
           self_attention=self_attention, y_range=y_range, norm_type=norm_type, last_cross=last_cross,


### PR DESCRIPTION
This is my simple test code, and I want to use unet_learner with raw pytorch.
```python
import numpy as np
from torch.utils.data import Dataset, DataLoader
from fastai.vision import unet_learner, DataBunch
from torchvision.models import resnet18


class TDataset(Dataset):
    def __init__(self):
        self.c = 2

    def __getitem__(self, index):
        return np.random.rand(3, 224, 224), np.random.rand(1, 224, 224)

    def __len__(self):
        return 24

dl = DataLoader(TDataset(), batch_size=2)
db = DataBunch(dl, dl)
learn = unet_learner(db, resnet18, pretrained=False)

model=learn.model
x=np.random.rand(3, 224, 224)
model(x)
```
but encounted this error info
```
C:\ProgramData\Anaconda3\python.exe C:/Users/Javis/Downloads/UNet-Zoo-master/javis_unet.py
Traceback (most recent call last):
  File "C:/Users/Javis/Downloads/UNet-Zoo-master/javis_unet.py", line 22, in <module>
    learn = unet_learner(db, resnet18, pretrained=False)
  File "C:\ProgramData\Anaconda3\lib\site-packages\fastai\vision\learner.py", line 123, in unet_learner
    bottle=bottle), data.device)
  File "C:\ProgramData\Anaconda3\lib\site-packages\fastai\core.py", line 66, in _init
    old_init(self, *args,**kwargs)
  File "C:\ProgramData\Anaconda3\lib\site-packages\fastai\vision\models\unet.py", line 43, in __init__
    sfs_szs = model_sizes(encoder, size=imsize)
  File "C:\ProgramData\Anaconda3\lib\site-packages\fastai\callbacks\hooks.py", line 113, in model_sizes
    x = dummy_eval(m, size)
  File "C:\ProgramData\Anaconda3\lib\site-packages\fastai\callbacks\hooks.py", line 108, in dummy_eval
    return m.eval()(dummy_batch(m, size))
  File "C:\ProgramData\Anaconda3\lib\site-packages\fastai\callbacks\hooks.py", line 104, in dummy_batch
    return one_param(m).new(1, ch_in, *size).requires_grad_(False).uniform_(-1.,1.)
TypeError: new() argument after * must be an iterable, not int
``` 

