### PR TITLE
Expand on tabular documentation, clean up predict, and allow TabularModel to have custom activation functions

### DIFF
--- a/fastai/tabular/learner.py
+++ b/fastai/tabular/learner.py
@@ -12,14 +12,12 @@ from .model import *
 class TabularLearner(Learner):
     "`Learner` for tabular data"
     def predict(self, row):
-        tst_to = self.dls.valid_ds.new(pd.DataFrame(row).T)
-        tst_to.process()
-        tst_to.conts = tst_to.conts.astype(np.float32)
-        dl = self.dls.valid.new(tst_to)
+        "Predict on a Pandas Series"
+        dl = self.dls.test_dl(row.to_frame().T)
+        dl.dataset.conts = dl.dataset.conts.astype(np.float32)
         inp,preds,_,dec_preds = self.get_preds(dl=dl, with_input=True, with_decoded=True)
-        i = getattr(self.dls, 'n_inp', -1)
         b = (*tuplify(inp),*tuplify(dec_preds))
-        full_dec = self.dls.decode((*tuplify(inp),*tuplify(dec_preds)))
+        full_dec = self.dls.decode(b)
         return full_dec,dec_preds[0],preds[0]
 
 # Cell

--- a/fastai/tabular/model.py
+++ b/fastai/tabular/model.py
@@ -28,7 +28,7 @@ def get_emb_sz(to, sz_dict=None):
 class TabularModel(Module):
     "Basic model for tabular data."
     def __init__(self, emb_szs, n_cont, out_sz, layers, ps=None, embed_p=0.,
-                 y_range=None, use_bn=True, bn_final=False, bn_cont=True):
+                 y_range=None, use_bn=True, bn_final=False, bn_cont=True, act_cls=nn.ReLU(inplace=True)):
         ps = ifnone(ps, [0]*len(layers))
         if not is_listy(ps): ps = [ps]*len(layers)
         self.embeds = nn.ModuleList([Embedding(ni, nf) for ni,nf in emb_szs])
@@ -37,7 +37,7 @@ class TabularModel(Module):
         n_emb = sum(e.embedding_dim for e in self.embeds)
         self.n_emb,self.n_cont = n_emb,n_cont
         sizes = [n_emb + n_cont] + layers + [out_sz]
-        actns = [nn.ReLU(inplace=True) for _ in range(len(sizes)-2)] + [None]
+        actns = [act_cls for _ in range(len(sizes)-2)] + [None]
         _layers = [LinBnDrop(sizes[i], sizes[i+1], bn=use_bn and (i!=len(actns)-1 or bn_final), p=p, act=a)
                        for i,(p,a) in enumerate(zip(ps+[0.],actns))]
         if y_range is not None: _layers.append(SigmoidRange(*y_range))
@@ -56,5 +56,5 @@ class TabularModel(Module):
 # Cell
 @delegates(TabularModel.__init__)
 def tabular_config(**kwargs):
-    "Convenience function to easily create a config for `tabular_model`"
+    "Convenience function to easily create a config for `TabularModel`"
     return kwargs

--- a/nbs/42_tabular.model.ipynb
+++ b/nbs/42_tabular.model.ipynb
@@ -81,7 +81,7 @@
     "* A dimension space of 600\n",
     "* A dimension space equal to 1.6 times the cardinality of the variable to 0.56.\n",
     "\n",
