### PR TITLE
adds std argument to Embedding layer init

### DIFF
--- a/fastai/layers.py
+++ b/fastai/layers.py
@@ -280,9 +280,9 @@ def trunc_normal_(x, mean=0., std=1.):
 # Cell
 class Embedding(nn.Embedding):
     "Embedding layer with truncated normal initialization"
-    def __init__(self, ni, nf):
+    def __init__(self, ni, nf, std=0.01):
         super().__init__(ni, nf)
-        trunc_normal_(self.weight.data, std=0.01)
+        trunc_normal_(self.weight.data, std=std)
 
 # Cell
 class SelfAttention(Module):

--- a/nbs/01_layers.ipynb
+++ b/nbs/01_layers.ipynb
@@ -1046,16 +1046,16 @@
     "# export\n",
     "class Embedding(nn.Embedding):\n",
     "    \"Embedding layer with truncated normal initialization\"\n",
-    "    def __init__(self, ni, nf):\n",
+    "    def __init__(self, ni, nf, std=0.01):\n",
     "        super().__init__(ni, nf)\n",
-    "        trunc_normal_(self.weight.data, std=0.01)"
+    "        trunc_normal_(self.weight.data, std=std)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Truncated normal initialization bounds the distribution to avoid large value. For a given standard deviation `std`, the bounds are roughly `-std`, `std`."
+    "Truncated normal initialization bounds the distribution to avoid large value. For a given standard deviation `std`, the bounds are roughly `-2*std`, `2*std`."
    ]
   },
   {
@@ -1064,11 +1064,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tst = Embedding(10, 30)\n",
-    "assert tst.weight.min() > -0.02\n",
-    "assert tst.weight.max() < 0.02\n",
+    "std = 0.02\n",
+    "tst = Embedding(10, 30, std)\n",
+    "assert tst.weight.min() > -2*std\n",
+    "assert tst.weight.max() < 2*std\n",
     "test_close(tst.weight.mean(), 0, 1e-2)\n",
-    "test_close(tst.weight.std(), 0.01, 0.1)"
+    "test_close(tst.weight.std(), std, 0.1)"
    ]
   },
   {
@@ -2107,11 +2108,11 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python [conda env:fastai21]",
+   "display_name": "Python [conda env:fastdev]",
    "language": "python",
-   "name": "conda-env-fastai21-py"
+   "name": "conda-env-fastdev-py"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
`torch.nn.init` has `trunc_normal_` which is slightly different from one currently used in fastai. Here is a [gist with details](https://gist.github.com/arampacha/1689fd1bd5dd7f29bc76d4ba76226f9c).