### PR TITLE
Add GAN to the sidebar

### DIFF
--- a/docs_src/sidebar.json
+++ b/docs_src/sidebar.json
@@ -77,6 +77,7 @@
     "Vision Core": "/vision.core",
     "Vision Utils": "/vision.utils",
     "Vision Widgets": "/vision.widgets",
+    "GAN": "/vision.gan",
     "": {
       "Models": {
         "XResnet": "/vision.models.xresnet",


### PR DESCRIPTION
Mentioned in Discord, the GAN docs at https://docs.fast.ai/vision.gan was missing on the sidebar.

@jph00 I am not sure what is your typical docs workflow. Do you need me to update the corresponding yaml file as well? If so, I can build the docs and add that change to this pull request.