-    "This provides a good starter for a good embedding space for your variables. For more advanced users who wish to lean into this practice, you can tweak these values to at discretion. It is not uncommon for slight adjustments to this general formula to provide more success."
+    "This provides a good starter for a good embedding space for your variables. For more advanced users who wish to lean into this practice, you can tweak these values to your discretion. It is not uncommon for slight adjustments to this general formula to provide more success."
    ]
   },
   {

--- a/nbs/42_tabular.model.ipynb
+++ b/nbs/42_tabular.model.ipynb
@@ -81,7 +81,7 @@
     "* A dimension space of 600\n",
     "* A dimension space equal to 1.6 times the cardinality of the variable to 0.56.\n",
     "\n",
-    "This provides a good starter for a good embedding space for your variables. For more advanced users who wish to lean into this practice, you can tweak these values to your discression. It is not uncommon for slight adjustments to this general formula to provide more success."
+    "This provides a good starter for a good embedding space for your variables. For more advanced users who wish to lean into this practice, you can tweak these values to at discretion. It is not uncommon for slight adjustments to this general formula to provide more success."
    ]
   },
   {
@@ -285,5 +285,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbs/42_tabular.model.ipynb
+++ b/nbs/42_tabular.model.ipynb
@@ -43,7 +43,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Model"
+    "## Embeddings"
    ]
   },
   {
@@ -74,6 +74,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Through trial and error, this general rule takes the lower of two values:\n",
+    "* A dimension space of 600\n",
+    "* A dimension space equal to 1.6 times the cardinality of the variable to 0.56.\n",
+    "\n",
+    "This provides a good starter for a good embedding space for your variables. For more advanced users who wish to lean into this practice, you can tweak these values to your discression. It is not uncommon for slight adjustments to this general formula to provide more success."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -95,7 +106,7 @@
     "class TabularModel(Module):\n",
     "    \"Basic model for tabular data.\"\n",
     "    def __init__(self, emb_szs, n_cont, out_sz, layers, ps=None, embed_p=0.,\n",
-    "                 y_range=None, use_bn=True, bn_final=False, bn_cont=True):\n",
+    "                 y_range=None, use_bn=True, bn_final=False, bn_cont=True, act_cls=nn.ReLU(inplace=True)):\n",
     "        ps = ifnone(ps, [0]*len(layers))\n",
     "        if not is_listy(ps): ps = [ps]*len(layers)\n",
     "        self.embeds = nn.ModuleList([Embedding(ni, nf) for ni,nf in emb_szs])\n",
@@ -104,7 +115,7 @@
     "        n_emb = sum(e.embedding_dim for e in self.embeds)\n",
     "        self.n_emb,self.n_cont = n_emb,n_cont\n",
     "        sizes = [n_emb + n_cont] + layers + [out_sz]\n",
-    "        actns = [nn.ReLU(inplace=True) for _ in range(len(sizes)-2)] + [None]\n",
+    "        actns = [act_cls for _ in range(len(sizes)-2)] + [None]\n",
     "        _layers = [LinBnDrop(sizes[i], sizes[i+1], bn=use_bn and (i!=len(actns)-1 or bn_final), p=p, act=a)\n",
     "                       for i,(p,a) in enumerate(zip(ps+[0.],actns))]\n",
     "        if y_range is not None: _layers.append(SigmoidRange(*y_range))\n",
@@ -122,6 +133,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This model expects your `cat` and `cont` variables seperated. `cat` is passed through an `Embedding` layer and potential `Dropout`, while `cont` is passed though potential `BatchNorm1d`. Afterwards both are concatenated and passed through a series of `LinBnDrop`, before a final `Linear` layer corresponding to the expected outputs. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "emb_szs = [(4,2), (17,8)]\n",
+    "m = TabularModel(emb_szs, n_cont=2, out_sz=2, layers=[200,100]).eval()\n",
+    "x_cat = torch.tensor([[2,12]]).long()\n",
+    "x_cont = torch.tensor([[0.7633, -0.1887]]).float()\n",
+    "out = m(x_cat, x_cont)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -130,8 +161,37 @@
     "#export\n",
     "@delegates(TabularModel.__init__)\n",
     "def tabular_config(**kwargs):\n",
-    "    \"Convenience function to easily create a config for `tabular_model`\"\n",
+    "    \"Convenience function to easily create a config for `TabularModel`\"\n",
     "    return kwargs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Any direct setup of `TabularModel`'s internals should be passed through here:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'embed_p': 0.6, 'use_bn': False}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "config = tabular_config(embed_p=0.6, use_bn=False); config"
    ]
   },
   {
@@ -212,13 +272,6 @@
     "from nbdev.export import notebook2script\n",
     "notebook2script()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -232,5 +285,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 0
 }

--- a/nbs/43_tabular.learner.ipynb
+++ b/nbs/43_tabular.learner.ipynb
@@ -53,7 +53,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The main function you probably want to use in this module is `tabular_learner`. It will automatically create a `TabulaModel` suitable for your data and infer the irght loss function. See the [tabular tutorial](http://docs.fast.ai/tutorial.tabular) for an example of use in context."
+    "The main function you probably want to use in this module is `tabular_learner`. It will automatically create a `TabulaModel` suitable for your data and infer the right loss function. See the [tabular tutorial](http://docs.fast.ai/tutorial.tabular) for an example of use in context."
    ]
   },
   {
@@ -74,14 +74,12 @@
     "class TabularLearner(Learner):\n",
     "    \"`Learner` for tabular data\"\n",
     "    def predict(self, row):\n",
-    "        tst_to = self.dls.valid_ds.new(pd.DataFrame(row).T)\n",
-    "        tst_to.process()\n",
-    "        tst_to.conts = tst_to.conts.astype(np.float32)\n",
-    "        dl = self.dls.valid.new(tst_to)\n",
+    "        \"Predict on a Pandas Series\"\n",
+    "        dl = self.dls.test_dl(row.to_frame().T)\n",
+    "        dl.dataset.conts = dl.dataset.conts.astype(np.float32)\n",
     "        inp,preds,_,dec_preds = self.get_preds(dl=dl, with_input=True, with_decoded=True)\n",
-    "        i = getattr(self.dls, 'n_inp', -1)\n",
     "        b = (*tuplify(inp),*tuplify(dec_preds))\n",
-    "        full_dec = self.dls.decode((*tuplify(inp),*tuplify(dec_preds)))\n",
+    "        full_dec = self.dls.decode(b)\n",
     "        return full_dec,dec_preds[0],preds[0]"
    ]
   },
