### PR TITLE
fix sequentialex memory leak

### DIFF
--- a/fastai/layers.py
+++ b/fastai/layers.py
@@ -396,7 +396,7 @@ class SequentialEx(Module):
             res.orig = x
             nres = l(res)
             # We have to remove res.orig to avoid hanging refs and therefore memory leaks
-            res.orig = None
+            res.orig, nres.orig = None, None
             res = nres
         return res
 

--- a/nbs/01_layers.ipynb
+++ b/nbs/01_layers.ipynb
@@ -137,9 +137,7 @@
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "tags": []
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -1408,7 +1406,7 @@
     "            res.orig = x\n",
     "            nres = l(res)\n",
     "            # We have to remove res.orig to avoid hanging refs and therefore memory leaks\n",
-    "            res.orig = None\n",
+    "            res.orig, nres.orig = None, None\n",
     "            res = nres\n",
     "        return res\n",
     "\n",
@@ -1450,6 +1448,17 @@
     "y = res_block(x)\n",
     "test_eq(y.shape, [32, 16, 8, 8])\n",
     "test_eq(y, x + res_block[1](res_block[0](x)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = TensorBase(torch.randn(32, 16, 8, 8))\n",
+    "y = res_block(x)\n",
+    "test_is(y.orig, None)"
    ]
   },
   {
@@ -2100,9 +2109,9 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:fastai21]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-fastai21-py"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
fixes #2946
[Here](https://gist.github.com/ababino/cbe0c1d55573dcfe6e3b9bfad9dfa872) is gist showing the memory leak.
[Here](https://gist.github.com/muellerzr/3777fac2613eba1da9995acf916830d3) is the gist showing the solution.

The new test makes sure that `orig` attribute is set to `None` in tensor subclasses.

13a_learner.ipynb fails, but it also fails in the main branch, so I think it's not a related issue.
