### PR TITLE
fix SaveModelCallback to work with learn.summary()

### DIFF
--- a/fastai/callback/hook.py
+++ b/fastai/callback/hook.py
@@ -147,7 +147,9 @@ def layer_info(learn, *xb):
     def _track(m, i, o): return (m.__class__.__name__,)+total_params(m)+(apply(lambda x:x.shape, o),)
     with Hooks(flatten_model(learn.model), _track) as h:
         batch = apply(lambda o:o[:1], xb)
-        with learn: r = learn.get_preds(dl=[batch], inner=True, reorder=False)
+        train_only_cbs = [cb for cb in learn.cbs if hasattr(cb, '_only_train_loop')]
+        with learn.removed_cbs(train_only_cbs) as l:
+            with l: r = l.get_preds(dl=[batch], inner=True, reorder=False)
         return h.stored
 
 # Cell

--- a/fastai/callback/tracker.py
+++ b/fastai/callback/tracker.py
@@ -65,6 +65,7 @@ class EarlyStoppingCallback(TrackerCallback):
 @log_args
 class SaveModelCallback(TrackerCallback):
     "A `TrackerCallback` that saves the model's best during training and loads it at the end."
+    _only_train_loop = True
     def __init__(self, monitor='valid_loss', comp=None, min_delta=0., fname='model', every_epoch=False, with_opt=False, reset_on_fit=True):
         super().__init__(monitor=monitor, comp=comp, min_delta=min_delta, reset_on_fit=reset_on_fit)
         # keep track of file path for loggers

--- a/nbs/15_callback.hook.ipynb
+++ b/nbs/15_callback.hook.ipynb
@@ -966,7 +966,9 @@
     "    def _track(m, i, o): return (m.__class__.__name__,)+total_params(m)+(apply(lambda x:x.shape, o),)\n",
     "    with Hooks(flatten_model(learn.model), _track) as h:\n",
     "        batch = apply(lambda o:o[:1], xb)\n",
-    "        with learn: r = learn.get_preds(dl=[batch], inner=True, reorder=False)\n",
+    "        train_only_cbs = [cb for cb in learn.cbs if hasattr(cb, '_only_train_loop')]\n",
+    "        with learn.removed_cbs(train_only_cbs) as l:\n",
+    "            with l: r = l.get_preds(dl=[batch], inner=True, reorder=False)\n",
     "        return h.stored"
    ]
   },

--- a/nbs/17_callback.tracker.ipynb
+++ b/nbs/17_callback.tracker.ipynb
@@ -571,6 +571,7 @@
     "@log_args\n",
     "class SaveModelCallback(TrackerCallback):\n",
     "    \"A `TrackerCallback` that saves the model's best during training and loads it at the end.\"\n",
+    "    _only_train_loop = True\n",
     "    def __init__(self, monitor='valid_loss', comp=None, min_delta=0., fname='model', every_epoch=False, with_opt=False, reset_on_fit=True):\n",
     "        super().__init__(monitor=monitor, comp=comp, min_delta=min_delta, reset_on_fit=reset_on_fit)\n",
     "        # keep track of file path for loggers\n",


### PR DESCRIPTION
Fixes issue: https://github.com/fastai/fastai/issues/2852

The fix simply temporarily removes `SavedModelCallback` so it can run through the problem code then adds it back on.

**Important explanation:** Why use nested `with` statements?
```
        with learn.removed_cbs(train_only_cbs) as l:
            with l: r = l.get_preds(dl=[batch], inner=True, reorder=False)
```

The original code uses `with learn:` which triggers `learn.__enter__()` and  `learn.__exit__()` before and after the call to `get_preds()`. This could be important for setup/teardown reasons.

When we add the block `with learn.remove_cbs(...):` this does *not* fire `__enter__` and `__exit__` for learn. Instead this with-block is really about temporarily removing cbs and restoring them. In other words, the inner with-block preserves the behavior of the previous code; the outer loop fixes the bug.

**Future Extensions:**
`_train_loop_only` can be attached to other callbacks to prevent them from creating an error