@@ -95,15 +93,17 @@
       "text/markdown": [
        "<h3 id=\"TabularLearner\" class=\"doc_header\"><code>class</code> <code>TabularLearner</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h3>\n",
        "\n",
-       "> <code>TabularLearner</code>(**`dls`**, **`model`**, **`loss_func`**=*`None`*, **`opt_func`**=*`'Adam'`*, **`lr`**=*`0.001`*, **`splitter`**=*`'trainable_params'`*, **`cbs`**=*`None`*, **`metrics`**=*`None`*, **`path`**=*`None`*, **`model_dir`**=*`'models'`*, **`wd`**=*`None`*, **`wd_bn_bias`**=*`False`*, **`train_bn`**=*`True`*, **`moms`**=*`(0.95, 0.85, 0.95)`*) :: [`Learner`](/13a_learner#Learner)\n",
+       "> <code>TabularLearner</code>(**`dls`**, **`model`**, **`loss_func`**=*`None`*, **`opt_func`**=*`Adam`*, **`lr`**=*`0.001`*, **`splitter`**=*`trainable_params`*, **`cbs`**=*`None`*, **`metrics`**=*`None`*, **`path`**=*`None`*, **`model_dir`**=*`'models'`*, **`wd`**=*`None`*, **`wd_bn_bias`**=*`False`*, **`train_bn`**=*`True`*, **`moms`**=*`(0.95, 0.85, 0.95)`*) :: `Learner`\n",
        "\n",
-       "[`Learner`](/13a_learner#Learner) for tabular data"
+       "`Learner` for tabular data"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "tags": []
+     },
      "output_type": "display_data"
     }
    ],
@@ -171,10 +171,123 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<h4 id=\"TabularLearner.predict\" class=\"doc_header\"><code>TabularLearner.predict</code><a href=\"__main__.py#L5\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "\n",
+       "> <code>TabularLearner.predict</code>(**`row`**)\n",
+       "\n",
+       "Predict on a Pandas Series"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "show_doc(TabularLearner.predict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can pass in an individual row of data into our `TabularLearner`'s `predict` method. It's output is slightly different from the other `predict` methods, as this one will always return the input as well:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "#hide\n",
-    "tst = learn.predict(df.iloc[0])"
+    "row, clas, probs = learn.predict(df.iloc[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>workclass</th>\n",
+       "      <th>education</th>\n",
+       "      <th>marital-status</th>\n",
+       "      <th>occupation</th>\n",
+       "      <th>relationship</th>\n",
+       "      <th>race</th>\n",
+       "      <th>education-num_na</th>\n",
+       "      <th>age</th>\n",
+       "      <th>fnlwgt</th>\n",
+       "      <th>education-num</th>\n",
+       "      <th>salary</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Private</td>\n",
+       "      <td>Assoc-acdm</td>\n",
+       "      <td>Married-civ-spouse</td>\n",
+       "      <td>#na#</td>\n",
+       "      <td>Wife</td>\n",
+       "      <td>White</td>\n",
+       "      <td>False</td>\n",
+       "      <td>49.0</td>\n",
+       "      <td>101320.001685</td>\n",
+       "      <td>12.0</td>\n",
+       "      <td>&lt;50k</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "row.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(tensor(0), tensor([0.5264, 0.4736]))"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "clas, probs"
    ]
   },
   {
@@ -303,7 +416,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    ""
+   ]
   }
  ],
  "metadata": {
@@ -317,5 +432,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 0
 }

--- a/nbs/43_tabular.learner.ipynb
+++ b/nbs/43_tabular.learner.ipynb
@@ -416,9 +416,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    ""
-   ]
+   "source": []
   }
  ],
  "metadata": {
@@ -432,5 +430,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbs/44_tutorial.tabular.ipynb
+++ b/nbs/44_tutorial.tabular.ipynb
@@ -39,9 +39,7 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       ""
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -592,9 +590,7 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       ""
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -792,9 +788,7 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       ""
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -920,9 +914,7 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       ""
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -1197,59 +1189,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And now we can directly send this in! An example with `XGBoost` is below:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from xgboost import XGBClassifier\n",
-    "\n",
-    "model = XGBClassifier()\n",
-    "model = model.fit(X_train,y_train)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can then gather predictions as well:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "preds = model.predict_proba(X_test)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[9.9995238e-01, 4.7629295e-05],\n",
-       "       [9.9995238e-01, 4.7629295e-05],\n",
-       "       [9.9995238e-01, 4.7629295e-05]], dtype=float32)"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {
-      "tags": []
-     },
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "preds[:3]"
+    "And now we can directly send this in!"
    ]
   }
  ],
