### PR TITLE
Make requires_grad_ consistent with PyTorch

### DIFF
--- a/fastai/torch_core.py
+++ b/fastai/torch_core.py
@@ -340,9 +340,9 @@ class TensorBase(Tensor):
         res = self.as_subclass(Tensor).new() if x is None else self.as_subclass(Tensor).new(x)
         return res.as_subclass(cls)
 
-    def requires_grad_(self):
+    def requires_grad_(self, requires_grad=True):
         # Workaround https://github.com/pytorch/pytorch/issues/50219
-        self.requires_grad = True
+        self.requires_grad = requires_grad
         return self
 
 # Cell

--- a/nbs/00_torch_core.ipynb
+++ b/nbs/00_torch_core.ipynb
@@ -1214,9 +1214,9 @@
     "        res = self.as_subclass(Tensor).new() if x is None else self.as_subclass(Tensor).new(x)\n",
     "        return res.as_subclass(cls)\n",
     "    \n",
-    "    def requires_grad_(self):\n",
+    "    def requires_grad_(self, requires_grad=True):\n",
     "        # Workaround https://github.com/pytorch/pytorch/issues/50219\n",
-    "        self.requires_grad = True\n",
+    "        self.requires_grad = requires_grad\n",
     "        return self"
    ]
   },


### PR DESCRIPTION
Closes https://github.com/fastai/fastai/issues/3182

PyTorch's `requires_grad_` passes in a `requires_grad` param. This is needed when exporting to jit (and potentially other libraries/frameworks) as they want to adjust that param. The default remains `True`, so no code currently in the library is affected (and should be continued to be used as `TensorBase.requires_grad_()`

<s>@jph00 let me know if you would like me to make an adjustment to instances of `requires_grad_()` in the framework to expose the `requires_grad` param inside of it or not. </s>

cc: @Isaac-Flath as it's relevant to jit