### PR TITLE
fix README, CONTRIBUTING links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # How to contribute to fastai
 
 First, thanks a lot for wanting to help! Make sure you have read the [doc on code style](
-https://docs.fast.ai/dev/style.html) first. (Note that we don't follow PEP8, but instead follow a coding style designed specifically for numerical and interactive programming.) For help running and building the code, see the [developers guide](https://docs.fast.ai/dev/develop.html).
+https://docs.fast.ai/style.html) first. (Note that we don't follow PEP8, but instead follow a coding style designed specifically for numerical and interactive programming.) For help running and building the code, see the [developers guide](https://docs.fast.ai/dev/develop.html).
 
 ## Note for new contributors from Jeremy
 
@@ -17,7 +17,7 @@ It can be tempting to jump into a new project by questioning the stylistic decis
 
 Here are some ways that you can learn a lot about the library, whilst also contributing to the community:
 
-- Pick a class, function, or method and write tests for it. For instance, here are the tests for [fastai.core](https://github.com/fastai/fastai/blob/master/tests/test_core.py). Adding tests for anything without good test coverage is a great way to really understand that part of the library deeply, and have in-depth conversations with the dev team about the reasoning behind decisions in the code.
+- Pick a class, function, or method and write tests for it. For instance, here are the tests for [fastai.core](https://github.com/fastai/fastai1/blob/master/tests/test_core.py). Adding tests for anything without good test coverage is a great way to really understand that part of the library deeply, and have in-depth conversations with the dev team about the reasoning behind decisions in the code.
 - Document something that is currently undocumented. You can find them by looking for the “new methods” section in any doc notebook. Here’s a [search](https://github.com/fastai/fastai/search?q=%22new+methods%22&unscoped_q=%22new+methods%22) that lists them
 - Add an example of use to the docs for something that doesn’t currently have an example of use. We’d like everything soon in the docs to include an actual piece of working code demonstrating it. Currently, we’ve largely only provided working examples for stuff higher up the abstraction ladder.
 
@@ -31,7 +31,7 @@ Here are some ways that you can learn a lot about the library, whilst also contr
 #### Did you write a patch that fixes a bug?
 
 * Open a new GitHub pull request with the patch.
-* Ensure that your PR includes [tests](https://docs.fast.ai/dev/test.html) that fail without your patch, and pass with it.
+* Ensure that your PR includes [tests](https://docs.fast.ai/test.html) that fail without your patch, and pass with it.
 * Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
 * Before submitting, please be sure you abide by our [coding style](https://docs.fast.ai/dev/style.html) and [the guide on abbreviations](https://docs.fast.ai/dev/abbr.html) and clean-up your code accordingly.
 
@@ -42,7 +42,7 @@ Here are some ways that you can learn a lot about the library, whilst also contr
 * You can suggest your change on the [fastai forum](http://forums.fast.ai/) to see if others are interested or want to help. [This topic](http://forums.fast.ai/t/fastai-v1-adding-features/23041/8) lists the features that will be added to fastai in the foreseeable future. Be sure to read it too!
 * Before implementing a non-trivial new feature, first create a notebook version of your new feature, like those in [dev_nb](https://github.com/fastai/fastai_docs/tree/master/dev_nb). It should show step-by-step what your code is doing, and why, with the result of each step. Try to simplify the code as much as possible. When you're happy with it, let us know on the forum (include a link to gist with your notebook.)
 * Once your approach has been discussed and confirmed on the forum, you are welcome to push a PR, including a complete description of the new feature and an example of how it's used. Be sure to document your code and read the [doc on code style](https://docs.fast.ai/dev/style.html) and [the one on abbreviations](https://docs.fast.ai/dev/abbr.html).
-* Ensure that your PR includes [tests](https://docs.fast.ai/dev/test.html) that exercise not only your feature, but also any other code that might be impacted. Currently we have poor test coverage of existing features, so often you'll need to add tests of existing code. Your help here is much appreciated!
+* Ensure that your PR includes [tests](https://docs.fast.ai/test.html) that exercise not only your feature, but also any other code that might be impacted. Currently we have poor test coverage of existing features, so often you'll need to add tests of existing code. Your help here is much appreciated!
 
 ## How to submit notebook PRs?
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ pip install -e "fastai[dev]"
 
 The best way to get start with fastai (and deep learning) is to read [the book](https://www.amazon.com/Deep-Learning-Coders-fastai-PyTorch/dp/1492045527), and complete [the free course](https://course.fast.ai).
 
-To see what's possible with fastai, take a look at the [Quick Start](quick_start), which shows how to use around 5 lines of code to build an image classifier, an image segmentation model, a text sentiment model, a recommendation system, and a tabular model. For each of the applications, the code is much the same.
+To see what's possible with fastai, take a look at the [Quick Start](https://docs.fast.ai/quick_start), which shows how to use around 5 lines of code to build an image classifier, an image segmentation model, a text sentiment model, a recommendation system, and a tabular model. For each of the applications, the code is much the same.
 
-Read through the [Tutorials](tutorial) to learn how to train your own models on your own datasets. Use the navigation sidebar to look through the fastai documentation. Every class, function, and method is documented here.
+Read through the [Tutorials](https://docs.fast.ai/tutorial
+) to learn how to train your own models on your own datasets. Use the navigation sidebar to look through the fastai documentation. Every class, function, and method is documented here.
 
 To learn about the design and motivation of the library, read the [peer reviewed paper](https://www.mdpi.com/2078-2489/11/2/108/htm).
 
@@ -48,10 +49,10 @@ fastai is organized around two main design goals: to be approachable and rapidly
 
 It's very easy to migrate from plain PyTorch, Ignite, or any other PyTorch-based library, or even to use fastai in conjunction with other libraries. Generally, you'll be able to use all your existing data processing code, but will be able to reduce the amount of code you require for training, and more easily take advantage of modern best practices. Here are migration guides from some popular libraries to help you on your way:
 
-- [Plain PyTorch](migrating_pytorch)
-- [Ignite](migrating_ignite)
-- [Lightning](migrating_lightning)
-- [Catalyst](migrating_catalys)
+- [Plain PyTorch](https://docs.fast.ai/migrating_pytorch)
+- [Ignite](https://docs.fast.ai/migrating_ignite)
+- [Lightning](https://docs.fast.ai/migrating_lightning)
+- [Catalyst](https://docs.fast.ai/migrating_catalyst)
 
 ## Tests
 


### PR DESCRIPTION
Fixing links in `README.md` and `CONTRIBUTING.md` files as mentioned in [this](https://github.com/fastai/fastai/issues/2652) issue:
- [x]  https://github.com/fastai/fastai/blob/master/quick_start --> https://docs.fast.ai/quick_start
- [x]  https://github.com/fastai/fastai/blob/master/tutorial --> https://docs.fast.ai/tutorial
- [x]  https://github.com/fastai/fastai/blob/master/migrating_pytorch --> https://docs.fast.ai/migrating_pytorch
- [x]  https://github.com/fastai/fastai/blob/master/migrating_ignite --> https://docs.fast.ai/migrating_ignite
- [x]  https://github.com/fastai/fastai/blob/master/migrating_lightning --> https://docs.fast.ai/migrating_lightning
- [x]  https://github.com/fastai/fastai/blob/master/migrating_catalys --> https://docs.fast.ai/migrating_catalyst
- [x]  https://docs.fast.ai/dev/style.html --> https://docs.fast.ai/style.html (occurs multiple times)
- [ ]  https://docs.fast.ai/dev/develop.html --> ? (occurs multiple times)
- [x]  https://github.com/fastai/fastai/blob/master/tests/test_core.py --> https://github.com/fastai/fastai1/blob/master/tests/test_core.py (occurs multiple times)
- [x]  https://docs.fast.ai/dev/test.html --> https://docs.fast.ai/test.html (occurs multiple times)
- [ ]  https://docs.fast.ai/dev/abbr.html --> ? (occurs multiple times)