### PR TITLE
migrating_pytorch.ipynb: fix 2 typos

### DIFF
--- a/nbs/examples/migrating_pytorch.ipynb
+++ b/nbs/examples/migrating_pytorch.ipynb
@@ -66,7 +66,7 @@
    "source": [
     "We also added `CudaCallback` to have the model and data moved to the GPU for us. Alternatively, you can use the fastai `DataLoader`, which provides a superset of the functionality of PyTorch's (with the same API), and can handle moving data to the GPU for us (see `migrating_ignite.ipynb` for an example of this approach). \n",
     "\n",
-    "fastai supports many schedulers. We recommend fitting with 1cycle training:"
+    "fastai supports many schedulers. We recommend fitting with one cycle training:"
    ]
   },
   {
@@ -118,7 +118,7 @@
     "\n",
     "Once you've made this change, you can then benefit from fastai's rich set of callbacks, transforms, visualizations, and so forth.\n",
     "\n",
-    "Note that fastai much more than just a training loop (although we're only using the training loop in this example) - it is a complete framework including GPU-accelerated transformations, end-to-end inference, integrated applications for vision, text, tabular, and collaborative filtering, and so forth. You can use any part of the framework on its own, or combine them together, as described in the [fastai paper](https://arxiv.org/abs/2002.04688)."
+    "Note that fastai is much more than just a training loop (although we're only using the training loop in this example) - it is a complete framework including GPU-accelerated transformations, end-to-end inference, integrated applications for vision, text, tabular, and collaborative filtering, and so forth. You can use any part of the framework on its own, or combine them together, as described in the [fastai paper](https://arxiv.org/abs/2002.04688)."
    ]
   },
   {


### PR DESCRIPTION
- add missing space
- add missing verb