### PR TITLE
deal with non-Boolean selectors in `ColSplitter()` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 docs/
 conda/
 tmp/

--- a/fastai/data/transforms.py
+++ b/fastai/data/transforms.py
@@ -146,7 +146,7 @@ def ColSplitter(col='is_valid'):
     "Split `items` (supposed to be a dataframe) by value in `col`"
     def _inner(o):
         assert isinstance(o, pd.DataFrame), "ColSplitter only works when your items are a pandas DataFrame"
-        valid_idx = (o.iloc[:,col] if isinstance(col, int) else o[col]).values
+        valid_idx = (o.iloc[:,col] if isinstance(col, int) else o[col]).values.astype('bool')
         return IndexSplitter(mask2idxs(valid_idx))(o)
     return _inner
 

--- a/nbs/05_data.transforms.ipynb
+++ b/nbs/05_data.transforms.ipynb
@@ -619,7 +619,11 @@
     "test_eq(splits, [[1,4], [0,2,3]])\n",
     "#Works with strings or index\n",
     "splits = ColSplitter(1)(df)\n",
-    "test_eq(splits, [[1,4], [0,2,3]])"
+    "test_eq(splits, [[1,4], [0,2,3]])\n",
+    "# does not get confused if the type of 'b' is integer, but it meant to be a yes/no\n",
+    "df = pd.DataFrame({'a': [0,1,2,3,4], 'is_valid': [1,0,1,1,0]})\n",
+    "splits_by_int = ColSplitter('is_valid')(df)\n",
+    "test_eq(splits_by_int, [[1,4], [0,2,3]])"
    ]
   },
   {
@@ -1754,13 +1758,6 @@
     "from nbdev.export import notebook2script\n",
     "notebook2script()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
There is an unexpected behaviour in `ColSplitter()` in `vision/transforms.py` :

``` python
valid_idx = (o.iloc[:,col] if isinstance(col, int) else o[col]).values`
```

this means that if we have a DataFrame:
``` python
df = pd.DataFrame({'a': [5,6,7,8,9], 'is_valid': [1,0,1,1,0]})
splits_by_int = ColSplitter('is_valid')(df)
```
then it would fail without raising an error. It would create a broken validation set with only two observations `5, 6` repeated 5 times: `[6, 5, 6, 6, 5]`. This is unexpected.

**Expected output:** `[5,7,8]`

**Fix:** Make sure that the selector is boolean by casting to boolean.

**Alternate fix:** raise a helpful error when the selector is non-boolean.
