### PR TITLE
Have interp safely use ds_idx, add tests

### DIFF
--- a/fastai/interpret.py
+++ b/fastai/interpret.py
@@ -25,7 +25,7 @@ class Interpretation():
     @classmethod
     def from_learner(cls, learn, ds_idx=1, dl=None, act=None):
         "Construct interpretation object from a learner"
-        if dl is None: dl = learn.dls[ds_idx]
+        if dl is None: dl = learn.dls[ds_idx].new(shuffled=False, drop_last=False)
         return cls(dl, *learn.get_preds(dl=dl, with_input=True, with_loss=True, with_decoded=True, act=None))
 
     def top_losses(self, k=None, largest=True):

--- a/nbs/20_interpret.ipynb
+++ b/nbs/20_interpret.ipynb
@@ -58,6 +58,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#hide\n",
+    "def filter_files(o): return o[:100]\n",
+    "from fastai.vision.all import *\n",
+    "mnist = DataBlock(blocks=(ImageBlock(cls=PILImageBW), CategoryBlock), \n",
+    "                  get_items=Pipeline([get_image_files, filter_files]), \n",
+    "                  splitter=RandomSubsetSplitter(.1,.1, seed=42),\n",
+    "                  get_y=parent_label)\n",
+    "test_dls = mnist.dataloaders(untar_data(URLs.MNIST_SAMPLE), bs=8)\n",
+    "test_learner = cnn_learner(test_dls, resnet18)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "#export\n",
     "@typedispatch\n",
     "def plot_top_losses(x, y, *args, **kwargs):\n",
@@ -89,7 +106,7 @@
     "    @classmethod\n",
     "    def from_learner(cls, learn, ds_idx=1, dl=None, act=None):\n",
     "        \"Construct interpretation object from a learner\"\n",
-    "        if dl is None: dl = learn.dls[ds_idx]\n",
+    "        if dl is None: dl = learn.dls[ds_idx].new(shuffled=False, drop_last=False)\n",
     "        return cls(dl, *learn.get_preds(dl=dl, with_input=True, with_loss=True, with_decoded=True, act=None))\n",
     "\n",
     "    def top_losses(self, k=None, largest=True):\n",
@@ -116,16 +133,61 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "learn = synth_learner()\n",
-    "interp = Interpretation.from_learner(learn)\n",
-    "x,y = learn.dls.valid_ds.tensors\n",
+    "#hide\n",
+    "interp = Interpretation.from_learner(test_learner)\n",
+    "x, y = [], []\n",
+    "for batch in test_learner.dls.valid:\n",
+    "    x += batch[0]\n",
+    "    y += batch[1]\n",
+    "x,y = torch.stack(x, dim=0), torch.stack(y, dim=0)\n",
     "test_eq(interp.inputs, x)\n",
     "test_eq(interp.targs, y)\n",
