### PR TITLE
Give explicit orders to TrackerCallback derived Callbacks

### DIFF
--- a/fastai/callback/tracker.py
+++ b/fastai/callback/tracker.py
@@ -43,6 +43,7 @@ class TrackerCallback(Callback):
 # Cell
 class EarlyStoppingCallback(TrackerCallback):
     "A `TrackerCallback` that terminates training when monitored quantity stops improving."
+    order=TrackerCallback.order+3
     def __init__(self, monitor='valid_loss', comp=None, min_delta=0., patience=1, reset_on_fit=True):
         super().__init__(monitor=monitor, comp=comp, min_delta=min_delta, reset_on_fit=reset_on_fit)
         self.patience = patience
@@ -61,7 +62,7 @@ class EarlyStoppingCallback(TrackerCallback):
 # Cell
 class SaveModelCallback(TrackerCallback):
     "A `TrackerCallback` that saves the model's best during training and loads it at the end."
-    _only_train_loop = True
+    _only_train_loop,order = True,TrackerCallback.order+1
     def __init__(self, monitor='valid_loss', comp=None, min_delta=0., fname='model', every_epoch=False, at_end=False,
                  with_opt=False, reset_on_fit=True):
         super().__init__(monitor=monitor, comp=comp, min_delta=min_delta, reset_on_fit=reset_on_fit)
@@ -89,6 +90,7 @@ class SaveModelCallback(TrackerCallback):
 # Cell
 class ReduceLROnPlateau(TrackerCallback):
     "A `TrackerCallback` that reduces learning rate when a metric has stopped improving."
+    order=TrackerCallback.order+2
     def __init__(self, monitor='valid_loss', comp=None, min_delta=0., patience=1, factor=10., min_lr=0, reset_on_fit=True):
         super().__init__(monitor=monitor, comp=comp, min_delta=min_delta, reset_on_fit=reset_on_fit)
         self.patience,self.factor,self.min_lr = patience,factor,min_lr

--- a/nbs/17_callback.tracker.ipynb
+++ b/nbs/17_callback.tracker.ipynb
@@ -351,6 +351,7 @@
     "# export\n",
     "class EarlyStoppingCallback(TrackerCallback):\n",
     "    \"A `TrackerCallback` that terminates training when monitored quantity stops improving.\"\n",
+    "    order=TrackerCallback.order+3\n",
     "    def __init__(self, monitor='valid_loss', comp=None, min_delta=0., patience=1, reset_on_fit=True):\n",
     "        super().__init__(monitor=monitor, comp=comp, min_delta=min_delta, reset_on_fit=reset_on_fit)\n",
     "        self.patience = patience\n",
@@ -552,7 +553,7 @@
     "#export\n",
     "class SaveModelCallback(TrackerCallback):\n",
     "    \"A `TrackerCallback` that saves the model's best during training and loads it at the end.\"\n",
-    "    _only_train_loop = True\n",
+    "    _only_train_loop,order = True,TrackerCallback.order+1\n",
     "    def __init__(self, monitor='valid_loss', comp=None, min_delta=0., fname='model', every_epoch=False, at_end=False,\n",
     "                 with_opt=False, reset_on_fit=True):\n",
     "        super().__init__(monitor=monitor, comp=comp, min_delta=min_delta, reset_on_fit=reset_on_fit)\n",
@@ -740,6 +741,7 @@
     "# export\n",
     "class ReduceLROnPlateau(TrackerCallback):\n",
     "    \"A `TrackerCallback` that reduces learning rate when a metric has stopped improving.\"\n",
+    "    order=TrackerCallback.order+2\n",
     "    def __init__(self, monitor='valid_loss', comp=None, min_delta=0., patience=1, factor=10., min_lr=0, reset_on_fit=True):\n",
     "        super().__init__(monitor=monitor, comp=comp, min_delta=min_delta, reset_on_fit=reset_on_fit)\n",
     "        self.patience,self.factor,self.min_lr = patience,factor,min_lr\n",
@@ -919,6 +921,20 @@
    "source": [
     "#hide\n",
     "test_eq(learn.opt.hypers[-1]['lr'], 1e-8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Each of these three derived `TrackerCallback`s (`SaveModelCallback`, `ReduceLROnPlateu`, and `EarlyStoppingCallback`) all have an adjusted order so they can each run with each other without interference. That order is as follows:\n",
+    "\n",
+    "> Note: in parenthesis is the actual `Callback` order number\n",
+    "\n",
+    "1. `TrackerCallback` (60)\n",
+    "2. `SaveModelCallback` (61)\n",
+    "3. `ReduceLrOnPlateu` (62)\n",
+    "4. `EarlyStoppingCallback` (63)"
    ]
   },
   {


### PR DESCRIPTION
Originally based on https://github.com/fastai/fastai/pull/3319

Sets each derived TrackerCallback to have specific orders so that each cannot interfere with each other, and the order is logical in regards to when each event should occur. 

Also included documentation on their orders along with the Callback's actual `order` val

cc @jph00 