### PR TITLE
Fix BnFreeze bug. 

### DIFF
--- a/fastai/callback/training.py
+++ b/fastai/callback/training.py
@@ -44,6 +44,7 @@ def set_bn_eval(m:nn.Module, use_eval=True)->None:
         set_bn_eval(l)
 
 class BnFreeze(Callback):
+    run_after=TrainEvalCallback
     "Freeze moving average statistics in all non-trainable batchnorm layers."
-    def before_epoch(self):
+    def before_train(self):
         set_bn_eval(self.model)

--- a/nbs/18a_callback.training.ipynb
+++ b/nbs/18a_callback.training.ipynb
@@ -133,7 +133,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>0</td>\n",
-       "      <td>12.395771</td>\n",
+       "      <td>22.425219</td>\n",
        "      <td>00:00</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -172,7 +172,7 @@
     "\n",
     "    def __init__(self, n_acc=32): store_attr('n_acc')\n",
     "    def before_fit(self): self.count=0\n",
-    "\n",
+    "        \n",
     "    def after_backward(self):\n",
     "        self.count += find_bs(self.learn.yb)\n",
     "        if self.count < self.n_acc: raise CancelBatchException() #skip weight update\n",
@@ -202,14 +202,14 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>0</td>\n",
-       "      <td>10.566907</td>\n",
-       "      <td>3.633753</td>\n",
+       "      <td>21.207645</td>\n",
+       "      <td>7.123090</td>\n",
        "      <td>00:00</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>1</td>\n",
-       "      <td>5.525984</td>\n",
-       "      <td>0.397483</td>\n",
+       "      <td>10.964176</td>\n",
+       "      <td>0.831573</td>\n",
        "      <td>00:00</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -237,14 +237,14 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>0</td>\n",
-       "      <td>0.476599</td>\n",
-       "      <td>0.397483</td>\n",
+       "      <td>1.129959</td>\n",
+       "      <td>0.831573</td>\n",
        "      <td>00:00</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>1</td>\n",
-       "      <td>0.478213</td>\n",
-       "      <td>0.397483</td>\n",
+       "      <td>1.133095</td>\n",
+       "      <td>0.831573</td>\n",
        "      <td>00:00</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -283,6 +283,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#from fastai.vision.all import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "#export\n",
     "bn_types = (nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d)\n",
     "\n",
@@ -295,8 +304,9 @@
     "        set_bn_eval(l)\n",
     "\n",
     "class BnFreeze(Callback):\n",
+    "    run_after=TrainEvalCallback\n",
     "    \"Freeze moving average statistics in all non-trainable batchnorm layers.\"\n",
-    "    def before_epoch(self):\n",
+    "    def before_train(self):\n",
     "        set_bn_eval(self.model)"
    ]
   },
@@ -390,9 +400,9 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>0</td>\n",
-       "      <td>1.058304</td>\n",
-       "      <td>0.713414</td>\n",
-       "      <td>00:02</td>\n",
+       "      <td>1.198288</td>\n",
+       "      <td>0.325709</td>\n",
+       "      <td>00:03</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>"
@@ -408,7 +418,7 @@
    "source": [
     "#slow\n",
     "learn1.fit(1, lr=0.02)\n",
-    "test_ne(learn1.model[0][1].running_mean, m)"
+    "test_ne(to_detach(learn1.model[0][1].running_mean), m)"
    ]
   },
   {
@@ -438,8 +448,8 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>0</td>\n",
-       "      <td>0.540841</td>\n",
-       "      <td>0.432421</td>\n",
+       "      <td>0.400471</td>\n",
+       "      <td>0.257127</td>\n",
        "      <td>00:02</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -456,9 +466,9 @@
    "source": [
     "#slow\n",
     "learn1 = cnn_learner(deepcopy(dls), resnet18, pretrained=True, train_bn=False, cbs=BnFreeze)\n",
-    "m = learn1.model[0][1].running_mean.clone()\n",
+    "m = learn1.model[0][1].running_mean.detach().clone()\n",
     "learn1.fit(1, lr=0.02)\n",
-    "test_eq(learn1.model[0][1].running_mean, m)"
+    "test_eq(to_detach(learn1.model[0][1].running_mean), m)"
    ]
   },
   {
@@ -479,6 +489,7 @@
      "text": [
       "Converted 00_torch_core.ipynb.\n",
       "Converted 01_layers.ipynb.\n",
+      "Converted 01a_losses.ipynb.\n",
       "Converted 02_data.load.ipynb.\n",
       "Converted 03_data.core.ipynb.\n",
       "Converted 04_data.external.ipynb.\n",
@@ -490,6 +501,7 @@
       "Converted 09b_vision.utils.ipynb.\n",
       "Converted 09c_vision.widgets.ipynb.\n",
       "Converted 10_tutorial.pets.ipynb.\n",
+      "Converted 10b_tutorial.albumentations.ipynb.\n",
       "Converted 11_vision.models.xresnet.ipynb.\n",
       "Converted 12_optimizer.ipynb.\n",
       "Converted 13_callback.core.ipynb.\n",
@@ -503,6 +515,7 @@
       "Converted 17_callback.tracker.ipynb.\n",
       "Converted 18_callback.fp16.ipynb.\n",
       "Converted 18a_callback.training.ipynb.\n",
+      "Converted 18b_callback.preds.ipynb.\n",
       "Converted 19_callback.mixup.ipynb.\n",
       "Converted 20_interpret.ipynb.\n",
       "Converted 20a_distributed.ipynb.\n",
@@ -539,7 +552,9 @@
       "Converted 74_callback.cutmix.ipynb.\n",
       "Converted 97_test_utils.ipynb.\n",
       "Converted 99_pytorch_doc.ipynb.\n",
+      "Converted dev-setup.ipynb.\n",
       "Converted index.ipynb.\n",
+      "Converted quick_start.ipynb.\n",
       "Converted tutorial.ipynb.\n"
      ]
     }


### PR DESCRIPTION
Moved BnFreeze after begin_train in TrainEvalCallback. This now makes the slow test pass, before it did not pass, though we did not notice it because it was a slow test. I am adding this because I am currently working on fp16 related changes, and this was blocking me, those will be in future pull requests.

TrainEvalCallback should truthfully run before everything else, but there is no current way to do this easily, as only `towards_end` exists and no concept of numerical order exists. Issue for this created here: https://github.com/fastai/fastcore/issues/227