### PR TITLE
add .DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Mac stuff
+.DS_Store


### PR DESCRIPTION
macs leave these files all over the place when browsing in Finder (gui file browser). especially as the "creating a PR" documentation uses `git commit -am` this could result in unwanted files commited.