@@ -1264,5 +1204,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbs/44_tutorial.tabular.ipynb
+++ b/nbs/44_tutorial.tabular.ipynb
@@ -29,7 +29,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can download a sample of this dataset with the usual command:"
+    "We can download a sample of this dataset with the usual `untar_data` command:"
    ]
   },
   {
@@ -39,12 +39,28 @@
    "outputs": [
     {
      "data": {
+      "text/html": [
+       ""
+      ],
       "text/plain": [
-       "(#3) [Path('/home/sgugger/.fastai/data/adult_sample/models'),Path('/home/sgugger/.fastai/data/adult_sample/adult.csv'),Path('/home/sgugger/.fastai/data/adult_sample/export.pkl')]"
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(#3) [Path('/root/.fastai/data/adult_sample/adult.csv'),Path('/root/.fastai/data/adult_sample/models'),Path('/root/.fastai/data/adult_sample/export.pkl')]"
       ]
      },
      "execution_count": null,
-     "metadata": {},
+     "metadata": {
+      "tags": []
+     },
      "output_type": "execute_result"
     }
    ],
@@ -199,30 +215,20 @@
        "</div>"
       ],
       "text/plain": [
-       "   age          workclass  fnlwgt     education  education-num  \\\n",
-       "0   49            Private  101320    Assoc-acdm           12.0   \n",
-       "1   44            Private  236746       Masters           14.0   \n",
-       "2   38            Private   96185       HS-grad            NaN   \n",
-       "3   38       Self-emp-inc  112847   Prof-school           15.0   \n",
-       "4   42   Self-emp-not-inc   82297       7th-8th            NaN   \n",
+       "   age          workclass  fnlwgt  ... hours-per-week  native-country salary\n",
+       "0   49            Private  101320  ...             40   United-States  >=50k\n",
+       "1   44            Private  236746  ...             45   United-States  >=50k\n",
+       "2   38            Private   96185  ...             32   United-States   <50k\n",
+       "3   38       Self-emp-inc  112847  ...             40   United-States  >=50k\n",
+       "4   42   Self-emp-not-inc   82297  ...             50   United-States   <50k\n",
        "\n",
-       "        marital-status        occupation    relationship                 race  \\\n",
-       "0   Married-civ-spouse               NaN            Wife                White   \n",
-       "1             Divorced   Exec-managerial   Not-in-family                White   \n",
-       "2             Divorced               NaN       Unmarried                Black   \n",
-       "3   Married-civ-spouse    Prof-specialty         Husband   Asian-Pac-Islander   \n",
-       "4   Married-civ-spouse     Other-service            Wife                Black   \n",
-       "\n",
-       "       sex  capital-gain  capital-loss  hours-per-week  native-country salary  \n",
-       "0   Female             0          1902              40   United-States  >=50k  \n",
-       "1     Male         10520             0              45   United-States  >=50k  \n",
-       "2   Female             0             0              32   United-States   <50k  \n",
-       "3     Male             0             0              40   United-States  >=50k  \n",
-       "4   Female             0             0              50   United-States   <50k  "
+       "[5 rows x 15 columns]"
       ]
      },
      "execution_count": null,
-     "metadata": {},
+     "metadata": {
+      "tags": []
+     },
      "output_type": "execute_result"
     }
    ],
@@ -259,7 +265,65 @@
     "- `Categorify` is going to take every categorical variable and make a map from integer to unique categories, then replace the values by the corresponding index.\n",
     "- `FillMissing` will fille the missing values in the continuous variables by the median of existing values (you can choose a specific value if you prefer)\n",
     "- `Normalize` will normalize the continuous variables (substract the mean and divide by the std)\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To further expose what's going on below the surface, let's rewrite this utilizing `fastai`'s `TabularPandas` class. We will need to make one adjustment, which is defining how we want to split our data. By default the factory method above used a random 80/20 split, so we will do the same:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "splits = RandomSplitter(valid_pct=0.2)(range_of(df))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "to = TabularPandas(df, procs=[Categorify, FillMissing,Normalize],\n",
+    "                   cat_names = ['workclass', 'education', 'marital-status', 'occupation', 'relationship', 'race'],\n",
+    "                   cont_names = ['age', 'fnlwgt', 'education-num'],\n",
+    "                   y_names='salary',\n",
+    "                   splits=splits)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before finally building our `DataLoaders` again:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dls = to.dataloaders(bs=64)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Later we will explore why using `TabularPandas` to preprocess will be valuable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The `show_batch` method works like for every other application:"
    ]
   },
@@ -291,142 +355,142 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>?</td>\n",
-       "      <td>Some-college</td>\n",
-       "      <td>Never-married</td>\n",
-       "      <td>?</td>\n",
-       "      <td>Own-child</td>\n",
+       "      <td>State-gov</td>\n",
+       "      <td>Bachelors</td>\n",
+       "      <td>Married-civ-spouse</td>\n",
+       "      <td>Prof-specialty</td>\n",
+       "      <td>Wife</td>\n",
        "      <td>White</td>\n",
        "      <td>False</td>\n",
-       "      <td>22.000000</td>\n",
-       "      <td>32731.996436</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>&lt;50k</td>\n",
+       "      <td>41.000000</td>\n",
+       "      <td>75409.001182</td>\n",
+       "      <td>13.0</td>\n",
+       "      <td>&gt;=50k</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>Private</td>\n",
-       "      <td>7th-8th</td>\n",
-       "      <td>Married-civ-spouse</td>\n",
-       "      <td>Machine-op-inspct</td>\n",
-       "      <td>Husband</td>\n",
+       "      <td>Some-college</td>\n",
+       "      <td>Never-married</td>\n",
+       "      <td>Craft-repair</td>\n",
+       "      <td>Not-in-family</td>\n",
        "      <td>White</td>\n",
        "      <td>False</td>\n",
