### PR TITLE
callback.core doc fix avail attrs: "data" -> "dls"

### DIFF
--- a/nbs/13_callback.core.ipynb
+++ b/nbs/13_callback.core.ipynb
@@ -529,7 +529,7 @@
    "source": [
     "When writing a callback, the following attributes of `Learner` are available:\n",
     "- `model`: the model used for training/validation\n",
-    "- `data`: the underlying `DataLoaders`\n",
+    "- `dls`: the underlying `DataLoaders`\n",
     "- `loss_func`: the loss function used\n",
     "- `opt`: the optimizer used to update the model parameters\n",
     "- `opt_func`: the function used to create the optimizer\n",


### PR DESCRIPTION
callback core doc lists 'data' as available attribute, but should read 'dls' instead