### PR TITLE
Fix test in text.data and add ninja to dev requirements

### DIFF
--- a/nbs/31_text.data.ipynb
+++ b/nbs/31_text.data.ipynb
@@ -17,15 +17,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install nbdev"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "#export\n",
     "from fastai.torch_basics import *\n",
     "from fastai.data.all import *\n",
@@ -255,9 +246,7 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       ""
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -998,9 +987,7 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       ""
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -1010,9 +997,7 @@
     },
     {
      "data": {
-      "text/html": [
-       ""
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -1252,9 +1237,7 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       ""
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -1264,9 +1247,7 @@
     },
     {
      "data": {
-      "text/html": [
-       ""
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -1458,9 +1439,7 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       ""
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -1495,9 +1474,7 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       ""
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -1565,9 +1542,7 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       ""
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -1666,9 +1641,7 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       ""
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -1757,5 +1730,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbs/31_text.data.ipynb
+++ b/nbs/31_text.data.ipynb
@@ -17,6 +17,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!pip install nbdev"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "#export\n",
     "from fastai.torch_basics import *\n",
     "from fastai.data.all import *\n",
@@ -371,7 +380,13 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": "<h2 id=\"LMDataLoader\" class=\"doc_header\"><code>class</code> <code>LMDataLoader</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\n\n> <code>LMDataLoader</code>(**`dataset`**, **`lens`**=*`None`*, **`cache`**=*`2`*, **`bs`**=*`64`*, **`seq_len`**=*`72`*, **`num_workers`**=*`0`*, **`shuffle`**=*`False`*, **`verbose`**=*`False`*, **`do_setup`**=*`True`*, **`pin_memory`**=*`False`*, **`timeout`**=*`0`*, **`batch_size`**=*`None`*, **`drop_last`**=*`False`*, **`indexed`**=*`None`*, **`n`**=*`None`*, **`device`**=*`None`*, **`persistent_workers`**=*`False`*, **`wif`**=*`None`*, **`before_iter`**=*`None`*, **`after_item`**=*`None`*, **`before_batch`**=*`None`*, **`after_batch`**=*`None`*, **`after_iter`**=*`None`*, **`create_batches`**=*`None`*, **`create_item`**=*`None`*, **`create_batch`**=*`None`*, **`retain`**=*`None`*, **`get_idxs`**=*`None`*, **`sample`**=*`None`*, **`shuffle_fn`**=*`None`*, **`do_batch`**=*`None`*) :: `TfmdDL`\n\nA `DataLoader` suitable for language modeling",
+      "text/markdown": [
+       "<h2 id=\"LMDataLoader\" class=\"doc_header\"><code>class</code> <code>LMDataLoader</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\n",
+       "\n",
+       "> <code>LMDataLoader</code>(**`dataset`**, **`lens`**=*`None`*, **`cache`**=*`2`*, **`bs`**=*`64`*, **`seq_len`**=*`72`*, **`num_workers`**=*`0`*, **`shuffle`**=*`False`*, **`verbose`**=*`False`*, **`do_setup`**=*`True`*, **`pin_memory`**=*`False`*, **`timeout`**=*`0`*, **`batch_size`**=*`None`*, **`drop_last`**=*`False`*, **`indexed`**=*`None`*, **`n`**=*`None`*, **`device`**=*`None`*, **`persistent_workers`**=*`False`*, **`wif`**=*`None`*, **`before_iter`**=*`None`*, **`after_item`**=*`None`*, **`before_batch`**=*`None`*, **`after_batch`**=*`None`*, **`after_iter`**=*`None`*, **`create_batches`**=*`None`*, **`create_item`**=*`None`*, **`create_batch`**=*`None`*, **`retain`**=*`None`*, **`get_idxs`**=*`None`*, **`sample`**=*`None`*, **`shuffle_fn`**=*`None`*, **`do_batch`**=*`None`*) :: `TfmdDL`\n",
+       "\n",
+       "A `DataLoader` suitable for language modeling"
+      ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
       ]
@@ -950,7 +965,13 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": "<h4 id=\"TextBlock.from_df\" class=\"doc_header\"><code>TextBlock.from_df</code><a href=\"__main__.py#L12\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n\n> <code>TextBlock.from_df</code>(**`text_cols`**, **`vocab`**=*`None`*, **`is_lm`**=*`False`*, **`seq_len`**=*`72`*, **`backwards`**=*`False`*, **`min_freq`**=*`3`*, **`max_vocab`**=*`60000`*, **`tok`**=*`None`*, **`rules`**=*`None`*, **`sep`**=*`' '`*, **`n_workers`**=*`2`*, **`mark_fields`**=*`None`*, **`tok_text_col`**=*`'text'`*, **\\*\\*`kwargs`**)\n\nBuild a `TextBlock` from a dataframe using `text_cols`",
+      "text/markdown": [
+       "<h4 id=\"TextBlock.from_df\" class=\"doc_header\"><code>TextBlock.from_df</code><a href=\"__main__.py#L12\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "\n",
+       "> <code>TextBlock.from_df</code>(**`text_cols`**, **`vocab`**=*`None`*, **`is_lm`**=*`False`*, **`seq_len`**=*`72`*, **`backwards`**=*`False`*, **`min_freq`**=*`3`*, **`max_vocab`**=*`60000`*, **`tok`**=*`None`*, **`rules`**=*`None`*, **`sep`**=*`' '`*, **`n_workers`**=*`2`*, **`mark_fields`**=*`None`*, **`tok_text_col`**=*`'text'`*, **\\*\\*`kwargs`**)\n",
+       "\n",
+       "Build a `TextBlock` from a dataframe using `text_cols`"
+      ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
       ]
@@ -1066,7 +1087,13 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": "<h4 id=\"TextBlock.from_folder\" class=\"doc_header\"><code>TextBlock.from_folder</code><a href=\"__main__.py#L19\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n\n> <code>TextBlock.from_folder</code>(**`path`**, **`vocab`**=*`None`*, **`is_lm`**=*`False`*, **`seq_len`**=*`72`*, **`backwards`**=*`False`*, **`min_freq`**=*`3`*, **`max_vocab`**=*`60000`*, **`tok`**=*`None`*, **`rules`**=*`None`*, **`extensions`**=*`None`*, **`folders`**=*`None`*, **`output_dir`**=*`None`*, **`skip_if_exists`**=*`True`*, **`output_names`**=*`None`*, **`n_workers`**=*`2`*, **`encoding`**=*`'utf8'`*, **\\*\\*`kwargs`**)\n\nBuild a `TextBlock` from a `path`",
+      "text/markdown": [
+       "<h4 id=\"TextBlock.from_folder\" class=\"doc_header\"><code>TextBlock.from_folder</code><a href=\"__main__.py#L19\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "\n",
+       "> <code>TextBlock.from_folder</code>(**`path`**, **`vocab`**=*`None`*, **`is_lm`**=*`False`*, **`seq_len`**=*`72`*, **`backwards`**=*`False`*, **`min_freq`**=*`3`*, **`max_vocab`**=*`60000`*, **`tok`**=*`None`*, **`rules`**=*`None`*, **`extensions`**=*`None`*, **`folders`**=*`None`*, **`output_dir`**=*`None`*, **`skip_if_exists`**=*`True`*, **`output_names`**=*`None`*, **`n_workers`**=*`2`*, **`encoding`**=*`'utf8'`*, **\\*\\*`kwargs`**)\n",
+       "\n",
+       "Build a `TextBlock` from a `path`"
+      ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
       ]
@@ -1149,7 +1176,13 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": "<h2 id=\"TextDataLoaders\" class=\"doc_header\"><code>class</code> <code>TextDataLoaders</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\n\n> <code>TextDataLoaders</code>(**\\*`loaders`**, **`path`**=*`'.'`*, **`device`**=*`None`*) :: `DataLoaders`\n\nBasic wrapper around several `DataLoader`s with factory methods for NLP problems",
+      "text/markdown": [
+       "<h2 id=\"TextDataLoaders\" class=\"doc_header\"><code>class</code> <code>TextDataLoaders</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\n",
+       "\n",
+       "> <code>TextDataLoaders</code>(**\\*`loaders`**, **`path`**=*`'.'`*, **`device`**=*`None`*) :: `DataLoaders`\n",
+       "\n",
+       "Basic wrapper around several `DataLoader`s with factory methods for NLP problems"
+      ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
       ]
@@ -1184,7 +1217,13 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": "<h4 id=\"TextDataLoaders.from_folder\" class=\"doc_header\"><code>TextDataLoaders.from_folder</code><a href=\"__main__.py#L4\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n\n> <code>TextDataLoaders.from_folder</code>(**`path`**, **`train`**=*`'train'`*, **`valid`**=*`'valid'`*, **`valid_pct`**=*`None`*, **`seed`**=*`None`*, **`vocab`**=*`None`*, **`text_vocab`**=*`None`*, **`is_lm`**=*`False`*, **`tok_tfm`**=*`None`*, **`seq_len`**=*`72`*, **`backwards`**=*`False`*, **`bs`**=*`64`*, **`val_bs`**=*`None`*, **`shuffle_train`**=*`True`*, **`device`**=*`None`*)\n\nCreate from imagenet style dataset in `path` with `train` and `valid` subfolders (or provide `valid_pct`)",
+      "text/markdown": [
+       "<h4 id=\"TextDataLoaders.from_folder\" class=\"doc_header\"><code>TextDataLoaders.from_folder</code><a href=\"__main__.py#L4\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "\n",
+       "> <code>TextDataLoaders.from_folder</code>(**`path`**, **`train`**=*`'train'`*, **`valid`**=*`'valid'`*, **`valid_pct`**=*`None`*, **`seed`**=*`None`*, **`vocab`**=*`None`*, **`text_vocab`**=*`None`*, **`is_lm`**=*`False`*, **`tok_tfm`**=*`None`*, **`seq_len`**=*`72`*, **`backwards`**=*`False`*, **`bs`**=*`64`*, **`val_bs`**=*`None`*, **`shuffle`**=*`True`*, **`device`**=*`None`*)\n",
+       "\n",
+       "Create from imagenet style dataset in `path` with `train` and `valid` subfolders (or provide `valid_pct`)"
+      ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
       ]
@@ -1214,6 +1253,30 @@
     {
      "data": {
       "text/html": [
+       ""
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       ""
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -1230,12 +1293,12 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>xxbos xxmaj by now you 've probably heard a bit about the new xxmaj disney dub of xxmaj miyazaki 's classic film , xxmaj laputa : xxmaj castle xxmaj in xxmaj the xxmaj sky . xxmaj during late summer of 1998 , xxmaj disney released \" kiki 's xxmaj delivery xxmaj service \" on video which included a preview of the xxmaj laputa dub saying it was due out in \" 1 xxrep 3 9 \" . xxmaj it 's obviously way past that year now , but the dub has been finally completed . xxmaj and it 's not \" laputa : xxmaj castle xxmaj in xxmaj the xxmaj sky \" , just \" castle xxmaj in xxmaj the xxmaj sky \" for the dub , since xxmaj laputa is not such a nice word in xxmaj spanish ( even though they use the word xxmaj laputa many times</td>\n",
-       "      <td>pos</td>\n",
+       "      <td>xxbos xxmaj this movie was recently released on xxup dvd in the xxup us and i finally got the chance to see this hard - to - find gem . xxmaj it even came with original theatrical previews of other xxmaj italian horror classics like \" xxunk \" and \" beyond xxup the xxup darkness \" . xxmaj unfortunately , the previews were the best thing about this movie . \\n\\n \" zombi 3 \" in a bizarre way is actually linked to the infamous xxmaj lucio xxmaj fulci \" zombie \" franchise which began in 1979 . xxmaj similarly compared to \" zombie \" , \" zombi 3 \" consists of a threadbare plot and a handful of extremely bad actors that keeps this ' horror ' trash barely afloat . xxmaj the gore is nearly non - existent ( unless one is frightened of people running around with</td>\n",
+       "      <td>neg</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>xxbos xxmaj jim xxmaj carrey is back to much the same role that he played in xxmaj the xxmaj mask , a timid guy who is trying to get ahead in the world but who seems to be plagued with bad luck . xxmaj even when he tries to help a homeless guy from being harassed by a bunch of hoodlums ( and of course they have to be xxmaj mexican , obviously ) , his good will towards his fellow man backfires . xxmaj in that case , it was n't too hard to predict that he was about to have a handful of angry hoodlums , but i like that the movie suggests that things like that should n't be ignored . xxmaj i 'm reminded of the episode of xxmaj michael xxmaj moore 's brilliant xxmaj the xxmaj awful xxmaj truth , when they had a man</td>\n",
+       "      <td>xxbos xxup anchors xxup aweigh sees two eager young sailors , xxmaj joe xxmaj brady ( gene xxmaj kelly ) and xxmaj clarence xxmaj doolittle / xxmaj brooklyn ( frank xxmaj sinatra ) , get a special four - day shore leave . xxmaj eager to get to the girls , particularly xxmaj joe 's xxmaj lola , neither xxmaj joe nor xxmaj brooklyn figure on the interruption of little xxmaj navy - mad xxmaj donald ( dean xxmaj stockwell ) and his xxmaj aunt xxmaj susie ( kathryn xxmaj grayson ) . xxmaj unexperienced in the ways of females and courting , xxmaj brooklyn quickly enlists xxmaj joe to help him win xxmaj aunt xxmaj susie over . xxmaj along the way , however , xxmaj joe finds himself falling for the gal he thinks belongs to his best friend . xxmaj how is xxmaj brooklyn going to take</td>\n",
        "      <td>pos</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -1263,7 +1326,13 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": "<h4 id=\"TextDataLoaders.from_df\" class=\"doc_header\"><code>TextDataLoaders.from_df</code><a href=\"__main__.py#L19\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n\n> <code>TextDataLoaders.from_df</code>(**`df`**, **`path`**=*`'.'`*, **`valid_pct`**=*`0.2`*, **`seed`**=*`None`*, **`text_col`**=*`0`*, **`label_col`**=*`1`*, **`label_delim`**=*`None`*, **`y_block`**=*`None`*, **`text_vocab`**=*`None`*, **`is_lm`**=*`False`*, **`valid_col`**=*`None`*, **`tok_tfm`**=*`None`*, **`tok_text_col`**=*`'text'`*, **`seq_len`**=*`72`*, **`backwards`**=*`False`*, **`bs`**=*`64`*, **`val_bs`**=*`None`*, **`shuffle_train`**=*`True`*, **`device`**=*`None`*)\n\nCreate from `df` in `path` with `valid_pct`",
+      "text/markdown": [
+       "<h4 id=\"TextDataLoaders.from_df\" class=\"doc_header\"><code>TextDataLoaders.from_df</code><a href=\"__main__.py#L19\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "\n",
+       "> <code>TextDataLoaders.from_df</code>(**`df`**, **`path`**=*`'.'`*, **`valid_pct`**=*`0.2`*, **`seed`**=*`None`*, **`text_col`**=*`0`*, **`label_col`**=*`1`*, **`label_delim`**=*`None`*, **`y_block`**=*`None`*, **`text_vocab`**=*`None`*, **`is_lm`**=*`False`*, **`valid_col`**=*`None`*, **`tok_tfm`**=*`None`*, **`tok_text_col`**=*`'text'`*, **`seq_len`**=*`72`*, **`backwards`**=*`False`*, **`bs`**=*`64`*, **`val_bs`**=*`None`*, **`shuffle`**=*`True`*, **`device`**=*`None`*)\n",
+       "\n",
+       "Create from `df` in `path` with `valid_pct`"
+      ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
       ]
@@ -1440,7 +1509,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/yizhang/anaconda3/envs/fastai/lib/python3.8/site-packages/numpy/core/_asarray.py:83: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray\n",
+      "/usr/local/lib/python3.6/dist-packages/numpy/core/_asarray.py:83: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray\n",
       "  return array(a, dtype, copy=False, order=order)\n"
      ]
     },
@@ -1484,6 +1553,7 @@
    ],
    "source": [
     "path = untar_data(URLs.IMDB_SAMPLE)\n",
+    "df = pd.read_csv(path/\"texts.csv\")\n",
     "dls = TextDataLoaders.from_df(df, path=path, text_col='text', label_col='label', valid_col='is_valid')\n",
     "dls.show_batch(max_n=3)"
    ]
@@ -1509,7 +1579,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/yizhang/anaconda3/envs/fastai/lib/python3.8/site-packages/numpy/core/_asarray.py:83: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray\n",
+      "/usr/local/lib/python3.6/dist-packages/numpy/core/_asarray.py:83: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray\n",
       "  return array(a, dtype, copy=False, order=order)\n"
      ]
     },
@@ -1527,18 +1597,18 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>xxbos i have seen many , many productions of xxmaj the xxmaj nutcracker . xxmaj now perhaps i viewed this movie from the xxunk point of view of a theatrical director , but i was disappointed . xxmaj i 'm sure people in the specific business of ballet choreography find this production impressive but from a purely theatrical perspective i found everything from design to choreography to be xxunk and xxunk of</td>\n",
-       "      <td>i have seen many , many productions of xxmaj the xxmaj nutcracker . xxmaj now perhaps i viewed this movie from the xxunk point of view of a theatrical director , but i was disappointed . xxmaj i 'm sure people in the specific business of ballet choreography find this production impressive but from a purely theatrical perspective i found everything from design to choreography to be xxunk and xxunk of a</td>\n",
+       "      <td>xxbos xxmaj sarah xxmaj xxunk is a dangerous xxmaj bitch ! xxmaj she 's beautiful , sexy , funny and talent , dark and demonic . i read the other ' comment ' on this show as well as the message board stuff and people just do n't get it . xxmaj nothing that appears on xxup t.v . is an accident . xxmaj too much money , time and work is</td>\n",
+       "      <td>xxmaj sarah xxmaj xxunk is a dangerous xxmaj bitch ! xxmaj she 's beautiful , sexy , funny and talent , dark and demonic . i read the other ' comment ' on this show as well as the message board stuff and people just do n't get it . xxmaj nothing that appears on xxup t.v . is an accident . xxmaj too much money , time and work is put</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>xxmaj john and xxmaj paul had come to life  so intimate and convincing is the script , and so committed are the actors . xxmaj two xxmaj of xxmaj us gives you priceless insight into the lives of two geniuses , and a tale that is both sad and funny . xxmaj most certainly recommended . xxbos xxmaj sure , it 's a 50 's drive - in special , but</td>\n",
-       "      <td>john and xxmaj paul had come to life  so intimate and convincing is the script , and so committed are the actors . xxmaj two xxmaj of xxmaj us gives you priceless insight into the lives of two geniuses , and a tale that is both sad and funny . xxmaj most certainly recommended . xxbos xxmaj sure , it 's a 50 's drive - in special , but do</td>\n",
+       "      <td>do not have xxunk on about the xxunk that may xxunk them , we xxunk with their hopes and dreams without dwelling on the negative . xxmaj our xxmaj song is an emotionally satisfying film about growing up in the projects that refuses to see life in any terms other than possibility . xxbos xxmaj kubrick again puts on display his stunning ability to craft a perfect ambiance for a film .</td>\n",
+       "      <td>not have xxunk on about the xxunk that may xxunk them , we xxunk with their hopes and dreams without dwelling on the negative . xxmaj our xxmaj song is an emotionally satisfying film about growing up in the projects that refuses to see life in any terms other than possibility . xxbos xxmaj kubrick again puts on display his stunning ability to craft a perfect ambiance for a film . xxmaj</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>felt the xxunk xxup did n't . xxunk were xxunk , xxunk and meaningless . xxmaj just a xxunk for xxmaj xxunk sexual antics . \\n\\n i watched this film with the kind of morbid curiosity that makes me think ' what makes a guy be a serial killer ? ' as well as wondering the specifics about the xxmaj dahmer story , of which i know very little . xxmaj people</td>\n",
-       "      <td>the xxunk xxup did n't . xxunk were xxunk , xxunk and meaningless . xxmaj just a xxunk for xxmaj xxunk sexual antics . \\n\\n i watched this film with the kind of morbid curiosity that makes me think ' what makes a guy be a serial killer ? ' as well as wondering the specifics about the xxmaj dahmer story , of which i know very little . xxmaj people here</td>\n",
+       "      <td>myself . i want my money and time back . \\n\\n xxup do xxup not xxup watch xxup this xxup movie . \\n\\n xxmaj even if curiosity is xxunk you , stick xxunk xxunk in your eyes instead . xxmaj it will be much more enjoyable . xxmaj you have been warned ! xxbos xxmaj this is one of those movies that made me feel strongly for the need of making movies</td>\n",
+       "      <td>. i want my money and time back . \\n\\n xxup do xxup not xxup watch xxup this xxup movie . \\n\\n xxmaj even if curiosity is xxunk you , stick xxunk xxunk in your eyes instead . xxmaj it will be much more enjoyable . xxmaj you have been warned ! xxbos xxmaj this is one of those movies that made me feel strongly for the need of making movies at</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>"
@@ -1563,7 +1633,13 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": "<h4 id=\"TextDataLoaders.from_csv\" class=\"doc_header\"><code>TextDataLoaders.from_csv</code><a href=\"__main__.py#L35\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n\n> <code>TextDataLoaders.from_csv</code>(**`path`**, **`csv_fname`**=*`'labels.csv'`*, **`header`**=*`'infer'`*, **`delimiter`**=*`None`*, **`valid_pct`**=*`0.2`*, **`seed`**=*`None`*, **`text_col`**=*`0`*, **`label_col`**=*`1`*, **`label_delim`**=*`None`*, **`y_block`**=*`None`*, **`text_vocab`**=*`None`*, **`is_lm`**=*`False`*, **`valid_col`**=*`None`*, **`tok_tfm`**=*`None`*, **`tok_text_col`**=*`'text'`*, **`seq_len`**=*`72`*, **`backwards`**=*`False`*, **`bs`**=*`64`*, **`val_bs`**=*`None`*, **`shuffle_train`**=*`True`*, **`device`**=*`None`*)\n\nCreate from `csv` file in `path/csv_fname`",
+      "text/markdown": [
+       "<h4 id=\"TextDataLoaders.from_csv\" class=\"doc_header\"><code>TextDataLoaders.from_csv</code><a href=\"__main__.py#L35\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "\n",
+       "> <code>TextDataLoaders.from_csv</code>(**`path`**, **`csv_fname`**=*`'labels.csv'`*, **`header`**=*`'infer'`*, **`delimiter`**=*`None`*, **`valid_pct`**=*`0.2`*, **`seed`**=*`None`*, **`text_col`**=*`0`*, **`label_col`**=*`1`*, **`label_delim`**=*`None`*, **`y_block`**=*`None`*, **`text_vocab`**=*`None`*, **`is_lm`**=*`False`*, **`valid_col`**=*`None`*, **`tok_tfm`**=*`None`*, **`tok_text_col`**=*`'text'`*, **`seq_len`**=*`72`*, **`backwards`**=*`False`*, **`bs`**=*`64`*, **`val_bs`**=*`None`*, **`shuffle`**=*`True`*, **`device`**=*`None`*)\n",
+       "\n",
+       "Create from `csv` file in `path/csv_fname`"
+      ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
       ]
@@ -1604,7 +1680,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/yizhang/anaconda3/envs/fastai/lib/python3.8/site-packages/numpy/core/_asarray.py:83: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray\n",
+      "/usr/local/lib/python3.6/dist-packages/numpy/core/_asarray.py:83: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray\n",
       "  return array(a, dtype, copy=False, order=order)\n"
      ]
     },
@@ -1662,83 +1738,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Converted 00_torch_core.ipynb.\n",
-      "Converted 01_layers.ipynb.\n",
-      "Converted 01a_losses.ipynb.\n",
-      "Converted 02_data.load.ipynb.\n",
-      "Converted 03_data.core.ipynb.\n",
-      "Converted 04_data.external.ipynb.\n",
-      "Converted 05_data.transforms.ipynb.\n",
-      "Converted 06_data.block.ipynb.\n",
-      "Converted 07_vision.core.ipynb.\n",
-      "Converted 08_vision.data.ipynb.\n",
-      "Converted 09_vision.augment.ipynb.\n",
-      "Converted 09b_vision.utils.ipynb.\n",
-      "Converted 09c_vision.widgets.ipynb.\n",
-      "Converted 10_tutorial.pets.ipynb.\n",
-      "Converted 10b_tutorial.albumentations.ipynb.\n",
-      "Converted 11_vision.models.xresnet.ipynb.\n",
-      "Converted 12_optimizer.ipynb.\n",
-      "Converted 13_callback.core.ipynb.\n",
-      "Converted 13a_learner.ipynb.\n",
-      "Converted 13b_metrics.ipynb.\n",
-      "Converted 14_callback.schedule.ipynb.\n",
-      "Converted 14a_callback.data.ipynb.\n",
-      "Converted 15_callback.hook.ipynb.\n",
-      "Converted 15a_vision.models.unet.ipynb.\n",
-      "Converted 16_callback.progress.ipynb.\n",
-      "Converted 17_callback.tracker.ipynb.\n",
-      "Converted 18_callback.fp16.ipynb.\n",
-      "Converted 18a_callback.training.ipynb.\n",
-      "Converted 18b_callback.preds.ipynb.\n",
-      "Converted 19_callback.mixup.ipynb.\n",
-      "Converted 20_interpret.ipynb.\n",
-      "Converted 20a_distributed.ipynb.\n",
-      "Converted 21_vision.learner.ipynb.\n",
-      "Converted 22_tutorial.imagenette.ipynb.\n",
-      "Converted 23_tutorial.vision.ipynb.\n",
-      "Converted 24_tutorial.siamese.ipynb.\n",
-      "Converted 24_vision.gan.ipynb.\n",
-      "Converted 30_text.core.ipynb.\n",
-      "Converted 31_text.data.ipynb.\n",
-      "Converted 32_text.models.awdlstm.ipynb.\n",
-      "Converted 33_text.models.core.ipynb.\n",
-      "Converted 34_callback.rnn.ipynb.\n",
-      "Converted 35_tutorial.wikitext.ipynb.\n",
-      "Converted 36_text.models.qrnn.ipynb.\n",
-      "Converted 37_text.learner.ipynb.\n",
-      "Converted 38_tutorial.text.ipynb.\n",
-      "Converted 39_tutorial.transformers.ipynb.\n",
-      "Converted 40_tabular.core.ipynb.\n",
-      "Converted 41_tabular.data.ipynb.\n",
-      "Converted 42_tabular.model.ipynb.\n",
-      "Converted 43_tabular.learner.ipynb.\n",
-      "Converted 44_tutorial.tabular.ipynb.\n",
-      "Converted 45_collab.ipynb.\n",
-      "Converted 46_tutorial.collab.ipynb.\n",
-      "Converted 50_tutorial.datablock.ipynb.\n",
-      "Converted 60_medical.imaging.ipynb.\n",
-      "Converted 61_tutorial.medical_imaging.ipynb.\n",
-      "Converted 65_medical.text.ipynb.\n",
-      "Converted 70_callback.wandb.ipynb.\n",
-      "Converted 71_callback.tensorboard.ipynb.\n",
-      "Converted 72_callback.neptune.ipynb.\n",
-      "Converted 73_callback.captum.ipynb.\n",
-      "Converted 74_callback.azureml.ipynb.\n",
-      "Converted 97_test_utils.ipynb.\n",
-      "Converted 99_pytorch_doc.ipynb.\n",
-      "Converted dev-setup.ipynb.\n",
-      "Converted index.ipynb.\n",
-      "Converted quick_start.ipynb.\n",
-      "Converted tutorial.ipynb.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#hide\n",
     "from nbdev.export import notebook2script\n",

--- a/nbs/36_text.models.qrnn.ipynb
+++ b/nbs/36_text.models.qrnn.ipynb
@@ -570,5 +570,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 1
 }