-       "      <td>44.000000</td>\n",
-       "      <td>99202.998578</td>\n",
-       "      <td>4.0</td>\n",
+       "      <td>24.000000</td>\n",
+       "      <td>38455.005013</td>\n",
+       "      <td>10.0</td>\n",
        "      <td>&lt;50k</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>Private</td>\n",
-       "      <td>HS-grad</td>\n",
-       "      <td>Divorced</td>\n",
-       "      <td>Farming-fishing</td>\n",
-       "      <td>Not-in-family</td>\n",
+       "      <td>Assoc-acdm</td>\n",
+       "      <td>Married-civ-spouse</td>\n",
+       "      <td>Prof-specialty</td>\n",
+       "      <td>Husband</td>\n",
        "      <td>White</td>\n",
        "      <td>False</td>\n",
-       "      <td>63.000001</td>\n",
-       "      <td>117680.996997</td>\n",
-       "      <td>9.0</td>\n",
+       "      <td>48.000000</td>\n",
+       "      <td>101299.003093</td>\n",
+       "      <td>12.0</td>\n",
        "      <td>&lt;50k</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>Private</td>\n",
        "      <td>HS-grad</td>\n",
-       "      <td>Married-civ-spouse</td>\n",
-       "      <td>Machine-op-inspct</td>\n",
-       "      <td>Husband</td>\n",
-       "      <td>White</td>\n",
+       "      <td>Never-married</td>\n",
+       "      <td>Other-service</td>\n",
+       "      <td>Other-relative</td>\n",
+       "      <td>Black</td>\n",
        "      <td>False</td>\n",
-       "      <td>33.000000</td>\n",
-       "      <td>194141.000170</td>\n",
+       "      <td>42.000000</td>\n",
+       "      <td>227465.999281</td>\n",
        "      <td>9.0</td>\n",
        "      <td>&lt;50k</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>Private</td>\n",
-       "      <td>Assoc-voc</td>\n",
-       "      <td>Divorced</td>\n",
-       "      <td>Transport-moving</td>\n",
+       "      <td>State-gov</td>\n",
+       "      <td>Some-college</td>\n",
+       "      <td>Never-married</td>\n",
+       "      <td>Prof-specialty</td>\n",
        "      <td>Not-in-family</td>\n",
        "      <td>White</td>\n",
        "      <td>False</td>\n",
-       "      <td>35.000000</td>\n",
-       "      <td>172570.999732</td>\n",
-       "      <td>11.0</td>\n",
+       "      <td>20.999999</td>\n",
+       "      <td>258489.997130</td>\n",
+       "      <td>10.0</td>\n",
        "      <td>&lt;50k</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
        "      <td>Local-gov</td>\n",
-       "      <td>HS-grad</td>\n",
-       "      <td>Divorced</td>\n",
-       "      <td>Exec-managerial</td>\n",
-       "      <td>Unmarried</td>\n",
-       "      <td>Amer-Indian-Eskimo</td>\n",
+       "      <td>12th</td>\n",
+       "      <td>Married-civ-spouse</td>\n",
+       "      <td>Tech-support</td>\n",
+       "      <td>Husband</td>\n",
+       "      <td>White</td>\n",
        "      <td>False</td>\n",
-       "      <td>43.000000</td>\n",
-       "      <td>196308.000036</td>\n",
-       "      <td>9.0</td>\n",
+       "      <td>39.000000</td>\n",
+       "      <td>207853.000067</td>\n",
+       "      <td>8.0</td>\n",
        "      <td>&lt;50k</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
        "      <td>Private</td>\n",
-       "      <td>HS-grad</td>\n",
-       "      <td>Never-married</td>\n",
-       "      <td>Exec-managerial</td>\n",
-       "      <td>Not-in-family</td>\n",
+       "      <td>Assoc-voc</td>\n",
+       "      <td>Married-civ-spouse</td>\n",
+       "      <td>Sales</td>\n",
+       "      <td>Husband</td>\n",
        "      <td>White</td>\n",
        "      <td>False</td>\n",
-       "      <td>43.000000</td>\n",
-       "      <td>336642.996235</td>\n",
-       "      <td>9.0</td>\n",
-       "      <td>&lt;50k</td>\n",
+       "      <td>36.000000</td>\n",
+       "      <td>238414.998930</td>\n",
+       "      <td>11.0</td>\n",
+       "      <td>&gt;=50k</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
        "      <td>Private</td>\n",
        "      <td>HS-grad</td>\n",
        "      <td>Never-married</td>\n",
-       "      <td>Other-service</td>\n",
+       "      <td>Craft-repair</td>\n",
        "      <td>Not-in-family</td>\n",
        "      <td>White</td>\n",
        "      <td>False</td>\n",
