### PR TITLE
fixes #2978

### DIFF
--- a/fastai/text/core.py
+++ b/fastai/text/core.py
@@ -221,7 +221,7 @@ def tokenize_df(df, text_cols, n_workers=defaults.cpus, rules=None, mark_fields=
 
     other_cols = df.columns[~df.columns.isin(text_cols)]
     res = df[other_cols].copy()
-    res[tok_text_col] = pd.Series(outputs, dtype=object)
+    res[tok_text_col] = outputs
     res[f'{tok_text_col}_length'] = [len(o) for o in outputs]
     return res,Counter(outputs.concat())
 

--- a/nbs/30_text.core.ipynb
+++ b/nbs/30_text.core.ipynb
@@ -787,7 +787,7 @@
     "\n",
     "    other_cols = df.columns[~df.columns.isin(text_cols)]\n",
     "    res = df[other_cols].copy()\n",
-    "    res[tok_text_col] = pd.Series(outputs, dtype=object)\n",
+    "    res[tok_text_col] = outputs\n",
     "    res[f'{tok_text_col}_length'] = [len(o) for o in outputs]\n",
     "    return res,Counter(outputs.concat())"
    ]


### PR DESCRIPTION
Does not address the numpy warning re: deprecation, but does revert to the state where TextDataLoaders are functional again.