### PR TITLE
Fix Issue #3315: PixelShuffle_icnr icnr_init with weight_norm

### DIFF
--- a/fastai/layers.py
+++ b/fastai/layers.py
@@ -372,7 +372,11 @@ class PixelShuffle_ICNR(nn.Sequential):
         nf = ifnone(nf, ni)
         layers = [ConvLayer(ni, nf*(scale**2), ks=1, norm_type=norm_type, act_cls=act_cls, bias_std=0),
                   nn.PixelShuffle(scale)]
-        layers[0][0].weight.data.copy_(icnr_init(layers[0][0].weight.data))
+        if norm_type == NormType.Weight:
+            layers[0][0].weight_v.data.copy_(icnr_init(layers[0][0].weight_v.data))
+            layers[0][0].weight_g.data.copy_(((layers[0][0].weight_v.data**2).sum(dim=[1,2,3])**0.5)[:,None,None,None])
+        else:
+            layers[0][0].weight.data.copy_(icnr_init(layers[0][0].weight.data))
         if blur: layers += [nn.ReplicationPad2d((1,0,1,0)), nn.AvgPool2d(2, stride=1)]
         super().__init__(*layers)
 

--- a/nbs/01_layers.ipynb
+++ b/nbs/01_layers.ipynb
@@ -1372,6 +1372,24 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "psfl = PixelShuffle_ICNR(16, norm_type=None)\n",
+    "x = torch.randn(64, 16, 8, 8)\n",
+    "y = psfl(x)\n",
+    "test_eq(y.shape, [64, 16, 16, 16])\n",
+    "#ICNR init makes every 2x2 window (stride 2) have the same elements\n",
+    "for i in range(0,16,2):\n",
+    "    for j in range(0,16,2):\n",
+    "        test_eq(y[:,:,i,j],y[:,:,i+1,j])\n",
+    "        test_eq(y[:,:,i,j],y[:,:,i  ,j+1])\n",
+    "        test_eq(y[:,:,i,j],y[:,:,i+1,j+1])"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/nbs/01_layers.ipynb
+++ b/nbs/01_layers.ipynb
@@ -133,7 +133,7 @@
     {
      "data": {
       "text/plain": [
-       "Lambda(func=<function _add2 at 0x7f6d5c369170>)"
+       "Lambda(func=<function _add2 at 0x7f6500efa680>)"
       ]
      },
      "execution_count": null,
@@ -1335,7 +1335,11 @@
     "        nf = ifnone(nf, ni)\n",
     "        layers = [ConvLayer(ni, nf*(scale**2), ks=1, norm_type=norm_type, act_cls=act_cls, bias_std=0),\n",
     "                  nn.PixelShuffle(scale)]\n",
-    "        layers[0][0].weight.data.copy_(icnr_init(layers[0][0].weight.data))\n",
+    "        if norm_type == NormType.Weight:\n",
+    "            layers[0][0].weight_v.data.copy_(icnr_init(layers[0][0].weight_v.data))\n",
+    "            layers[0][0].weight_g.data.copy_(((layers[0][0].weight_v.data**2).sum(dim=[1,2,3])**0.5)[:,None,None,None])\n",
+    "        else:\n",
+    "            layers[0][0].weight.data.copy_(icnr_init(layers[0][0].weight.data))\n",
     "        if blur: layers += [nn.ReplicationPad2d((1,0,1,0)), nn.AvgPool2d(2, stride=1)]\n",
     "        super().__init__(*layers)"
    ]
@@ -1355,7 +1359,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "psfl = PixelShuffle_ICNR(16, norm_type=None) #Deactivate weight norm as it changes the weight\n",
+    "psfl = PixelShuffle_ICNR(16)\n",
     "x = torch.randn(64, 16, 8, 8)\n",
     "y = psfl(x)\n",
     "test_eq(y.shape, [64, 16, 16, 16])\n",

--- a/nbs/01_layers.ipynb
+++ b/nbs/01_layers.ipynb
@@ -133,7 +133,7 @@
     {
      "data": {
       "text/plain": [
-       "Lambda(func=<function _add2 at 0x7f6500efa680>)"
+       "Lambda(func=<function _add2 at 0x7fe6fe15c680>)"
       ]
      },
      "execution_count": null,
@@ -1390,6 +1390,24 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "psfl = PixelShuffle_ICNR(16, norm_type=NormType.Spectral)\n",
+    "x = torch.randn(64, 16, 8, 8)\n",
+    "y = psfl(x)\n",
+    "test_eq(y.shape, [64, 16, 16, 16])\n",
+    "#ICNR init makes every 2x2 window (stride 2) have the same elements\n",
+    "for i in range(0,16,2):\n",
+    "    for j in range(0,16,2):\n",
+    "        test_eq(y[:,:,i,j],y[:,:,i+1,j])\n",
+    "        test_eq(y[:,:,i,j],y[:,:,i  ,j+1])\n",
+    "        test_eq(y[:,:,i,j],y[:,:,i+1,j+1])"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2107,6 +2125,7 @@
       "Converted 71_callback.tensorboard.ipynb.\n",
       "Converted 72_callback.neptune.ipynb.\n",
       "Converted 73_callback.captum.ipynb.\n",
+      "Converted 74_callback.azureml.ipynb.\n",
       "Converted 97_test_utils.ipynb.\n",
       "Converted 99_pytorch_doc.ipynb.\n",
       "Converted dev-setup.ipynb.\n",


### PR DESCRIPTION
When using weight_norm (the current default), PixelShuffle_icnr needs to icnr_init weight_g and weight_v.
Issue https://github.com/fastai/fastai/issues/3315