### PR TITLE
fix CSVLogger to not erase on get_preds()

### DIFF
--- a/fastai/callback/progress.py
+++ b/fastai/callback/progress.py
@@ -100,6 +100,7 @@ class CSVLogger(Callback):
 
     def before_fit(self):
         "Prepare file with metric names."
+        if hasattr(self, "gather_preds"): return
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self.file = (self.path/self.fname).open('a' if self.append else 'w')
         self.file.write(','.join(self.recorder.metric_names) + '\n')
@@ -112,5 +113,6 @@ class CSVLogger(Callback):
 
     def after_fit(self):
         "Close the file and clean up."
+        if hasattr(self, "gather_preds"): return
         self.file.close()
         self.learn.logger = self.old_logger

--- a/nbs/16_callback.progress.ipynb
+++ b/nbs/16_callback.progress.ipynb
@@ -647,6 +647,7 @@
     "\n",
     "    def before_fit(self):\n",
     "        \"Prepare file with metric names.\"\n",
+    "        if hasattr(self, \"gather_preds\"): return\n",
     "        self.path.parent.mkdir(parents=True, exist_ok=True)\n",
     "        self.file = (self.path/self.fname).open('a' if self.append else 'w')\n",
     "        self.file.write(','.join(self.recorder.metric_names) + '\\n')\n",
@@ -659,6 +660,7 @@
     "\n",
     "    def after_fit(self):\n",
     "        \"Close the file and clean up.\"\n",
+    "        if hasattr(self, \"gather_preds\"): return\n",
     "        self.file.close()\n",
     "        self.learn.logger = self.old_logger"
    ]


### PR DESCRIPTION
**tl;dr - Bug & Solution Explained**
When you attach a CSVLogger as a callback to a learner and run .fit, the table gets saved to disk correctly.

However, if you subsequently call `learn.get_preds()` or `learn.validate()`, the values in the CSVLogger get erased on disk (and replaced with the value from the single validation loop).  This behavior is demonstrated in this [notebook](https://github.com/sutt/fastai-tutorial/blob/master/bug-csvlog-2.ipynb). This behavior can be disappointing if you've just lost valuable data from a long training run.

This PR proposes a simple fix to make sure CSVLogger doesn't get called when a Learner is calling to `get_preds()` or `validate()`, but will remain attached to the Learner.

**General notes on related code:**
The solution to this code uses a solution similar to ShowGraphCallback, but does not make use of the Callback.run property due to the way `Callback.__call__()` works.

There was a [large commit Aug 14](https://github.com/fastai/fastai/commit/d9ed4a8337bab36d3680fd787494e83ebd2f9a4b) which changed the way get_preds() works: this commit added the Learner itself to the ContextManagers under which `learner._do_epoch_validate(dl=dl)` executes. I believe this was added to enable MixedPeecision callbacks. It's questionable to me if this is what's desired: why run methods in a context manager block if the full un-altered Learner is attached to the context?

One other note: the final line in get_preds() never executes because it is below a non-conditional return statement: https://github.com/fastai/fastai/blob/87f4d528535e083aabf5af24f04b911b856057df/fastai/learner.py#L242-L244