### PR TITLE
Add pct feature to get_files

### DIFF
--- a/nbs/05_data.transforms.ipynb
+++ b/nbs/05_data.transforms.ipynb
@@ -4,7 +4,17 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[K     |████████████████████████████████| 204kB 3.8MB/s \n",
+      "\u001b[K     |████████████████████████████████| 61kB 5.4MB/s \n",
+      "\u001b[?25h"
+     ]
+    }
+   ],
    "source": [
     "#hide\n",
     "#skip\n",
@@ -94,7 +104,7 @@
     {
      "data": {
       "text/plain": [
-       "(#2) [Path('/home/yizhang/.fastai/data/mnist_tiny/train/7'),Path('/home/yizhang/.fastai/data/mnist_tiny/train/3')]"
+       "(#2) [Path('/root/.fastai/data/mnist_tiny/train/7'),Path('/root/.fastai/data/mnist_tiny/train/3')]"
       ]
      },
      "execution_count": null,
@@ -114,10 +124,12 @@
    "outputs": [],
    "source": [
     "# export\n",
-    "def _get_files(p, fs, extensions=None):\n",
+    "def _get_files(p, fs, extensions=None,pct=1.):\n",
     "    p = Path(p)\n",
+    "    assert 0.<=pct<=1., f\"pct of files should be a floating between 0. and 1.\"\n",
     "    res = [p/f for f in fs if not f.startswith('.')\n",
-    "           and ((not extensions) or f'.{f.split(\".\")[-1].lower()}' in extensions)]\n",
+    "           and ((not extensions) or f'.{f.split(\".\")[-1].lower()}' in extensions)\n",
+    "           and torch.bernoulli(tensor(pct))]\n",
     "    return res"
    ]
   },
@@ -128,8 +140,8 @@
    "outputs": [],
    "source": [
     "# export\n",
-    "def get_files(path, extensions=None, recurse=True, folders=None, followlinks=True):\n",
-    "    \"Get all the files in `path` with optional `extensions`, optionally with `recurse`, only in `folders`, if specified.\"\n",
+    "def get_files(path, extensions=None, recurse=True, folders=None, followlinks=True,pct=1.):\n",
+    "    \"Get `pct` fraction of files (all files by default) in `path` with optional `extensions`, optionally with `recurse`, only in `folders`, if specified.\"\n",
     "    path = Path(path)\n",
     "    folders=L(folders)\n",
     "    extensions = setify(extensions)\n",
@@ -140,10 +152,10 @@
     "            if len(folders) !=0 and i==0: d[:] = [o for o in d if o in folders]\n",
     "            else:                         d[:] = [o for o in d if not o.startswith('.')]\n",
     "            if len(folders) !=0 and i==0 and '.' not in folders: continue\n",
-    "            res += _get_files(p, f, extensions)\n",
+    "            res += _get_files(p, f, extensions,pct=pct)\n",
     "    else:\n",
     "        f = [o.name for o in os.scandir(path) if o.is_file()]\n",
-    "        res = _get_files(path, f, extensions)\n",
+    "        res = _get_files(path, f, extensions,pct=pct)\n",
     "    return L(res)"
    ]
   },
