### PR TITLE
replaced-broken-urls-in-CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # How to contribute to fastai
 
 First, thanks a lot for wanting to help! Make sure you have read the [doc on code style](
-https://docs.fast.ai/style.html) first. (Note that we don't follow PEP8, but instead follow a coding style designed specifically for numerical and interactive programming.) For help running and building the code, see the [developers guide](https://docs.fast.ai/dev/develop.html).
+https://docs.fast.ai/dev/style.html) first. (Note that we don't follow PEP8, but instead follow a coding style designed specifically for numerical and interactive programming.) For help running and building the code, see the [developers guide](https://docs.fast.ai/dev/develop.html).
 
 ## Note for new contributors from Jeremy
 
@@ -31,7 +31,7 @@ Here are some ways that you can learn a lot about the library, whilst also contr
 #### Did you write a patch that fixes a bug?
 
 * Open a new GitHub pull request with the patch.
-* Ensure that your PR includes [tests](https://docs.fast.ai/test.html) that fail without your patch, and pass with it.
+* Ensure that your PR includes [tests](https://docs.fast.ai/dev/test.html) that fail without your patch, and pass with it.
 * Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
 * Before submitting, please be sure you abide by our [coding style](https://docs.fast.ai/dev/style.html) and [the guide on abbreviations](https://docs.fast.ai/dev/abbr.html) and clean-up your code accordingly.
 
@@ -42,7 +42,7 @@ Here are some ways that you can learn a lot about the library, whilst also contr
 * You can suggest your change on the [fastai forum](http://forums.fast.ai/) to see if others are interested or want to help. [This topic](http://forums.fast.ai/t/fastai-v1-adding-features/23041/8) lists the features that will be added to fastai in the foreseeable future. Be sure to read it too!
 * Before implementing a non-trivial new feature, first create a notebook version of your new feature, like those in [dev_nb](https://github.com/fastai/fastai_docs/tree/master/dev_nb). It should show step-by-step what your code is doing, and why, with the result of each step. Try to simplify the code as much as possible. When you're happy with it, let us know on the forum (include a link to gist with your notebook.)
 * Once your approach has been discussed and confirmed on the forum, you are welcome to push a PR, including a complete description of the new feature and an example of how it's used. Be sure to document your code and read the [doc on code style](https://docs.fast.ai/dev/style.html) and [the one on abbreviations](https://docs.fast.ai/dev/abbr.html).
-* Ensure that your PR includes [tests](https://docs.fast.ai/test.html) that exercise not only your feature, but also any other code that might be impacted. Currently we have poor test coverage of existing features, so often you'll need to add tests of existing code. Your help here is much appreciated!
+* Ensure that your PR includes [tests](https://docs.fast.ai/dev/test.html) that exercise not only your feature, but also any other code that might be impacted. Currently we have poor test coverage of existing features, so often you'll need to add tests of existing code. Your help here is much appreciated!
 
 ## How to submit notebook PRs?
 


### PR DESCRIPTION
Replaced broken links to [FastAI Style guide](git push --set-upstream origin replaced-broken-urls-in-CONTRIBUTING.md) and [testing guide](https://docs.fast.ai/dev/test.html) in CONTRIBUTION.md file.