### PR TITLE
Fixed MixHandler to use own loss definition when stack_y

### DIFF
--- a/fastai/callback/mixup.py
+++ b/fastai/callback/mixup.py
@@ -20,7 +20,7 @@ class MixHandler(Callback):
 
     def before_fit(self):
         self.stack_y = getattr(self.learn.loss_func, 'y_int', False)
-        if self.stack_y: self.old_lf,self.learn.loss_func = self.learn.loss_func,self.loss_func
+        if self.stack_y: self.old_lf,self.learn.loss_func = self.learn.loss_func,self.lf
 
     def after_fit(self):
         if self.stack_y: self.learn.loss_func = self.old_lf

--- a/nbs/19_callback.mixup.ipynb
+++ b/nbs/19_callback.mixup.ipynb
@@ -87,7 +87,7 @@
     "        \n",
     "    def before_fit(self):\n",
     "        self.stack_y = getattr(self.learn.loss_func, 'y_int', False)\n",
-    "        if self.stack_y: self.old_lf,self.learn.loss_func = self.learn.loss_func,self.loss_func\n",
+    "        if self.stack_y: self.old_lf,self.learn.loss_func = self.learn.loss_func,self.lf\n",
     "\n",
     "    def after_fit(self):\n",
     "        if self.stack_y: self.learn.loss_func = self.old_lf\n",


### PR DESCRIPTION
Hi, 
I think the current implementation of MixHandler has a tiny bug. It does not change the loss function to the one defined by the MixHandler if stack_y is true.