### PR TITLE
renames `modules` to `ms` in `HookCallback`

### DIFF
--- a/fastai/callback/hook.py
+++ b/fastai/callback/hook.py
@@ -104,16 +104,16 @@ def has_params(m):
 # Cell
 @funcs_kwargs
 class HookCallback(Callback):
-    "`Callback` that can be used to register hooks on `modules`"
+    "`Callback` that can be used to register hooks on modules in `ms`"
     _methods = ["hook"]
     hook = noops
-    def __init__(self, modules=None, every=None, remove_end=True, is_forward=True, detach=True, cpu=True, **kwargs):
-        store_attr('modules,every,remove_end,is_forward,detach,cpu')
+    def __init__(self, ms=None, every=None, remove_end=True, is_forward=True, detach=True, cpu=True, **kwargs):
+        store_attr('ms,every,remove_end,is_forward,detach,cpu')
         assert not kwargs
 
     def before_fit(self):
-        "Register the `Hooks` on `self.modules`."
-        if self.modules is None: self.modules = [m for m in flatten_model(self.model) if has_params(m)]
+        "Register the `Hooks` on `self.ms`."
+        if self.ms is None: self.ms = [m for m in flatten_model(self.model) if has_params(m)]
         if self.every is None: self._register()
 
     def before_batch(self):
@@ -128,7 +128,7 @@ class HookCallback(Callback):
         "Remove the `Hooks`."
         if self.remove_end: self._remove()
 
-    def _register(self): self.hooks = Hooks(self.modules, self.hook, self.is_forward, self.detach, self.cpu)
+    def _register(self): self.hooks = Hooks(self.ms, self.hook, self.is_forward, self.detach, self.cpu)
     def _remove(self):
         if getattr(self, 'hooks', None): self.hooks.remove()
 

--- a/nbs/15_callback.hook.ipynb
+++ b/nbs/15_callback.hook.ipynb
@@ -84,13 +84,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Linear(in_features=5, out_features=3, bias=True) (tensor([[-1.2270,  0.3393,  0.5718, -0.5177, -1.2104],\n",
-      "        [ 0.0354, -0.1312,  0.4349, -0.9000,  1.1018],\n",
-      "        [-1.5961,  1.1750, -1.1201, -1.5117,  1.9888],\n",
-      "        [ 1.5914,  0.4621,  0.9078, -0.6504, -0.4852]]),) tensor([[ 0.9606,  0.3859,  0.8708],\n",
-      "        [-0.1754, -0.4515,  0.6353],\n",
-      "        [ 0.7625,  0.8009,  1.7342],\n",
-      "        [ 0.2908, -0.3984,  0.3174]], grad_fn=<AddmmBackward>)\n"
+      "Linear(in_features=5, out_features=3, bias=True) (tensor([[-1.9240, -0.8747,  0.9869, -1.6077,  1.0609],\n",
+      "        [-1.5670,  1.4226, -0.0713, -0.2670,  0.6576],\n",
+      "        [-0.1294, -0.2573, -0.9771, -0.6220,  0.5335],\n",
+      "        [ 0.1533, -0.0102,  1.1075,  0.3112,  0.6921]]),) tensor([[-1.0256,  0.0178,  1.4624],\n",
+      "        [-0.1573, -0.0705,  0.9666],\n",
+      "        [ 0.3035, -0.4094,  0.0281],\n",
+      "        [-0.5194,  0.1359,  0.4371]], grad_fn=<AddmmBackward>)\n"
      ]
     }
    ],
@@ -120,14 +120,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Linear(in_features=5, out_features=3, bias=True) (tensor([0.4103, 0.0804, 0.4298]), None, tensor([[-0.7980, -0.7526, -0.7505],\n",
-      "        [ 0.1685,  0.2370,  0.1919],\n",
-      "        [-0.4391, -0.4002, -0.4031],\n",
-      "        [-0.1246, -0.0397, -0.2264],\n",
-      "        [-0.0704,  0.0269,  0.0509]])) (tensor([[ 0.0558, -0.0538, -0.0166],\n",
-      "        [ 0.2879,  0.2239,  0.2653],\n",
-      "        [ 0.0227,  0.0017,  0.0994],\n",
-      "        [ 0.0439, -0.0915,  0.0817]]),)\n"
+      "Linear(in_features=5, out_features=3, bias=True) (tensor([-0.5348,  0.3523,  0.1382]), None, tensor([[ 0.5932, -0.4655, -0.1595],\n",
+      "        [ 0.1723, -0.0946,  0.4070],\n",
+      "        [ 0.0404, -0.2330,  0.2039],\n",
+      "        [-1.2180,  0.8617, -0.3118],\n",
+      "        [-0.5190,  0.0510,  0.1311]])) (tensor([[-0.1909,  0.2159, -0.1278],\n",
+      "        [-0.2410,  0.0840,  0.0677],\n",
+      "        [-0.1581,  0.0278,  0.0351],\n",
+      "        [ 0.0551,  0.0245,  0.1632]]),)\n"
      ]
     }
    ],
