### PR TITLE
wandb callback: support logging lists of parameters

### DIFF
--- a/fastai/callback/wandb.py
+++ b/fastai/callback/wandb.py
@@ -136,13 +136,27 @@ def _make_plt(img):
     return fig, ax
 
 # Cell
+def _format_config_value(config_value):
+    "Format a single config parameter value before logging it"
+    if callable(config_value):
+        config_value = (
+            f'{config_value.__module__}.{config_value.__qualname__}'
+            if hasattr(config_value, '__qualname__') and hasattr(config_value, '__module__')
+            else str(config_value)
+        )
+    return config_value
+
+# Cell
 def _format_config(log_config):
     "Format config parameters before logging them"
     for k,v in log_config.items():
-        if callable(v):
-            if hasattr(v,'__qualname__') and hasattr(v,'__module__'): log_config[k] = f'{v.__module__}.{v.__qualname__}'
-            else: log_config[k] = str(v)
-        if isinstance(v, slice): log_config[k] = dict(slice_start=v.start, slice_step=v.step, slice_stop=v.stop)
+        if isinstance(v, slice):
+            v = dict(slice_start=v.start, slice_step=v.step, slice_stop=v.stop)
+        elif isinstance(v, list):
+            v = [_format_config_value(item) for item in v]
+        else:
+            v = _format_config_value(v)
+        log_config[k] = v
 
 # Cell
 def _format_metadata(metadata):

--- a/nbs/70_callback.wandb.ipynb
+++ b/nbs/70_callback.wandb.ipynb
@@ -248,13 +248,34 @@
    "outputs": [],
    "source": [
     "#export\n",
+    "def _format_config_value(config_value):\n",
+    "    \"Format a single config parameter value before logging it\"\n",
+    "    if callable(config_value):\n",
+    "        config_value = (\n",
+    "            f'{config_value.__module__}.{config_value.__qualname__}'\n",
+    "            if hasattr(config_value, '__qualname__') and hasattr(config_value, '__module__')\n",
+    "            else str(config_value)\n",
+    "        )\n",
+    "    return config_value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#export\n",
     "def _format_config(log_config):\n",
     "    \"Format config parameters before logging them\"\n",
     "    for k,v in log_config.items():\n",
-    "        if callable(v):\n",
-    "            if hasattr(v,'__qualname__') and hasattr(v,'__module__'): log_config[k] = f'{v.__module__}.{v.__qualname__}'\n",
-    "            else: log_config[k] = str(v)\n",
-    "        if isinstance(v, slice): log_config[k] = dict(slice_start=v.start, slice_step=v.step, slice_stop=v.stop)"
+    "        if isinstance(v, slice):\n",
+    "            v = dict(slice_start=v.start, slice_step=v.step, slice_stop=v.stop)\n",
+    "        elif isinstance(v, list):\n",
+    "            v = [_format_config_value(item) for item in v]\n",
+    "        else:\n",
+    "            v = _format_config_value(v) \n",
+    "        log_config[k] = v"
    ]
   },
   {


### PR DESCRIPTION
When using `WandbCallback` I got an exception:
"WandbCallback could not log config parameters -> Object of type function is not JSON serializable"

This happens because the config dictionary contains an item that's mapped to a list of functions (`Learner.__init__.metrics` is mapped to the list of metrics used by fastai's Learner).
`wandb._format_config()` supports serializing functions, but not lists of functions - which is the type of the fastai metrics object.
This PR updates `_format_config()` with that required support.