### PR TITLE
Wandb callback CUDA exception

### DIFF
--- a/fastai/callback/wandb.py
+++ b/fastai/callback/wandb.py
@@ -90,7 +90,7 @@ class WandbCallback(Callback):
             self._wandb_step += 1
             self._wandb_epoch += 1/self.n_iter
             hypers = {f'{k}_{i}':v for i,h in enumerate(self.opt.hypers) for k,v in h.items()}
-            wandb.log({'epoch': self._wandb_epoch, 'train_loss': self.smooth_loss, 'raw_loss': self.loss, **hypers}, step=self._wandb_step)
+            wandb.log({'epoch': self._wandb_epoch, 'train_loss': to_detach(self.smooth_loss.clone()), 'raw_loss': to_detach(self.loss.clone()), **hypers}, step=self._wandb_step)
 
     def after_epoch(self):
         "Log validation loss and custom metrics & log prediction samples"

--- a/nbs/70_callback.wandb.ipynb
+++ b/nbs/70_callback.wandb.ipynb
@@ -151,7 +151,7 @@
     "            self._wandb_step += 1\n",
     "            self._wandb_epoch += 1/self.n_iter\n",
     "            hypers = {f'{k}_{i}':v for i,h in enumerate(self.opt.hypers) for k,v in h.items()}\n",
-    "            wandb.log({'epoch': self._wandb_epoch, 'train_loss': self.smooth_loss, 'raw_loss': self.loss, **hypers}, step=self._wandb_step)\n",
+    "            wandb.log({'epoch': self._wandb_epoch, 'train_loss': to_detach(self.smooth_loss.clone()), 'raw_loss': to_detach(self.loss.clone()), **hypers}, step=self._wandb_step)\n",
     "\n",
     "    def after_epoch(self):\n",
     "        \"Log validation loss and custom metrics & log prediction samples\"\n",


### PR DESCRIPTION
When using WandbCallback with the following AnnealedLossCallback I get an exception:

```
import wandb
from fastai.callback.wandb import *

wandb.init(project='VAE-MNIST')

scheds = {'kl_weight': combine_scheds([.3, .5, .2], [SchedCos(0,10), SchedCos(10,1), SchedNo(1,1)]) }

class AnnealedLossCallback(Callback):
    def after_pred(self):
        kl = self.learn.pred[0].new(1)
        kl[0] = self.opt.hypers[0]['kl_weight']
        self.learn.pred = self.learn.pred + (kl,)
        
model = VAE(image_channels=1, h_dim=196, z_dim=128).cuda()

learn = Learner(dls, model, cbs=[ParamScheduler(scheds), AnnealedLossCallback(), WandbCallback()], loss_func=loss_fn, metrics=[BCEMetric(), KLDMetric(), MUMetric(), StdMetric()])
learn = learn.to_fp16()
```

I get the following exception:

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/learner.py in _with_events(self, f, event_type, ex, final)
    154     def _with_events(self, f, event_type, ex, final=noop):
--> 155         try:       self(f'before_{event_type}')       ;f()
    156         except ex: self(f'after_cancel_{event_type}')

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/learner.py in _do_epoch(self)
    187     def _do_epoch(self):
--> 188         self._do_epoch_train()
    189         self._do_epoch_validate()

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/learner.py in _do_epoch_train(self)
    179         self.dl = self.dls.train
--> 180         self._with_events(self.all_batches, 'train', CancelTrainException)
    181 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/learner.py in _with_events(self, f, event_type, ex, final)
    154     def _with_events(self, f, event_type, ex, final=noop):
--> 155         try:       self(f'before_{event_type}')       ;f()
    156         except ex: self(f'after_cancel_{event_type}')

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/learner.py in all_batches(self)
    160         self.n_iter = len(self.dl)
--> 161         for o in enumerate(self.dl): self.one_batch(*o)
    162 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/learner.py in one_batch(self, i, b)
    175         self._split(b)
--> 176         self._with_events(self._do_one_batch, 'batch', CancelBatchException)
    177 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/learner.py in _with_events(self, f, event_type, ex, final)
    156         except ex: self(f'after_cancel_{event_type}')
--> 157         finally:   self(f'after_{event_type}')        ;final()
    158 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/learner.py in __call__(self, event_name)
    132 