@@ -776,16 +776,16 @@
     "#export\n",
     "@funcs_kwargs\n",
     "class HookCallback(Callback):\n",
-    "    \"`Callback` that can be used to register hooks on `modules`\"\n",
+    "    \"`Callback` that can be used to register hooks on modules in `ms`\"\n",
     "    _methods = [\"hook\"]\n",
     "    hook = noops\n",
-    "    def __init__(self, modules=None, every=None, remove_end=True, is_forward=True, detach=True, cpu=True, **kwargs):\n",
-    "        store_attr('modules,every,remove_end,is_forward,detach,cpu')\n",
+    "    def __init__(self, ms=None, every=None, remove_end=True, is_forward=True, detach=True, cpu=True, **kwargs):\n",
+    "        store_attr('ms,every,remove_end,is_forward,detach,cpu')\n",
     "        assert not kwargs\n",
     "\n",
     "    def before_fit(self):\n",
-    "        \"Register the `Hooks` on `self.modules`.\"\n",
-    "        if self.modules is None: self.modules = [m for m in flatten_model(self.model) if has_params(m)]\n",
+    "        \"Register the `Hooks` on `self.ms`.\"\n",
+    "        if self.ms is None: self.ms = [m for m in flatten_model(self.model) if has_params(m)]\n",
     "        if self.every is None: self._register()\n",
     "\n",
     "    def before_batch(self):\n",
@@ -800,7 +800,7 @@
     "        \"Remove the `Hooks`.\"\n",
     "        if self.remove_end: self._remove()\n",
     "\n",
-    "    def _register(self): self.hooks = Hooks(self.modules, self.hook, self.is_forward, self.detach, self.cpu)\n",
+    "    def _register(self): self.hooks = Hooks(self.ms, self.hook, self.is_forward, self.detach, self.cpu)\n",
     "    def _remove(self):\n",
     "        if getattr(self, 'hooks', None): self.hooks.remove()\n",
     "\n",
@@ -813,7 +813,7 @@
    "source": [
     "You can either subclass and implement a `hook` function (along with any event you want) or pass that a `hook` function when initializing. Such a function needs to take three argument: a layer, input and output (for a backward hook, input means gradient with respect to the inputs, output, gradient with respect to the output) and can either modify them or update the state according to them.\n",
     "\n",
-    "If not provided, `modules` will default to the layers of `self.model` that have a `weight` attribute. Depending on `do_remove`, the hooks will be properly removed at the end of training (or in case of error). `is_forward` , `detach` and `cpu` are passed to `Hooks`.\n",
+    "If not provided, `ms` will default to the layers of `self.model` that have a `weight` attribute. Depending on `do_remove`, the hooks will be properly removed at the end of training (or in case of error). `is_forward` , `detach` and `cpu` are passed to `Hooks`.\n",
     "\n",
     "The function called at each forward (or backward) pass is `self.hook` and must be implemented when subclassing this callback."
    ]
@@ -827,7 +827,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[0, 14.660037994384766, 11.780715942382812, '00:00']\n"
+      "[0, 25.165918350219727, 22.685569763183594, '00:00']\n"
      ]
     }
    ],
