### PR TITLE
Transformers Tutorial Bug Correction

### DIFF
--- a/nbs/39_tutorial.transformers.ipynb
+++ b/nbs/39_tutorial.transformers.ipynb
@@ -1059,7 +1059,7 @@
     }
    ],
    "source": [
-    "tokenizer.decode(preds[0])"
+    "tokenizer.decode(preds[0].cpu().numpy())"
    ]
   },
   {


### PR DESCRIPTION
In several places in the tutorial this preds[0].cpy().numpy() is done, but was missed in the last cell.  This causes a type error that looks like this (verified in datacrunch.io notebook as well as colab link provided at top of tutorial).  This tweak adds consistency to the tutorial and fixes a small bug.

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-27-9005c4c0aa21> in <module>
----> 1 tokenizer.decode(preds[0])

~/anaconda3/envs/fastai/lib/python3.8/site-packages/transformers/tokenization_utils_fast.py in decode(self, token_ids, skip_special_tokens, clean_up_tokenization_spaces, **kwargs)
    552         if isinstance(token_ids, int):
    553             token_ids = [token_ids]
--> 554         text = self._tokenizer.decode(token_ids, skip_special_tokens=skip_special_tokens)
    555 
    556         if clean_up_tokenization_spaces:

TypeError: Can't convert tensor([ 4826,  5817,   532, 46415,   318,   281,  2071,   326,  4446,   815,
          760,   546,    13,  1881,   286,   262,  1994,  1243,   284,  1394,
          287,  2000,   318,   326,   220,  1849,  5661,   318,   407,   281,
         2071,   326,   318,  1016,   284,   467,  1497, 17949,  2582,    13],
       device='cuda:0') to Sequence
```