### PR TITLE
Make Random Splitter use Numpy rather than Pytorch

### DIFF
--- a/fastai/data/transforms.py
+++ b/fastai/data/transforms.py
@@ -85,8 +85,8 @@ class AttrGetter(ItemTransform):
 def RandomSplitter(valid_pct=0.2, seed=None):
     "Create function that splits `items` between train/val with `valid_pct` randomly."
     def _inner(o):
-        if seed is not None: torch.manual_seed(seed)
-        rand_idx = L(int(i) for i in torch.randperm(len(o)))
+        if seed is not None: np.random.seed(seed)
+        rand_idx = L(int(i) for i in np.random.permutation(len(o)))
         cut = int(valid_pct * len(o))
         return rand_idx[cut:],rand_idx[:cut]
     return _inner
@@ -158,9 +158,9 @@ def RandomSubsetSplitter(train_sz, valid_sz, seed=None):
     assert train_sz + valid_sz <= 1.
 
     def _inner(o):
-        if seed is not None: torch.manual_seed(seed)
+        if seed is not None: np.random.seed(seed)
         train_len,valid_len = int(len(o)*train_sz),int(len(o)*valid_sz)
-        idxs = L(int(i) for i in torch.randperm(len(o)))
+        idxs = L(int(i) for i in np.random.permutation(len(o)))
         return idxs[:train_len],idxs[train_len:train_len+valid_len]
     return _inner
 

--- a/fastai/data/transforms.py
+++ b/fastai/data/transforms.py
@@ -86,7 +86,7 @@ def RandomSplitter(valid_pct=0.2, seed=None):
     "Create function that splits `items` between train/val with `valid_pct` randomly."
     def _inner(o):
         if seed is not None: np.random.seed(seed)
-        split_idxs = np.random.choice(len(o), size=len(len(o)), replace=False)
+        split_idxs = np.random.choice(len(o), size=len(o), replace=False)
         rand_idx = L(int(i) for i in split_idxs)
         cut = int(valid_pct * len(o))
         return rand_idx[cut:],rand_idx[:cut]
@@ -161,7 +161,7 @@ def RandomSubsetSplitter(train_sz, valid_sz, seed=None):
     def _inner(o):
         if seed is not None: np.random.seed(seed)
         train_len,valid_len = int(len(o)*train_sz),int(len(o)*valid_sz)
-        split_idxs = np.random.choice(len(o), size=len(len(o)), replace=False)
+        split_idxs = np.random.choice(len(o), size=len(o), replace=False)
         idxs = L(int(i) for i in split_idxs)
         return idxs[:train_len],idxs[train_len:train_len+valid_len]
     return _inner

--- a/fastai/data/transforms.py
+++ b/fastai/data/transforms.py
@@ -86,7 +86,8 @@ def RandomSplitter(valid_pct=0.2, seed=None):
     "Create function that splits `items` between train/val with `valid_pct` randomly."
     def _inner(o):
         if seed is not None: np.random.seed(seed)
-        rand_idx = L(int(i) for i in np.random.permutation(len(o)))
+        split_idxs = np.random.choice(len(o), size=len(len(o)), replace=False)
+        rand_idx = L(int(i) for i in split_idxs)
         cut = int(valid_pct * len(o))
         return rand_idx[cut:],rand_idx[:cut]
     return _inner
@@ -160,7 +161,8 @@ def RandomSubsetSplitter(train_sz, valid_sz, seed=None):
     def _inner(o):
         if seed is not None: np.random.seed(seed)
         train_len,valid_len = int(len(o)*train_sz),int(len(o)*valid_sz)
-        idxs = L(int(i) for i in np.random.permutation(len(o)))
+        split_idxs = np.random.choice(len(o), size=len(len(o)), replace=False)
+        idxs = L(int(i) for i in split_idxs)
         return idxs[:train_len],idxs[train_len:train_len+valid_len]
     return _inner
 

--- a/fastai/data/transforms.py
+++ b/fastai/data/transforms.py
@@ -86,8 +86,7 @@ def RandomSplitter(valid_pct=0.2, seed=None):
     "Create function that splits `items` between train/val with `valid_pct` randomly."
     def _inner(o):
         if seed is not None: np.random.seed(seed)
-        split_idxs = np.random.choice(len(o), size=len(o), replace=False)
-        rand_idx = L(int(i) for i in split_idxs)
+        rand_idx = L(int(i) for i in np.random.permutation(len(o)))
         cut = int(valid_pct * len(o))
         return rand_idx[cut:],rand_idx[:cut]
     return _inner
@@ -161,8 +160,7 @@ def RandomSubsetSplitter(train_sz, valid_sz, seed=None):
     def _inner(o):
         if seed is not None: np.random.seed(seed)
         train_len,valid_len = int(len(o)*train_sz),int(len(o)*valid_sz)
-        split_idxs = np.random.choice(len(o), size=len(o), replace=False)
-        idxs = L(int(i) for i in split_idxs)
+        idxs = L(int(i) for i in np.random.permutation(len(o)))
         return idxs[:train_len],idxs[train_len:train_len+valid_len]
     return _inner
 

--- a/nbs/05_data.transforms.ipynb
+++ b/nbs/05_data.transforms.ipynb
@@ -379,8 +379,8 @@
     "def RandomSplitter(valid_pct=0.2, seed=None):\n",
     "    \"Create function that splits `items` between train/val with `valid_pct` randomly.\"\n",
     "    def _inner(o):\n",