-    "out = learn.model.a * x + learn.model.b\n",
-    "test_eq(interp.preds, out)\n",
-    "test_eq(interp.losses, (out-y)[:,0]**2)"
+    "losses = torch.stack([test_learner.loss_func(p,t) for p,t in zip(out,y)], dim=0)\n",
+    "test_eq(interp.losses, losses)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#hide\n",
+    "#dummy test to ensure we can run on the training set\n",
+    "interp = Interpretation.from_learner(test_learner, ds_idx=0)\n",
+    "x, y = [], []\n",
+    "for batch in test_learner.dls.train.new(shuffle=False, drop_last=False):\n",
+    "    x += batch[0]\n",
+    "    y += batch[1]\n",
+    "x,y = torch.stack(x, dim=0), torch.stack(y, dim=0)\n",
+    "test_eq(interp.inputs, x)\n",
+    "test_eq(interp.targs, y)\n",
+    "losses = torch.stack([test_learner.loss_func(p,t) for p,t in zip(out,y)], dim=0)\n",
+    "test_eq(interp.losses, losses)"
    ]
   },
   {

--- a/nbs/20_interpret.ipynb
+++ b/nbs/20_interpret.ipynb
@@ -59,10 +59,9 @@
    "outputs": [],
    "source": [
     "#hide\n",
-    "def filter_files(o): return o[:100]\n",
     "from fastai.vision.all import *\n",
     "mnist = DataBlock(blocks=(ImageBlock(cls=PILImageBW), CategoryBlock), \n",
-    "                  get_items=Pipeline([get_image_files, filter_files]), \n",
+    "                  get_items=get_image_files, \n",
     "                  splitter=RandomSubsetSplitter(.1,.1, seed=42),\n",
     "                  get_y=parent_label)\n",
     "test_dls = mnist.dataloaders(untar_data(URLs.MNIST_SAMPLE), bs=8)\n",
@@ -148,15 +147,16 @@
    "source": [
     "#hide\n",
     "interp = Interpretation.from_learner(test_learner)\n",
-    "x, y = [], []\n",
+    "x, y, out = [], [], []\n",
     "for batch in test_learner.dls.valid:\n",
     "    x += batch[0]\n",
     "    y += batch[1]\n",
-    "x,y = torch.stack(x, dim=0), torch.stack(y, dim=0)\n",
+    "    out += test_learner.model(batch[0])\n",
+    "x,y,out = torch.stack(x), torch.stack(y, dim=0), torch.stack(out, dim=0)\n",
     "test_eq(interp.inputs, x)\n",
     "test_eq(interp.targs, y)\n",
     "losses = torch.stack([test_learner.loss_func(p,t) for p,t in zip(out,y)], dim=0)\n",
-    "test_eq(interp.losses, losses)"
+    "test_close(interp.losses, losses)"
    ]
   },
   {
@@ -179,15 +179,16 @@
     "#hide\n",
     "#dummy test to ensure we can run on the training set\n",
     "interp = Interpretation.from_learner(test_learner, ds_idx=0)\n",
-    "x, y = [], []\n",
-    "for batch in test_learner.dls.train.new(shuffle=False, drop_last=False):\n",
+    "x, y, out = [], [], []\n",
+    "for batch in test_learner.dls.train.new(drop_last=False, shuffle=False):\n",
     "    x += batch[0]\n",
     "    y += batch[1]\n",
-    "x,y = torch.stack(x, dim=0), torch.stack(y, dim=0)\n",
+    "    out += test_learner.model(batch[0])\n",
+    "x,y,out = torch.stack(x), torch.stack(y, dim=0), torch.stack(out, dim=0)\n",
     "test_eq(interp.inputs, x)\n",
     "test_eq(interp.targs, y)\n",
     "losses = torch.stack([test_learner.loss_func(p,t) for p,t in zip(out,y)], dim=0)\n",
-    "test_eq(interp.losses, losses)"
+    "test_close(interp.losses, losses)"
    ]
   },
   {


### PR DESCRIPTION
# Summary of Changes
The `Interpretation` class now calls `.new(shuffled=False, drop_last=False)` when generating the `DataLoader` if none were found. This is similar to what is done during `get_preds`, and is needed as shuffling and dropping last will cause `Interpretation` to complain about missing indexs (see issue here: https://github.com/fastai/fastai/issues/3248)

Closes: https://github.com/fastai/fastai/issues/3051 and https://github.com/fastai/fastai/issues/3248

# What This Does to the End Users
Allows them to specify `ds_idx=0` without raising any issues. 

# Added Tests

I've changed the tests in `Interpretation` as a result of the current tests not being extensive enough. 

Before the tests were:
```python
learn = synth_learner()
interp = Interpretation.from_learner(learn)
x,y = learn.dls.valid_ds.tensors
test_eq(interp.inputs, x)
test_eq(interp.targs, y)
out = learn.model.a * x + learn.model.b
test_eq(interp.preds, out)
test_eq(interp.losses, (out-y)[:,0]**2)
```
And while they do get the job done, they're not flexible enough for us to check if the training or validation dataset is doing okay, and that decoding went well (along with the rest of the pipeline).

As a result I've instead added in using the `MNIST_TINY` dataset, and a subsample of it:
```python
#hide
from fastai.vision.all import *
mnist = DataBlock(blocks=(ImageBlock(cls=PILImageBW), CategoryBlock), 
                  get_items=get_image_files, 
                  splitter=RandomSubsetSplitter(.1,.1, seed=42),
                  get_y=parent_label)
test_dls = mnist.dataloaders(untar_data(URLs.MNIST_SAMPLE), bs=8)
test_learner = cnn_learner(test_dls, resnet18)
```

Now here are the associated tests:
```python
#hide
interp = Interpretation.from_learner(test_learner)
x, y, out = [], [], []
for batch in test_learner.dls.valid:
    x += batch[0]
    y += batch[1]
    out += test_learner.model(batch[0])
x,y,out = torch.stack(x), torch.stack(y, dim=0), torch.stack(out, dim=0)
test_eq(interp.inputs, x)
test_eq(interp.targs, y)
losses = torch.stack([test_learner.loss_func(p,t) for p,t in zip(out,y)], dim=0)
test_close(interp.losses, losses)
```
```python
#hide
#dummy test to ensure we can run on the training set
interp = Interpretation.from_learner(test_learner, ds_idx=0)
x, y, out = [], [], []
for batch in test_learner.dls.train.new(drop_last=False, shuffle=False):
    x += batch[0]
    y += batch[1]
    out += test_learner.model(batch[0])
x,y,out = torch.stack(x), torch.stack(y, dim=0), torch.stack(out, dim=0)
test_eq(interp.inputs, x)
test_eq(interp.targs, y)
losses = torch.stack([test_learner.loss_func(p,t) for p,t in zip(out,y)], dim=0)
test_close(interp.losses, losses)
```
It's a bit longer, but it does the same thing that the previous test did, but also takes into account us using the true `DataBlock` api, and adds a test for the `ds_idx=0`.

Let me know if there are any suggestions, such as keeping that first test back in with addition to these, or having these in with `#slow`.

cc @jph00 and @hamelsmu 

