### PR TITLE
Modified XResNet to support Conv1d / Conv3d

### DIFF
--- a/fastai/vision/models/xresnet.py
+++ b/fastai/vision/models/xresnet.py
@@ -15,7 +15,7 @@ from torchvision.models.utils import load_state_dict_from_url
 # Cell
 def init_cnn(m):
     if getattr(m, 'bias', None) is not None: nn.init.constant_(m.bias, 0)
-    if isinstance(m, (nn.Conv2d,nn.Linear)): nn.init.kaiming_normal_(m.weight)
+    if isinstance(m, (nn.Conv1d,nn.Conv2d,nn.Conv3d,nn.Linear)): nn.init.kaiming_normal_(m.weight)
     for l in m.children(): init_cnn(l)
 
 # Cell

--- a/fastai/vision/models/xresnet.py
+++ b/fastai/vision/models/xresnet.py
@@ -22,28 +22,29 @@ def init_cnn(m):
 class XResNet(nn.Sequential):
     @delegates(ResBlock)
     def __init__(self, block, expansion, layers, p=0.0, c_in=3, n_out=1000, stem_szs=(32,32,64),
-                 widen=1.0, sa=False, act_cls=defaults.activation, ndim=2, ks=3, **kwargs):
+                 widen=1.0, sa=False, act_cls=defaults.activation, ndim=2, ks=3, stride=2, **kwargs):
         store_attr(self, 'block,expansion,act_cls,ndim,ks')
         if ks % 2 == 0: raise Exception('kernel size has to be odd!')
         stem_szs = [c_in, *stem_szs]
