### PR TITLE
This semicolon should not be there

### DIFF
--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -181,7 +181,7 @@ class Learner():
 
     def _do_epoch_validate(self, ds_idx=1, dl=None):
         if dl is None: dl = self.dls[ds_idx]
-        self.dl = dl;
+        self.dl = dl
         with torch.no_grad(): self._with_events(self.all_batches, 'validate', CancelValidException)
 
     def _do_epoch(self):

--- a/nbs/13a_learner.ipynb
+++ b/nbs/13a_learner.ipynb
@@ -376,7 +376,7 @@
     "\n",
     "    def _do_epoch_validate(self, ds_idx=1, dl=None):\n",
     "        if dl is None: dl = self.dls[ds_idx]\n",
-    "        self.dl = dl;\n",
+    "        self.dl = dl\n",
     "        with torch.no_grad(): self._with_events(self.all_batches, 'validate', CancelValidException)\n",
     "\n",
     "    def _do_epoch(self):\n",


### PR DESCRIPTION
This semicolon was probably a typo.