### PR TITLE
Fix iterable datasets

### DIFF
--- a/fastai/data/core.py
+++ b/fastai/data/core.py
@@ -48,7 +48,7 @@ class TfmdDL(DataLoader):
                 kwargs[nm].setup(self)
 
     def _one_pass(self):
-        b = self.do_batch([self.do_item(0)])
+        b = self.do_batch([self.do_item(None)])
         if self.device is not None: b = to_device(b, self.device)
         its = self.after_batch(b)
         self._n_inp = 1 if not isinstance(its, (list,tuple)) or len(its)==1 else len(its)-1

--- a/fastai/tabular/core.py
+++ b/fastai/tabular/core.py
@@ -346,12 +346,12 @@ def show_batch(x: Tabular, y, its, max_n=10, ctxs=None):
 @delegates()
 class TabDataLoader(TfmdDL):
     "A transformed `DataLoader` for Tabular data"
-    do_item = noops
     def __init__(self, dataset, bs=16, shuffle=False, after_batch=None, num_workers=0, **kwargs):
         if after_batch is None: after_batch = L(TransformBlock().batch_tfms)+ReadTabBatch(dataset)
         super().__init__(dataset, bs=bs, shuffle=shuffle, after_batch=after_batch, num_workers=num_workers, **kwargs)
 
     def create_batch(self, b): return self.dataset.iloc[b]
+    def do_item(self, s):      return 0 if s is None else s
 
 TabularPandas._dl_type = TabDataLoader
 

--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -92,6 +92,7 @@ class LMDataLoader(TfmdDL):
         return idxs
 
     def create_item(self, seq):
+        if seq is None: seq = 0
         if seq>=self.n: raise IndexError
         sl = self.last_len if seq//self.bs==self.n_batches-1 else self.seq_len
         st = (seq%self.bs)*self.bl + (seq//self.bs)*self.seq_len

--- a/fastai/vision/core.py
+++ b/fastai/vision/core.py
@@ -244,7 +244,7 @@ class PointScaler(Transform):
     def _get_sz(self, x): return getattr(x, 'img_size') if self.sz is None else self.sz
 
     def setups(self, dl):
-        res = first(dl.do_item(0), risinstance(TensorPoint))
+        res = first(dl.do_item(None), risinstance(TensorPoint))
         if res is not None: self.c = res.numel()
 
     def encodes(self, x:(PILBase,TensorImageBase)): return self._grab_sz(x)

--- a/nbs/02_data.load.ipynb
+++ b/nbs/02_data.load.ipynb
@@ -228,7 +228,9 @@
     "                 shuffle=False, drop_last=False, indexed=None, n=None, device=None, persistent_workers=False, **kwargs):\n",
     "        if batch_size is not None: bs = batch_size # PyTorch compatibility\n",
     "        assert not (bs is None and drop_last)\n",
-    "        if indexed is None: indexed = dataset is not None and hasattr(dataset,'__getitem__')\n",
+    "        if indexed is None: indexed = (hasattr(dataset,'__getitem__')\n",
+    "                                       and not isinstance(dataset, IterableDataset))\n",
+    "        if not indexed and shuffle: raise ValueError(\"Can only shuffle an indexed dataset (not an iterable one).\")\n",
     "        if n is None:\n",
     "            try: n = len(dataset)\n",
     "            except TypeError: pass\n",
@@ -261,7 +263,7 @@
     "        if hasattr(self, 'it'): del(self.it)\n",
     "\n",
     "    def create_batches(self, samps):\n",
-    "        self.it = iter(self.dataset) if self.dataset is not None else None\n",
+    "        if self.dataset is not None: self.it = iter(self.dataset)\n",
     "        res = filter(lambda o:o is not None, map(self.do_item, samps))\n",
     "        yield from map(self.do_batch, self.chunkify(res))\n",
     "\n",
@@ -284,7 +286,10 @@
     "    def shuffle_fn(self, idxs): return self.rng.sample(idxs, len(idxs))\n",
     "    def randomize(self): self.rng = random.Random(self.rng.randint(0,2**32-1))\n",
     "    def retain(self, res, b):  return retain_types(res, b[0] if is_listy(b) else b)\n",
-    "    def create_item(self, s):  return next(self.it) if s is None else self.dataset[s]\n",
+    "    def create_item(self, s):\n",
+    "        if self.indexed: return self.dataset[s or 0]\n",
+    "        elif s is None:  return next(self.it)\n",
+    "        else: raise IndexError(\"Cannot index an iterable dataset numerically - must use `None`.\")\n",
     "    def create_batch(self, b): return (fa_collate,fa_convert)[self.prebatched](b)\n",
     "    def do_batch(self, b): return self.retain(self.create_batch(self.before_batch(b)), b)\n",
     "    def to(self, device): self.device = device\n",
@@ -339,8 +344,8 @@
     "* `batch_size` (int): It is only provided for PyTorch compatibility. Use `bs`.\n",
     "* `shuffle` (bool): If `True`, then data is shuffled every time dataloader is fully read/iterated.\n",
     "* `drop_last` (bool): If `True`, then the last incomplete batch is dropped.\n",
-    "* `indexed` (bool): Set to `False`, if you are using iterable-style dataset. Otherwise it is set to `True` by default.\n",
-    "* `n` (int): Defaults to `len(dataset)`. If you are using iterable-style dataset, you can specify the size of batch using `n`.\n",
+    "* `indexed` (bool): The `DataLoader` will make a guess as to whether the dataset can be indexed (or is iterable), but you can override it with this parameter. `True` by default.\n",
+    "* `n` (int): Defaults to `len(dataset)`. If you are using iterable-style dataset, you can specify the size with `n`.\n",
     "* `device` (torch.device): Defaults to `default_device()` which is CUDA by default. You can specify device as `torch.device('cpu')."
    ]
   },
