### PR TITLE
tests(wandb): use a temporary directory

### DIFF
--- a/nbs/70_callback.wandb.ipynb
+++ b/nbs/70_callback.wandb.ipynb
@@ -510,9 +510,9 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>0</td>\n",
-       "      <td>0.576998</td>\n",
-       "      <td>0.292549</td>\n",
-       "      <td>00:02</td>\n",
+       "      <td>0.673884</td>\n",
+       "      <td>0.271727</td>\n",
+       "      <td>00:01</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>"
@@ -539,8 +539,8 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>0</td>\n",
-       "      <td>0.749050</td>\n",
-       "      <td>0.168469</td>\n",
+       "      <td>0.703907</td>\n",
+       "      <td>0.224920</td>\n",
        "      <td>00:01</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -552,12 +552,87 @@
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<br/>Waiting for W&B process to finish, PID 14063<br/>Program ended successfully."
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "Find user logs for this run at: <code>/tmp/tmp4dxl57wf/wandb/offline-run-20201123_123213-2bjgoc2p/logs/debug.log</code>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "Find internal logs for this run at: <code>/tmp/tmp4dxl57wf/wandb/offline-run-20201123_123213-2bjgoc2p/logs/debug-internal.log</code>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h3>Run summary:</h3><br/><style>\n",
+       "    table.wandb td:nth-child(1) { padding: 0 10px; text-align: right }\n",
+       "    </style><table class=\"wandb\">\n",
+       "<tr><td>epoch</td><td>2</td></tr><tr><td>train_loss</td><td>0.70391</td></tr><tr><td>raw_loss</td><td>0.50715</td></tr><tr><td>wd_0</td><td>0.01</td></tr><tr><td>sqr_mom_0</td><td>0.99</td></tr><tr><td>lr_0</td><td>0.0005</td></tr><tr><td>mom_0</td><td>0.9</td></tr><tr><td>eps_0</td><td>1e-05</td></tr><tr><td>wd_1</td><td>0.01</td></tr><tr><td>sqr_mom_1</td><td>0.99</td></tr><tr><td>lr_1</td><td>0.0005</td></tr><tr><td>mom_1</td><td>0.9</td></tr><tr><td>eps_1</td><td>1e-05</td></tr><tr><td>wd_2</td><td>0.01</td></tr><tr><td>sqr_mom_2</td><td>0.99</td></tr><tr><td>lr_2</td><td>0.005</td></tr><tr><td>mom_2</td><td>0.9</td></tr><tr><td>eps_2</td><td>1e-05</td></tr><tr><td>_step</td><td>21</td></tr><tr><td>_runtime</td><td>4</td></tr><tr><td>_timestamp</td><td>1606156337</td></tr><tr><td>valid_loss</td><td>0.22492</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h3>Run history:</h3><br/><style>\n",
+       "    table.wandb td:nth-child(1) { padding: 0 10px; text-align: right }\n",
+       "    </style><table class=\"wandb\">\n",
+       "<tr><td>epoch</td><td>▁▁▂▂▂▃▃▃▄▄▄▅▅▅▆▆▆▇▇▇██</td></tr><tr><td>train_loss</td><td>█▅▅▃▃▃▂▂▂▁▁▆▅▄▃▃▂▁▁▁▂▁</td></tr><tr><td>raw_loss</td><td>█▄▅▂▅▄▂▃▂▃▁▇▅▄▄▃▂▂▄▂▆▂</td></tr><tr><td>wd_0</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>sqr_mom_0</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>lr_0</td><td>███████████▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>mom_0</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>eps_0</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>wd_1</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>sqr_mom_1</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>lr_1</td><td>███████████▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>mom_1</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>eps_1</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>wd_2</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>sqr_mom_2</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>lr_2</td><td>▁▁▁▁▁▁▁▁▁▁▁███████████</td></tr><tr><td>mom_2</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>eps_2</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>_step</td><td>▁▁▂▂▂▃▃▃▄▄▄▅▅▅▆▆▆▇▇▇██</td></tr><tr><td>_runtime</td><td>▁▁▁▁▁▁▁▁▁▁▃▆▆▆▆▆▆▆▆▆▆█</td></tr><tr><td>_timestamp</td><td>▁▁▁▁▁▁▁▁▁▁▅▅▅█████████</td></tr><tr><td>valid_loss</td><td>█▁</td></tr></table><br/>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[34m\u001b[1mwandb\u001b[0m: You can sync this run to the cloud by running:\n",
+      "\u001b[34m\u001b[1mwandb\u001b[0m: \u001b[33mwandb sync /tmp/tmp4dxl57wf/wandb/offline-run-20201123_123213-2bjgoc2p\u001b[0m\n"
+     ]
     }
    ],
    "source": [
     "#hide\n",
     "#slow\n",
     "from fastai.vision.all import *\n",
+    "import tempfile\n",
     "\n",
     "path = untar_data(URLs.MNIST_TINY)\n",
     "items = get_image_files(path)\n",
@@ -565,13 +640,17 @@
     "dls = tds.dataloaders(after_item=[ToTensor(), IntToFloatTensor()])\n",
     "\n",
     "os.environ['WANDB_MODE'] = 'dryrun' # run offline\n",
-    "wandb.init(anonymous='allow')\n",
-    "learn = cnn_learner(dls, resnet18, loss_func=CrossEntropyLossFlat(), cbs=WandbCallback(log_model=False))\n",
-    "learn.fit(1)\n",
+    "with tempfile.TemporaryDirectory() as wandb_local_dir:\n",
+    "    wandb.init(anonymous='allow', dir=wandb_local_dir)\n",
+    "    learn = cnn_learner(dls, resnet18, loss_func=CrossEntropyLossFlat(), cbs=WandbCallback(log_model=False))\n",
+    "    learn.fit(1)\n",
     "\n",
-    "# add more data from a new learner on same run\n",
-    "learn = cnn_learner(dls, resnet18, loss_func=CrossEntropyLossFlat(), cbs=WandbCallback(log_model=False))\n",
-    "learn.fit(1, lr=slice(0.005))"
+    "    # add more data from a new learner on same run\n",
+    "    learn = cnn_learner(dls, resnet18, loss_func=CrossEntropyLossFlat(), cbs=WandbCallback(log_model=False))\n",
+    "    learn.fit(1, lr=slice(0.005))\n",
+    "    \n",
+    "    # finish writing files to temporary folder\n",
+    "    wandb.finish()"
    ]
   },
   {


### PR DESCRIPTION
This will prevent from creating a `wandb` folder when running tests.