### PR TITLE
PILDicom update

### DIFF
--- a/fastai/medical/imaging.py
+++ b/fastai/medical/imaging.py
@@ -45,11 +45,11 @@ class PILDicom(PILBase):
     @classmethod
     def create(cls, fn:(Path,str,bytes), mode=None)->None:
         "Open a `DICOM file` from path `fn` or bytes `fn` and load it as a `PIL Image`"
-        if isinstance(fn,bytes): im = Image.fromarray(pydicom.dcmread(pydicom.filebase.DicomBytesIO(fn)).pixel_array)
-        if isinstance(fn,(Path,str)): im = Image.fromarray(dcmread(fn).pixel_array)
-        im.load()
-        im = im._new(im.im)
-        return cls(im.convert(mode) if mode else im)
+        if isinstance(fn,bytes): im = pydicom.dcmread(pydicom.filebase.DicomBytesIO(fn))
+        if isinstance(fn,(Path,str)): im = dcmread(fn)
+        scaled = np.array(im.hist_scaled(min_px =-1100, max_px=None).numpy())*255
+        scaled = scaled.astype(np.uint8)
+        return cls(Image.fromarray(scaled))
 
 PILDicom._tensor_cls = TensorDicom
 

--- a/fastai/medical/imaging.py
+++ b/fastai/medical/imaging.py
@@ -43,7 +43,7 @@ class TensorDicom(TensorImage):
 class PILDicom(PILBase):
     _open_args,_tensor_cls,_show_args = {},TensorDicom,TensorDicom._show_args
     @classmethod
-    def create(cls, fn:(Path,str,bytes), mode=None)->None:
+    def create(cls, fn:(Path,str,bytes))->None:
         "Open a `DICOM file` from path `fn` or bytes `fn` and load it as a `PIL Image`"
         if isinstance(fn,bytes): im = pydicom.dcmread(pydicom.filebase.DicomBytesIO(fn))
         if isinstance(fn,(Path,str)): im = dcmread(fn)

--- a/nbs/60_medical.imaging.ipynb
+++ b/nbs/60_medical.imaging.ipynb
@@ -215,7 +215,7 @@
     "class PILDicom(PILBase):\n",
     "    _open_args,_tensor_cls,_show_args = {},TensorDicom,TensorDicom._show_args\n",
     "    @classmethod\n",
-    "    def create(cls, fn:(Path,str,bytes), mode=None)->None:\n",
+    "    def create(cls, fn:(Path,str,bytes))->None:\n",
     "        \"Open a `DICOM file` from path `fn` or bytes `fn` and load it as a `PIL Image`\"\n",
     "        if isinstance(fn,bytes): im = pydicom.dcmread(pydicom.filebase.DicomBytesIO(fn))\n",
     "        if isinstance(fn,(Path,str)): im = dcmread(fn)\n",

--- a/nbs/60_medical.imaging.ipynb
+++ b/nbs/60_medical.imaging.ipynb
@@ -217,11 +217,11 @@
     "    @classmethod\n",
     "    def create(cls, fn:(Path,str,bytes), mode=None)->None:\n",
     "        \"Open a `DICOM file` from path `fn` or bytes `fn` and load it as a `PIL Image`\"\n",
-    "        if isinstance(fn,bytes): im = Image.fromarray(pydicom.dcmread(pydicom.filebase.DicomBytesIO(fn)).pixel_array)\n",
-    "        if isinstance(fn,(Path,str)): im = Image.fromarray(dcmread(fn).pixel_array)\n",
-    "        im.load()\n",
-    "        im = im._new(im.im)\n",
-    "        return cls(im.convert(mode) if mode else im)\n",
+    "        if isinstance(fn,bytes): im = pydicom.dcmread(pydicom.filebase.DicomBytesIO(fn))\n",
+    "        if isinstance(fn,(Path,str)): im = dcmread(fn)\n",
+    "        scaled = np.array(im.hist_scaled(min_px =-1100, max_px=None).numpy())*255\n",
+    "        scaled = scaled.astype(np.uint8)\n",
+    "        return cls(Image.fromarray(scaled))\n",
     "\n",
     "PILDicom._tensor_cls = TensorDicom"
    ]


### PR DESCRIPTION
For a majority of DICOM images we usually need to `scale` the images so that the pixels represent the correct tissue densities.  Once the images are scaled you can view the normalized images using the `show` function.  This however does not get translated when you use `PILDicom`.  By default `PILDicom` should display the best visualization.  This update also gets round `ValueError: image has wrong mode` errors.

**Examples and Tests**

**SIIM dataset**
(current `PILDicom`)

![scale1](https://user-images.githubusercontent.com/25020209/95036881-1ac9a280-067e-11eb-9a14-1da2567c2c1e.PNG)

(updated `PILDicom`)

![scale2](https://user-images.githubusercontent.com/25020209/95037000-7431d180-067e-11eb-8fe6-0236aa84d6e0.PNG)

minor visual changes (checking to see that there are no errors with the update) and this dataset does not have a `RescaleSlope` or `RescaleIntercept` so does not really take into consideration the full scale of the update.

**osic-pulmonary-fibrosis**  [dataset](https://www.kaggle.com/c/osic-pulmonary-fibrosis-progression)

(current `PILDicom`)
This throws a `ValueError: image has wrong mode` because the images are 32-bit signed integer pixels.  However even after converting the mode to 32-bit floating point pixels results in the following images .

![scale3](https://user-images.githubusercontent.com/25020209/95039079-aa724f80-0684-11eb-9479-d2ea197862a8.PNG)

(updated `PILDicom`)

![scale4](https://user-images.githubusercontent.com/25020209/95039163-e0173880-0684-11eb-9fbb-df49b8d60ef9.PNG)

The updated version no longer throws the wrong mode error and the images look a lot better out of the box.

**Melanoma** [dataset](https://www.kaggle.com/c/siim-isic-melanoma-classification) - Note that the `Photometric Interpretation` in this dataset is `YBR_FULL_422` hence the color of the images.

(current `PILDicom`)

![scale5](https://user-images.githubusercontent.com/25020209/95039429-8a8f5b80-0685-11eb-8e2c-8a92a99168fe.PNG)

(updated `PILDicom`)

![scale6](https://user-images.githubusercontent.com/25020209/95039469-ad217480-0685-11eb-9261-97cf578f8546.PNG)

**RSNA Pulmonary** [dataset](https://www.kaggle.com/c/rsna-str-pulmonary-embolism-detection)

(current `PILDicom`) - will throw a `ValueError: image has wrong mode`  error and after changing the mode:

![scale7](https://user-images.githubusercontent.com/25020209/95039712-67b17700-0686-11eb-9a41-89bc833f4603.PNG)

(updated `PILDicom`)

![scale8](https://user-images.githubusercontent.com/25020209/95039768-92033480-0686-11eb-8d85-9f8f040fdee3.PNG)

