### PR TITLE
Change learn.epoch handling in learn.tta

### DIFF
--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -542,22 +542,12 @@ def load_learner(fname, cpu=True):
     return res
 
 # Cell
-def _tta(self:Learner, ds_idx=1, dl=None, n=4, item_tfms=None, batch_tfms=None, beta=0.25, use_max=False):
-    with dl.dataset.set_split_idx(0), self.no_mbar():
-        if hasattr(self,'progress'): self.progress.mbar = master_bar(list(range(n)))
-        aug_preds = []
-        for i in self.progress.mbar if hasattr(self,'progress') else range(n):
-            self.epoch = i #To keep track of progress on mbar since the progress callback will use self.epoch
-            aug_preds.append(self.get_preds(dl=dl, inner=True)[0][None])
-    aug_preds = torch.cat(aug_preds)
-    aug_preds = aug_preds.max(0)[0] if use_max else aug_preds.mean(0)
-    self.epoch = n
-    with dl.dataset.set_split_idx(1): preds,targs = self.get_preds(dl=dl, inner=True)
-
-# Cell
 @patch
 def tta(self:Learner, ds_idx=1, dl=None, n=4, item_tfms=None, batch_tfms=None, beta=0.25, use_max=False):
     "Return predictions on the `ds_idx` dataset or `dl` using Test Time Augmentation"
+    # progress bar requires epoch=0 to initialize
+    self.orig_epoch,self.epoch = self.epoch,0
+
     if dl is None: dl = self.dls[ds_idx]
     if item_tfms is not None or batch_tfms is not None: dl = dl.new(after_item=item_tfms, after_batch=batch_tfms)
     try:
@@ -574,7 +564,7 @@ def tta(self:Learner, ds_idx=1, dl=None, n=4, item_tfms=None, batch_tfms=None, b
         with dl.dataset.set_split_idx(1): preds,targs = self.get_preds(dl=dl, inner=True)
     except CancelFitException:             self(event.after_cancel_fit)
     finally:                               self(event.after_fit)
-
+    self.epoch = self.orig_epoch
     if use_max: return torch.stack([preds, aug_preds], 0).max(0)[0],targs
     preds = (aug_preds,preds) if beta is None else torch.lerp(aug_preds, preds, beta)
     return preds,targs

--- a/nbs/13a_learner.ipynb
+++ b/nbs/13a_learner.ipynb
@@ -3496,29 +3496,12 @@
    "outputs": [],
    "source": [
     "#export\n",
-    "def _tta(self:Learner, ds_idx=1, dl=None, n=4, item_tfms=None, batch_tfms=None, beta=0.25, use_max=False):\n",
-    "    with dl.dataset.set_split_idx(0), self.no_mbar():\n",
-    "        if hasattr(self,'progress'): self.progress.mbar = master_bar(list(range(n)))\n",
-    "        aug_preds = []\n",
-    "        for i in self.progress.mbar if hasattr(self,'progress') else range(n):\n",
-    "            self.epoch = i #To keep track of progress on mbar since the progress callback will use self.epoch\n",
-    "            aug_preds.append(self.get_preds(dl=dl, inner=True)[0][None])\n",
-    "    aug_preds = torch.cat(aug_preds)\n",
-    "    aug_preds = aug_preds.max(0)[0] if use_max else aug_preds.mean(0)\n",
-    "    self.epoch = n\n",
-    "    with dl.dataset.set_split_idx(1): preds,targs = self.get_preds(dl=dl, inner=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#export\n",
     "@patch\n",
     "def tta(self:Learner, ds_idx=1, dl=None, n=4, item_tfms=None, batch_tfms=None, beta=0.25, use_max=False):\n",
     "    \"Return predictions on the `ds_idx` dataset or `dl` using Test Time Augmentation\"\n",
+    "    # progress bar requires epoch=0 to initialize\n",
+    "    self.orig_epoch,self.epoch = self.epoch,0\n",
+    "    \n",
     "    if dl is None: dl = self.dls[ds_idx]\n",
     "    if item_tfms is not None or batch_tfms is not None: dl = dl.new(after_item=item_tfms, after_batch=batch_tfms)\n",
     "    try:\n",
@@ -3535,7 +3518,7 @@
     "        with dl.dataset.set_split_idx(1): preds,targs = self.get_preds(dl=dl, inner=True)\n",
     "    except CancelFitException:             self(event.after_cancel_fit)\n",
     "    finally:                               self(event.after_fit)\n",
-    "\n",
+    "    self.epoch = self.orig_epoch\n",
     "    if use_max: return torch.stack([preds, aug_preds], 0).max(0)[0],targs\n",
     "    preds = (aug_preds,preds) if beta is None else torch.lerp(aug_preds, preds, beta)\n",
     "    return preds,targs"


### PR DESCRIPTION
Fixes #2764 

I don't know if `_tta` method was to be used or not, so I removed it. `tta` does not call this method and instead copies the code.

EDIT: There is also a similar issue #2735 using `learn.summary`. So maybe my solution is a temporary solution of a bigger problem.