### PR TITLE
Fix misidentification of in channels when using grouped convolution

### DIFF
--- a/fastai/torch_core.py
+++ b/fastai/torch_core.py
@@ -259,7 +259,9 @@ def apply_init(m, init_func:LayerFunc):
 def in_channels(m:nn.Module) -> List[int]:
     "Return the shape of the first weight layer in `m`."
     for l in flatten_model(m):
-        if hasattr(l, 'weight'): return l.weight.shape[1]
+        if hasattr(l, 'weight'):
+            return l.weight.shape[1] * l.groups if hasattr(l, 'groups') else l.weight.shape[1]
+
     raise Exception('No weight layer')
 
 class ModelOnCPU():

--- a/tests/test_torch_core.py
+++ b/tests/test_torch_core.py
@@ -69,8 +69,8 @@ def test_in_channels_no_weights():
     
 def test_in_channels_groups():
     this_tests(in_channels)
-    m = nn.Conv2d(6, 2, 3, groups=2)
-    assert in_channels(m) == 6
+    m = nn.Conv2d(10, 2, 3, groups=2)
+    assert in_channels(m) == 10
 
 def test_range_children():
     this_tests(range_children)

--- a/tests/test_torch_core.py
+++ b/tests/test_torch_core.py
@@ -67,6 +67,11 @@ def test_in_channels_no_weights():
         in_channels(nn.Sequential())
     assert e_info.value.args[0] == 'No weight layer'
     
+def test_in_channels_groups():
+    this_tests(in_channels)
+    m = nn.Conv2d(6, 2, 3, groups=2)
+    assert in_channels(m) == 6
+
 def test_range_children():
     this_tests(range_children)
     m = simple_cnn(b)


### PR DESCRIPTION
 <!-- Feel free to remove check-list items aren't relevant to your change -->
 
 - [x] Read the [contributing docs](https://github.com/fastai/fastai/blob/master/CONTRIBUTING.md)
 - [x] Include a test in your PR that fails without your code, and passes with it.
 - [x] Add details about your PR.

Torch's `Conv2d` class allows a `groups` flag for grouped convolution to segregate channels into groups, for example to run parallel images at once.  When using the flag, the `weight` tensor is `out_channels` x `in_channels // groups` x `kernel_size` x `kernel_size`, while the module expects input with `in_channels` channels. This means the `in_channels` function will misidentify the channels the module is expecting when `groups` is not 1. This can cause errors when doing a `dummy_eval`, for example.

This PR provides a fix for that, as well as a test that reveals the misidentification.