### PR TITLE
Fix typo in docstring for BCEWithLogitsLossFlat

### DIFF
--- a/fastai/layers.py
+++ b/fastai/layers.py
@@ -311,7 +311,7 @@ class CrossEntropyLossFlat(BaseLoss):
 @log_args
 @delegates()
 class BCEWithLogitsLossFlat(BaseLoss):
-    "Same as `nn.CrossEntropyLoss`, but flattens input and target."
+    "Same as `nn.BCEWithLogitsLoss`, but flattens input and target."
     @use_kwargs_dict(keep=True, weight=None, reduction='mean', pos_weight=None)
     def __init__(self, *args, axis=-1, floatify=True, thresh=0.5, **kwargs):
         super().__init__(nn.BCEWithLogitsLoss, *args, axis=axis, floatify=floatify, is_2d=False, **kwargs)

--- a/nbs/01_layers.ipynb
+++ b/nbs/01_layers.ipynb
@@ -1167,7 +1167,7 @@
     "@log_args\n",
     "@delegates()\n",
     "class BCEWithLogitsLossFlat(BaseLoss):\n",
-    "    \"Same as `nn.CrossEntropyLoss`, but flattens input and target.\"\n",
+    "    \"Same as `nn.BCEWithLogitsLoss`, but flattens input and target.\"\n",
     "    @use_kwargs_dict(keep=True, weight=None, reduction='mean', pos_weight=None)\n",
     "    def __init__(self, *args, axis=-1, floatify=True, thresh=0.5, **kwargs):\n",
     "        super().__init__(nn.BCEWithLogitsLoss, *args, axis=axis, floatify=floatify, is_2d=False, **kwargs)\n",


### PR DESCRIPTION
It's based on nn.BCEWithLogitsLoss, not on nn.CrossEntropyLoss. Updates the classes' docstring to reflect that.