### PR TITLE
Fix link typo

### DIFF
--- a/nbs/38_tutorial.text.ipynb
+++ b/nbs/38_tutorial.text.ipynb
@@ -33,7 +33,7 @@
    "source": [
     "In this tutorial, we will see how we can train a model to classify text (here based on their sentiment). First we will see how to do this quickly in a few lines of code, then how to get state-of-the art results using the approach of the [ULMFit paper](https://arxiv.org/abs/1801.06146).\n",
     "\n",
-    "We will use the IMDb dataset from the paper [Learning Word Vectors for Sentiment Analysis]((https://ai.stanford.edu/~amaas/data/sentiment/)), containing a few thousand movie reviews."
+    "We will use the IMDb dataset from the paper [Learning Word Vectors for Sentiment Analysis](https://ai.stanford.edu/~amaas/data/sentiment/), containing a few thousand movie reviews."
    ]
   },
   {
@@ -1320,6 +1320,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/nbs/38_tutorial.text.ipynb
+++ b/nbs/38_tutorial.text.ipynb
@@ -1313,25 +1313,10 @@
   }
  ],
  "metadata": {
-  "jupytext": {
-   "split_at_heading": true
-  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The link was broken and showed up as: https://docs.fast.ai/(https://ai.stanford.edu/~amaas/data/sentiment/ on Tutorials page. This removes the typo brackets and restores the intended direct link. 