--> 133     def __call__(self, event_name): L(event_name).map(self._call_one)
    134 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastcore/foundation.py in map(self, f, *args, **kwargs)
    382              else f.__getitem__)
--> 383         return self._new(map(g, self))
    384 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastcore/foundation.py in _new(self, items, *args, **kwargs)
    332     def _xtra(self): return None
--> 333     def _new(self, items, *args, **kwargs): return type(self)(items, *args, use_list=None, **kwargs)
    334     def __getitem__(self, idx): return self._get(idx) if is_indexer(idx) else L(self._get(idx), use_list=None)

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastcore/foundation.py in __call__(cls, x, *args, **kwargs)
     46 
---> 47         res = super().__call__(*((x,) + args), **kwargs)
     48         res._newchk = 0

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastcore/foundation.py in __init__(self, items, use_list, match, *rest)
    323         if (use_list is not None) or not _is_array(items):
--> 324             items = list(items) if use_list else _listify(items)
    325         if match is not None:

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastcore/foundation.py in _listify(o)
    259     if isinstance(o, str) or _is_array(o): return [o]
--> 260     if is_iter(o): return list(o)
    261     return [o]

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastcore/foundation.py in __call__(self, *args, **kwargs)
    225         fargs = [args[x.i] if isinstance(x, _Arg) else x for x in self.pargs] + args[self.maxi+1:]
--> 226         return self.fn(*fargs, **kwargs)
    227 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/learner.py in _call_one(self, event_name)
    136         assert hasattr(event, event_name), event_name
--> 137         [cb(event_name) for cb in sort_by_run(self.cbs)]
    138 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/learner.py in <listcomp>(.0)
    136         assert hasattr(event, event_name), event_name
--> 137         [cb(event_name) for cb in sort_by_run(self.cbs)]
    138 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/callback/core.py in __call__(self, event_name)
     43         res = None
---> 44         if self.run and _run: res = getattr(self, event_name, noop)()
     45         if event_name=='after_fit': self.run=True #Reset self.run to True at each end of fit

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/callback/wandb.py in after_batch(self)
     92             hypers = {f'{k}_{i}':v for i,h in enumerate(self.opt.hypers) for k,v in h.items()}
---> 93             wandb.log({'epoch': self._wandb_epoch, 'train_loss': self.smooth_loss, 'raw_loss': self.loss, **hypers}, step=self._wandb_step)
     94 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/__init__.py in log(row, commit, step, sync, *args, **kwargs)
    925 
--> 926     run.log(row, commit, step, sync, *args, **kwargs)
    927 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/wandb_run.py in log(self, row, commit, step, sync, *args, **kwargs)
    823         if commit is not False or step is not None:
--> 824             self.history.add(row, *args, step=step, commit=commit, **kwargs)
    825         else:

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/history.py in add(self, row, step, timestamp, commit)
    161                 else:  # step > self._steps
--> 162                     self._write()
    163                     self._steps = step

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/history.py in _write(self)
    246                 self._transform()
--> 247                 self._file.write(util.json_dumps_safer_history(self.row))
    248                 self._file.write('\n')

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/util.py in json_dumps_safer_history(obj, **kwargs)
    513     """Convert obj to json, with some extra encodable types, including histograms"""
--> 514     return json.dumps(obj, cls=WandBHistoryJSONEncoder, **kwargs)
    515 

~/anaconda3/envs/fastai/lib/python3.8/json/__init__.py in dumps(obj, skipkeys, ensure_ascii, check_circular, allow_nan, cls, indent, separators, default, sort_keys, **kw)
    233         cls = JSONEncoder
--> 234     return cls(
    235         skipkeys=skipkeys, ensure_ascii=ensure_ascii,

~/anaconda3/envs/fastai/lib/python3.8/json/encoder.py in encode(self, o)
    198         # equivalent to the PySequence_Fast that ''.join() would do.
--> 199         chunks = self.iterencode(o, _one_shot=True)
    200         if not isinstance(chunks, (list, tuple)):

~/anaconda3/envs/fastai/lib/python3.8/json/encoder.py in iterencode(self, o, _one_shot)
    256                 self.skipkeys, _one_shot)
--> 257         return _iterencode(o, 0)
    258 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/util.py in default(self, obj)
    481     def default(self, obj):
--> 482         obj, converted = json_friendly(obj)
    483         obj, compressed = maybe_compress_history(obj)

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/util.py in json_friendly(obj)
    339         if obj.size():
