### PR TITLE
Regression fix: Ensure add_datepart adds elapsed as numeric column

### DIFF
--- a/fastai/tabular/core.py
+++ b/fastai/tabular/core.py
@@ -33,7 +33,7 @@ def add_datepart(df, field_name, prefix=None, drop=True, time=False):
     week = field.dt.isocalendar().week.astype(field.dt.day.dtype) if hasattr(field.dt, 'isocalendar') else field.dt.week
     for n in attr: df[prefix + n] = getattr(field.dt, n.lower()) if n != 'Week' else week
     mask = ~field.isna()
-    df[prefix + 'Elapsed'] = np.where(mask,field.values.astype(np.int64) // 10 ** 9,None)
+    df[prefix + 'Elapsed'] = np.where(mask,field.values.astype(np.int64) // 10 ** 9,np.nan)
     if drop: df.drop(field_name, axis=1, inplace=True)
     return df
 

--- a/nbs/40_tabular.core.ipynb
+++ b/nbs/40_tabular.core.ipynb
@@ -113,7 +113,7 @@
     "    week = field.dt.isocalendar().week.astype(field.dt.day.dtype) if hasattr(field.dt, 'isocalendar') else field.dt.week\n",
     "    for n in attr: df[prefix + n] = getattr(field.dt, n.lower()) if n != 'Week' else week\n",
     "    mask = ~field.isna()\n",
-    "    df[prefix + 'Elapsed'] = np.where(mask,field.values.astype(np.int64) // 10 ** 9,None)\n",
+    "    df[prefix + 'Elapsed'] = np.where(mask,field.values.astype(np.int64) // 10 ** 9,np.nan)\n",
     "    if drop: df.drop(field_name, axis=1, inplace=True)\n",
     "    return df"
    ]
@@ -181,7 +181,7 @@
        "      <td>False</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
-       "      <td>1575417600</td>\n",
+       "      <td>1.575418e+09</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -197,7 +197,7 @@
        "      <td>False</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
-       "      <td>None</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
@@ -213,7 +213,7 @@
        "      <td>False</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
-       "      <td>1573776000</td>\n",
+       "      <td>1.573776e+09</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -229,7 +229,7 @@
        "      <td>False</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
-       "      <td>1571875200</td>\n",
+       "      <td>1.571875e+09</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -248,11 +248,11 @@
        "2           False           False             False        False   \n",
        "3           False           False             False        False   \n",
        "\n",
-       "   Is_year_start     Elapsed  \n",
-       "0          False  1575417600  \n",
-       "1          False        None  \n",
-       "2          False  1573776000  \n",
-       "3          False  1571875200  "
+       "   Is_year_start       Elapsed  \n",
+       "0          False  1.575418e+09  \n",
+       "1          False           NaN  \n",
+       "2          False  1.573776e+09  \n",
+       "3          False  1.571875e+09  "
       ]
      },
      "execution_count": null,
@@ -278,7 +278,9 @@
     "test_eq(df[df.Elapsed.isna()].shape,(1, 13))\n",
     "\n",
     "# Test that week dtype is consistent with other datepart fields\n",
-    "test_eq(df['Year'].dtype, df['Week'].dtype)"
+    "test_eq(df['Year'].dtype, df['Week'].dtype)\n",
+    "\n",
+    "test_eq(pd.api.types.is_numeric_dtype(df['Elapsed']), True)"
    ]
   },
   {
@@ -345,7 +347,7 @@
        "      <td>False</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
-       "      <td>1575417600</td>\n",
+       "      <td>1.575418e+09</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -358,8 +360,8 @@
        "   Is_month_end  Is_month_start  Is_quarter_end  Is_quarter_start  \\\n",
        "0         False           False           False             False   \n",
        "\n",
-       "   Is_year_end  Is_year_start     Elapsed  \n",
-       "0        False          False  1575417600  "
+       "   Is_year_end  Is_year_start       Elapsed  \n",
+       "0        False          False  1.575418e+09  "
       ]
      },
      "execution_count": null,
@@ -661,8 +663,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "cont_names: ['ui32', 'i64', 'f16', 'd1_Year', 'd1_Month', 'd1_Week', 'd1_Day', 'd1_Dayofweek', 'd1_Dayofyear']\n",
-      "cat_names: ['cat1', 'd1_date', 'd1_Is_month_end', 'd1_Is_month_start', 'd1_Is_quarter_end', 'd1_Is_quarter_start', 'd1_Is_year_end', 'd1_Is_year_start', 'd1_Elapsed']\n"
+      "cont_names: ['ui32', 'i64', 'f16', 'd1_Year', 'd1_Month', 'd1_Week', 'd1_Day', 'd1_Dayofweek', 'd1_Dayofyear', 'd1_Elapsed']\n",
+      "cat_names: ['cat1', 'd1_date', 'd1_Is_month_end', 'd1_Is_month_start', 'd1_Is_quarter_end', 'd1_Is_quarter_start', 'd1_Is_year_end', 'd1_Is_year_start']\n"
      ]
     }
    ],
@@ -680,8 +682,8 @@
     "#hide\n",
     "cont, cat = cont_cat_split(df, max_card=0)\n",
     "test_eq((cont, cat), (\n",
-    "    ['ui32', 'i64', 'f16', 'd1_Year', 'd1_Month', 'd1_Week', 'd1_Day', 'd1_Dayofweek', 'd1_Dayofyear'], \n",
-    "    ['cat1', 'd1_date', 'd1_Is_month_end', 'd1_Is_month_start', 'd1_Is_quarter_end', 'd1_Is_quarter_start', 'd1_Is_year_end', 'd1_Is_year_start', 'd1_Elapsed']\n",
+    "    ['ui32', 'i64', 'f16', 'd1_Year', 'd1_Month', 'd1_Week', 'd1_Day', 'd1_Dayofweek', 'd1_Dayofyear', 'd1_Elapsed'], \n",
+    "    ['cat1', 'd1_date', 'd1_Is_month_end', 'd1_Is_month_start', 'd1_Is_quarter_end', 'd1_Is_quarter_start', 'd1_Is_year_end', 'd1_Is_year_start']\n",
     "    ))"
    ]
   },


### PR DESCRIPTION
After the merge of #2640 the `elapsed` column added by `add_date_part` is always of type `object`. 

This causes problems like the one described [here](https://forums.fast.ai/t/lesson-7-official-topic/69896/282?u=aberres).

Before #2640 the added column was always of type int. With my change it will always be of type float. This will also cause `cont_cat_split` to consider the new column as continuous. While this would be a behavioral change, isn't this what we want after all?

The other option would be to cast to int if there are no `nan` input values.

@kevinbird15  @jph00 