-    "        if seed is not None: torch.manual_seed(seed)\n",
-    "        rand_idx = L(int(i) for i in torch.randperm(len(o)))\n",
+    "        if seed is not None: np.random.seed(seed)\n",
+    "        rand_idx = L(int(i) for i in np.random.permutation(len(o)))\n",
     "        cut = int(valid_pct * len(o))\n",
     "        return rand_idx[cut:],rand_idx[:cut]\n",
     "    return _inner"
@@ -651,9 +651,9 @@
     "    assert train_sz + valid_sz <= 1.\n",
     "\n",
     "    def _inner(o):\n",
-    "        if seed is not None: torch.manual_seed(seed)\n",
+    "        if seed is not None: np.random.seed(seed)\n",
     "        train_len,valid_len = int(len(o)*train_sz),int(len(o)*valid_sz)\n",
-    "        idxs = L(int(i) for i in torch.randperm(len(o)))\n",
+    "        idxs = L(int(i) for i in np.random.permutation(len(o)))\n",
     "        return idxs[:train_len],idxs[train_len:train_len+valid_len]\n",
     "    return _inner"
    ]

--- a/nbs/05_data.transforms.ipynb
+++ b/nbs/05_data.transforms.ipynb
@@ -380,7 +380,8 @@
     "    \"Create function that splits `items` between train/val with `valid_pct` randomly.\"\n",
     "    def _inner(o):\n",
     "        if seed is not None: np.random.seed(seed)\n",
-    "        rand_idx = L(int(i) for i in np.random.permutation(len(o)))\n",
+    "        split_idxs = np.random.choice(len(o), size=len(len(o)), replace=False)\n",
+    "        rand_idx = L(int(i) for i in split_idxs)\n",
     "        cut = int(valid_pct * len(o))\n",
     "        return rand_idx[cut:],rand_idx[:cut]\n",
     "    return _inner"
@@ -653,7 +654,8 @@
     "    def _inner(o):\n",
     "        if seed is not None: np.random.seed(seed)\n",
     "        train_len,valid_len = int(len(o)*train_sz),int(len(o)*valid_sz)\n",
-    "        idxs = L(int(i) for i in np.random.permutation(len(o)))\n",
+    "        split_idxs = np.random.choice(len(o), size=len(len(o)), replace=False)\n",
+    "        idxs = L(int(i) for i in split_idxs)\n",
     "        return idxs[:train_len],idxs[train_len:train_len+valid_len]\n",
     "    return _inner"
    ]

--- a/nbs/05_data.transforms.ipynb
+++ b/nbs/05_data.transforms.ipynb
@@ -380,8 +380,7 @@
     "    \"Create function that splits `items` between train/val with `valid_pct` randomly.\"\n",
     "    def _inner(o):\n",
     "        if seed is not None: np.random.seed(seed)\n",
-    "        split_idxs = np.random.choice(len(o), size=len(o), replace=False)\n",
-    "        rand_idx = L(int(i) for i in split_idxs)\n",
+    "        rand_idx = L(int(i) for i in np.random.permutation(len(o)))\n",
     "        cut = int(valid_pct * len(o))\n",
     "        return rand_idx[cut:],rand_idx[:cut]\n",
     "    return _inner"
@@ -654,8 +653,7 @@
     "    def _inner(o):\n",
     "        if seed is not None: np.random.seed(seed)\n",
     "        train_len,valid_len = int(len(o)*train_sz),int(len(o)*valid_sz)\n",
-    "        split_idxs = np.random.choice(len(o), size=len(o), replace=False)\n",
-    "        idxs = L(int(i) for i in split_idxs)\n",
+    "        idxs = L(int(i) for i in np.random.permutation(len(o)))\n",
     "        return idxs[:train_len],idxs[train_len:train_len+valid_len]\n",
     "    return _inner"
    ]

--- a/nbs/05_data.transforms.ipynb
+++ b/nbs/05_data.transforms.ipynb
@@ -380,7 +380,7 @@
     "    \"Create function that splits `items` between train/val with `valid_pct` randomly.\"\n",
     "    def _inner(o):\n",
     "        if seed is not None: np.random.seed(seed)\n",
-    "        split_idxs = np.random.choice(len(o), size=len(len(o)), replace=False)\n",
+    "        split_idxs = np.random.choice(len(o), size=len(o), replace=False)\n",
     "        rand_idx = L(int(i) for i in split_idxs)\n",
     "        cut = int(valid_pct * len(o))\n",
     "        return rand_idx[cut:],rand_idx[:cut]\n",
@@ -654,7 +654,7 @@
     "    def _inner(o):\n",
     "        if seed is not None: np.random.seed(seed)\n",
     "        train_len,valid_len = int(len(o)*train_sz),int(len(o)*valid_sz)\n",
-    "        split_idxs = np.random.choice(len(o), size=len(len(o)), replace=False)\n",
+    "        split_idxs = np.random.choice(len(o), size=len(o), replace=False)\n",
     "        idxs = L(int(i) for i in split_idxs)\n",
     "        return idxs[:train_len],idxs[train_len:train_len+valid_len]\n",
     "    return _inner"


### PR DESCRIPTION
As the title says when doing RandomSplitter on a large dataset it winds up taking a long time and can lead to a weird spike in memory (when its obscenely large).

For a quick example when trying on 1,000,000 numbers I found that torch.permute took 7.24 seconds while np.random.permutation only took 377ms

(git history is now good @jph00 :) )