### PR TITLE
type hint and default added to valid_pct in from_folder method in ima…

### DIFF
--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -101,7 +101,7 @@ class ImageDataBunch(DataBunch):
 
     @classmethod
     def from_folder(cls, path:PathOrStr, train:PathOrStr='train', valid:PathOrStr='valid', test:Optional[PathOrStr]=None,
-                    valid_pct=None, seed:int=None, classes:Collection=None, **kwargs:Any)->'ImageDataBunch':
+            valid_pct:float=0.2:, seed:int=None, classes:Collection=None, **kwargs:Any)->'ImageDataBunch':
         "Create from imagenet style dataset in `path` with `train`,`valid`,`test` subfolders (or provide `valid_pct`)."
         path=Path(path)
         il = ImageList.from_folder(path, exclude=test)

--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -101,7 +101,7 @@ class ImageDataBunch(DataBunch):
 
     @classmethod
     def from_folder(cls, path:PathOrStr, train:PathOrStr='train', valid:PathOrStr='valid', test:Optional[PathOrStr]=None,
-            valid_pct:float=0.2:, seed:int=None, classes:Collection=None, **kwargs:Any)->'ImageDataBunch':
+            valid_pct:float=0.2, seed:int=None, classes:Collection=None, **kwargs:Any)->'ImageDataBunch':
         "Create from imagenet style dataset in `path` with `train`,`valid`,`test` subfolders (or provide `valid_pct`)."
         path=Path(path)
         il = ImageList.from_folder(path, exclude=test)


### PR DESCRIPTION
…gedatabunch

 - [x] Read the [contributing docs](https://github.com/fastai/fastai/blob/master/CONTRIBUTING.md)
 - [x] Add details about your PR.

The *from_folder* method in ImageDataBunch class in vision.data doesn't have any type hints present. It just says *valid_pct=None*. All the other ImageDataBunch constructor methods have *valid_pct:float=0.2*.  

Since *valid_pct* is not a mandatory argument (since it's default is None), it gave an error. Then I troubleshooted and figured out and I had to specify a valid_pct. Since it's a percentage, I gave value 30 and it again gave error. Then I read the source code and realized that you have to give the decimal value of the percentage, by looking at the similar functions below. 

This is my first ever PR to fastai and apologies for lack of test code or relevant logs( I encountered the bugs long time back and just got time to actually make the contribution). The default value of 0.2 was taken from similar functions in the class.

Thanks the whole community for this wonderful project. It was the most easiest ML library to learn and work with. 