--> 340             obj = obj.numpy()
    341         else:

TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.

During handling of the above exception, another exception occurred:

TypeError                                 Traceback (most recent call last)
~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/learner.py in _with_events(self, f, event_type, ex, final)
    154     def _with_events(self, f, event_type, ex, final=noop):
--> 155         try:       self(f'before_{event_type}')       ;f()
    156         except ex: self(f'after_cancel_{event_type}')

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/learner.py in _do_fit(self)
    193             self.epoch=epoch
--> 194             self._with_events(self._do_epoch, 'epoch', CancelEpochException)
    195 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/learner.py in _with_events(self, f, event_type, ex, final)
    156         except ex: self(f'after_cancel_{event_type}')
--> 157         finally:   self(f'after_{event_type}')        ;final()
    158 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/learner.py in __call__(self, event_name)
    132 
--> 133     def __call__(self, event_name): L(event_name).map(self._call_one)
    134 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastcore/foundation.py in map(self, f, *args, **kwargs)
    382              else f.__getitem__)
--> 383         return self._new(map(g, self))
    384 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastcore/foundation.py in _new(self, items, *args, **kwargs)
    332     def _xtra(self): return None
--> 333     def _new(self, items, *args, **kwargs): return type(self)(items, *args, use_list=None, **kwargs)
    334     def __getitem__(self, idx): return self._get(idx) if is_indexer(idx) else L(self._get(idx), use_list=None)

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastcore/foundation.py in __call__(cls, x, *args, **kwargs)
     46 
---> 47         res = super().__call__(*((x,) + args), **kwargs)
     48         res._newchk = 0

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastcore/foundation.py in __init__(self, items, use_list, match, *rest)
    323         if (use_list is not None) or not _is_array(items):
--> 324             items = list(items) if use_list else _listify(items)
    325         if match is not None:

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastcore/foundation.py in _listify(o)
    259     if isinstance(o, str) or _is_array(o): return [o]
--> 260     if is_iter(o): return list(o)
    261     return [o]

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastcore/foundation.py in __call__(self, *args, **kwargs)
    225         fargs = [args[x.i] if isinstance(x, _Arg) else x for x in self.pargs] + args[self.maxi+1:]
--> 226         return self.fn(*fargs, **kwargs)
    227 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/learner.py in _call_one(self, event_name)
    136         assert hasattr(event, event_name), event_name
--> 137         [cb(event_name) for cb in sort_by_run(self.cbs)]
    138 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/learner.py in <listcomp>(.0)
    136         assert hasattr(event, event_name), event_name
--> 137         [cb(event_name) for cb in sort_by_run(self.cbs)]
    138 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/callback/core.py in __call__(self, event_name)
     43         res = None
---> 44         if self.run and _run: res = getattr(self, event_name, noop)()
     45         if event_name=='after_fit': self.run=True #Reset self.run to True at each end of fit

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/callback/wandb.py in after_epoch(self)
     98         self._wandb_epoch = round(self._wandb_epoch)
---> 99         wandb.log({'epoch': self._wandb_epoch}, step=self._wandb_step)
    100         # Log sample predictions

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/__init__.py in log(row, commit, step, sync, *args, **kwargs)
    925 
--> 926     run.log(row, commit, step, sync, *args, **kwargs)
    927 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/wandb_run.py in log(self, row, commit, step, sync, *args, **kwargs)
    823         if commit is not False or step is not None:
--> 824             self.history.add(row, *args, step=step, commit=commit, **kwargs)
    825         else:

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/history.py in add(self, row, step, timestamp, commit)
    161                 else:  # step > self._steps
--> 162                     self._write()
    163                     self._steps = step

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/history.py in _write(self)
    246                 self._transform()
--> 247                 self._file.write(util.json_dumps_safer_history(self.row))
    248                 self._file.write('\n')

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/util.py in json_dumps_safer_history(obj, **kwargs)
    513     """Convert obj to json, with some extra encodable types, including histograms"""
--> 514     return json.dumps(obj, cls=WandBHistoryJSONEncoder, **kwargs)
    515 

~/anaconda3/envs/fastai/lib/python3.8/json/__init__.py in dumps(obj, skipkeys, ensure_ascii, check_circular, allow_nan, cls, indent, separators, default, sort_keys, **kw)
    233         cls = JSONEncoder