--- a/settings.ini
+++ b/settings.ini
@@ -16,7 +16,7 @@ language = English
 requirements = fastcore>=1.3.8,<1.4 torchvision>=0.8,<0.9 matplotlib pandas requests pyyaml fastprogress>=0.2.4 pillow>6.0.0 scikit-learn scipy spacy<3
 pip_requirements = torch>=1.7.0,<1.8
 conda_requirements = pytorch>=1.7.0,<1.8
-dev_requirements = nbdev>=1.0.10,<2 ipywidgets pytorch-lightning pytorch-ignite transformers sentencepiece tensorboard pydicom catalyst captum>=0.3 flask wandb kornia scikit-image neptune-client albumentations opencv-python pyarrow catalyst
+dev_requirements = nbdev>=1.0.10,<2 ipywidgets pytorch-lightning pytorch-ignite transformers sentencepiece tensorboard pydicom catalyst captum>=0.3 flask wandb kornia scikit-image neptune-client albumentations opencv-python pyarrow catalyst ninja
 nbs_path = nbs
 doc_path = docs
 doc_src_path = docs_src


### PR DESCRIPTION
This PR solves two current issues regarding tests:

First in `text.data` we downloaded the data again but never used it, so now `df = pd.read_csv(path/'texts.csv')` was added. In regards to QRNN failing, it seemed (on my machine) to stem from ninja not being installed to properly handle the c++, so I added this to the dev requirements.

(cc @jph00 )