### PR TITLE
Fix #3246

### DIFF
--- a/fastai/vision/augment.py
+++ b/fastai/vision/augment.py
@@ -665,7 +665,7 @@ class Warp(AffineCoordTfm):
 
 # Cell
 @patch
-def lighting(x: TensorImage, func): return TensorImage(torch.sigmoid(func(logit(x))))
+def lighting(x: TensorImage, func): return torch.sigmoid(func(logit(x)))
 
 # Cell
 class SpaceTfm(RandTransform):


### PR DESCRIPTION
Do not convert possible `TensorImage` subclass to `TensorImage` in `.lighting` function.
Add hidden test to ensure that the original subclass is indeed untouched.