--> 234     return cls(
    235         skipkeys=skipkeys, ensure_ascii=ensure_ascii,

~/anaconda3/envs/fastai/lib/python3.8/json/encoder.py in encode(self, o)
    198         # equivalent to the PySequence_Fast that ''.join() would do.
--> 199         chunks = self.iterencode(o, _one_shot=True)
    200         if not isinstance(chunks, (list, tuple)):

~/anaconda3/envs/fastai/lib/python3.8/json/encoder.py in iterencode(self, o, _one_shot)
    256                 self.skipkeys, _one_shot)
--> 257         return _iterencode(o, 0)
    258 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/util.py in default(self, obj)
    481     def default(self, obj):
--> 482         obj, converted = json_friendly(obj)
    483         obj, compressed = maybe_compress_history(obj)

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/util.py in json_friendly(obj)
    339         if obj.size():
--> 340             obj = obj.numpy()
    341         else:

TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.

During handling of the above exception, another exception occurred:

TypeError                                 Traceback (most recent call last)
<ipython-input-16-ebeb24fc79f5> in <module>
----> 1 learn.fit_one_cycle(200)
      2 
      3 learn.save(datetime.now().strftime('%Y-%m-%d %Hh%M.%S') + '.model')

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastcore/utils.py in _f(*args, **kwargs)
    452         init_args.update(log)
    453         setattr(inst, 'init_args', init_args)
--> 454         return inst if to_return else f(*args, **kwargs)
    455     return _f
    456 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/callback/schedule.py in fit_one_cycle(self, n_epoch, lr_max, div, div_final, pct_start, wd, moms, cbs, reset_opt)
    111     scheds = {'lr': combined_cos(pct_start, lr_max/div, lr_max, lr_max/div_final),
    112               'mom': combined_cos(pct_start, *(self.moms if moms is None else moms))}
--> 113     self.fit(n_epoch, cbs=ParamScheduler(scheds)+L(cbs), reset_opt=reset_opt, wd=wd)
    114 
    115 # Cell

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastcore/utils.py in _f(*args, **kwargs)
    452         init_args.update(log)
    453         setattr(inst, 'init_args', init_args)
--> 454         return inst if to_return else f(*args, **kwargs)
    455     return _f
    456 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/learner.py in fit(self, n_epoch, lr, wd, cbs, reset_opt)
    202             self.opt.set_hypers(lr=self.lr if lr is None else lr)
    203             self.n_epoch,self.loss = n_epoch,tensor(0.)
--> 204             self._with_events(self._do_fit, 'fit', CancelFitException, self._end_cleanup)
    205 
    206     def _end_cleanup(self): self.dl,self.xb,self.yb,self.pred,self.loss = None,(None,),(None,),None,None

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/learner.py in _with_events(self, f, event_type, ex, final)
    155         try:       self(f'before_{event_type}')       ;f()
    156         except ex: self(f'after_cancel_{event_type}')
--> 157         finally:   self(f'after_{event_type}')        ;final()
    158 
    159     def all_batches(self):

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/learner.py in __call__(self, event_name)
    131     def ordered_cbs(self, event): return [cb for cb in sort_by_run(self.cbs) if hasattr(cb, event)]
    132 
--> 133     def __call__(self, event_name): L(event_name).map(self._call_one)
    134 
    135     def _call_one(self, event_name):

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastcore/foundation.py in map(self, f, *args, **kwargs)
    381              else f.format if isinstance(f,str)
    382              else f.__getitem__)
--> 383         return self._new(map(g, self))
    384 
    385     def filter(self, f, negate=False, **kwargs):

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastcore/foundation.py in _new(self, items, *args, **kwargs)
    331     @property
    332     def _xtra(self): return None
--> 333     def _new(self, items, *args, **kwargs): return type(self)(items, *args, use_list=None, **kwargs)
    334     def __getitem__(self, idx): return self._get(idx) if is_indexer(idx) else L(self._get(idx), use_list=None)
    335     def copy(self): return self._new(self.items.copy())

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastcore/foundation.py in __call__(cls, x, *args, **kwargs)
     45             return x
     46 
---> 47         res = super().__call__(*((x,) + args), **kwargs)
     48         res._newchk = 0
     49         return res

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastcore/foundation.py in __init__(self, items, use_list, match, *rest)
    322         if items is None: items = []
    323         if (use_list is not None) or not _is_array(items):
