### PR TITLE
Update fp16.py

### DIFF
--- a/fastai/callback/fp16.py
+++ b/fastai/callback/fp16.py
@@ -37,7 +37,7 @@ class MixedPrecision(Callback):
 class FP16TestCallback(Callback):
     "Asserts that predictions are `float16` values"
     order = 9
-    def after_pred(self): assert self.pred.dtype==torch.float16
+    def after_pred(self): assert floatify(self.pred)[0].dtype==torch.float16
 
 # Cell
 @patch

--- a/fastai/callback/fp16.py
+++ b/fastai/callback/fp16.py
@@ -19,7 +19,7 @@ class MixedPrecision(Callback):
     def before_fit(self): self.learn.scaler,self.scales = GradScaler(**self.kwargs),L()
     def before_batch(self): self.autocast.__enter__()
     def after_pred(self):
-        if self.pred.dtype==torch.float16: self.learn.pred = to_float(self.pred)
+        if listify(self.pred)[0].dtype==torch.float16: self.learn.pred = to_float(self.pred)
     def after_loss(self): self.autocast.__exit__()
     def before_backward(self): self.learn.loss_grad = self.scaler.scale(self.loss_grad)
     def before_step(self):
@@ -37,7 +37,7 @@ class MixedPrecision(Callback):
 class FP16TestCallback(Callback):
     "Asserts that predictions are `float16` values"
     order = 9
-    def after_pred(self): assert floatify(self.pred)[0].dtype==torch.float16
+    def after_pred(self): assert listify(self.pred)[0].dtype==torch.float16
 
 # Cell
 @patch


### PR DESCRIPTION
When self.pred is a tuple of tensors, calling .dtype on self.pred raises an AttributeError,

listify(self.pred)[0].dtype can fix this error when self.pred is a tensor or a tuple.

However, this checks if the zeroth element of tuple self.pred is a of dtype float16, not the first element and onwards.
But this should not be an issue because the elements of self.pred are typedcasted in an all or none fashion.