### PR TITLE
Increase testing granularity for speedup (v2)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,6 @@ jobs:
         ipython /root/download_testdata.py
         mkdir -p $HOME/.fastai/data
         find $HOME/.fastai/archive/ -name "*.tgz" -exec tar -xzvf {} -C $HOME/.fastai/data \;
-    - name: Test notebooks batch ${{matrix.nb}}
-      run: nbdev_test_nbs --flags '' --n_workers 3 --pause 1.0 --fname "nbs/[0-9]${{matrix.nb}}*.ipynb"
+    - name: Test notebooks batch ${{matrix.nb}}${{matrix.nb}}
+      run: nbdev_test_nbs --flags '' --n_workers 3 --pause 1.0 --fname "nbs/${{matrix.nb}}${{matrix.nb}}*.ipynb"
   

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,8 @@ jobs:
       caching: "true"
     strategy:
       matrix:
-        nb: ['[0-2]','[3-5]','[6-9]']
+        nb_dec : ['[0-2]','[3-5]','[6-9]']
+        nb_unit: ['[0-2]','[3-5]','[6-9]']
     steps:        
     - name: checkout contents of PR
       uses: actions/checkout@v2
@@ -82,6 +83,6 @@ jobs:
         ipython /root/download_testdata.py
         mkdir -p $HOME/.fastai/data
         find $HOME/.fastai/archive/ -name "*.tgz" -exec tar -xzvf {} -C $HOME/.fastai/data \;
-    - name: Test notebooks batch ${{matrix.nb}}${{matrix.nb}}
-      run: nbdev_test_nbs --flags '' --n_workers 3 --pause 1.0 --fname "nbs/${{matrix.nb}}${{matrix.nb}}*.ipynb"
+    - name: Test notebooks batch ${{matrix.nb_dec}}${{matrix.nb_unit}}
+      run: nbdev_test_nbs --flags '' --n_workers 3 --pause 1.0 --fname "nbs/${{matrix.nb_dec}}${{matrix.nb_unit}}*.ipynb"
   

--- a/nbs/04_data.external.ipynb
+++ b/nbs/04_data.external.ipynb
@@ -1206,18 +1206,6 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/nbs/04_data.external.ipynb
+++ b/nbs/04_data.external.ipynb
@@ -1098,28 +1098,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "url = URLs.CALTECH_101\n",
-    "untar_data(url)\n",
-    "_add_check(url, URLs.path(url))"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1228,6 +1206,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Using 9 batches instead of 3:

Current setup of 3 batches means that 20+ notebooks fall into the [5-7] batch and it takes 9minutes to test all the notebooks, example: https://github.com/fastai/fastai/pull/3235/checks?check_run_id=1969103831

With minimal code changes, we can split notebooks into 9 batches instead of 3, which should speed-up testing