--> 324             items = list(items) if use_list else _listify(items)
    325         if match is not None:
    326             if is_coll(match): match = len(match)

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastcore/foundation.py in _listify(o)
    258     if isinstance(o, list): return o
    259     if isinstance(o, str) or _is_array(o): return [o]
--> 260     if is_iter(o): return list(o)
    261     return [o]
    262 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastcore/foundation.py in __call__(self, *args, **kwargs)
    224             if isinstance(v,_Arg): kwargs[k] = args.pop(v.i)
    225         fargs = [args[x.i] if isinstance(x, _Arg) else x for x in self.pargs] + args[self.maxi+1:]
--> 226         return self.fn(*fargs, **kwargs)
    227 
    228 # Cell

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/learner.py in _call_one(self, event_name)
    135     def _call_one(self, event_name):
    136         assert hasattr(event, event_name), event_name
--> 137         [cb(event_name) for cb in sort_by_run(self.cbs)]
    138 
    139     def _bn_bias_state(self, with_bias): return norm_bias_params(self.model, with_bias).map(self.opt.state)

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/learner.py in <listcomp>(.0)
    135     def _call_one(self, event_name):
    136         assert hasattr(event, event_name), event_name
--> 137         [cb(event_name) for cb in sort_by_run(self.cbs)]
    138 
    139     def _bn_bias_state(self, with_bias): return norm_bias_params(self.model, with_bias).map(self.opt.state)

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/callback/core.py in __call__(self, event_name)
     42                (self.run_valid and not getattr(self, 'training', False)))
     43         res = None
---> 44         if self.run and _run: res = getattr(self, event_name, noop)()
     45         if event_name=='after_fit': self.run=True #Reset self.run to True at each end of fit
     46         return res

~/anaconda3/envs/fastai/lib/python3.8/site-packages/fastai/callback/wandb.py in after_fit(self)
    119         self.run = True
    120         if self.log_preds: self.remove_cb(FetchPredsCallback)
--> 121         wandb.log({}) # ensure sync of last step
    122 
    123 # Cell

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/__init__.py in log(row, commit, step, sync, *args, **kwargs)
    924             "You must call `wandb.init` in the same process before calling log")
    925 
--> 926     run.log(row, commit, step, sync, *args, **kwargs)
    927 
    928 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/wandb_run.py in log(self, row, commit, step, sync, *args, **kwargs)
    822 
    823         if commit is not False or step is not None:
--> 824             self.history.add(row, *args, step=step, commit=commit, **kwargs)
    825         else:
    826             self.history.update(row, *args, **kwargs)

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/history.py in add(self, row, step, timestamp, commit)
    137             self.update(row)
    138             if not self.batched:
--> 139                 self._write()
    140         else:
    141             if not isinstance(step, numbers.Number):

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/history.py in _write(self)
    245                     self.row["_stream"] = self.stream_name
    246                 self._transform()
--> 247                 self._file.write(util.json_dumps_safer_history(self.row))
    248                 self._file.write('\n')
    249                 self._file.flush()

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/util.py in json_dumps_safer_history(obj, **kwargs)
    512 def json_dumps_safer_history(obj, **kwargs):
    513     """Convert obj to json, with some extra encodable types, including histograms"""
--> 514     return json.dumps(obj, cls=WandBHistoryJSONEncoder, **kwargs)
    515 
    516 def make_json_if_not_number(v):

~/anaconda3/envs/fastai/lib/python3.8/json/__init__.py in dumps(obj, skipkeys, ensure_ascii, check_circular, allow_nan, cls, indent, separators, default, sort_keys, **kw)
    232     if cls is None:
    233         cls = JSONEncoder
--> 234     return cls(
    235         skipkeys=skipkeys, ensure_ascii=ensure_ascii,
    236         check_circular=check_circular, allow_nan=allow_nan, indent=indent,

~/anaconda3/envs/fastai/lib/python3.8/json/encoder.py in encode(self, o)
    197         # exceptions aren't as detailed.  The list call should be roughly
    198         # equivalent to the PySequence_Fast that ''.join() would do.
--> 199         chunks = self.iterencode(o, _one_shot=True)
    200         if not isinstance(chunks, (list, tuple)):
    201             chunks = list(chunks)

~/anaconda3/envs/fastai/lib/python3.8/json/encoder.py in iterencode(self, o, _one_shot)
    255                 self.key_separator, self.item_separator, self.sort_keys,
    256                 self.skipkeys, _one_shot)