@@ -151,7 +163,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is the most general way to grab a bunch of file names from disk. If you pass `extensions` (including the `.`) then returned file names are filtered by that list. Only those files directly in `path` are included, unless you pass `recurse`, in which case all child folders are also searched recursively. `folders` is an optional list of directories to limit the search to."
+    "This is the most general way to grab a bunch of file names from disk. If you pass `extensions` (including the `.`) then returned file names are filtered by that list. Only those files directly in `path` are included, unless you pass `recurse`, in which case all child folders are also searched recursively. `folders` is an optional list of directories to limit the search to.\n",
+    "\n",
+    "Sometimes, when dealing with extremely large datasets, and you wish to experiment with a smaller subset, you can pass an optional argument `pct` (floating point number between 0 and 1), which will only grab a smaller subset randomly. The relative distribution of categories will remain unchanged. It is however not necessary nor advised to do for smaller datasets, because of random uncertainty in the number of files included when `pct` is not 0 or 1.   "
    ]
   },
   {
@@ -162,7 +176,7 @@
     {
      "data": {
       "text/plain": [
-       "(#709) [Path('/home/yizhang/.fastai/data/mnist_tiny/train/7/7994.png'),Path('/home/yizhang/.fastai/data/mnist_tiny/train/7/8286.png'),Path('/home/yizhang/.fastai/data/mnist_tiny/train/7/7731.png'),Path('/home/yizhang/.fastai/data/mnist_tiny/train/7/724.png'),Path('/home/yizhang/.fastai/data/mnist_tiny/train/7/9343.png'),Path('/home/yizhang/.fastai/data/mnist_tiny/train/7/8637.png'),Path('/home/yizhang/.fastai/data/mnist_tiny/train/7/9200.png'),Path('/home/yizhang/.fastai/data/mnist_tiny/train/7/8437.png'),Path('/home/yizhang/.fastai/data/mnist_tiny/train/7/9767.png'),Path('/home/yizhang/.fastai/data/mnist_tiny/train/7/7236.png')...]"
+       "(#709) [Path('/root/.fastai/data/mnist_tiny/train/7/7380.png'),Path('/root/.fastai/data/mnist_tiny/train/7/9833.png'),Path('/root/.fastai/data/mnist_tiny/train/7/8038.png'),Path('/root/.fastai/data/mnist_tiny/train/7/9882.png'),Path('/root/.fastai/data/mnist_tiny/train/7/8362.png'),Path('/root/.fastai/data/mnist_tiny/train/7/8791.png'),Path('/root/.fastai/data/mnist_tiny/train/7/9955.png'),Path('/root/.fastai/data/mnist_tiny/train/7/9603.png'),Path('/root/.fastai/data/mnist_tiny/train/7/9716.png'),Path('/root/.fastai/data/mnist_tiny/train/7/981.png')...]"
       ]
      },
      "execution_count": null,
@@ -178,6 +192,29 @@
     "test_eq(len(get_files(path/'train'/'3', extensions='.jpg', recurse=False)),0)\n",
     "test_eq(len(t), len(get_files(path, extensions='.png', recurse=True, folders='train')))\n",
     "t"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(355, 709)"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pct=0.5\n",
+    "t_sub=get_files(path/'train', extensions='.png', recurse=True,pct=pct)\n",
+    "t  = get_files(path/'train', extensions='.png', recurse=True)\n",
+    "len(t_sub), len(t)"
    ]
   },
   {
@@ -207,10 +244,10 @@
    "outputs": [],
    "source": [
     "#export\n",
-    "def FileGetter(suf='', extensions=None, recurse=True, folders=None):\n",
+    "def FileGetter(suf='', extensions=None, recurse=True, folders=None,pct=1.):\n",
     "    \"Create `get_files` partial function that searches path suffix `suf`, only in `folders`, if specified, and passes along args\"\n",
-    "    def _inner(o, extensions=extensions, recurse=recurse, folders=folders):\n",
-    "        return get_files(o/suf, extensions, recurse, folders)\n",
+    "    def _inner(o, extensions=extensions, recurse=recurse, folders=folders,pct=pct):\n",
+    "        return get_files(o/suf, extensions, recurse, folders,pct=pct)\n",
     "    return _inner"
    ]
   },
@@ -244,9 +281,9 @@
    "outputs": [],
    "source": [
     "#export\n",
-    "def get_image_files(path, recurse=True, folders=None):\n",
-    "    \"Get image files in `path` recursively, only in `folders`, if specified.\"\n",
-    "    return get_files(path, extensions=image_extensions, recurse=recurse, folders=folders)"
+    "def get_image_files(path, recurse=True, folders=None,pct=1.):\n",
+    "    \"Get `pct` fraction of files(all by default) image files in `path` recursively, only in `folders`, if specified.\"\n",
+    "    return get_files(path, extensions=image_extensions, recurse=recurse, folders=folders,pct=pct)"
    ]
   },
   {
@@ -272,9 +309,9 @@
    "outputs": [],
    "source": [
     "#export\n",
-    "def ImageGetter(suf='', recurse=True, folders=None):\n",
+    "def ImageGetter(suf='', recurse=True, folders=None, pct=1.):\n",
     "    \"Create `get_image_files` partial that searches suffix `suf` and passes along `kwargs`, only in `folders`, if specified\"\n",
-    "    def _inner(o, recurse=recurse, folders=folders): return get_image_files(o/suf, recurse, folders)\n",
+    "    def _inner(o, recurse=recurse, folders=folders,pct=pct): return get_image_files(o/suf, recurse, folders,pct=pct)\n",
     "    return _inner"
    ]
   },
@@ -302,9 +339,9 @@
    "outputs": [],
    "source": [
     "#export\n",
-    "def get_text_files(path, recurse=True, folders=None):\n",
-    "    \"Get text files in `path` recursively, only in `folders`, if specified.\"\n",
-    "    return get_files(path, extensions=['.txt'], recurse=recurse, folders=folders)"
+    "def get_text_files(path, recurse=True, folders=None,pct=1.):\n",
+    "    \"Get `pct` fraction of (all by defualt) text files in `path` recursively, only in `folders`, if specified.\"\n",
+    "    return get_files(path, extensions=['.txt'], recurse=recurse, folders=folders, pct=pct)"
    ]
   },
   {
@@ -1791,13 +1828,6 @@
     "from nbdev.export import notebook2script\n",
     "notebook2script()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -1811,5 +1841,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
Added `pct` argument to get_files and its derivatives (get_image_files, get_text_files, etc). This returns only a certain percent of files from the data when the dataset is too large to experiment with. By default, pct=1., meaning all the files will be extracted (as expected). Using pct, one can get a smaller, more manageable subset of data.