### PR TITLE
clip_remove_empty removes boxes with area 0

### DIFF
--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -24,7 +24,7 @@ def get_grid(n, nrows=None, ncols=None, add_vert=0, figsize=None, double=False, 
 def clip_remove_empty(bbox, label):
     "Clip bounding boxes with image border and label background the empty ones"
     bbox = torch.clamp(bbox, -1, 1)
-    empty = ((bbox[...,2] - bbox[...,0])*(bbox[...,3] - bbox[...,1]) < 0.)
+    empty = ((bbox[...,2] - bbox[...,0])*(bbox[...,3] - bbox[...,1]) <= 0.)
     return (bbox[~empty], label[~empty])
 
 # Cell

--- a/nbs/08_vision.data.ipynb
+++ b/nbs/08_vision.data.ipynb
@@ -102,7 +102,7 @@
     "def clip_remove_empty(bbox, label):\n",
     "    \"Clip bounding boxes with image border and label background the empty ones\"\n",
     "    bbox = torch.clamp(bbox, -1, 1)\n",
-    "    empty = ((bbox[...,2] - bbox[...,0])*(bbox[...,3] - bbox[...,1]) < 0.)\n",
+    "    empty = ((bbox[...,2] - bbox[...,0])*(bbox[...,3] - bbox[...,1]) <= 0.)\n",
     "    return (bbox[~empty], label[~empty])"
    ]
   },
@@ -112,8 +112,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bb = tensor([[-2,-0.5,0.5,1.5], [-0.5,-0.5,0.5,0.5], [1,0.5,0.5,0.75], [-0.5,-0.5,0.5,0.5]])\n",
-    "bb,lbl = clip_remove_empty(bb, tensor([1,2,3,2]))\n",
+    "bb = tensor([[-2,-0.5,0.5,1.5], [-0.5,-0.5,0.5,0.5], [1,0.5,0.5,0.75], [-0.5,-0.5,0.5,0.5], [-2, -0.5, -1.5, 0.5]])\n",
+    "bb,lbl = clip_remove_empty(bb, tensor([1,2,3,2,5]))\n",
     "test_eq(bb, tensor([[-1,-0.5,0.5,1.], [-0.5,-0.5,0.5,0.5], [-0.5,-0.5,0.5,0.5]]))\n",
     "test_eq(lbl, tensor([1,2,2]))"
    ]


### PR DESCRIPTION
fixes #2893

The follwing nbs did not fail:
- 00_torch_core.ipynb
- 04_data.external.ipynb
- 07_vision.core.ipynb
- 09_vision.augment.ipynb
- 20a_distributed.ipynb

The same notebooks failed while testing in the main branch, so I believe this is not related to the change. Let me know if you think differently.