### PR TITLE
Error when self.pred is a tuple of tensors

### DIFF
--- a/fastai/callback/fp16.py
+++ b/fastai/callback/fp16.py
@@ -19,7 +19,7 @@ class MixedPrecision(Callback):
     def before_fit(self): self.learn.scaler,self.scales = GradScaler(**self.kwargs),L()
     def before_batch(self): self.autocast.__enter__()
     def after_pred(self):
-        if self.pred.dtype==torch.float16: self.learn.pred = to_float(self.pred)
+        if listify(self.pred)[0].dtype==torch.float16: self.learn.pred = to_float(self.pred)
     def after_loss(self): self.autocast.__exit__()
     def before_backward(self): self.learn.loss_grad = self.scaler.scale(self.loss_grad)
     def before_step(self):
@@ -37,7 +37,7 @@ class MixedPrecision(Callback):
 class FP16TestCallback(Callback):
     "Asserts that predictions are `float16` values"
     order = 9
-    def after_pred(self): assert self.pred.dtype==torch.float16
+    def after_pred(self): assert listify(self.pred)[0].dtype==torch.float16
 
 # Cell
 @patch


### PR DESCRIPTION
When self.pred is a tuple of tensors, calling .dtype on self.pred raises a AttributeError.
When self.pred is a tuple of tensors, the component tensors are (usually) of the same type.
Thus, we can check the dtype of the zeroth element of the listify(self.pred).