### PR TITLE
Decrease default batch size for Transformers Notebook Tutorial 

### DIFF
--- a/nbs/39_tutorial.transformers.ipynb
+++ b/nbs/39_tutorial.transformers.ipynb
@@ -505,7 +505,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bs,sl = 8,1024\n",
+    "bs,sl = 4,1024\n",
     "dls = tls.dataloaders(bs=bs, seq_len=sl)"
    ]
   },


### PR DESCRIPTION
Running the notebook in google colab as is with 16GB results in an out of memory error. Changing batch size from 8 to 4 fixes it. 
See https://github.com/fastai/fastai/issues/3082