### PR TITLE
Avoid redundant BatchNorm in create_head

### DIFF
--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -5,6 +5,7 @@ __all__ = ['has_pool_type', 'create_body', 'create_head', 'default_split', 'mode
 
 # Cell
 from ..basics import *
+from ..callback.hook import *
 from .core import *
 from .data import *
 from .augment import *
@@ -73,17 +74,19 @@ def create_body(arch, n_in=3, pretrained=True, cut=None):
     else:                           raise NamedError("cut must be either integer or a function")
 
 # Cell
-def create_head(nf, n_out, lin_ftrs=None, ps=0.5, concat_pool=True, bn_final=False, lin_first=False, y_range=None):
+def create_head(nf, n_out, lin_ftrs=None, ps=0.5, concat_pool=True, first_bn=True, bn_final=False,
+                lin_first=False, y_range=None):
     "Model head that takes `nf` features, runs through `lin_ftrs`, and out `n_out` classes."
     lin_ftrs = [nf, 512, n_out] if lin_ftrs is None else [nf] + lin_ftrs + [n_out]
+    bns = [first_bn] + [True]*len(lin_ftrs[1:])
     ps = L(ps)
     if len(ps) == 1: ps = [ps[0]/2] * (len(lin_ftrs)-2) + ps
     actns = [nn.ReLU(inplace=True)] * (len(lin_ftrs)-2) + [None]
     pool = AdaptiveConcatPool2d() if concat_pool else nn.AdaptiveAvgPool2d(1)
     layers = [pool, Flatten()]
     if lin_first: layers.append(nn.Dropout(ps.pop(0)))
-    for ni,no,p,actn in zip(lin_ftrs[:-1], lin_ftrs[1:], ps, actns):
-        layers += LinBnDrop(ni, no, bn=True, p=p, act=actn, lin_first=lin_first)
+    for ni,no,bn,p,actn in zip(lin_ftrs[:-1], lin_ftrs[1:], bns, ps, actns):
+        layers += LinBnDrop(ni, no, bn=bn, p=p, act=actn, lin_first=lin_first)
     if lin_first: layers.append(nn.Linear(lin_ftrs[-2], n_out))
     if bn_final: layers.append(nn.BatchNorm1d(lin_ftrs[-1], momentum=0.01))
     if y_range is not None: layers.append(SigmoidRange(*y_range))
@@ -140,7 +143,12 @@ def create_cnn_model(arch, n_out, pretrained=True, cut=None, n_in=3, init=nn.ini
     body = create_body(arch, n_in, pretrained, ifnone(cut, meta['cut']))
     if custom_head is None:
         nf = num_features_model(nn.Sequential(*body.children())) * (2 if concat_pool else 1)
-        head = create_head(nf, n_out, concat_pool=concat_pool, **kwargs)
+        last_layer = first(flatten_model(body)[::-1], lambda x: hasattr(x, 'weight'))
+        if isinstance(last_layer, nn.BatchNorm2d):
+            with hook_output(last_layer) as hook: out = dummy_eval(body)
+            first_bn = not (hook.stored == out).all()
+        else: first_bn = True
+        head = create_head(nf, n_out, concat_pool=concat_pool, first_bn=first_bn, **kwargs)
     else: head = custom_head
     model = nn.Sequential(body, head)
     if init is not None: apply_init(model[1], init)

--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -5,7 +5,6 @@ __all__ = ['has_pool_type', 'create_body', 'create_head', 'default_split', 'mode
 
 # Cell
 from ..basics import *
-from ..callback.hook import *
 from .core import *
 from .data import *
 from .augment import *
@@ -143,12 +142,7 @@ def create_cnn_model(arch, n_out, pretrained=True, cut=None, n_in=3, init=nn.ini
     body = create_body(arch, n_in, pretrained, ifnone(cut, meta['cut']))
     if custom_head is None:
         nf = num_features_model(nn.Sequential(*body.children())) * (2 if concat_pool else 1)
-        last_layer = first(flatten_model(body)[::-1], lambda x: hasattr(x, 'weight'))
-        if isinstance(last_layer, nn.BatchNorm2d):
-            with hook_output(last_layer) as hook: out = dummy_eval(body)
-            first_bn = not (hook.stored == out).all()
-        else: first_bn = True
-        head = create_head(nf, n_out, concat_pool=concat_pool, first_bn=first_bn, **kwargs)
+        head = create_head(nf, n_out, concat_pool=concat_pool, **kwargs)
     else: head = custom_head
     model = nn.Sequential(body, head)
     if init is not None: apply_init(model[1], init)

--- a/fastai/vision/utils.py
+++ b/fastai/vision/utils.py
@@ -34,7 +34,8 @@ def download_images(dest, url_file=None, urls=None, max_pics=1000, n_workers=8, 
     if urls is None: urls = url_file.read_text().strip().split("\n")[:max_pics]
     dest = Path(dest)
     dest.mkdir(exist_ok=True)
-    parallel(partial(_download_image_inner, dest, timeout=timeout, preserve_filename=preserve_filename), list(enumerate(urls)), n_workers=n_workers)
+    parallel(partial(_download_image_inner, dest, timeout=timeout, preserve_filename=preserve_filename),
+             list(enumerate(urls)), n_workers=n_workers)
 
 # Cell
 def resize_to(img, targ_sz, use_min=False):

--- a/nbs/21_vision.learner.ipynb
+++ b/nbs/21_vision.learner.ipynb
@@ -738,25 +738,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/renato/anaconda3/envs/fastai_dev/lib/python3.7/site-packages/ipykernel_launcher.py:12: UserWarning: config param is deprecated. Pass your args directly to unet_learner.\n",
-      "  if sys.path[0] == '':\n"
-     ]
-    }
-   ],
-   "source": [
-    "#hide\n",
-    "learn = unet_learner(dls, models.resnet34, pretrained=True, config={'n_in':4})"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/nbs/21_vision.learner.ipynb
+++ b/nbs/21_vision.learner.ipynb
@@ -19,6 +19,7 @@
    "source": [
     "#export \n",
     "from fastai.basics import *\n",
+    "from fastai.callback.hook import *\n",
     "from fastai.vision.core import *\n",
     "from fastai.vision.data import *\n",
     "from fastai.vision.augment import *\n",
@@ -242,17 +243,19 @@
    "outputs": [],
    "source": [
     "#export\n",
-    "def create_head(nf, n_out, lin_ftrs=None, ps=0.5, concat_pool=True, bn_final=False, lin_first=False, y_range=None):\n",
+    "def create_head(nf, n_out, lin_ftrs=None, ps=0.5, concat_pool=True, first_bn=True, bn_final=False,\n",
+    "                lin_first=False, y_range=None):\n",
     "    \"Model head that takes `nf` features, runs through `lin_ftrs`, and out `n_out` classes.\"\n",
     "    lin_ftrs = [nf, 512, n_out] if lin_ftrs is None else [nf] + lin_ftrs + [n_out]\n",
+    "    bns = [first_bn] + [True]*len(lin_ftrs[1:])\n",
     "    ps = L(ps)\n",
     "    if len(ps) == 1: ps = [ps[0]/2] * (len(lin_ftrs)-2) + ps\n",
     "    actns = [nn.ReLU(inplace=True)] * (len(lin_ftrs)-2) + [None]\n",
     "    pool = AdaptiveConcatPool2d() if concat_pool else nn.AdaptiveAvgPool2d(1)\n",
     "    layers = [pool, Flatten()]\n",
     "    if lin_first: layers.append(nn.Dropout(ps.pop(0)))\n",
-    "    for ni,no,p,actn in zip(lin_ftrs[:-1], lin_ftrs[1:], ps, actns):\n",
-    "        layers += LinBnDrop(ni, no, bn=True, p=p, act=actn, lin_first=lin_first)\n",
+    "    for ni,no,bn,p,actn in zip(lin_ftrs[:-1], lin_ftrs[1:], bns, ps, actns):\n",
+    "        layers += LinBnDrop(ni, no, bn=bn, p=p, act=actn, lin_first=lin_first)\n",
     "    if lin_first: layers.append(nn.Linear(lin_ftrs[-2], n_out))\n",
     "    if bn_final: layers.append(nn.BatchNorm1d(lin_ftrs[-1], momentum=0.01))\n",
     "    if y_range is not None: layers.append(SigmoidRange(*y_range))\n",
@@ -267,7 +270,7 @@
     "\n",
     "Those blocks start at `nf`, then every element of `lin_ftrs` (defaults to `[512]`) and end at `n_out`. `ps` is a list of probabilities used for the dropouts (if you only pass 1, it will use half the value then that value as many times as necessary).\n",
     "\n",
-    "If `bn_final=True`, a final `BatchNorm` layer is added. If `y_range` is passed, the function adds a `SigmoidRange` to that range."
+    "If `first_bn=True`, a `BatchNorm` added just after the pooling operations. If `bn_final=True`, a final `BatchNorm` layer is added. If `y_range` is passed, the function adds a `SigmoidRange` to that range."
    ]
   },
   {
@@ -317,6 +320,11 @@
     "assert isinstance(mods[-1], nn.Linear)\n",
     "\n",
     "tst = create_head(5, 10, lin_first=True)\n",
+    "mods = list(tst.children())\n",
+    "test_eq(len(mods), 8)\n",
+    "assert isinstance(mods[2], nn.Dropout)\n",
+    "\n",
+    "tst = create_head(5, 10, first_bn=False)\n",
     "mods = list(tst.children())\n",
     "test_eq(len(mods), 8)\n",
     "assert isinstance(mods[2], nn.Dropout)"
@@ -427,7 +435,12 @@
     "    body = create_body(arch, n_in, pretrained, ifnone(cut, meta['cut']))\n",
     "    if custom_head is None:\n",
     "        nf = num_features_model(nn.Sequential(*body.children())) * (2 if concat_pool else 1)\n",
-    "        head = create_head(nf, n_out, concat_pool=concat_pool, **kwargs)\n",
+    "        last_layer = first(flatten_model(body)[::-1], lambda x: hasattr(x, 'weight'))\n",
+    "        if isinstance(last_layer, nn.BatchNorm2d):\n",
+    "            with hook_output(last_layer) as hook: out = dummy_eval(body)\n",
+    "            first_bn = not (hook.stored == out).all()\n",
+    "        else: first_bn = True\n",
+    "        head = create_head(nf, n_out, concat_pool=concat_pool, first_bn=first_bn, **kwargs)\n",
     "    else: head = custom_head\n",
     "    model = nn.Sequential(body, head)\n",
     "    if init is not None: apply_init(model[1], init)\n",
@@ -444,7 +457,7 @@
       "text/markdown": [
        "<h4 id=\"create_cnn_model\" class=\"doc_header\"><code>create_cnn_model</code><a href=\"__main__.py#L2\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
-       "> <code>create_cnn_model</code>(**`arch`**, **`n_out`**, **`pretrained`**=*`True`*, **`cut`**=*`None`*, **`n_in`**=*`3`*, **`init`**=*`kaiming_normal_`*, **`custom_head`**=*`None`*, **`concat_pool`**=*`True`*, **`lin_ftrs`**=*`None`*, **`ps`**=*`0.5`*, **`bn_final`**=*`False`*, **`lin_first`**=*`False`*, **`y_range`**=*`None`*)\n",
+       "> <code>create_cnn_model</code>(**`arch`**, **`n_out`**, **`pretrained`**=*`True`*, **`cut`**=*`None`*, **`n_in`**=*`3`*, **`init`**=*`kaiming_normal_`*, **`custom_head`**=*`None`*, **`concat_pool`**=*`True`*, **`lin_ftrs`**=*`None`*, **`ps`**=*`0.5`*, **`first_bn`**=*`True`*, **`bn_final`**=*`False`*, **`lin_first`**=*`False`*, **`y_range`**=*`None`*)\n",
        "\n",
        "Create custom convnet architecture"
       ],
@@ -475,6 +488,17 @@
    "source": [
     "tst = create_cnn_model(models.resnet18, 10, True)\n",
     "tst = create_cnn_model(models.resnet18, 10, True, n_in=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mods = list(tst[1].children())\n",
+    "test_eq(len(mods), 8)\n",
+    "assert isinstance(mods[2], nn.Dropout)"
    ]
   },
   {
@@ -701,7 +725,18 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "path = untar_data(URLs.CAMVID_TINY)\n",
     "fnames = get_image_files(path/'images')\n",
@@ -936,8 +971,6 @@
       "Converted 74_callback.cutmix.ipynb.\n",
       "Converted 97_test_utils.ipynb.\n",
       "Converted 99_pytorch_doc.ipynb.\n",
-      "Converted Untitled.ipynb.\n",
-      "Converted decorate.ipynb.\n",
       "Converted dev-setup.ipynb.\n",
       "Converted index.ipynb.\n",
       "Converted quick_start.ipynb.\n",
@@ -950,6 +983,13 @@
     "from nbdev.export import notebook2script\n",
     "notebook2script()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",

--- a/nbs/21_vision.learner.ipynb
+++ b/nbs/21_vision.learner.ipynb
@@ -19,7 +19,6 @@
    "source": [
     "#export \n",
     "from fastai.basics import *\n",
-    "from fastai.callback.hook import *\n",
     "from fastai.vision.core import *\n",
     "from fastai.vision.data import *\n",
     "from fastai.vision.augment import *\n",
@@ -435,12 +434,7 @@
     "    body = create_body(arch, n_in, pretrained, ifnone(cut, meta['cut']))\n",
     "    if custom_head is None:\n",
     "        nf = num_features_model(nn.Sequential(*body.children())) * (2 if concat_pool else 1)\n",
-    "        last_layer = first(flatten_model(body)[::-1], lambda x: hasattr(x, 'weight'))\n",
-    "        if isinstance(last_layer, nn.BatchNorm2d):\n",
-    "            with hook_output(last_layer) as hook: out = dummy_eval(body)\n",
-    "            first_bn = not (hook.stored == out).all()\n",
-    "        else: first_bn = True\n",
-    "        head = create_head(nf, n_out, concat_pool=concat_pool, first_bn=first_bn, **kwargs)\n",
+    "        head = create_head(nf, n_out, concat_pool=concat_pool, **kwargs)\n",
     "    else: head = custom_head\n",
     "    model = nn.Sequential(body, head)\n",
     "    if init is not None: apply_init(model[1], init)\n",
@@ -488,17 +482,6 @@
    "source": [
     "tst = create_cnn_model(models.resnet18, 10, True)\n",
     "tst = create_cnn_model(models.resnet18, 10, True, n_in=1)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "mods = list(tst[1].children())\n",
-    "test_eq(len(mods), 8)\n",
-    "assert isinstance(mods[2], nn.Dropout)"
    ]
   },
   {
@@ -725,18 +708,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "path = untar_data(URLs.CAMVID_TINY)\n",
     "fnames = get_image_files(path/'images')\n",
@@ -774,8 +746,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<ipython-input-34-1a35cbb396b7>:12: UserWarning: config param is deprecated. Pass your args directly to unet_learner.\n",
-      "  warnings.warn('config param is deprecated. Pass your args directly to unet_learner.')\n"
+      "/home/renato/anaconda3/envs/fastai_dev/lib/python3.7/site-packages/ipykernel_launcher.py:12: UserWarning: config param is deprecated. Pass your args directly to unet_learner.\n",
+      "  if sys.path[0] == '':\n"
      ]
     }
    ],
@@ -1004,9 +976,9 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:fastai_dev]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-fastai_dev-py"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
An attempt to solve the issue #3012 

I added a `first_bn` param in `create_head`.
And in `create_cnn_model`, it checks if the last layer is a `nn.BatchNorm2d` to set the `first_bn` param.

I though that may not be enough since some operations can be done after the batchnorm that are not necessarily a `nn.Module`, so I added a 2nd check to see if the output of the last batchnorm is the same as the output of the model.