-       "      <td>27.000000</td>\n",
-       "      <td>158156.001081</td>\n",
+       "      <td>19.000000</td>\n",
+       "      <td>445727.998937</td>\n",
        "      <td>9.0</td>\n",
        "      <td>&lt;50k</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
-       "      <td>?</td>\n",
+       "      <td>Local-gov</td>\n",
        "      <td>Bachelors</td>\n",
-       "      <td>Never-married</td>\n",
-       "      <td>?</td>\n",
-       "      <td>Unmarried</td>\n",
+       "      <td>Married-civ-spouse</td>\n",
+       "      <td>#na#</td>\n",
+       "      <td>Husband</td>\n",
        "      <td>White</td>\n",
-       "      <td>False</td>\n",
-       "      <td>26.000000</td>\n",
-       "      <td>130832.001756</td>\n",
-       "      <td>13.0</td>\n",
-       "      <td>&lt;50k</td>\n",
+       "      <td>True</td>\n",
+       "      <td>59.000000</td>\n",
+       "      <td>196013.000174</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>&gt;=50k</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
        "      <td>Private</td>\n",
-       "      <td>Assoc-voc</td>\n",
+       "      <td>HS-grad</td>\n",
        "      <td>Married-civ-spouse</td>\n",
-       "      <td>Tech-support</td>\n",
-       "      <td>Husband</td>\n",
-       "      <td>White</td>\n",
+       "      <td>Prof-specialty</td>\n",
+       "      <td>Wife</td>\n",
+       "      <td>Black</td>\n",
        "      <td>False</td>\n",
-       "      <td>27.000000</td>\n",
-       "      <td>62737.003461</td>\n",
-       "      <td>11.0</td>\n",
+       "      <td>39.000000</td>\n",
+       "      <td>147500.000403</td>\n",
+       "      <td>9.0</td>\n",
        "      <td>&lt;50k</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -436,7 +500,9 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "tags": []
+     },
      "output_type": "display_data"
     }
    ],
@@ -490,9 +556,9 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>0</td>\n",
-       "      <td>0.366727</td>\n",
-       "      <td>0.351524</td>\n",
-       "      <td>0.835842</td>\n",
+       "      <td>0.369360</td>\n",
+       "      <td>0.348096</td>\n",
+       "      <td>0.840756</td>\n",
        "      <td>00:05</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -502,7 +568,9 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "tags": []
+     },
      "output_type": "display_data"
     }
    ],
@@ -524,12 +592,16 @@
    "outputs": [
     {
      "data": {
-      "text/html": [],
+      "text/html": [
+       ""
+      ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "tags": []
+     },
      "output_type": "display_data"
     },
     {
@@ -559,133 +631,133 @@
        "      <td>5.0</td>\n",
        "      <td>12.0</td>\n",
        "      <td>3.0</td>\n",
-       "      <td>15.0</td>\n",
+       "      <td>8.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>5.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>-0.333356</td>\n",
-       "      <td>-0.900977</td>\n",
-       "      <td>-0.419934</td>\n",
-       "      <td>1.0</td>\n",
+       "      <td>0.324868</td>\n",
+       "      <td>-1.138177</td>\n",
+       "      <td>-0.424022</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>7.0</td>\n",
-       "      <td>12.0</td>\n",
        "      <td>5.0</td>\n",
-       "      <td>6.0</td>\n",
+       "      <td>10.0</td>\n",
        "      <td>5.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
        "      <td>5.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>0.916167</td>\n",
-       "      <td>-1.457755</td>\n",
-       "      <td>-0.419934</td>\n",
+       "      <td>-0.482055</td>\n",
+       "      <td>-1.351911</td>\n",
+       "      <td>1.148438</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>5.0</td>\n",
-       "      <td>10.0</td>\n",
+       "      <td>12.0</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>12.0</td>\n",
        "      <td>3.0</td>\n",
-       "      <td>2.0</td>\n",
-       "      <td>1.0</td>\n",
        "      <td>5.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>-0.774364</td>\n",
-       "      <td>-0.030944</td>\n",
-       "      <td>1.150726</td>\n",
+       "      <td>-0.775482</td>\n",
+       "      <td>0.138709</td>\n",
+       "      <td>-0.424022</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>5.0</td>\n",
-       "      <td>13.0</td>\n",
-       "      <td>3.0</td>\n",
+       "      <td>16.0</td>\n",
        "      <td>5.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>4.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>-0.259855</td>\n",
-       "      <td>-0.668491</td>\n",
-       "      <td>1.543390</td>\n",
+       "      <td>-1.362335</td>\n",
+       "      <td>-0.227515</td>\n",
+       "      <td>-0.030907</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>5.0</td>\n",
-       "      <td>13.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>13.0</td>\n",
        "      <td>2.0</td>\n",
        "      <td>5.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>5.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>0.622161</td>\n",
-       "      <td>0.409060</td>\n",
-       "      <td>1.543390</td>\n",
-       "      <td>1.0</td>\n",
+       "      <td>-1.509048</td>\n",
+       "      <td>-0.191191</td>\n",
+       "      <td>-1.210252</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>3.0</td>\n",
+       "      <td>5.0</td>\n",
        "      <td>16.0</td>\n",
        "      <td>3.0</td>\n",
-       "      <td>4.0</td>\n",
+       "      <td>13.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>5.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>0.254654</td>\n",
-       "      <td>-0.870132</td>\n",
-       "      <td>-0.027269</td>\n",
+       "      <td>1.498575</td>\n",
+       "      <td>-0.051096</td>\n",
+       "      <td>-0.030907</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
        "      <td>5.0</td>\n",
        "      <td>12.0</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>13.0</td>\n",
-       "      <td>2.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>15.0</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>5.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>-0.259855</td>\n",
-       "      <td>-0.464552</td>\n",
-       "      <td>-0.419934</td>\n",
+       "      <td>-0.555412</td>\n",
+       "      <td>0.039167</td>\n",
+       "      <td>-0.424022</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
        "      <td>5.0</td>\n",
-       "      <td>9.0</td>\n",
-       "      <td>3.0</td>\n",
-       "      <td>4.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>5.0</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>5.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>0.989668</td>\n",
-       "      <td>-0.430562</td>\n",
-       "      <td>0.365396</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>1.0</td>\n",
+       "      <td>-1.582405</td>\n",
+       "      <td>-1.396391</td>\n",
+       "      <td>-1.603367</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
-       "      <td>6.0</td>\n",
-       "      <td>16.0</td>\n",
+       "      <td>5.0</td>\n",
        "      <td>3.0</td>\n",
-       "      <td>4.0</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>13.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>5.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>3.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>-0.627362</td>\n",
-       "      <td>-0.110140</td>\n",
-       "      <td>-0.027269</td>\n",
+       "      <td>-1.362335</td>\n",
+       "      <td>0.158354</td>\n",
+       "      <td>-0.817137</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
@@ -696,7 +768,9 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "tags": []
+     },
      "output_type": "display_data"
     }
    ],
