### PR TITLE
change set_seed default to reproducible=True

### DIFF
--- a/fastai/torch_core.py
+++ b/fastai/torch_core.py
@@ -133,7 +133,7 @@ def tensor(x, *rest, **kwargs):
     return res
 
 # Cell
-def set_seed(s, reproducible=False):
+def set_seed(s, reproducible=True):
     "Set random seed for `random`, `torch`, and `numpy` (where available)"
     try: torch.manual_seed(s)
     except NameError: pass

--- a/nbs/00_torch_core.ipynb
+++ b/nbs/00_torch_core.ipynb
@@ -532,7 +532,7 @@
    "outputs": [],
    "source": [
     "#export\n",
-    "def set_seed(s, reproducible=False):\n",
+    "def set_seed(s, reproducible=True):\n",
     "    \"Set random seed for `random`, `torch`, and `numpy` (where available)\"\n",
     "    try: torch.manual_seed(s)\n",
     "    except NameError: pass\n",


### PR DESCRIPTION
For some reason, in set_seed, the default is that `reproducible=False`. For this reason, training with a set seed will still result in different results. I believe most people would expect the opposite. Now I always use `reproducible=True`, but I figure other people might be confused so I figured it might be best to update fastai's default.

cc: @jph00