### PR TITLE
remove submodules from README

### DIFF
--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -52,7 +52,7 @@
     "If you plan to develop fastai yourself, or want to be on the cutting edge, you can use an editable install (if you do this, you should also use an editable install of [fastcore](https://github.com/fastai/fastcore) to go with it.):\n",
     "\n",
     "``` \n",
-    "git clone --recurse-submodules https://github.com/fastai/fastai\n",
+    "git clone https://github.com/fastai/fastai\n",
     "pip install -e \"fastai[dev]\"\n",
     "``` "
    ]
@@ -163,12 +163,6 @@
    "metadata": {},
    "source": [
     "After you clone this repository, please run `nbdev_install_git_hooks` in your terminal. This sets up git hooks, which clean up the notebooks to remove the extraneous stuff stored in the notebooks (e.g. which cells you ran) which causes unnecessary merge conflicts.\n",
-    "\n",
-    "Remember that fastai uses [Git submodules](https://git-scm.com/docs/gitsubmodules), so you have to include the flag `--recurse-submodules` in some of your Git commands (`git clone`, `git pull`). Alternatively, you can set the Git configuration option (since Git 2.15):\n",
-    "\n",
-    "```\n",
-    "git config --local submodule.recurse true\n",
-    "```\n",
     "\n",
     "Before submitting a PR, check that the local library and notebooks match. The script `nbdev_diff_nbs` can let you know if there is a difference between the local library and the notebooks.\n",
     "\n",


### PR DESCRIPTION
For some reason `nbdev_build_lib` is not updating the README.