--> 257         return _iterencode(o, 0)
    258 
    259 def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/util.py in default(self, obj)
    480 
    481     def default(self, obj):
--> 482         obj, converted = json_friendly(obj)
    483         obj, compressed = maybe_compress_history(obj)
    484         if converted:

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/util.py in json_friendly(obj)
    338 
    339         if obj.size():
--> 340             obj = obj.numpy()
    341         else:
    342             return obj.item(), True

TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
Error in callback <function _init_jupyter.<locals>.cleanup at 0x7f1b7a482040> (for post_run_cell):
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
~/anaconda3/envs/fastai/lib/python3.8/site-packages/backcall/backcall.py in adapted(*args, **kwargs)
    102                 kwargs.pop(name)
    103 #            print(args, kwargs, unmatched_pos, cut_positional, unmatched_kw)
--> 104             return callback(*args, **kwargs)
    105 
    106         return adapted

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/__init__.py in cleanup()
    528         # shutdown async logger because _user_process_finished isn't called in jupyter
    529         shutdown_async_log_thread()
--> 530         run._stop_jupyter_agent()
    531     if hasattr(ipython.events, "_orig_post_run"):
    532         ipython.events.unregister("post_run_cell", ipython.events._orig_post_run)

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/wandb_run.py in _stop_jupyter_agent(self)
    211 
    212     def _stop_jupyter_agent(self):
--> 213         self._jupyter_agent.stop()
    214 
    215     def send_message(self, options):

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/jupyter.py in stop(self)
    140             self.save_history()
    141             self.rm.unmirror_stdout_stderr()
--> 142             wandb.run.close_files()
    143             self.rm.shutdown()
    144             self.paused = True

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/wandb_run.py in close_files(self)
    910             self._events = None
    911         if self._history is not None:
--> 912             self._history.close()
    913             self._history = None
    914 

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/history.py in close(self)
    260 
    261     def close(self):
--> 262         self._write()
    263         self._lock.acquire()
    264         try:

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/history.py in _write(self)
    245                     self.row["_stream"] = self.stream_name
    246                 self._transform()
--> 247                 self._file.write(util.json_dumps_safer_history(self.row))
    248                 self._file.write('\n')
    249                 self._file.flush()

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/util.py in json_dumps_safer_history(obj, **kwargs)
    512 def json_dumps_safer_history(obj, **kwargs):
    513     """Convert obj to json, with some extra encodable types, including histograms"""
--> 514     return json.dumps(obj, cls=WandBHistoryJSONEncoder, **kwargs)
    515 
    516 def make_json_if_not_number(v):

~/anaconda3/envs/fastai/lib/python3.8/json/__init__.py in dumps(obj, skipkeys, ensure_ascii, check_circular, allow_nan, cls, indent, separators, default, sort_keys, **kw)
    232     if cls is None:
    233         cls = JSONEncoder
--> 234     return cls(
    235         skipkeys=skipkeys, ensure_ascii=ensure_ascii,
    236         check_circular=check_circular, allow_nan=allow_nan, indent=indent,

~/anaconda3/envs/fastai/lib/python3.8/json/encoder.py in encode(self, o)
    197         # exceptions aren't as detailed.  The list call should be roughly
    198         # equivalent to the PySequence_Fast that ''.join() would do.
--> 199         chunks = self.iterencode(o, _one_shot=True)
    200         if not isinstance(chunks, (list, tuple)):
    201             chunks = list(chunks)

~/anaconda3/envs/fastai/lib/python3.8/json/encoder.py in iterencode(self, o, _one_shot)
    255                 self.key_separator, self.item_separator, self.sort_keys,
    256                 self.skipkeys, _one_shot)
--> 257         return _iterencode(o, 0)
    258 
    259 def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/util.py in default(self, obj)
    480 
    481     def default(self, obj):
--> 482         obj, converted = json_friendly(obj)
    483         obj, compressed = maybe_compress_history(obj)
    484         if converted:

~/anaconda3/envs/fastai/lib/python3.8/site-packages/wandb/util.py in json_friendly(obj)
    338 
    339         if obj.size():
--> 340             obj = obj.numpy()
    341         else:
    342             return obj.item(), True

TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
```

Making sure to clone and detach the loss before sending them to Wandb seems to fix the problem.