### PR TITLE
fix TabularDataLoaders inference of cont_names to keep y_names separate

### DIFF
--- a/fastai/tabular/data.py
+++ b/fastai/tabular/data.py
@@ -16,7 +16,7 @@ class TabularDataLoaders(DataLoaders):
                 valid_idx=None, **kwargs):
         "Create from `df` in `path` using `procs`"
         if cat_names is None: cat_names = []
-        if cont_names is None: cont_names = list(set(df)-set(cat_names)-set(y_names))
+        if cont_names is None: cont_names = list(set(df)-set(L(cat_names))-set(L(y_names)))
         splits = RandomSplitter()(df) if valid_idx is None else IndexSplitter(valid_idx)(df)
         to = TabularPandas(df, procs, cat_names, cont_names, y_names, splits=splits, y_block=y_block)
         return to.dataloaders(path=path, **kwargs)

--- a/nbs/41_tabular.data.ipynb
+++ b/nbs/41_tabular.data.ipynb
@@ -80,7 +80,7 @@
     "                valid_idx=None, **kwargs):\n",
     "        \"Create from `df` in `path` using `procs`\"\n",
     "        if cat_names is None: cat_names = []\n",
-    "        if cont_names is None: cont_names = list(set(df)-set(cat_names)-set(y_names))\n",
+    "        if cont_names is None: cont_names = list(set(df)-set(L(cat_names))-set(L(y_names)))\n",
     "        splits = RandomSplitter()(df) if valid_idx is None else IndexSplitter(valid_idx)(df)\n",
     "        to = TabularPandas(df, procs, cat_names, cont_names, y_names, splits=splits, y_block=y_block)\n",
     "        return to.dataloaders(path=path, **kwargs)\n",


### PR DESCRIPTION
In `TabularDataLoaders.from_df` we figure out which columns are `cont_names` by removing columns listed under `cat_names` or `y_names`. 

However when either `cat_names` or `y_names` are input to the function as a string (e.g. `y_names= 'column1'`) instead of as a list of a string(s) (e.g. `y_names= ['column1']`), this inference does not work, because it includes the y-column(s) as a cont_names which are only for X's. In fact, this happens in the documentation example where load the ADULT dataset using: `y_names="salary"`.

This has impact downstream because the data for y now get's transformed by any of the transforms listed in the dataloader's `procs`. So y could get scaled from (-1,1) -> (-4, 4) if the procs include Normalize. (In the case of ADULT example, there is no impact since it's a non-numeric column.)

This [notebook](https://github.com/sutt/fastai-tutorial/blob/master/bug-procs-on-y.ipynb)  demonstrates the problem and shows how we can correct the code to get the desired result. we change the code to do `set(L(y_names))` to make sure y_names is a list of strings before the (If y_names is already a list, it will work as well).

Fallout: We may indeed want to apply procs to y, including Normalize. However, with the existing code we can't get it to apply the procs on y if there's more than one column in y_names (e.g. y_names = ['pt_x','pt_y']`). Ultimately, there should be a separate PR to apply transforms to y in tabular dataloaders as desired.