### PR TITLE
fix #3047

### DIFF
--- a/fastai/data/load.py
+++ b/fastai/data/load.py
@@ -21,6 +21,7 @@ class _FakeLoader:
     _IterableDataset_len_called,_auto_collation,collate_fn,drop_last = None,False,noops,False
     _index_sampler,generator,prefetch_factor  = Inf.count,None,2
     dataset_kind = _dataset_kind = _DatasetKind.Iterable
+    noops = noops
     def __init__(self, d, pin_memory, num_workers, timeout, persistent_workers):
         self.dataset,self.default,self.worker_init_fn = self,d,_wif
         store_attr('d,pin_memory,num_workers,timeout,persistent_workers')


### PR DESCRIPTION
I was trying to understand why that happens and how to fix it
For me it happens when fastai used under `spawn` method from another thread
I'm not fully sure still where exactly it's calling `noops` from _FakeLoader (haven't found that in code)

However if I just add missing attribute to _FakeLoader it's working fine seems like, at least my code seems like fixed with that.
