### PR TITLE
Update dev container

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -4,6 +4,7 @@
     "service": "watcher",
     "settings": {"terminal.integrated.shell.linux": "/bin/bash"},
     "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+    "workspaceFolder": "/data",
     "forwardPorts": [4000, 8080],
     "appPort": [4000, 8080],
     "extensions": ["ms-python.python",


### PR DESCRIPTION
Hi there, I'm a Program Manager on the Visual Studio Code team working on remote development. 

We're so glad to see fastai has a .devcontainer.json, and it looks like it loads up properly in Codespaces. We also have an extension for working with containers locally in VS Code: [Remote - Containers](https://code.visualstudio.com/docs/remote/containers). The same devcontainer.json format works across Codespaces and Remote - Containers.

Currently, if you use the command **Remote-Containers: Clone Repository in Container Volume**, the fastai repo will load up properly. However, if you clone the fastai repo locally and then attempt to reload in a dev container, you get the error: "Workspace folder not specified in devcontainer.json."

This PR adds the workspace folder setting to devcontainer.json, which I've made to be to the name of the volume in the Docker Compose file.

If you have any questions, or it makes sense to update/discuss this dev container in any other ways, please let me know - we'd love to collaborate! 