### PR TITLE
update the show function so that you view all frames if the .dcm image has more than 1 frame per file

### DIFF
--- a/fastai/medical/imaging.py
+++ b/fastai/medical/imaging.py
@@ -161,6 +161,24 @@ def show(self:DcmDataset, scale=True, cmap=plt.cm.bone, min_px=-1100, max_px=Non
 
 # Cell
 @patch
+@delegates(show_image, show_images)
+def show(self:DcmDataset, frames=1, scale=True, cmap=plt.cm.bone, min_px=-1100, max_px=None, **kwargs):
+    """Adds the ability to view dicom images where each file may have more than 1 frame"""
+    px = (self.windowed(*scale) if isinstance(scale,tuple)
+          else self.hist_scaled(min_px=min_px,max_px=max_px,brks=scale) if isinstance(scale,(ndarray,Tensor))
+          else self.hist_scaled(min_px=min_px,max_px=max_px) if scale
+          else self.scaled_px)
+    if px.ndim > 2:
+        gh=[]
+        p = px.shape; print(f'{p[0]} frames per file')
+        for i in range(frames): u = px[i]; gh.append(u)
+        show_images(gh, **kwargs)
+    else:
+        print('1 frame per file')
+        show_image(px, cmap=cmap, **kwargs)
+
+# Cell
+@patch
 def pct_in_window(dcm:DcmDataset, w, l):
     "% of pixels in the window `(w,l)`"
     px = dcm.scaled_px

--- a/nbs/60_medical.imaging.ipynb
+++ b/nbs/60_medical.imaging.ipynb
@@ -411,11 +411,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Some dicom datasets such as the [The Thyroid Segmentation in Ultrasonography Dataset](https://opencas.webarchiv.kit.edu/?q=node/29) is a dataset where each image has multiple frames per file. By default the `show` function will display 1 frame but if the dataset has multiple frames you can specify the number of frames to view."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "#export\n",
     "@patch\n",
     "@delegates(show_image, show_images)\n",
     "def show(self:DcmDataset, frames=1, scale=True, cmap=plt.cm.bone, min_px=-1100, max_px=None, **kwargs):\n",

--- a/nbs/60_medical.imaging.ipynb
+++ b/nbs/60_medical.imaging.ipynb
@@ -407,6 +407,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "@patch\n",
+    "@delegates(show_image, show_images)\n",
+    "def show(self:DcmDataset, frames=1, scale=True, cmap=plt.cm.bone, min_px=-1100, max_px=None, **kwargs):\n",
+    "    \"\"\"Adds the ability to view dicom images where each file may have more than 1 frame\"\"\"\n",
+    "    px = (self.windowed(*scale) if isinstance(scale,tuple)\n",
+    "          else self.hist_scaled(min_px=min_px,max_px=max_px,brks=scale) if isinstance(scale,(ndarray,Tensor))\n",
+    "          else self.hist_scaled(min_px=min_px,max_px=max_px) if scale\n",
+    "          else self.scaled_px)\n",
+    "    if px.ndim > 2: \n",
+    "        gh=[]\n",
+    "        p = px.shape; print(f'{p[0]} frames per file')\n",
+    "        for i in range(frames): u = px[i]; gh.append(u)\n",
+    "        show_images(gh, **kwargs)    \n",
+    "    else: \n",
+    "        print('1 frame per file')\n",
+    "        show_image(px, cmap=cmap, **kwargs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "#export\n",
     "@patch\n",
     "def pct_in_window(dcm:DcmDataset, w, l):\n",

--- a/nbs/60_medical.imaging.ipynb
+++ b/nbs/60_medical.imaging.ipynb
@@ -414,7 +414,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Some dicom datasets such as the [The Thyroid Segmentation in Ultrasonography Dataset](https://opencas.webarchiv.kit.edu/?q=node/29) is a dataset where each image has multiple frames per file. By default the `show` function will display 1 frame but if the dataset has multiple frames you can specify the number of frames to view."
+    "Some dicom datasets such as the [The Thyroid Segmentation in Ultrasonography Dataset](https://opencas.webarchiv.kit.edu/?q=node/29) is a dataset where each image has multiple frames per file (hundreds in this case). By default the `show` function will display 1 frame but if the dataset has multiple frames you can specify the number of frames to view."
    ]
   },
   {
@@ -427,17 +427,17 @@
     "@patch\n",
     "@delegates(show_image, show_images)\n",
     "def show(self:DcmDataset, frames=1, scale=True, cmap=plt.cm.bone, min_px=-1100, max_px=None, **kwargs):\n",
-    "    \"\"\"Adds the ability to view dicom images where each file may have more than 1 frame\"\"\"\n",
+    "    \"\"\"Adds functionality to view dicom images where each file may have more than 1 frame\"\"\"\n",
     "    px = (self.windowed(*scale) if isinstance(scale,tuple)\n",
     "          else self.hist_scaled(min_px=min_px,max_px=max_px,brks=scale) if isinstance(scale,(ndarray,Tensor))\n",
     "          else self.hist_scaled(min_px=min_px,max_px=max_px) if scale\n",
     "          else self.scaled_px)\n",
-    "    if px.ndim > 2: \n",
+    "    if px.ndim > 2:\n",
     "        gh=[]\n",
     "        p = px.shape; print(f'{p[0]} frames per file')\n",
     "        for i in range(frames): u = px[i]; gh.append(u)\n",
-    "        show_images(gh, **kwargs)    \n",
-    "    else: \n",
+    "        show_images(gh, **kwargs)\n",
+    "    else:\n",
     "        print('1 frame per file')\n",
     "        show_image(px, cmap=cmap, **kwargs)"
    ]


### PR DESCRIPTION
Most .dcm datasets have 1 frame per file but some datasets have more than 1 frame per .dcm file. In this case the show function fails with a type error.  This update allows the show function to check for the number of ndims and specify how many frames to view (default being set at 1). 