@@ -849,14 +849,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[0, 15.180420875549316, 15.292489051818848, '00:00']\n"
+      "[0, 10.980981826782227, 11.999584197998047, '00:00']\n"
      ]
     }
    ],
    "source": [
     "class TstCallback(HookCallback):\n",
-    "    def __init__(self, modules=None, remove_end=True, detach=True, cpu=False):\n",
-    "        super().__init__(modules, None, remove_end, False, detach, cpu)\n",
+    "    def __init__(self, ms=None, remove_end=True, detach=True, cpu=False):\n",
+    "        super().__init__(ms, None, remove_end, False, detach, cpu)\n",
     "    def hook(self, m, i, o): return o\n",
     "    def after_batch(self):\n",
     "        if self.training:\n",
@@ -878,7 +878,7 @@
        "\n",
        "> <code>HookCallback.before_fit</code>()\n",
        "\n",
-       "Register the [`Hooks`](/callback.hook.html#Hooks) on `self.modules`."
+       "Register the [`Hooks`](/callback.hook.html#Hooks) on `self.ms`."
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -1131,7 +1131,7 @@
        "Total trainable params: 251\n",
        "Total non-trainable params: 0\n",
        "\n",
-       "Optimizer used: functools.partial(<function SGD at 0x7f74e6301320>, mom=0.9)\n",
+       "Optimizer used: functools.partial(<function SGD at 0x7ff2d7f1bca0>, mom=0.9)\n",
        "Loss function: FlattenedLoss of MSELoss()\n",
        "\n",
        "Callbacks:\n",
@@ -1174,7 +1174,7 @@
        "Total trainable params: 251\n",
        "Total non-trainable params: 0\n",
        "\n",
-       "Optimizer used: functools.partial(<function SGD at 0x7f74e6301320>, mom=0.9)\n",
+       "Optimizer used: functools.partial(<function SGD at 0x7ff2d7f1bca0>, mom=0.9)\n",
        "Loss function: FlattenedLoss of MSELoss()\n",
        "\n",
        "Callbacks:\n",
@@ -1214,7 +1214,7 @@
        "Total trainable params: 36\n",
        "Total non-trainable params: 0\n",
        "\n",
-       "Optimizer used: functools.partial(<function SGD at 0x7f74e6301320>, mom=0.9)\n",
+       "Optimizer used: functools.partial(<function SGD at 0x7ff2d7f1bca0>, mom=0.9)\n",
        "Loss function: FlattenedLoss of MSELoss()\n",
        "\n",
        "Callbacks:\n",
@@ -1335,7 +1335,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[0, 23.258834838867188, 25.094209671020508, '00:00']\n"
+      "[0, 12.9636812210083, 9.674224853515625, '00:00']\n"
      ]
     }
    ],
@@ -1352,7 +1352,7 @@
     {
      "data": {
       "text/plain": [
-       "(#2) [[{'mean': -1.286624789237976, 'std': 0.5204624533653259, 'near_zero': 1.0}],[{'mean': -0.8293845057487488, 'std': 0.9002514481544495, 'near_zero': 0.8125}]]"
+       "(#2) [[{'mean': 0.4897254705429077, 'std': 0.5485014319419861, 'near_zero': 0.25}],[{'mean': 0.5858372449874878, 'std': 0.4981028437614441, 'near_zero': 0.125}]]"
       ]
      },
      "execution_count": null,
@@ -1380,12 +1380,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[0, 13.364368438720703, 8.206254005432129, '00:00']\n",
-      "[0, 28.091310501098633, 20.91598892211914, '00:00']\n",
-      "[0, 12.561519622802734, 11.980316162109375, '00:00']\n",
-      "[0, 14.071392059326172, 15.907712936401367, '00:00']\n",
-      "[0, 19.315099716186523, 16.30086898803711, '00:00']\n",
-      "[0, 19.391584396362305, 12.741905212402344, '00:00']\n"
+      "[0, 13.73015308380127, 12.906360626220703, '00:00']\n",
+      "[0, 9.10430908203125, 8.880518913269043, '00:00']\n",
+      "[0, 20.54332733154297, 21.516599655151367, '00:00']\n",
+      "[0, 11.91109561920166, 7.690512657165527, '00:00']\n",
+      "[0, 16.551713943481445, 14.238609313964844, '00:00']\n",
+      "[0, 10.778675079345703, 7.992913246154785, '00:00']\n"
      ]
     }
    ],
@@ -1411,7 +1411,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[0, 13.564225196838379, 11.621339797973633, '00:00']\n"
+      "[0, 15.884718894958496, 14.010619163513184, '00:00']\n"
      ]
     }
    ],
@@ -1540,11 +1540,11 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:fastdev]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-fastdev-py"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Since `Learner` now delegates attributes to `model` the `HookCallback`  by using `modules` attribute causes following warning:
```
/usr/local/lib/python3.6/dist-packages/fastai/callback/core.py:50: UserWarning: You are shadowing an attribute (modules) that exists in the learner. Use `self.learn.modules` to avoid this
  warn(f"You are shadowing an attribute ({name}) that exists in the learner. Use `self.learn.{name}` to avoid this")
```
Renaming `modules` to `ms` resolves it