### PR TITLE
Add backtick

### DIFF
--- a/nbs/02_data.load.ipynb
+++ b/nbs/02_data.load.ipynb
@@ -354,7 +354,7 @@
     "* `drop_last` (bool): If `True`, then the last incomplete batch is dropped.\n",
     "* `indexed` (bool): The `DataLoader` will make a guess as to whether the dataset can be indexed (or is iterable), but you can override it with this parameter. `True` by default.\n",
     "* `n` (int): Defaults to `len(dataset)`. If you are using iterable-style dataset, you can specify the size with `n`.\n",
-    "* `device` (torch.device): Defaults to `default_device()` which is CUDA by default. You can specify device as `torch.device('cpu')."
+    "* `device` (torch.device): Defaults to `default_device()` which is CUDA by default. You can specify device as `torch.device('cpu')`."
    ]
   },
   {


### PR DESCRIPTION
I found a minor typo: missing backtick for inline code in `nbs/02_data.load.ipynb`.