### PR TITLE
Fix min version for fastcore requirement

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -13,7 +13,7 @@ status = 1
 min_python = 3.6
 audience = Developers
 language = English
-requirements = fastcore>=0.1.34 torchvision>=0.7 matplotlib pandas requests pyyaml fastprogress>=0.2.4 pillow scikit-learn scipy spacy
+requirements = fastcore>=0.1.35 torchvision>=0.7 matplotlib pandas requests pyyaml fastprogress>=0.2.4 pillow scikit-learn scipy spacy
 pip_requirements = torch>=1.6.0
 conda_requirements = pytorch>=1.6.0
 dev_requirements = nbdev>=0.2.20


### PR DESCRIPTION
Renaming of `Tuple` to `fastuple` was tagged as version 0.1.35.