### PR TITLE
Fix EncodedMultiCategorize sort

### DIFF
--- a/fastai/data/transforms.py
+++ b/fastai/data/transforms.py
@@ -282,7 +282,7 @@ class EncodedMultiCategorize(Categorize):
     "Transform of one-hot encoded multi-category that decodes with `vocab`"
     loss_func,order=BCEWithLogitsLossFlat(),1
     def __init__(self, vocab):
-        super().__init__(vocab)
+        super().__init__(vocab, sort=vocab==None)
         self.c = len(vocab)
     def encodes(self, o): return TensorMultiCategory(tensor(o).float())
     def decodes(self, o): return MultiCategory (one_hot_decode(o, self.vocab))

--- a/nbs/05_data.transforms.ipynb
+++ b/nbs/05_data.transforms.ipynb
@@ -1160,7 +1160,7 @@
     "    \"Transform of one-hot encoded multi-category that decodes with `vocab`\"\n",
     "    loss_func,order=BCEWithLogitsLossFlat(),1\n",
     "    def __init__(self, vocab):\n",
-    "        super().__init__(vocab)\n",
+    "        super().__init__(vocab, sort=vocab==None)\n",
     "        self.c = len(vocab)\n",
     "    def encodes(self, o): return TensorMultiCategory(tensor(o).float())\n",
     "    def decodes(self, o): return MultiCategory (one_hot_decode(o, self.vocab))"
@@ -1175,15 +1175,11 @@
     "_tfm = EncodedMultiCategorize(vocab=['a', 'b', 'c'])\n",
     "test_eq(_tfm([1,0,1]), tensor([1., 0., 1.]))\n",
     "test_eq(type(_tfm([1,0,1])), TensorMultiCategory)\n",
-    "test_eq(_tfm.decode(tensor([False, True, True])), ['b','c'])"
+    "test_eq(_tfm.decode(tensor([False, True, True])), ['b','c'])\n",
+    "\n",
+    "_tfm2 = EncodedMultiCategorize(vocab=['c', 'b', 'a'])\n",
+    "test_eq(_tfm2.vocab, ['c', 'b', 'a'])"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -1193,7 +1189,7 @@
     {
      "data": {
       "text/plain": [
-       "EncodedMultiCategorize -- {'vocab': (#3) ['a','b','c'], 'sort': True, 'add_na': False}:\n",
+       "EncodedMultiCategorize -- {'vocab': (#3) ['a','b','c'], 'sort': False, 'add_na': False}:\n",
        "encodes: (object,object) -> encodes\n",
        "(object,object) -> encodes\n",
        "decodes: (object,object) -> decodes\n",

--- a/nbs/05_data.transforms.ipynb
+++ b/nbs/05_data.transforms.ipynb
@@ -1182,6 +1182,13 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [
     {
      "data": {


### PR DESCRIPTION
This fix ensures that EncodedMultiCategorize does not sort if a vocab is passed in.

Basically the same fix that I made for MultiCategorize earlier, except with its Encoded counterpart.