@@ -718,33 +792,100 @@
    "outputs": [
     {
      "data": {
-      "text/html": [],
+      "text/html": [
+       ""
+      ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "tags": []
+     },
      "output_type": "display_data"
-    },
+    }
+   ],
+   "source": [
+    "row, clas, probs = learn.predict(df.iloc[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>workclass</th>\n",
+       "      <th>education</th>\n",
+       "      <th>marital-status</th>\n",
+       "      <th>occupation</th>\n",
+       "      <th>relationship</th>\n",
+       "      <th>race</th>\n",
+       "      <th>education-num_na</th>\n",
+       "      <th>age</th>\n",
+       "      <th>fnlwgt</th>\n",
+       "      <th>education-num</th>\n",
+       "      <th>salary</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Private</td>\n",
+       "      <td>Assoc-acdm</td>\n",
+       "      <td>Married-civ-spouse</td>\n",
+       "      <td>#na#</td>\n",
+       "      <td>Wife</td>\n",
+       "      <td>White</td>\n",
+       "      <td>False</td>\n",
+       "      <td>49.0</td>\n",
+       "      <td>101319.99788</td>\n",
+       "      <td>12.0</td>\n",
+       "      <td>&gt;=50k</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "row.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
     {
      "data": {
       "text/plain": [
-       "(   workclass  education  marital-status  occupation  relationship  race  \\\n",
-       " 0        5.0        8.0             3.0         0.0           6.0   5.0   \n",
-       " \n",
-       "    education-num_na       age    fnlwgt  education-num  salary  \n",
-       " 0               1.0  0.769164 -0.835926       0.758061     0.0  ,\n",
-       " tensor(0),\n",
-       " tensor([0.5200, 0.4800]))"
+       "(tensor(1), tensor([0.4995, 0.5005]))"
       ]
      },
      "execution_count": null,
-     "metadata": {},
+     "metadata": {
+      "tags": []
+     },
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "learn.predict(df.iloc[0])"
+    "clas, probs"
    ]
   },
   {
@@ -779,28 +920,34 @@
    "outputs": [
     {
      "data": {
-      "text/html": [],
+      "text/html": [
+       ""
+      ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "tags": []
+     },
      "output_type": "display_data"
     },
     {
      "data": {
       "text/plain": [
-       "(tensor([[0.5200, 0.4800],\n",
-       "         [0.5536, 0.4464],\n",
-       "         [0.9767, 0.0233],\n",
+       "(tensor([[0.4995, 0.5005],\n",
+       "         [0.4882, 0.5118],\n",
+       "         [0.9824, 0.0176],\n",
        "         ...,\n",
-       "         [0.6025, 0.3975],\n",
-       "         [0.7228, 0.2772],\n",
-       "         [0.5157, 0.4843]]), None)"
+       "         [0.5324, 0.4676],\n",
+       "         [0.7628, 0.2372],\n",
+       "         [0.5934, 0.4066]]), None)"
       ]
      },
      "execution_count": null,
-     "metadata": {},
+     "metadata": {
+      "tags": []
+     },
      "output_type": "execute_result"
     }
    ],
@@ -809,11 +956,301 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `fastai` with Other Libraries\n",
+    "\n",
+    "As mentioned earlier, `TabularPandas` is a powerful and easy preprocessing tool for tabular data. Integration with libraries such as Random Forests and XGBoost requires only one extra step, that the `.dataloaders` call did for us. Let's look at our `to` again. It's values are stored in a `DataFrame` like object, where we can extract the `cats`, `conts,` `xs` and `ys` if we want to:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>workclass</th>\n",
+       "      <th>education</th>\n",
+       "      <th>marital-status</th>\n",
+       "      <th>occupation</th>\n",
+       "      <th>relationship</th>\n",
+       "      <th>race</th>\n",
+       "      <th>education-num_na</th>\n",
+       "      <th>age</th>\n",
+       "      <th>fnlwgt</th>\n",
+       "      <th>education-num</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>25387</th>\n",
+       "      <td>5</td>\n",
+       "      <td>16</td>\n",
+       "      <td>3</td>\n",
+       "      <td>5</td>\n",
+       "      <td>1</td>\n",
+       "      <td>5</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.471582</td>\n",
+       "      <td>-1.467756</td>\n",
+       "      <td>-0.030907</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16872</th>\n",
+       "      <td>1</td>\n",
+       "      <td>16</td>\n",
+       "      <td>5</td>\n",
+       "      <td>1</td>\n",
+       "      <td>4</td>\n",
+       "      <td>5</td>\n",
+       "      <td>1</td>\n",
+       "      <td>-1.215622</td>\n",
+       "      <td>-0.649792</td>\n",
+       "      <td>-0.030907</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25852</th>\n",
+       "      <td>5</td>\n",
+       "      <td>16</td>\n",
+       "      <td>3</td>\n",
+       "      <td>5</td>\n",
+       "      <td>1</td>\n",
+       "      <td>5</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.865358</td>\n",
+       "      <td>-0.218915</td>\n",
+       "      <td>-0.030907</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       workclass  education  marital-status  ...       age    fnlwgt  education-num\n",
+       "25387          5         16               3  ...  0.471582 -1.467756      -0.030907\n",
+       "16872          1         16               5  ... -1.215622 -0.649792      -0.030907\n",
+       "25852          5         16               3  ...  1.865358 -0.218915      -0.030907\n",
+       "\n",
+       "[3 rows x 10 columns]"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "to.xs[:3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To then preprocess our data, all we need to do is call `process` to apply all of our `procs` inplace:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>workclass</th>\n",
+       "      <th>education</th>\n",
+       "      <th>marital-status</th>\n",
+       "      <th>occupation</th>\n",
+       "      <th>relationship</th>\n",
+       "      <th>race</th>\n",
+       "      <th>education-num_na</th>\n",
+       "      <th>age</th>\n",
+       "      <th>fnlwgt</th>\n",
+       "      <th>education-num</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>25387</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>-3.034491</td>\n",
+       "      <td>-1.792679</td>\n",
+       "      <td>-5.524377</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16872</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>-3.043570</td>\n",
+       "      <td>-1.792679</td>\n",
+       "      <td>-5.524377</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25852</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>-3.026991</td>\n",
+       "      <td>-1.792679</td>\n",
+       "      <td>-5.524377</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       workclass  education  marital-status  ...       age    fnlwgt  education-num\n",
+       "25387          0          0               0  ... -3.034491 -1.792679      -5.524377\n",
+       "16872          0          0               0  ... -3.043570 -1.792679      -5.524377\n",
+       "25852          0          0               0  ... -3.026991 -1.792679      -5.524377\n",
+       "\n",
+       "[3 rows x 10 columns]"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "to.process()\n",
+    "to.xs[:3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that everything is encoded, you can then send this off to XGBoost or Random Forests by extracting the train and validation sets and their values:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "X_train, y_train = to.train.xs, to.train.ys.values.ravel()\n",
+    "X_test, y_test = to.valid.xs, to.valid.ys.values.ravel()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And now we can directly send this in! An example with `XGBoost` is below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from xgboost import XGBClassifier\n",
+    "\n",
+    "model = XGBClassifier()\n",
+    "model = model.fit(X_train,y_train)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then gather predictions as well:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preds = model.predict_proba(X_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[9.9995238e-01, 4.7629295e-05],\n",
+       "       [9.9995238e-01, 4.7629295e-05],\n",
+       "       [9.9995238e-01, 4.7629295e-05]], dtype=float32)"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "preds[:3]"
+   ]
   }
  ],
  "metadata": {
@@ -827,5 +1264,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
As the title says, expands on most of the tabular documentation. Predict was cleaned up to only need a few lines, and a slight adjustment to `TabularModel` was performed to allow for custom activation functions (in case people want to experiment easily). Along with this, Tutorial Tabular now also includes using `TabularPandas` to integrate with other libraries such as `xgboost`

Let me know if there are any adjustments that should be made!