-        stem = [ConvLayer(stem_szs[i], stem_szs[i+1], ks=ks, stride=2 if i==0 else 1, act_cls=act_cls, ndim=ndim)
+        stem = [ConvLayer(stem_szs[i], stem_szs[i+1], ks=ks, stride=stride if i==0 else 1,
+                          act_cls=act_cls, ndim=ndim)
                 for i in range(3)]
 
         block_szs = [int(o*widen) for o in [64,128,256,512] +[256]*(len(layers)-4)]
         block_szs = [64//expansion] + block_szs
-        blocks    = self._make_blocks(layers, block_szs, sa, **kwargs)
+        blocks    = self._make_blocks(layers, block_szs, sa, stride, **kwargs)
 
         super().__init__(
-            *stem, MaxPool(ks=ks, stride=2, padding=1, ndim=ndim),
+            *stem, MaxPool(ks=ks, stride=stride, padding=1, ndim=ndim),
             *blocks,
             AdaptiveAvgPool(sz=1, ndim=ndim), Flatten(), nn.Dropout(p),
             nn.Linear(block_szs[-1]*expansion, n_out),
         )
         init_cnn(self)
 
-    def _make_blocks(self, layers, block_szs, sa, **kwargs):
+    def _make_blocks(self, layers, block_szs, sa, stride, **kwargs):
         return [self._make_layer(ni=block_szs[i], nf=block_szs[i+1], blocks=l,
-                                 stride=1 if i==0 else 2, sa=sa and i==len(layers)-4, **kwargs)
+                                 stride=1 if i==0 else stride, sa=sa and i==len(layers)-4, **kwargs)
                 for i,l in enumerate(layers)]
 
     def _make_layer(self, ni, nf, blocks, stride, sa, **kwargs):

--- a/fastai/vision/models/xresnet.py
+++ b/fastai/vision/models/xresnet.py
@@ -35,7 +35,7 @@ class XResNet(nn.Sequential):
         blocks    = self._make_blocks(layers, block_szs, sa, stride, **kwargs)
 
         super().__init__(
-            *stem, MaxPool(ks=ks, stride=stride, padding=1, ndim=ndim),
+            *stem, MaxPool(ks=ks, stride=stride, padding=ks//2, ndim=ndim),
             *blocks,
             AdaptiveAvgPool(sz=1, ndim=ndim), Flatten(), nn.Dropout(p),
             nn.Linear(block_szs[-1]*expansion, n_out),

--- a/nbs/11_vision.models.xresnet.ipynb
+++ b/nbs/11_vision.models.xresnet.ipynb
@@ -62,28 +62,29 @@
     "class XResNet(nn.Sequential):\n",
     "    @delegates(ResBlock)\n",
     "    def __init__(self, block, expansion, layers, p=0.0, c_in=3, n_out=1000, stem_szs=(32,32,64),\n",
-    "                 widen=1.0, sa=False, act_cls=defaults.activation, ndim=2, ks=3, **kwargs):\n",
+    "                 widen=1.0, sa=False, act_cls=defaults.activation, ndim=2, ks=3, stride=2, **kwargs):\n",
     "        store_attr(self, 'block,expansion,act_cls,ndim,ks')\n",
     "        if ks % 2 == 0: raise Exception('kernel size has to be odd!')\n",
     "        stem_szs = [c_in, *stem_szs]\n",
-    "        stem = [ConvLayer(stem_szs[i], stem_szs[i+1], ks=ks, stride=2 if i==0 else 1, act_cls=act_cls, ndim=ndim)\n",
+    "        stem = [ConvLayer(stem_szs[i], stem_szs[i+1], ks=ks, stride=stride if i==0 else 1, \n",
+    "                          act_cls=act_cls, ndim=ndim)\n",
     "                for i in range(3)]\n",
     "\n",
     "        block_szs = [int(o*widen) for o in [64,128,256,512] +[256]*(len(layers)-4)]\n",
     "        block_szs = [64//expansion] + block_szs\n",
-    "        blocks    = self._make_blocks(layers, block_szs, sa, **kwargs)\n",
+    "        blocks    = self._make_blocks(layers, block_szs, sa, stride, **kwargs)\n",
     "\n",
     "        super().__init__(\n",
-    "            *stem, MaxPool(ks=ks, stride=2, padding=1, ndim=ndim),\n",
+    "            *stem, MaxPool(ks=ks, stride=stride, padding=1, ndim=ndim),\n",
     "            *blocks,\n",
     "            AdaptiveAvgPool(sz=1, ndim=ndim), Flatten(), nn.Dropout(p),\n",
     "            nn.Linear(block_szs[-1]*expansion, n_out),\n",
     "        )\n",
     "        init_cnn(self)\n",
     "\n",
-    "    def _make_blocks(self, layers, block_szs, sa, **kwargs):\n",
+    "    def _make_blocks(self, layers, block_szs, sa, stride, **kwargs):\n",
     "        return [self._make_layer(ni=block_szs[i], nf=block_szs[i+1], blocks=l,\n",
-    "                                 stride=1 if i==0 else 2, sa=sa and i==len(layers)-4, **kwargs)\n",
+    "                                 stride=1 if i==0 else stride, sa=sa and i==len(layers)-4, **kwargs)\n",
     "                for i,l in enumerate(layers)]\n",
     "\n",
     "    def _make_layer(self, ni, nf, blocks, stride, sa, **kwargs):\n",
@@ -214,9 +215,20 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([8, 1000])"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "tst = xresnext50(ndim=1, c_in=2, ks=31)\n",
+    "tst = xresnext50(ndim=1, c_in=2, ks=31, stride=4)\n",
     "x = torch.randn(8, 2, 128)\n",
     "y = tst(x)"
    ]

--- a/nbs/11_vision.models.xresnet.ipynb
+++ b/nbs/11_vision.models.xresnet.ipynb
@@ -75,7 +75,7 @@
     "        blocks    = self._make_blocks(layers, block_szs, sa, stride, **kwargs)\n",
     "\n",
     "        super().__init__(\n",
-    "            *stem, MaxPool(ks=ks, stride=stride, padding=1, ndim=ndim),\n",
+    "            *stem, MaxPool(ks=ks, stride=stride, padding=ks//2, ndim=ndim),\n",
     "            *blocks,\n",
     "            AdaptiveAvgPool(sz=1, ndim=ndim), Flatten(), nn.Dropout(p),\n",
     "            nn.Linear(block_szs[-1]*expansion, n_out),\n",

--- a/nbs/11_vision.models.xresnet.ipynb
+++ b/nbs/11_vision.models.xresnet.ipynb
@@ -48,7 +48,7 @@
     "#export\n",
     "def init_cnn(m):\n",
     "    if getattr(m, 'bias', None) is not None: nn.init.constant_(m.bias, 0)\n",
-    "    if isinstance(m, (nn.Conv2d,nn.Linear)): nn.init.kaiming_normal_(m.weight)\n",
+    "    if isinstance(m, (nn.Conv1d,nn.Conv2d,nn.Conv3d,nn.Linear)): nn.init.kaiming_normal_(m.weight)\n",
     "    for l in m.children(): init_cnn(l)"
    ]
   },
@@ -215,18 +215,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "torch.Size([8, 1000])"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "tst = xresnext50(ndim=1, c_in=2, ks=31, stride=4)\n",
     "x = torch.randn(8, 2, 128)\n",
@@ -303,6 +292,7 @@
       "Converted 36_text.models.qrnn.ipynb.\n",
       "Converted 37_text.learner.ipynb.\n",
       "Converted 38_tutorial.text.ipynb.\n",
