### PR TITLE
Enable Codespaces

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,4 +1,12 @@
 {
     "name": "fastai-codespaces",
-    "extensions": ["ms-python.python"]
+    "dockerComposeFile": "docker-compose.yml",
+    "service": "watcher",
+    "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+    "forwardPorts": [4000, 8080],
+    "appPort": [4000, 8080],
+    "extensions": ["ms-python.python",
+                   "ms-azuretools.vscode-docker"],
+    "runServices": ["notebook", "jekyll", "watcher"],
+    "postStartCommand": "pip install -e ."
 }

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -2,6 +2,7 @@
     "name": "fastai-codespaces",
     "dockerComposeFile": "docker-compose.yml",
     "service": "watcher",
+    "settings": {"terminal.integrated.shell.linux": "/bin/bash"},
     "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
     "forwardPorts": [4000, 8080],
     "appPort": [4000, 8080],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "3"
+services:
+  fastai: &fastai
+    restart: unless-stopped
+    working_dir: /data
+    image: fastai/codespaces
+    logging:
+      driver: json-file
+      options:
+        max-size: 50m
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/data/
+
+  notebook:
+    <<: *fastai
+    command: bash -c "pip install -e . && jupyter notebook --allow-root --no-browser --ip=0.0.0.0 --port=8080 --NotebookApp.token='' --NotebookApp.password=''"
+    ports:
+      - "8080:8080"
+
+  watcher:
+    <<: *fastai
+    command: watchmedo shell-command --command nbdev_build_docs --pattern *.ipynb --recursive --drop
+    network_mode: host # for GitHub Codespaces https://github.com/features/codespaces/
+
+  jekyll:
+    <<: *fastai
+    ports:
+     - "4000:4000"
+    command: >
+     bash -c "cp -r docs_src docs
+     && pip install .
+     && nbdev_build_docs && cd docs
+     && bundle i
+     && chmod -R u+rwx . && bundle exec jekyll serve --host 0.0.0.0"


### PR DESCRIPTION
I tested this configuration and it does the following:

1. Starts a VSCode in your browser with an editable install
2. Serves Jupyter Notebook on Port 8080 (click on tool in VSCode to see URL)
3. Serves Jekyll on Port 4000 (click on tool in VSCode to see URL)

Demo: https://youtu.be/j5Zdj-wnnao

@jph00 ready for review