### PR TITLE
Fix typo in tutorial.ipynb

### DIFF
--- a/nbs/tutorial.ipynb
+++ b/nbs/tutorial.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The most important thing to remember is that each page of this documentation comes from a notebook. You can find them in the \"nbs\" folder in the [main repo](https://github.com/fastai/fastai2/tree/master/nbs). For tutorials, you can play around with the code and tweak if to do your own experiments. For the pages documenting the library, you will be able to see the source code and interact with all the tests."
+    "The most important thing to remember is that each page of this documentation comes from a notebook. You can find them in the \"nbs\" folder in the [main repo](https://github.com/fastai/fastai2/tree/master/nbs). For tutorials, you can play around with the code and tweak it to do your own experiments. For the pages documenting the library, you will be able to see the source code and interact with all the tests."
    ]
   },
   {


### PR DESCRIPTION
Changed 'if' to 'it'