### PR TITLE
show msg when model isnt complete (text)

### DIFF
--- a/fastai/text/learner.py
+++ b/fastai/text/learner.py
@@ -207,7 +207,8 @@ def language_model_learner(dls, arch, config=None, drop_mult=1., backwards=False
                 warn("There are no pretrained weights for that architecture yet!")
                 return learn
             model_path = untar_data(meta[url] , c_key='model')
-            fnames = [list(model_path.glob(f'*.{ext}'))[0] for ext in ['pth', 'pkl']]
+            try: fnames = [list(model_path.glob(f'*.{ext}'))[0] for ext in ['pth', 'pkl']]
+            except IndexError: print(f'The model in {model_path} is incomplete, download again'); raise
         learn = learn.load_pretrained(*fnames)
     return learn
 
@@ -230,7 +231,8 @@ def text_classifier_learner(dls, arch, seq_len=72, config=None, backwards=False,
             warn("There are no pretrained weights for that architecture yet!")
             return learn
         model_path = untar_data(meta[url], c_key='model')
-        fnames = [list(model_path.glob(f'*.{ext}'))[0] for ext in ['pth', 'pkl']]
+        try: fnames = [list(model_path.glob(f'*.{ext}'))[0] for ext in ['pth', 'pkl']]
+        except IndexError: print(f'The model in {model_path} is incomplete, download again'); raise
         learn = learn.load_pretrained(*fnames, model=learn.model[0])
         learn.freeze()
     return learn

--- a/nbs/37_text.learner.ipynb
+++ b/nbs/37_text.learner.ipynb
@@ -580,7 +580,8 @@
     "                warn(\"There are no pretrained weights for that architecture yet!\")\n",
     "                return learn\n",
     "            model_path = untar_data(meta[url] , c_key='model')\n",
-    "            fnames = [list(model_path.glob(f'*.{ext}'))[0] for ext in ['pth', 'pkl']]\n",
+    "            try: fnames = [list(model_path.glob(f'*.{ext}'))[0] for ext in ['pth', 'pkl']]\n",
+    "            except IndexError: print(f'The model in {model_path} is incomplete, download again'); raise\n",
     "        learn = learn.load_pretrained(*fnames)\n",
     "    return learn"
    ]
@@ -714,7 +715,8 @@
     "            warn(\"There are no pretrained weights for that architecture yet!\")\n",
     "            return learn\n",
     "        model_path = untar_data(meta[url], c_key='model')\n",
-    "        fnames = [list(model_path.glob(f'*.{ext}'))[0] for ext in ['pth', 'pkl']]\n",
+    "        try: fnames = [list(model_path.glob(f'*.{ext}'))[0] for ext in ['pth', 'pkl']]\n",
+    "        except IndexError: print(f'The model in {model_path} is incomplete, download again'); raise\n",
     "        learn = learn.load_pretrained(*fnames, model=learn.model[0])\n",
     "        learn.freeze()\n",
     "    return learn"


### PR DESCRIPTION
It seems that when a model is downloaded, it sometimes can include only one of the files, so catching this error and showing a little message to the user that hopefully instruct what to do.