### PR TITLE
Fix RandomSubsetSplitter upstream adjustment to RandomSplitter

### DIFF
--- a/fastai/data/transforms.py
+++ b/fastai/data/transforms.py
@@ -161,7 +161,7 @@ def RandomSubsetSplitter(train_sz, valid_sz, seed=None):
     def _inner(o):
         if seed is not None: torch.manual_seed(seed)
         train_len,valid_len = int(len(o)*train_sz),int(len(o)*valid_sz)
-        idxs = L(int(i) for i in torch.randperm(len(o)))
+        idxs = L(list(torch.randperm(len(o)).numpy()))
         return idxs[:train_len],idxs[train_len:train_len+valid_len]
     return _inner
 

--- a/nbs/05_data.transforms.ipynb
+++ b/nbs/05_data.transforms.ipynb
@@ -654,7 +654,7 @@
     "    def _inner(o):\n",
     "        if seed is not None: torch.manual_seed(seed)\n",
     "        train_len,valid_len = int(len(o)*train_sz),int(len(o)*valid_sz)\n",
-    "        idxs = L(int(i) for i in torch.randperm(len(o)))\n",
+    "        idxs = L(list(torch.randperm(len(o)).numpy()))\n",
     "        return idxs[:train_len],idxs[train_len:train_len+valid_len]\n",
     "    return _inner"
    ]


### PR DESCRIPTION
Applies the same logic as https://github.com/fastai/fastai/issues/2957 but to `RandomSubsetSplitter` too (cc: @jph00 )