### PR TITLE
fixes #2978

### DIFF
--- a/fastai/text/core.py
+++ b/fastai/text/core.py
@@ -221,7 +221,7 @@ def tokenize_df(df, text_cols, n_workers=defaults.cpus, rules=None, mark_fields=
 
     other_cols = df.columns[~df.columns.isin(text_cols)]
     res = df[other_cols].copy()
-    res[tok_text_col] = pd.Series(outputs, dtype=object)
+    res[tok_text_col] = outputs
     res[f'{tok_text_col}_length'] = [len(o) for o in outputs]
     return res,Counter(outputs.concat())
 

--- a/fastai/vision/utils.py
+++ b/fastai/vision/utils.py
@@ -34,7 +34,8 @@ def download_images(dest, url_file=None, urls=None, max_pics=1000, n_workers=8, 
     if urls is None: urls = url_file.read_text().strip().split("\n")[:max_pics]
     dest = Path(dest)
     dest.mkdir(exist_ok=True)
-    parallel(partial(_download_image_inner, dest, timeout=timeout, preserve_filename=preserve_filename), list(enumerate(urls)), n_workers=n_workers)
+    parallel(partial(_download_image_inner, dest, timeout=timeout, preserve_filename=preserve_filename),
+             list(enumerate(urls)), n_workers=n_workers)
 
 # Cell
 def resize_to(img, targ_sz, use_min=False):

--- a/nbs/30_text.core.ipynb
+++ b/nbs/30_text.core.ipynb
@@ -787,7 +787,7 @@
     "\n",
     "    other_cols = df.columns[~df.columns.isin(text_cols)]\n",
     "    res = df[other_cols].copy()\n",
-    "    res[tok_text_col] = pd.Series(outputs, dtype=object)\n",
+    "    res[tok_text_col] = outputs\n",
     "    res[f'{tok_text_col}_length'] = [len(o) for o in outputs]\n",
     "    return res,Counter(outputs.concat())"
    ]


### PR DESCRIPTION
1. Reverts code in `fastai/text/core.py` for `tokenize_df` to state from `fastai==2.1.4` to restore functionality to `TextDataLoaders`.
2. Does not address numpy warning re: specifying `type=object` for `ndarray`, which the original change was intended to address.