### PR TITLE
Update sidebar.json

### DIFF
--- a/docs_src/sidebar.json
+++ b/docs_src/sidebar.json
@@ -48,7 +48,7 @@
             "Callbacks": {
                 "Core": "/callback.core",
                 "Hooks": "/callback.hook",
-                "Progress": "/callback.hook",
+                "Progress": "/callback.progress",
                 "Schedulers": "/callback.schedule",
                 "CutMix": "/callback.cutmix",
                 "Data": "/callback.data",


### PR DESCRIPTION
Currently, the sidebar on https://docs.fast.ai/ has a bad link for callabcks/progress.

I believe this change should fix that
