### PR TITLE
Updated gh installation docs for linux

### DIFF
--- a/nbs/dev-setup.ipynb
+++ b/nbs/dev-setup.ipynb
@@ -47,23 +47,9 @@
    "source": [
     "In order to contribute to fastai (or any fast.ai library... or indeed most open source software!) you'll need to make a [pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests), also known as a *PR*. Here's an [example](https://github.com/fastai/fastai/pull/2648) of a pull request. In this case, you can see from the description that it's something that fixes some typos in the library. If you click on \"Files changed\" on that page, you can see all the changes made. We get notified when a pull request arrives, and after checking whether the changes look OK, we \"merge\" it (which means that we click a button in GitHub that causes all those changes to get automatically added to the repo).\n",
     "\n",
-    "Making a pull request for the first time can feel a bit over-whelming, so I've put together this guide to help you get started. We're going to use GitHub's command line tool `gh`, which makes things faster and easier than doing things through the web-site (in my opinion, at least!) The easiest way to install `gh` on Linux (works on any distribution, including Ubuntu) is using `conda`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "conda install -yc fastai gh"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "I'm assuming in this guide that you're using Linux, and that you've already got [Anaconda](https://www.anaconda.com/products/individual) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html) set up. This is the default in all of the fast.ai course guides, and is highly recommended. It should work fine on Mac too, although I haven't tested it. On Windows, use [Ubuntu on WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10). To install `gh` on Mac type: `brew install github/gh/gh`.\n",
+    "Making a pull request for the first time can feel a bit over-whelming, so I've put together this guide to help you get started. We're going to use GitHub's command line tool `gh`, which makes things faster and easier than doing things through the web-site (in my opinion, at least!). To install `gh` on Linux follow the instructions given [here](https://github.com/cli/cli/blob/trunk/docs/install_linux.md#installing-gh-on-linux). To install `gh` on Mac type: `brew install github/gh/gh`.\n",
+    "\n",
+    "I'm assuming in this guide that you're using Linux, and that you've already got [Anaconda](https://www.anaconda.com/products/individual) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html) set up. This is the default in all of the fast.ai course guides, and is highly recommended. It should work fine on Mac too, although I haven't tested it. On Windows, use [Ubuntu on WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10). \n",
     "\n",
     "> This document is created from a Jupyter Notebook. You can run the notebook yourself by getting it [from here](https://github.com/fastai/fastai/blob/master/nbs/dev-setup.ipynb). You'll need to install the [Jupyter Bash kernel](https://github.com/takluyver/bash_kernel)."
    ]


### PR DESCRIPTION
Changes: Dropped the conda install step for `gh` and added link from gh [docs](https://github.com/cli/cli/blob/trunk/docs/install_linux.md#installing-gh-on-linux) for installation steps on Linux.