### PR TITLE
update-LabelSmoothingCrossEntropy-dim=1

### DIFF
--- a/fastai/losses.py
+++ b/fastai/losses.py
@@ -103,11 +103,11 @@ class LabelSmoothingCrossEntropy(Module):
         store_attr()
 
     def forward(self, output, target):
-        c = output.size()[-1]
-        log_preds = F.log_softmax(output, dim=-1)
+        c = output.size()[1]
+        log_preds = F.log_softmax(output, dim=1)
         if self.reduction=='sum': loss = -log_preds.sum()
         else:
-            loss = -log_preds.sum(dim=-1) #We divide by that size at the return line so sum and not mean
+            loss = -log_preds.sum(dim=1) #We divide by that size at the return line so sum and not mean
             if self.reduction=='mean':  loss = loss.mean()
         return loss*self.eps/c + (1-self.eps) * F.nll_loss(log_preds, target.long(), weight=self.weight, reduction=self.reduction)
 

--- a/nbs/01a_losses.ipynb
+++ b/nbs/01a_losses.ipynb
@@ -361,16 +361,28 @@
     "        store_attr()\n",
     "\n",
     "    def forward(self, output, target):\n",
-    "        c = output.size()[-1]\n",
-    "        log_preds = F.log_softmax(output, dim=-1)\n",
+    "        c = output.size()[1]\n",
+    "        log_preds = F.log_softmax(output, dim=1)\n",
     "        if self.reduction=='sum': loss = -log_preds.sum()\n",
     "        else:\n",
-    "            loss = -log_preds.sum(dim=-1) #We divide by that size at the return line so sum and not mean\n",
+    "            loss = -log_preds.sum(dim=1) #We divide by that size at the return line so sum and not mean\n",
     "            if self.reduction=='mean':  loss = loss.mean()\n",
     "        return loss*self.eps/c + (1-self.eps) * F.nll_loss(log_preds, target.long(), weight=self.weight, reduction=self.reduction)\n",
     "\n",
     "    def activation(self, out): return F.softmax(out, dim=-1)\n",
     "    def decodes(self, out):    return out.argmax(dim=-1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lmce = LabelSmoothingCrossEntropy()\n",
+    "output = torch.randn(32, 5, 10)\n",
+    "target = torch.randint(0, 10, (32,5))\n",
+    "test_eq(lmce(output.flatten(0,1), target.flatten()), lmce(output.transpose(-1,-2), target))"
    ]
   },
   {


### PR DESCRIPTION
LabelSmoothingCrossEntropy's dim should be 1.
```python
# old_version
import torch
from fastcore.all import test_eq
from fastai.losses import LabelSmoothingCrossEntropy
lmce = LabelSmoothingCrossEntropy()
output = torch.randn(32, 5, 10) # [bs, seqlen, class]
target = torch.randint(0, 10, (32,5)) # [bs, seqlen]
test_eq(lmce(output.flatten(0,1), target.flatten()), lmce(output.transpose(-1,-2), target))
# error AssertionError: ==:
```
```python
# this pr
import torch
from fastcore.all import test_eq
from fastai.losses import LabelSmoothingCrossEntropy
lmce = LabelSmoothingCrossEntropy()
output = torch.randn(32, 5, 10) # [bs, seqlen, class]
target = torch.randint(0, 10, (32,5)) # [bs, seqlen]
test_eq(lmce(output.flatten(0,1), target.flatten()), lmce(output.transpose(-1,-2), target))
# success
```