### PR TITLE
Prevent schedule from crashing flakily close to the end of training 

### DIFF
--- a/fastai/callback/schedule.py
+++ b/fastai/callback/schedule.py
@@ -63,9 +63,9 @@ def combine_scheds(pcts, scheds):
     pcts = tensor([0] + L(pcts))
     assert torch.all(pcts >= 0)
     pcts = torch.cumsum(pcts, 0)
+    pct_lim = len(pcts) - 2
     def _inner(pos):
-        if int(pos) == 1: return scheds[-1](1.)
-        idx = (pos >= pcts).nonzero().max()
+        idx = min((pos >= pcts).nonzero().max(), pct_lim)
         actual_pos = (pos-pcts[idx]) / (pcts[idx+1]-pcts[idx])
         return scheds[idx](actual_pos.item())
     return _inner

--- a/nbs/14_callback.schedule.ipynb
+++ b/nbs/14_callback.schedule.ipynb
@@ -425,9 +425,9 @@
     "    pcts = tensor([0] + L(pcts))\n",
     "    assert torch.all(pcts >= 0)\n",
     "    pcts = torch.cumsum(pcts, 0)\n",
+    "    pct_lim = len(pcts) - 2\n",
     "    def _inner(pos):\n",
-    "        if int(pos) == 1: return scheds[-1](1.)\n",
-    "        idx = (pos >= pcts).nonzero().max()\n",
+    "        idx = min((pos >= pcts).nonzero().max(), pct_lim)\n",
     "        actual_pos = (pos-pcts[idx]) / (pcts[idx+1]-pcts[idx])\n",
     "        return scheds[idx](actual_pos.item())\n",
     "    return _inner"


### PR DESCRIPTION
The check introduced in #2792 is not strong enough.

In https://github.com/fastai/fastbook/issues/263 it was noted that sometimes in `fastai/callback/schedule.py` the lines:

```python
idx = (pos >= pcts).nonzero().max()
actual_pos = (pos-pcts[idx]) / (pcts[idx+1]-pcts[idx])
```

can lead to index-out-of-range errors when `pos` is very close to the final value of `pcts` (as can occur near the end of training  using `learner.fit_one_cycle()` when the total number of steps is very large).

The following check against this was introduced in #2792:

```python
if int(pos) == 1: return scheds[-1](1.)
```

But it looks like the error can still sneak through in some cases, check out the following:

```python
import torch

pos = 0.9999999999999997

print("greater or equal to float 1.:", pos >= 1.) 
print("cast to int and greater or equal to int 1:", int(pos) >= 1) 
print("greater or equal to tensor 1.:", pos >= torch.as_tensor(1.)) # Bad news bears 


pcts = torch.Tensor([0.0, 0.25, 1.0])
idx = (pos >= pcts).nonzero().max()
print("should never be more than 1:", idx)
actual_pos = (pos-pcts[idx]) / (pcts[idx+1]-pcts[idx])

# PRINTS:
# greater or equal to float 1.: False
# cast to int and greater or equal to int 1: False
# greater or equal to tensor 1.: tensor(True) 
# should never be more than 1: tensor(2)
# IndexError: index 3 is out of bounds for dimension 0 with size 3
```

This is my first contribution so I'm trying to keep this PR minimal. Initially I strengthened the check to 

```python
if int(pos) == 1 or pos == torch.Tensor(1.): return scheds[-1](1.)
```

but by then it seemed like the checks were getting a little out of hand. 

Very happy to hear feedback/make changes.

Probably a good idea to get this one in kind of soon if possible, since it's been cropping up on the forms a little recently, e.g.: [IndexError: index 3 is out of bounds for dimension 0 with size 3
](url)
