### PR TITLE
Assertion Error for fp16() in multioutput models (with example)

### DIFF
--- a/fastai/callback/fp16.py
+++ b/fastai/callback/fp16.py
@@ -19,7 +19,7 @@ class MixedPrecision(Callback):
     def before_fit(self): self.learn.scaler,self.scales = GradScaler(**self.kwargs),L()
     def before_batch(self): self.autocast.__enter__()
     def after_pred(self):
-        if self.pred.dtype==torch.float16: self.learn.pred = to_float(self.pred)
+        if listify(self.pred)[0].dtype==torch.float16: self.learn.pred = to_float(self.pred)
     def after_loss(self): self.autocast.__exit__()
     def before_backward(self): self.learn.loss_grad = self.scaler.scale(self.loss_grad)
     def before_step(self):
@@ -37,7 +37,7 @@ class MixedPrecision(Callback):
 class FP16TestCallback(Callback):
     "Asserts that predictions are `float16` values"
     order = 9
-    def after_pred(self): assert self.pred.dtype==torch.float16
+    def after_pred(self): assert listify(self.pred)[0].dtype==torch.float16
 
 # Cell
 @patch

--- a/nbs/18_callback.fp16.ipynb
+++ b/nbs/18_callback.fp16.ipynb
@@ -197,7 +197,7 @@
     "    def before_fit(self): self.learn.scaler,self.scales = GradScaler(**self.kwargs),L()\n",
     "    def before_batch(self): self.autocast.__enter__()\n",
     "    def after_pred(self):\n",
-    "        if self.pred.dtype==torch.float16: self.learn.pred = to_float(self.pred)\n",
+    "        if listify(self.pred)[0].dtype==torch.float16: self.learn.pred = to_float(self.pred)\n",
     "    def after_loss(self): self.autocast.__exit__()\n",
     "    def before_backward(self): self.learn.loss_grad = self.scaler.scale(self.loss_grad)\n",
     "    def before_step(self):\n",
@@ -222,7 +222,7 @@
     "class FP16TestCallback(Callback):\n",
     "    \"Asserts that predictions are `float16` values\"\n",
     "    order = 9\n",
-    "    def after_pred(self): assert self.pred.dtype==torch.float16"
+    "    def after_pred(self): assert listify(self.pred)[0].dtype==torch.float16"
    ]
   },
   {
@@ -279,6 +279,29 @@
     "learn.model = nn.Sequential(nn.Linear(1,1), nn.Linear(1,1)).cuda()\n",
     "learn.opt_func = partial(SGD, mom=0.)\n",
     "learn.splitter = lambda m: [list(m[0].parameters()), list(m[1].parameters())]\n",
+    "learn.fit(3)\n",
+    "assert learn.recorder.values[-1][-1]<learn.recorder.values[0][-1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#hide\n",
+    "#cuda\n",
+    "#Multioutput version\n",
+    "set_seed(99, True)\n",
+    "learn = synth_learner(cbs=[MixedPrecision,FP16TestCallback], cuda=True)\n",
+    "class MultiOutputModel(Module):\n",
+    "    def __init__(self): self.linear1, self.linear2 = nn.Linear(1,1) , nn.Linear(1,1)\n",
+    "    def forward(self,x): return self.linear1(x), self.linear2(x)\n",
+    "def multioutputloss(pred, val): return (val-pred[0]).abs() + 0.5 * (val-pred[1]).abs()\n",
+    "learn.model = MultiOutputModel()\n",
+    "learn.opt_func = partial(SGD, mom=0.)\n",
+    "learn.splitter = lambda m: [list(m.linear1.parameters()), list(m.linear2.parameters())]\n",
+    "learn.loss_func=multioutputloss\n",
     "learn.fit(3)\n",
     "assert learn.recorder.values[-1][-1]<learn.recorder.values[0][-1]"
    ]


### PR DESCRIPTION
As requested in [here](https://github.com/fastai/fastai/pull/3212) for an example.
Fixes assertionerror for mixedprecision callback using pytorch's native mixed precision function,
when using a multioutput model.

Added an example of a trivial multioutput model.
I used #cuda and #hide in the jupyter notebook cell,
Its my first time using github/contributing with nbdev, but wow is this super hard and complicated.
Im sure itll get better with the learning curve (steep).