### PR TITLE
Not existing autocast causing explosion of cuda memory.

### DIFF
--- a/nbs/18_callback.fp16.ipynb
+++ b/nbs/18_callback.fp16.ipynb
@@ -958,17 +958,21 @@
     "class NativeMixedPrecision(Callback):\n",
     "    \"Mixed precision training using Pytorch's `autocast` and `GradScaler`\"\n",
     "    @delegates(GradScaler.__init__)\n",
-    "    def __init__(self, **kwargs): self.scaler_kwargs,self.autocast = kwargs,autocast()\n",
+    "    def __init__(self, **kwargs): \n",
+    "      self.scaler_kwargs = kwargs\n",
+    "      self.autocast, self.in_autocast = autocast(), False\n",
     "\n",
     "    def before_fit(self):\n",
     "        self.learn.scaler = GradScaler(**self.scaler_kwargs)\n",
     "        self.learn._step,self.learn._backward = self._step,self._backward\n",
     "\n",
-    "    def before_batch(self): self.autocast.__enter__()\n",
+    "    def before_batch(self): self.autocast.__enter__(); self.in_autocast = True\n",
     "    def after_step(self): self.learn.scaler.update()\n",
-    "    def after_loss(self): self.autocast.__exit__()\n",
+    "    def after_loss(self): self.autocast.__exit__(); self.in_autocast = False\n",
     "    def _backward(self): self.scaler.scale(self.loss).backward()\n",
-    "    def _step(self): self.scaler.step(self.opt)"
+    "    def _step(self): self.scaler.step(self.opt)\n",
+    "    def after_batch(self):\n",
+    "      if self.in_autocast: self.autocast.__exit__(); self.in_autocast = False"
    ]
   },
   {


### PR DESCRIPTION
When using `native_fp16()` and try to `get_preds` on a test set which **with no labels**, it will run into `if len(self.yb)==0: return` and not do `self.autocast.__exist__`. And as batches iterated, the occupied cuda memory is keeping increasing and then cuda out of memory.

After this fix, it now consumes constant memory.