@@ -527,6 +532,34 @@
     "\n",
     "it = iter(DataLoader(map(noop,range(20)), bs=4, num_workers=1))\n",
     "test_eq_type([next(it) for _ in range(3)], [tensor([0,1,2,3]),tensor([4,5,6,7]),tensor([8,9,10,11])])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Iterable dataloaders require specific tests."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class DummyIterableDataset(IterableDataset):\n",
+    "    def __iter__(self):\n",
+    "        yield from range(11)\n",
+    "\n",
+    "ds1 = DataLoader(DummyIterableDataset(), bs=4)\n",
+    "# Check it yields fine, and check we can do multiple passes\n",
+    "for i in range(3):\n",
+    "    test_eq_type(L(ds1), L(tensor([0,1,2,3]),tensor([4,5,6,7]),tensor([8,9,10])))\n",
+    "\n",
+    "# Check `drop_last` works fine (with multiple passes, since this will prematurely terminate the iterator)\n",
+    "ds1 = DataLoader(DummyIterableDataset(), bs=4, drop_last=True)\n",
+    "for i in range(3):\n",
+    "    test_eq_type(L(ds1), L(tensor([0,1,2,3]),tensor([4,5,6,7])))"
    ]
   },
   {

--- a/nbs/03_data.core.ipynb
+++ b/nbs/03_data.core.ipynb
@@ -153,7 +153,7 @@
     "                kwargs[nm].setup(self)\n",
     "\n",
     "    def _one_pass(self):\n",
-    "        b = self.do_batch([self.do_item(0)])\n",
+    "        b = self.do_batch([self.do_item(None)])\n",
     "        if self.device is not None: b = to_device(b, self.device)\n",
     "        its = self.after_batch(b)\n",
     "        self._n_inp = 1 if not isinstance(its, (list,tuple)) or len(its)==1 else len(its)-1\n",

--- a/nbs/07_vision.core.ipynb
+++ b/nbs/07_vision.core.ipynb
@@ -1215,7 +1215,7 @@
     "    def _get_sz(self, x): return getattr(x, 'img_size') if self.sz is None else self.sz\n",
     "\n",
     "    def setups(self, dl):\n",
-    "        res = first(dl.do_item(0), risinstance(TensorPoint))\n",
+    "        res = first(dl.do_item(None), risinstance(TensorPoint))\n",
     "        if res is not None: self.c = res.numel()\n",
     "\n",
     "    def encodes(self, x:(PILBase,TensorImageBase)): return self._grab_sz(x)\n",

--- a/nbs/31_text.data.ipynb
+++ b/nbs/31_text.data.ipynb
@@ -347,6 +347,7 @@
     "        return idxs\n",
     "\n",
     "    def create_item(self, seq):\n",
+    "        if seq is None: seq = 0\n",
     "        if seq>=self.n: raise IndexError\n",
     "        sl = self.last_len if seq//self.bs==self.n_batches-1 else self.seq_len\n",
     "        st = (seq%self.bs)*self.bl + (seq//self.bs)*self.seq_len\n",

--- a/nbs/40_tabular.core.ipynb
+++ b/nbs/40_tabular.core.ipynb
@@ -1693,13 +1693,13 @@
     "#export\n",
     "@delegates()\n",
     "class TabDataLoader(TfmdDL):\n",
-    "    \"A transformed `DataLoader` for Tabular data\"\n",
-    "    do_item = noops\n",
+    "    \"A transformed `DataLoader` for Tabular data\"    \n",
     "    def __init__(self, dataset, bs=16, shuffle=False, after_batch=None, num_workers=0, **kwargs):\n",
     "        if after_batch is None: after_batch = L(TransformBlock().batch_tfms)+ReadTabBatch(dataset)\n",
     "        super().__init__(dataset, bs=bs, shuffle=shuffle, after_batch=after_batch, num_workers=num_workers, **kwargs)\n",
     "\n",
     "    def create_batch(self, b): return self.dataset.iloc[b]\n",
+    "    def do_item(self, s):      return 0 if s is None else s\n",
     "\n",
     "TabularPandas._dl_type = TabDataLoader"
    ]


### PR DESCRIPTION
`IterableDataset` objects currently don't work when `_one_pass` is called, because this method attempts to index item `0` but `None` would be required for an `IterableDataset`. However, passing `None` is incompatible with indexed datasets. This PR aims to fix the issues. 

The following changes are made:

- Fix `create_item` to be compatible with both iterable and indexed datasets.
- If a sample item is required, index `do_item` with `None`, not `0`. For iterable datasets, this will get the next item, for indexible datasets it will get the first item.
- Subclasses of `DataLoader` are updated to be compatible with this indexing scheme.
- Native PyTorch `IterableDataset`s have a stubbed `__getitem__` method (that just raises an error), so don't just rely on the presence of that method when establishing the `indexed` property - check for `IterableDataset` classes/subclasses too.

While I've tried to familiarise myself with how `_one_pass` is used, I'm a little unsure whether it could be called such that it consumed the first item of the iterator, then the iterator continued to be used by e.g. the training loop (effectively skipping the first item). Is this a problem, or is the iterator always reset by calling `create_batches`?