### PR TITLE
Added ability to have variable length draw

### DIFF
--- a/fastai/vision/augment.py
+++ b/fastai/vision/augment.py
@@ -458,7 +458,7 @@ def _draw_mask(x, def_draw, draw=None, p=0.5, neutral=0., batch=False):
     if draw is None: draw=def_draw
     if callable(draw): res=draw(x)
     elif is_listy(draw):
-        test(len(draw),x.size(0),lambda a,b:a>=b)
+        test(len(draw),x.size(0), ge)
         res = tensor(draw[:x.size(0)], dtype=x.dtype, device=x.device)
     else: res = x.new_zeros(x.size(0)) + draw
     return mask_tensor(res, p=p, neutral=neutral, batch=batch)

--- a/fastai/vision/augment.py
+++ b/fastai/vision/augment.py
@@ -458,8 +458,8 @@ def _draw_mask(x, def_draw, draw=None, p=0.5, neutral=0., batch=False):
     if draw is None: draw=def_draw
     if callable(draw): res=draw(x)
     elif is_listy(draw):
-        test_eq(len(draw), x.size(0))
-        res = tensor(draw, dtype=x.dtype, device=x.device)
+        test(len(draw),x.size(0),lambda a,b:a>=b)
+        res = tensor(draw[:x.size(0)], dtype=x.dtype, device=x.device)
     else: res = x.new_zeros(x.size(0)) + draw
     return mask_tensor(res, p=p, neutral=neutral, batch=batch)
 


### PR DESCRIPTION
Further tests for all identified Transforms can be found here. If we want all of these added I can add these: https://gist.github.com/marii-moe/07412da09f32054dca32373d26aa631e

Documentation of new and existing functionality is still being worked on. Wanted to know if you liked this approach for #2785 . If so I will document the functionality here as well as that which is not very clear as identified by this issue as well. Such as how to use draw as a function, as that actually seems to require understanding tensors. 

IF this behavior is not desired, I can also simply implement it so that only batch_size and 1 are legitimate values for the len(draw). I just thought is was a free win to allow variable length here. Batch size 1 is required because of TfmdDL._one_pass,similar to one_batch with bs=1, being used in decode to retain types. 