+      "Converted 39_tutorial.transformers.ipynb.\n",
       "Converted 40_tabular.core.ipynb.\n",
       "Converted 41_tabular.data.ipynb.\n",
       "Converted 42_tabular.model.ipynb.\n",
@@ -317,9 +307,13 @@
       "Converted 70_callback.wandb.ipynb.\n",
       "Converted 71_callback.tensorboard.ipynb.\n",
       "Converted 72_callback.neptune.ipynb.\n",
+      "Converted 73_callback.captum.ipynb.\n",
+      "Converted 74_callback.cutmix.ipynb.\n",
       "Converted 97_test_utils.ipynb.\n",
       "Converted 99_pytorch_doc.ipynb.\n",
+      "Converted dev-setup.ipynb.\n",
       "Converted index.ipynb.\n",
+      "Converted quick_start.ipynb.\n",
       "Converted tutorial.ipynb.\n"
      ]
     }

--- a/nbs/11_vision.models.xresnet.ipynb
+++ b/nbs/11_vision.models.xresnet.ipynb
@@ -62,10 +62,11 @@
     "class XResNet(nn.Sequential):\n",
     "    @delegates(ResBlock)\n",
     "    def __init__(self, block, expansion, layers, p=0.0, c_in=3, n_out=1000, stem_szs=(32,32,64),\n",
-    "                 widen=1.0, sa=False, act_cls=defaults.activation, **kwargs):\n",
-    "        store_attr(self, 'block,expansion,act_cls')\n",
+    "                 widen=1.0, sa=False, act_cls=defaults.activation, ndim=2, ks=3, **kwargs):\n",
+    "        store_attr(self, 'block,expansion,act_cls,ndim,ks')\n",
+    "        if ks % 2 == 0: raise Exception('kernel size has to be odd!')\n",
     "        stem_szs = [c_in, *stem_szs]\n",
-    "        stem = [ConvLayer(stem_szs[i], stem_szs[i+1], stride=2 if i==0 else 1, act_cls=act_cls)\n",
+    "        stem = [ConvLayer(stem_szs[i], stem_szs[i+1], ks=ks, stride=2 if i==0 else 1, act_cls=act_cls, ndim=ndim)\n",
     "                for i in range(3)]\n",
     "\n",
     "        block_szs = [int(o*widen) for o in [64,128,256,512] +[256]*(len(layers)-4)]\n",
@@ -73,9 +74,9 @@
     "        blocks    = self._make_blocks(layers, block_szs, sa, **kwargs)\n",
     "\n",
     "        super().__init__(\n",
-    "            *stem, nn.MaxPool2d(kernel_size=3, stride=2, padding=1),\n",
+    "            *stem, MaxPool(ks=ks, stride=2, padding=1, ndim=ndim),\n",
     "            *blocks,\n",
-    "            nn.AdaptiveAvgPool2d(1), Flatten(), nn.Dropout(p),\n",
+    "            AdaptiveAvgPool(sz=1, ndim=ndim), Flatten(), nn.Dropout(p),\n",
     "            nn.Linear(block_szs[-1]*expansion, n_out),\n",
     "        )\n",
     "        init_cnn(self)\n",
@@ -88,7 +89,7 @@
     "    def _make_layer(self, ni, nf, blocks, stride, sa, **kwargs):\n",
     "        return nn.Sequential(\n",
     "            *[self.block(self.expansion, ni if i==0 else nf, nf, stride=stride if i==0 else 1,\n",
-    "                      sa=sa and i==(blocks-1), act_cls=self.act_cls, **kwargs)\n",
+    "                      sa=sa and i==(blocks-1), act_cls=self.act_cls, ndim=self.ndim, ks=self.ks, **kwargs)\n",
     "              for i in range(blocks)])"
    ]
   },
@@ -199,6 +200,39 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tst = xresnet18(ndim=1, c_in=1, ks=15)\n",
+    "x = torch.randn(64, 1, 128)\n",
+    "y = tst(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tst = xresnext50(ndim=1, c_in=2, ks=31)\n",
+    "x = torch.randn(8, 2, 128)\n",
+    "y = tst(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tst = xresnet18(ndim=3, c_in=3, ks=3)\n",
+    "x = torch.randn(8, 3, 32, 32, 32)\n",
+    "y = tst(x)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -297,9 +331,9 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "fastaidev",
    "language": "python",
-   "name": "python3"
+   "name": "fastaidev"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I modified XResNet to support different input dimensions, kernel sizes and stride (added parameters ndim, ks, stride). Tested the changes with fastai_audio and fastai time series and got very promising results. 