### PR TITLE
Add dataloader indexing note to docs

### DIFF
--- a/nbs/13_callback.core.ipynb
+++ b/nbs/13_callback.core.ipynb
@@ -533,7 +533,7 @@
     "- `opt`: the optimizer used to update the model parameters\n",
     "- `opt_func`: the function used to create the optimizer\n",
     "- `cbs`: the list containing all `Callback`s\n",
-    "- `dl`: current `DataLoader` used for iteration\n",
+    "- `dl`: current `DataLoader` used for iteration.  `__dataloader__idxs` contains the indexes for the items in the current epoch and can be used in combonation with `iter` and your batch size to tie specific items in your batch to your input (ie an image file path).\n",
     "- `x`/`xb`: last input drawn from `self.dl` (potentially modified by callbacks). `xb` is always a tuple (potentially with one element) and `x` is detuplified. You can only assign to `xb`.\n",
     "- `y`/`yb`: last target drawn from `self.dl` (potentially modified by callbacks). `yb` is always a tuple (potentially with one element) and `y` is detuplified. You can only assign to `yb`.\n",
     "- `pred`: last predictions from `self.model` (potentially modified by callbacks)\n",
@@ -551,7 +551,7 @@
     "\n",
     "The following attribute is added by `Recorder` and should be available unless you went out of your way to remove that callback:\n",
     "\n",
-    "- `smooth_loss`: an exponentially-averaged version of the training loss"
+    "- `smooth_loss`: an exponentially-averaged version of the training loss\n"
    ]
   },
   {


### PR DESCRIPTION
Add line to docs to inform  how to access the current indexes of items in a batch in a callback.  No change to the library, just an extra tidbit of information to the docs.

**Why I think this should be added:**

Zach originally helped me find out how to do this, and since then I have answered the question several times for others.  Since it's a common question, I thought it would make sense for it to be answered in the docs.  

**An example of why this might be useful**

An example of when you may want to use this would be 'Soft Labeling' or 'knowledge distillation method'.  This is from a kaggle winner's explanation of his approach:  "We used the knowledge distillation method, first train a 5-fold models and get out-of-fold results about valid dataset, and then mix the out-of-fold results and ground truth by 3: 7 as the labels of a new training model."I have found that that 3:7 ratio is something to be tuned based on the dataset.

Kaggle post mentioned above (he links to his repo in the comments also):  https://www.kaggle.com/c/plant-pathology-2020-fgvc7/discussion/154056