### PR TITLE
add ability to pass in LR to partial `opt_func` (closes #3337)

### DIFF
--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -146,6 +146,9 @@ class Learner(GetAttr):
 
     def _bn_bias_state(self, with_bias): return norm_bias_params(self.model, with_bias).map(self.opt.state)
     def create_opt(self):
+        if isinstance(self.opt_func, partial):
+            if 'lr' in self.opt_func.keywords:
+                self.lr = self.opt_func.keywords['lr']
         self.opt = self.opt_func(self.splitter(self.model), lr=self.lr)
         if not self.wd_bn_bias:
             for p in self._bn_bias_state(True ): p['do_wd'] = False

--- a/nbs/13a_learner.ipynb
+++ b/nbs/13a_learner.ipynb
@@ -365,6 +365,9 @@
     "\n",
     "    def _bn_bias_state(self, with_bias): return norm_bias_params(self.model, with_bias).map(self.opt.state)\n",
     "    def create_opt(self):\n",
+    "        if isinstance(self.opt_func, partial):\n",
+    "            if 'lr' in self.opt_func.keywords:\n",
+    "                self.lr = self.opt_func.keywords['lr']\n",
     "        self.opt = self.opt_func(self.splitter(self.model), lr=self.lr)\n",
     "        if not self.wd_bn_bias:\n",
     "            for p in self._bn_bias_state(True ): p['do_wd'] = False\n",
@@ -560,7 +563,7 @@
       "text/markdown": [
        "<h2 id=\"Learner\" class=\"doc_header\"><code>class</code> <code>Learner</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h2>\n",
        "\n",
-       "> <code>Learner</code>(**`dls`**, **`model`**, **`loss_func`**=*`None`*, **`opt_func`**=*`Adam`*, **`lr`**=*`0.001`*, **`splitter`**=*`trainable_params`*, **`cbs`**=*`None`*, **`metrics`**=*`None`*, **`path`**=*`None`*, **`model_dir`**=*`'models'`*, **`wd`**=*`None`*, **`wd_bn_bias`**=*`False`*, **`train_bn`**=*`True`*, **`moms`**=*`(0.95, 0.85, 0.95)`*) :: `GetAttr`\n",
+       "> <code>Learner</code>(**`dls`**, **`model`**, **`loss_func`**=*`None`*, **`opt_func`**=*`Adam`*, **`lr`**=*`0.001`*, **`splitter`**=*`trainable_params`*, **`cbs`**=*`None`*, **`metrics`**=*`None`*, **`path`**=*`None`*, **`model_dir`**=*`'models'`*, **`wd`**=*`None`*, **`wd_bn_bias`**=*`False`*, **`train_bn`**=*`True`*, **`moms`**=*`(0.95, 0.85, 0.95)`*) :: [`GetAttr`](https://fastcore.fast.ai/basics#GetAttr)\n",
        "\n",
        "Group together a `model`, some `dls` and a `loss_func` to handle training"
       ],
@@ -645,7 +648,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.fit\" class=\"doc_header\"><code>Learner.fit</code><a href=\"__main__.py#L130\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.fit\" class=\"doc_header\"><code>Learner.fit</code><a href=\"__main__.py#L133\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>Learner.fit</code>(**`n_epoch`**, **`lr`**=*`None`*, **`wd`**=*`None`*, **`cbs`**=*`None`*, **`reset_opt`**=*`False`*)\n",
        "\n",
@@ -825,7 +828,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.one_batch\" class=\"doc_header\"><code>Learner.one_batch</code><a href=\"__main__.py#L106\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.one_batch\" class=\"doc_header\"><code>Learner.one_batch</code><a href=\"__main__.py#L109\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>Learner.one_batch</code>(**`i`**, **`b`**)\n",
        "\n",
@@ -967,7 +970,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.all_batches\" class=\"doc_header\"><code>Learner.all_batches</code><a href=\"__main__.py#L83\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.all_batches\" class=\"doc_header\"><code>Learner.all_batches</code><a href=\"__main__.py#L86\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>Learner.all_batches</code>()\n",
        "\n",
@@ -1114,6 +1117,49 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "after_create\n"
+     ]
+    }
+   ],
+   "source": [
+    "learn = synth_learner(n_train=5, cbs=VerboseCallback(), opt_func=partial(OptimWrapper, opt=torch.optim.Adam))\n",
+    "assert learn.opt is None\n",
+    "learn.create_opt()\n",
+    "assert learn.opt is not None\n",
+    "test_eq(learn.opt.hypers[0]['lr'], learn.lr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "after_create\n"
+     ]
+    }
+   ],
+   "source": [
+    "wrapper_lr = 1\n",
+    "learn = synth_learner(n_train=5, cbs=VerboseCallback(), opt_func=partial(OptimWrapper, opt=torch.optim.Adam, lr=wrapper_lr))\n",
+    "assert learn.opt is None\n",
+    "learn.create_opt()\n",
+    "assert learn.opt is not None\n",
+    "test_eq(learn.opt.hypers[0]['lr'], wrapper_lr)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1162,7 +1208,7 @@
        "\n",
        "> <code>Learner.__call__</code>(**`event_name`**)\n",
        "\n",
-       "Call `event_name` for all `Callback`s in `self.cbs`"
+       "Call `event_name` for all [`Callback`](/callback.core.html#Callback)s in `self.cbs`"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -1214,7 +1260,7 @@
        "\n",
        "> <code>Learner.add_cb</code>(**`cb`**)\n",
        "\n",
-       "Add `cb` to the list of `Callback` and register `self` as their learner"
+       "Add `cb` to the list of [`Callback`](/callback.core.html#Callback) and register `self` as their learner"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -1253,7 +1299,7 @@
        "\n",
        "> <code>Learner.add_cbs</code>(**`cbs`**)\n",
        "\n",
-       "Add `cbs` to the list of `Callback` and register `self` as their learner"
+       "Add `cbs` to the list of [`Callback`](/callback.core.html#Callback) and register `self` as their learner"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -1327,7 +1373,7 @@
        "\n",
        "> <code>Learner.ordered_cbs</code>(**`event`**)\n",
        "\n",
-       "List of `Callback`s, in order, for an `event` in the training loop"
+       "List of [`Callback`](/callback.core.html#Callback)s, in order, for an `event` in the training loop"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -1382,7 +1428,7 @@
        "\n",
        "> <code>Learner.remove_cb</code>(**`cb`**)\n",
        "\n",
-       "Add `cb` from the list of `Callback` and deregister `self` as their learner"
+       "Add `cb` from the list of [`Callback`](/callback.core.html#Callback) and deregister `self` as their learner"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -1443,7 +1489,7 @@
        "\n",
        "> <code>Learner.remove_cbs</code>(**`cbs`**)\n",
        "\n",
-       "Remove `cbs` from the list of `Callback` and deregister `self` as their learner"
+       "Remove `cbs` from the list of [`Callback`](/callback.core.html#Callback) and deregister `self` as their learner"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -1531,7 +1577,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.show_training_loop\" class=\"doc_header\"><code>Learner.show_training_loop</code><a href=\"__main__.py#L197\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.show_training_loop\" class=\"doc_header\"><code>Learner.show_training_loop</code><a href=\"__main__.py#L200\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>Learner.show_training_loop</code>()\n",
        "\n",
@@ -2565,7 +2611,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[0, 17.222135543823242, 17.353042602539062, 17.353042125701904, '00:00']\n"
+      "[0, 26.366287231445312, 22.167236328125, 22.167236328125, '00:00']\n"
      ]
     }
    ],
@@ -2754,7 +2800,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXoAAAD4CAYAAADiry33AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAjlklEQVR4nO3deXTX9Z3v8ec7CwkhK0nYspBFUfYlEVHWtpZxmUFbd2tLxwVoe0/Hzj29h+mZU6e9c+f2zHbm9t5WFsWlo1jFOlrH1jKtEhdcEmWJgCKQQAiQAEkIO0k+94/flwjxFwjJL/n+ltfjnJx8f9/l93vnq3nxyef7/b1/5pxDRESiV5zfBYiISP9S0IuIRDkFvYhIlFPQi4hEOQW9iEiUS/C7gGBycnJcUVGR32WIiESMqqqqg8653GDbwjLoi4qKqKys9LsMEZGIYWa13W3T1I2ISJRT0IuIRDkFvYhIlAvLOXoRkUtx5swZ6urqOHnypN+l9Lvk5GTy8/NJTEzs8TEKehGJeHV1daSlpVFUVISZ+V1Ov3HOcejQIerq6iguLu7xcZq6EZGId/LkSbKzs6M65AHMjOzs7Ev+y0VBLyJRIdpD/qze/JxRE/Qnz7SzsmIn7+485HcpIiJh5aJBb2YFZva6mW0xs4/N7K+89UPNbK2Zbfe+Z3Vz/EJvn+1mtjDUP8DnrwOPvrWTn/9xe3+9hIhIUM3Nzfzyl7+85ONuvPFGmpubQ19QFz0Z0bcB/905Nw6YAXzPzMYBS4E/OucuB/7oPT6PmQ0FHgauBqYDD3f3D0JfJSXEc9/MYt7ZcYhNdc398RIiIkF1F/RtbW0XPO7VV18lMzOzn6r63EWD3jm3zzn3obfcCmwF8oCbgSe93Z4Ebgly+J8Ba51zh51zTcBa4PoQ1B3UPVcXkpaUwPJ1O/vrJUREvmDp0qXs2LGDKVOmcNVVVzF79mwWLFjAuHHjALjlllsoKytj/PjxrFixovO4oqIiDh48SE1NDWPHjuXBBx9k/PjxzJ8/nxMnToSsvku6vdLMioCpwHvAcOfcPm/TfmB4kEPygD3nPK7z1gV77kXAIoDCwsJLKatTWnIi35gxmhUVO6g5eIyinCG9eh4RiVw/+e3HbKk/EtLnHDcqnYf/Yny323/2s59RXV3Nhg0beOONN7jpppuorq7uvAVy1apVDB06lBMnTnDVVVdx6623kp2dfd5zbN++ndWrV7Ny5UruuOMOXnjhBe69996Q1N/ji7Fmlgq8ADzknDvvLLrAB8/26cNnnXMrnHPlzrny3NygDdh65L6ZRSTExbHyTY3qRcQf06dPP+8+95///OdMnjyZGTNmsGfPHrZv/+K1xOLiYqZMmQJAWVkZNTU1IaunRyN6M0skEPJPO+d+460+YGYjnXP7zGwk0BDk0L3AvHMe5wNv9L7cixuWnszXp+XxfFUdD103hty0pP58OREJMxcaeQ+UIUM+n0144403+K//+i/Wr19PSkoK8+bNC3offFLS51kVHx8f0qmbntx1Y8BjwFbn3L+es+ll4OxdNAuBl4Ic/how38yyvIuw8711/erBOSWcae/gyXdq+vulRERIS0ujtbU16LaWlhaysrJISUlh27ZtvPvuuwNcXc+mbmYC3wS+bGYbvK8bgZ8BXzWz7cB13mPMrNzMHgVwzh0G/ifwgff1U29dvyrNTWX+uOE8tb6GY6cufNVbRKSvsrOzmTlzJhMmTOCHP/zheduuv/562traGDt2LEuXLmXGjBkDXp8FptfDS3l5uevrB498uLuJr//yHf72prE8MLskRJWJSDjaunUrY8eO9buMARPs5zWzKudcebD9o+adsV1NK8xievFQHntrF2faO/wuR0TEN1Eb9ABL5pawr+UkL2+o97sUERHfRHXQf+mKYVwxPI3lFTsIxykqEZGBENVBb2YsmlPCpweO8sYnjX6XIyLii6gOeoAFU0YxKiOZR9bt8LsUERFfRH3QJ8bHcd+sYt7fdZgPdzf5XY6IyICL+qAHuGt6IenJCSzXqF5EwkRqaioA9fX13HbbbUH3mTdvHn291RxiJOhTkxL41jVF/GHLAXY0HvW7HBGRTqNGjWLNmjX9+hoxEfQAC68tIjE+jpUVanYmIqG3dOlSfvGLX3Q+/ru/+zv+/u//nq985StMmzaNiRMn8tJLX+wUU1NTw4QJEwA4ceIEd911F2PHjuVrX/tayPrdXFKb4kiWm5bE7WX5PF9Zx19/dQzD0pP9LklE+sPvlsL+zaF9zhET4YafXXCXO++8k4ceeojvfe97ADz33HO89tprfP/73yc9PZ2DBw8yY8YMFixY0O3nvj7yyCOkpKSwdetWNm3axLRp00JSfsyM6AEenF1CW0cHj6vZmYiE2NSpU2loaKC+vp6NGzeSlZXFiBEj+NGPfsSkSZO47rrr2Lt3LwcOHOj2OSoqKjp70E+aNIlJkyaFpLaYGdEDFOUM4YYJI/n3d2v57rxS0pIT/S5JRELtIiPv/nT77bezZs0a9u/fz5133snTTz9NY2MjVVVVJCYmUlRUFLRFcX+LqRE9wKI5JbSebGP1+7v9LkVEosydd97Js88+y5o1a7j99ttpaWlh2LBhJCYm8vrrr1NbW3vB4+fMmcMzzzwDQHV1NZs2bQpJXTEX9JMLMrmmJJvH3trFqbZ2v8sRkSgyfvx4WltbycvLY+TIkXzjG9+gsrKSiRMn8tRTT3HllVde8PjvfOc7HD16lLFjx/LjH/+YsrKykNQVU1M3Zy2ZV8rCVe/z0oZ67igv8LscEYkimzd/fiE4JyeH9evXB93v6NHArd5FRUVUV1cDMHjwYJ599tmQ1xRzI3qAOZfnMHZkOsvX7aCjQ83ORCS6xWTQmxlL5pawo/EYf9wW7KNuRUSiR0wGPcBNE0eSlzlYbRFEokSstCLvzc8Zs0GfEB/Hg7OLqaxtorKm3z/GVkT6UXJyMocOHYr6sHfOcejQIZKTL+0NnzF5MfasO64q4N/+uJ1l63byaNFQv8sRkV7Kz8+nrq6Oxsbo/9yJ5ORk8vPzL+mYmA76lEGBZmc//+N2th9o5fLhaX6XJCK9kJiYSHFxsd9lhK2Ynbo5a+E1o0lOjGOFmp2JSJSK+aDPTk3ijvIC/mPDXva1hKZTnIhIOIn5oIdAs7P2Dsfjb9f4XYqISMgp6IGCoSncNGkUz7y3m5YTZ/wuR0QkpBT0nsVzSjh6qo2n37tw0yERkUhz0aA3s1Vm1mBm1eesm2xm681ss5n91szSuzm2xttng5n1/YMP+9GEvAxmX57D42/XcPKMmp2JSPToyYj+CeD6LuseBZY65yYCLwI/vMDxX3LOTXHOlfeuxIGzZG4pja2nePGjvX6XIiISMhcNeudcBdD1raNjgApveS1wa4jr8sW1pdlMyEtnZcVO2tXsTESiRG/n6D8GbvaWbwe66/XrgD+YWZWZLbrQE5rZIjOrNLNKv97dZmYsnlPKzoPHWLtlvy81iIiEWm+D/j7gu2ZWBaQBp7vZb5ZzbhpwA/A9M5vT3RM651Y458qdc+W5ubm9LKvvbpgwgsKhKTyybmfU980QkdjQq6B3zm1zzs13zpUBq4GgLSCdc3u97w0E5vKn97bQgXK22dnGPc28v0vNzkQk8vUq6M1smPc9DvhbYFmQfYaYWdrZZWA+UN11v3B0e3kB2UMGsUwtjEUkCvTk9srVwHrgCjOrM7P7gbvN7FNgG1APPO7tO8rMXvUOHQ68ZWYbgfeB/3TO/b4/fohQS06MZ+G1Rbz+SSPb9h/xuxwRkT6xcJyHLi8vd5WV/t5233z8NNf87z9xw4QR/OudU3ytRUTkYsysqrvb2PXO2G5kpgzirukFvLyxnr3NanYmIpFLQX8B988qxgGPvbnL71JERHpNQX8B+VkpLJg8imc/2E3z8e7uIBURCW8K+otYNKeE46fb+dV6NTsTkcikoL+IsSPTmXdFLk+8o2ZnIhKZFPQ9sHhOKYeOnWZNVZ3fpYiIXDIFfQ/MKBnK5IJMVr6pZmciEnkU9D1gZiyZU0LtoeP8vlrNzkQksijoe2j++BEU5wxh2bodanYmIhFFQd9D8XHGg7NL2Ly3hfU7DvldjohIjynoL8HXp+WRk5rEI2p2JiIRREF/CZIT4/nLmUW8uf0gH9e3+F2OiEiPKOgv0b1Xj2bIoHhWVOz0uxQRkR5R0F+ijJRE7rm6kFc27WPP4eN+lyMiclEK+l64b1YxcQaPvaVmZyIS/hT0vTAyYzA3T8nj2Q92c/iYmp2JSHhT0PfSojklnDzTwVPra/wuRUTkghT0vTRmeBpfuXIYT75Tw/HTbX6XIyLSLQV9HyyZV0rT8TM8X6lmZyISvhT0fVA+OotphYFmZ23tHX6XIyISlIK+D8yMJXNLqWs6wX9u3ud3OSIiQSno++i6scMpzR3C8nU71exMRMKSgr6P4uKMxXNK2bLvCG9uP+h3OSIiX6CgD4Gbp45iWFoSyyvU7ExEwo+CPgSSEuK5b1Yxb392iM11anYmIuFFQR8i91xdSFpSAss0qheRMHPRoDezVWbWYGbV56ybbGbrzWyzmf3WzNK7OfZ6M/vEzD4zs6WhLDzcpCcncs+MQn63eR+1h475XY6ISKeejOifAK7vsu5RYKlzbiLwIvDDrgeZWTzwC+AGYBxwt5mN61O1Ye6+mcUkxMWx8k21MBaR8HHRoHfOVQCHu6weA1R4y2uBW4McOh34zDm30zl3GngWuLkPtYa94enJfG1qHs9X1nHw6Cm/yxERAXo/R/8xn4f27UBBkH3ygD3nPK7z1gVlZovMrNLMKhsbG3tZlv8WzS3hdHsHT75T43cpIiJA74P+PuC7ZlYFpAF97tXrnFvhnCt3zpXn5ub29el8U5qbylfHDuep9bUcO6VmZyLiv14FvXNum3NuvnOuDFgNBLvVZC/nj/TzvXVRb8m8UlpOnOHZD/ZcfGcRkX7Wq6A3s2He9zjgb4FlQXb7ALjczIrNbBBwF/BybwuNJNMKs5heNJTH3tzJGTU7ExGf9eT2ytXAeuAKM6szs/sJ3EHzKbANqAce9/YdZWavAjjn2oD/BrwGbAWec8593D8/RvhZPLeE+paTvLKp3u9SRCTGWTg24iovL3eVlZV+l9EnHR2O6/9PBXFm/O6vZmNmfpckIlHMzKqcc+XBtumdsf0kLs5YNKeUbftbeePTyL2LSEQin4K+Hy2YPIqRGckse0NtEUTEPwr6fjQoIY77ZxXz3q7DfLS7ye9yRCRGKej72V3TC0lPTmD5OrVFEBF/KOj7WWpSAt+8ZjSvbdnPzsajfpcjIjFIQT8Avn1tMYnxcax8c5ffpYhIDFLQD4DctCRuK8vnhQ/raGg96Xc5IhJjFPQD5MHZJZxp7+CJt2v8LkVEYoyCfoAU5wzhhgkj+NW7tbSePON3OSISQxT0A2jxnFJaT7bx7PtqdiYiA0dBP4AmF2RyTUk2j721i9NtanYmIgNDQT/AFs8tYf+Rk7y0ISY6NotIGFDQD7C5Y3K5ckQaKyp20tERfg3lRCT6KOgHmJmxZG4p2xuO8qdtDX6XIyIxQEHvg5smjSQvczDLK9TsTET6n4LeB4nxcTwwu5gPapqoqj3sdzkiEuUU9D6586oCMlMSWaZmZyLSzxT0PkkZlMC3rili7ZYDfNbQ6nc5IhLFFPQ+WnjNaJIT41hRoVG9iPQfBb2PslOTuKO8gBc/2sv+FjU7E5H+oaD32QOzSmjvcDz+tloYi0j/UND7rDA7hRsnjuTp93ZzRM3ORKQfKOjDwJK5pRw91cbT7+72uxQRiUIK+jAwIS+DWZflsOrtXZxqa/e7HBGJMgr6MLFkbimNrad48UM1OxOR0FLQh4mZl2UzflS6mp2JSMhdNOjNbJWZNZhZ9TnrppjZu2a2wcwqzWx6N8e2e/tsMLOXQ1l4tDnb7GznwWP8YcsBv8sRkSjSkxH9E8D1Xdb9I/AT59wU4Mfe42BOOOemeF8Lel1ljLhhwggKhg5m2bodOKdRvYiExkWD3jlXAXTtvOWAdG85A6gPcV0xKSE+jkWzS9iwp5kPapr8LkdEokRv5+gfAv7JzPYA/wz8TTf7JXtTO++a2S0XekIzW+TtW9nY2NjLsiLfbWUFDB0yiGXr1MJYREKjt0H/HeAHzrkC4AfAY93sN9o5Vw7cA/ybmZV294TOuRXOuXLnXHlubm4vy4p8gwfFs/CaIv60rYFP9qvZmYj0XW+DfiHwG2/5eSDoxVjn3F7v+07gDWBqL18vpnzrmtEMTozXB5OISEj0Nujrgbne8peB7V13MLMsM0vylnOAmcCWXr5eTMkaMog7ryrg5Q311Def8LscEYlwPbm9cjWwHrjCzOrM7H7gQeBfzGwj8A/AIm/fcjN71Dt0LFDp7fM68DPnnIK+hx6YXYwDHntLzc5EpG8SLraDc+7ubjaVBdm3EnjAW34HmNin6mJYflYKfzFpJKvf3833v3w5GSmJfpckIhFK74wNY4vnlnL8dDv//l6t36WISART0IexsSPTmTsml8ff3sXJM2p2JiK9o6APc4vnlnDw6Gle+LDO71JEJEIp6MPcNSXZTM7PYGXFTtrV7ExEekFBH+bMjMVzS6k5dJzXPt7vdzkiEoEU9BHgz8aPoCg7Rc3ORKRXFPQRID7OeHBOCZvqWli/85Df5YhIhFHQR4hbp+WTkzqI5et2+l2KiEQYBX2ESE6M5y9nFrPu00a21B/xuxwRiSAK+ghy79WjGTIonhVqdiYil0BBH0EyUhK5e3ohv920jz2Hj/tdjohECAV9hLlvVjGGmp2JSM8p6CPMqMzB3Dwlj19/sIemY6f9LkdEIoCCPgItnlvCiTPtPLVezc5E5OIU9BFozPA0vnLlMJ5cX8OJ02p2JiIXpqCPUIvnlnL42Gmer9rjdykiEuYU9BHqqqIsphVmsvLNnbS1d/hdjoiEMQV9hDrb7GzP4RO8Wq1mZyLSPQV9BPvq2OGU5A5huZqdicgFKOgjWFycsXhOCR/XH+Gtzw76XY6IhCkFfYS7ZWoew9KS1OxMRLqloI9wSQnx3DermLc+O0j13ha/yxGRMKSgjwL3XF1IWlICy9ap2ZmIfJGCPgqkJydyz4xCXt28j92H1OxMRM6noI8S980sJj7OWPmm5upF5HwK+igxPD2Zr03N47nKPRw6esrvckQkjPQo6M1slZk1mFn1OeummNm7ZrbBzCrNbHo3xy40s+3e18JQFS5ftGhOKafaOnjynRq/SxGRMNLTEf0TwPVd1v0j8BPn3BTgx97j85jZUOBh4GpgOvCwmWX1tli5sMuGpfLVccN5cn0tx061+V2OiISJHgW9c64CONx1NZDuLWcA9UEO/TNgrXPusHOuCVjLF//BkBBaMreUlhNneK5Szc5EJKAvc/QPAf9kZnuAfwb+Jsg+ecC5iVPnrfsCM1vkTQFVNjY29qGs2FY2OourirJ49M1dnFGzMxGhb0H/HeAHzrkC4AfAY30pxDm3wjlX7pwrz83N7ctTxbwlc0vZ23yC/9y0z+9SRCQM9CXoFwK/8ZafJzAH39VeoOCcx/neOulHX7piGJcPS2WZmp2JCH0L+npgrrf8ZWB7kH1eA+abWZZ3EXa+t076UVxcoIXxtv2trPtU02Aisa6nt1euBtYDV5hZnZndDzwI/IuZbQT+AVjk7VtuZo8COOcOA/8T+MD7+qm3TvrZgsmjGJGerLYIIkJCT3Zyzt3dzaayIPtWAg+c83gVsKpX1UmvDUqI4/5ZxfyvV7eyYU8zUwoy/S5JRHyid8ZGsbuvLiQtOYHlGtWLxDQFfRRLTUrgmzNG8/uP97Pr4DG/yxERnyjoo9y3ZxaRGB+nZmciMUxBH+WGpSVz67R81lTV0dB60u9yRMQHCvoYsGhOCWfa1exMJFYp6GNAcc4Qrh8/gl+tr+Womp2JxBwFfYxYPLeUIyfbePb93X6XIiIDTEEfI6YUZDKjZCiPvrmL021qdiYSSxT0MWTx3FL2HznJyxuDdZQWkWiloI8h88bkcuWINFZU7KCjQ83ORGKFgj6GmBmL55bw6YGjvP5Jg9/liMgAUdDHmD+fNIq8zMEsX6c3UInECgV9jEmMDzQ7e7/mMFW1TX6XIyIDQEEfg+68qoCMwYlqdiYSIxT0MWhIUgILrxnN2q0H+KzhqN/liEg/61E/eok+37q2iOUVO7n1kXeYXJDJ5PwMJuVnMik/g+HpyX6XJyIhpKCPUTmpSTz+7at4aUM9G+ua+eUbB2n3brkcnp7EpPzzwz8zZZDPFYtIbynoY9i1l+Vw7WU5AJw43c7H9S1srGthU10zm+taWLvlQOe+hUNTmJSfwWQv+CfkZTAkSf/7iEQC/aYKAIMHxVNeNJTyoqGd61pOnKF6bwsb65rZtKeFD2ubeGXTPgDiDC4blsrEvEwmFwRG/mNHppGUEO/XjyAi3VDQS7cyBicy87IcZnqjfoDG1lNs3tvMxj2Bkf8bnzTwwod1ACTGG1eOSGdSfob3lcnlw1JJiNc1fxE/mXPh91b48vJyV1lZ6XcZ0gPOOepbTrJpT/N50z6tXjvkwYnxjB+VHpjzL8hgYl4GRdlDiIsznysXiS5mVuWcKw+6TUEvodbR4dh16Bib67xpn7oWPq5v4eSZQNfMtOSEzhH/2Qu+IzOSMVP4i/TWhYJeUzcScnFxRmluKqW5qdwyNQ+AtvYOPj1wlE11zWzaGxj5r6zYSZt3p09OalLnlM/ZC77ZqUl+/hgiUUNBLwMiIT6OcaPSGTcqnbu8dSfPtLN13xE2eSP/zXUtvP5JA2f/yMzLHHzeyH9CfgbpyYm+/QwikUpBL75JToxnamEWUwuzOtcdPdVGtTfi31jXwua6Fn5Xvb9ze0nuECbnZzIxL4PJBRmMH5VBcqLu9BG5EAW9hJXUpARmlGQzoyS7c13TsdOB6R7vgu/bnx3kxY/2AhAfZ4wZnnbem7uuGJFGou70Eel00YuxZrYK+HOgwTk3wVv3a+AKb5dMoNk5NyXIsTVAK9AOtHV3oaArXYyVizlw5CQb9zR3Tvtsqmuh5cQZAAYlxDFuZHpn+E8uyKAkJ1V3+khU69NdN2Y2BzgKPHU26Lts/xegxTn30yDbaoBy59zBSylYQS+XyjnH7sPH2VT3+bRP9d4Wjp9uB2DIoHgm5GUwuSCz84JvftZg3ekjUaNPd9045yrMrKibJzbgDuDLfapQpI/MjNHZQxidPYS/mDwKgPYOx47Go+eF/xNv13C6PXCbZ1ZKIhPPucVzcn4Gw9TQTaJQX+foZwMHnHPbu9nugD+YmQOWO+dWdPdEZrYIWARQWFjYx7JEPp+/HzM8jdvK8gE43dbBJ/tbO+/y6drQbUR68nnv7FVDN4kGfQ36u4HVF9g+yzm318yGAWvNbJtzriLYjt4/AisgMHXTx7pEghqUEMfE/Awm5md0rgvW0O0P5zR0G52dEgj9vAymFmYyIU93+khk6XXQm1kC8HWgrLt9nHN7ve8NZvYiMB0IGvQifulJQ7eqmsP8dmM9AIPi45iQl0550VDKRmdRNjqLHL25S8JYX0b01wHbnHN1wTaa2RAgzjnX6i3PB75wwVYkHHXX0O2j3U1U1TZRWdvEE2/XsKIi8CHrxTlDOkO/fHQWpbm6y0fCx0WD3sxWA/OAHDOrAx52zj0G3EWXaRszGwU86py7ERgOvOjd1ZAAPOOc+31oyxcZOLlpScwfP4L540cAgXf2Vu9tobK2icqaJv60rYE1VYFxT2ZKItMKPw/+yQWZmu4R36ipmUiIOOfYdfAYlbVNVNU0UVl7mB2NxwBIiDPG52VQ7gV/WVEWw9J0h4+EjrpXivik6dhpqmqbqNodCP+Ndc2cagvc3lk4NKUz9MtGZzFmWJqme6TXFPQiYeJ0WwfV9S2dI/6q2iYOHj0NBNo3Tyv8fMQ/pSCTlEHqUiI9o6AXCVPOOWoPHe+8wFtVe5hPDxwFAu8DGD8qPRD+RVmUjx7KiAxN90hwCnqRCNJy/Awf7g6M+Cu96Z6zH9qSlznYC/0sykYP5YoRacRrukfQB4+IRJSMlES+dOUwvnTlMADOtHewpf5I54h//Y5DvLQhcE9/alICUwszvbt7hjKlMJPUJP1ay/k0oheJMM456ppOdI74q2qb+ORAK85BnMHYkenePH/gDV15mYP9LlkGgKZuRKLckZNn+Gh3M1U1h6msbWLDnubOzp0jM5I77+cvLxrKlSPSSFC//qijqRuRKJeenMjcMbnMHZMLBD6jd+u+1sCo33tD1yub9gGQMig+MN1TGBj1Ty3M1Ec0RjmN6EVixN7mE1TWBG7prKxpYtv+I3Q4MIMrhqd13tlTNjpLvfojkKZuROQLjp5qY8Pu5s77+T/a3czRU20ADE9P8nr3DKV8dBbjRqXr4xnDnKZuROQLUpMSmHV5DrMuDzRua+9wbNt/pHPEX1XbxKubAx/MPjgxnskFGZ1390wrzCIjRdM9kUIjehHp1r6WE+cF/5Z9Rzo/pGXM8NTOEX95URaFQ1M03eMjTd2ISEgcO9XGxj3NgQu8tU18VNtEqzfdk5OaRNnozMA8f1EWE0ZlMChB0z0DRVM3IhISQ5ISuPayHK697PPpnu0NrZ0j/sraw7z2ceDTuZIS4pgzJpeV3wqaPTKAFPQi0mvxccaVI9K5ckQ6984YDUDDkZPeu3ib1J4hTCjoRSSkhqUnc+PEkdw4caTfpYhHE2giIlFOQS8iEuUU9CIiUU5BLyIS5RT0IiJRTkEvIhLlFPQiIlFOQS8iEuXCsteNmTUCtb08PAc4GMJyQkV1XRrVdWlU16WJxrpGO+dyg20Iy6DvCzOr7K6xj59U16VRXZdGdV2aWKtLUzciIlFOQS8iEuWiMehX+F1AN1TXpVFdl0Z1XZqYqivq5uhFROR80TiiFxGRcyjoRUSiXEQGvZmtMrMGM6vuZruZ2c/N7DMz22Rm08Kkrnlm1mJmG7yvHw9QXQVm9rqZbTGzj83sr4LsM+DnrId1Dfg5M7NkM3vfzDZ6df0kyD5JZvZr73y9Z2ZFYVLXt82s8Zzz9UB/13XOa8eb2Udm9kqQbQN+vnpYly/ny8xqzGyz95pf+IDskP8+Ouci7guYA0wDqrvZfiPwO8CAGcB7YVLXPOAVH87XSGCat5wGfAqM8/uc9bCuAT9n3jlI9ZYTgfeAGV32+S6wzFu+C/h1mNT1beD/DfT/Y95r/zXwTLD/Xn6crx7W5cv5AmqAnAtsD+nvY0SO6J1zFcDhC+xyM/CUC3gXyDSzfv9csx7U5Qvn3D7n3IfeciuwFcjrstuAn7Me1jXgvHNw1HuY6H11vWvhZuBJb3kN8BUz69cPSO1hXb4ws3zgJuDRbnYZ8PPVw7rCVUh/HyMy6HsgD9hzzuM6wiBAPNd4f3r/zszGD/SLe38yTyUwGjyXr+fsAnWBD+fM+3N/A9AArHXOdXu+nHNtQAuQHQZ1Adzq/bm/xswK+rsmz78B/wPo6Ga7L+erB3WBP+fLAX8wsyozWxRke0h/H6M16MPVhwT6UUwG/i/wHwP54maWCrwAPOScOzKQr30hF6nLl3PmnGt3zk0B8oHpZjZhIF73YnpQ12+BIufcJGAtn4+i+42Z/TnQ4Jyr6u/XuhQ9rGvAz5dnlnNuGnAD8D0zm9OfLxatQb8XOPdf5nxvna+cc0fO/untnHsVSDSznIF4bTNLJBCmTzvnfhNkF1/O2cXq8vOcea/ZDLwOXN9lU+f5MrMEIAM45HddzrlDzrlT3sNHgbIBKGcmsMDMaoBngS+b2b932ceP83XRunw6Xzjn9nrfG4AXgelddgnp72O0Bv3LwLe8K9czgBbn3D6/izKzEWfnJc1sOoHz3+/h4L3mY8BW59y/drPbgJ+zntTlxzkzs1wzy/SWBwNfBbZ12e1lYKG3fBvwJ+ddRfOzri7zuAsIXPfoV865v3HO5TvnighcaP2Tc+7eLrsN+PnqSV1+nC8zG2JmaWeXgflA1zv1Qvr7mNDran1kZqsJ3I2RY2Z1wMMELkzhnFsGvErgqvVnwHHgL8OkrtuA75hZG3ACuKu//2f3zAS+CWz25ncBfgQUnlObH+esJ3X5cc5GAk+aWTyBf1iec869YmY/BSqdcy8T+AfqV2b2GYEL8Hf1c009rev7ZrYAaPPq+vYA1BVUGJyvntTlx/kaDrzojV8SgGecc783syXQP7+PaoEgIhLlonXqRkREPAp6EZEop6AXEYlyCnoRkSinoBcRiXIKehGRKKegFxGJcv8fVxxYy5uzSasAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAD8CAYAAABn919SAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAIABJREFUeJzt3Xl8VdW5//HPExIIGZgyMSQhKIMIIkNIoSgyqLUOaCu1YLWtrVKnKtTbQfu7t962t7ett1q1rZRWe+sVUQp2sk6gDNIKGChlCvMYhiSgQJgDPL8/zjGGmJATzMlJNt/365VXT/Ze+5yHVfPNytpr723ujoiINH9xsS5AREQahgJdRCQgFOgiIgGhQBcRCQgFuohIQCjQRUQCQoEuIhIQCnQRkYBQoIuIBER8Y35Yenq65+XlNeZHiog0e0uWLNnj7hl1tWvUQM/Ly6OwsLAxP1JEpNkzs62RtNOUi4hIQCjQRUQCQoEuIhIQjTqHLiJSXxUVFRQXF3P06NFYlxJ1iYmJZGdnk5CQcFbHK9BFpEkrLi4mNTWVvLw8zCzW5USNu7N3716Ki4vp1q3bWb2HplxEpEk7evQoaWlpgQ5zADMjLS3tY/0lokAXkSYv6GH+gY/772wWgT53bSnPLNjMvsPHY12KiEiT1SwC/a01pXz/5dUU/OhNJr24jMWb30PPQhWRxrBv3z5+9atf1fu4q6++mn379kWhoto1i0D//vV9+dt9l/D5/Bxmry7hpl+/w+WPzuO3b2/i/UMatYtI9NQW6CdPnjzjca+88grt2rWLVlk1ahaBDtCnc1t+cENfFn13ND8d2482rRP44d+K+MSP3uT+F/7Jwk17NWoXkQb3ne98h40bN9K/f38GDx7MyJEjufnmm7nooosAuOGGGxg0aBB9+vRhypQplcfl5eWxZ88etmzZQu/evbnjjjvo06cPV155JUeOHIlKrdaYIZifn+8NeS+XNbsP8MLi7cxcWkz50ROcl57MuIIcbhyYTVpKqwb7HBGJnaKiInr37g3Af/51Fat3HmjQ97+wcxu+d12fWvdv2bKFa6+9lpUrVzJ37lyuueYaVq5cWbm08L333qNDhw4cOXKEwYMHM2/ePNLS0irvXXXw4EG6d+9OYWEh/fv356abbmLMmDHccsstdf57P2BmS9w9v65/S7MZodfkgo5teHhMHxY/dDk/+9zFdEhuyY9eWcOQ/36Te59fyj827OHUKY3aRaThFBQUnLZO/IknnuDiiy9myJAhbN++nfXr13/kmG7dutG/f38ABg0axJYtW6JSWyAuLGrdsgU3DsrmxkHZrCspZ9ribby0dAcvL99FXloS4wpyGTsom3SN2kWatTONpBtLcnJy5eu5c+cye/Zs3nnnHZKSkhgxYkSN68hbtfowe1q0aBG1KZdmPUKvSc+sVL53XR8WPTSaxz5/MZmpifz41TUM/e83uWfqUhas16hdRCKXmppKeXl5jfv2799P+/btSUpKYs2aNSxcuLCRqztdIEboNUlMaMFnBmTzmQHZbCgtZ1p4rv1vK3aR2yGJcQU5jB2UTWZqYqxLFZEmLC0tjWHDhtG3b19at25NVlZW5b6rrrqKyZMn069fP3r16sWQIUNiWGkzPylaX0crTvL6qt1MW7yNhZveIz7OuOLCLMYX5HJJ93Ti4s6Nq9FEmpOaThIG2cc5KRrYEXpNEhNacH3/Llzfvwsbyw7y4rvbmbGkmFdX7ia7fWvGF+TyuUHZZLbRqF1Emp8659DNLMfM5phZkZmtMrP7w9svNrN3zGyFmf3VzNpEv9yGc35GCg9d3Zt3HhzFk+MHkNshiUdeX8vQH7/FhGcLmbO2lJOaaxeRZiSSEfoJ4AF3X2pmqcASM5sF/Bb4N3efZ2ZfAb4J/HsUa42KVvEtuO7izlx3cWc27znEC+9uY0ZhMW+sLqFLu9Z8fnAON+Xn0LGtRu0i0rTVOUJ3913uvjT8uhwoAroAvYD54WazgBujVWRj6ZaezIOf7s07D47mlzcPpFt6Mo/OWscnf/wmt/++kLfWlGjULiJNVr3m0M0sDxgALAJWAmOAPwOfA3IauLaYaRkfxzX9OnFNv05s3XuIF97dzh8Ki5ldVELntoncFB61d27XOtaliohUingdupmlADOBie5+APgKcI+ZLQFSgRrvkmVmE8ys0MwKy8rKGqLmRtU1LZlvX3UB7zw4ism3DOT8zBR+Pns9l/zkLb76v+8ye3UJJ06einWZIiKRBbqZJRAK86nu/hKAu69x9yvdfRAwDdhY07HuPsXd8909PyMjo6HqbnQJLeK4qm8n/u+rn+Dtb43krhHns3zHfm5/tpBLfjKHR99YS/H7h2NdpojEWEpKCgA7d+5k7NixNbYZMWIE0VjCXeeUi4UeofE0UOTuj1bZnunupWYWB/w/YHKDV9dE5XRI4pufuoCJl/fkrTWlTFu8jSfnbODJORu4rGcG4wtyGXVBJgktAnchrohEqHPnzsyYMaNRPzOSOfRhwK3ACjNbFt72ENDDzO4Jf/8S8Lso1NekJbSI41N9OvKpPh0pfv8w09/dzouF2/na/y0hM7UVN+Xn8PnBOeR0SIp1qSJylr797W/TtWtX7r77bgAefvhhzIz58+fz/vvvU1FRwQ9/+EOuv/76046repfGI0eOcNttt7F69Wp69+4dtXu51Bno7r4AqO0SyscbtpzmK7t9Et+4shf3je7BnLVlTFu8jV/N3cAv527g0h4Z3FyQw+jeWRq1i3wcr34Hdq9o2PfseBF8+se17h43bhwTJ06sDPTp06fz2muvMWnSJNq0acOePXsYMmQIY8aMqfWZoE899RRJSUksX76c5cuXM3DgwIb9N4SdU1eKNob4FnFccWEWV1yYxY59R5j+7namF27nzueWkp7Sipvysxk3OJfcNI3aRZqDAQMGUFpays6dOykrK6N9+/Z06tSJSZMmMX/+fOLi4tixYwclJSV07NixxveYP38+9913HwD9+vWjX79+UalVgR5FXdq1ZtIVPfn6qO7MWxcatU+et5Ffzd3IpT3SGV+Qy+W9s2gZr1G7SETOMJKOprFjxzJjxgx2797NuHHjmDp1KmVlZSxZsoSEhATy8vJqvG1uVbWN3huSAr0RxLeIY3TvLEb3zmLX/iP8obCYF9/dzt1Tl5Ke0pKxg3IYNziHvPTkut9MRBrduHHjuOOOO9izZw/z5s1j+vTpZGZmkpCQwJw5c9i6desZjx8+fDhTp05l5MiRrFy5kuXLl0elTgV6I+vUtjX3je7BPSO7M399GdMWbeM3b29i8ryNDOuexrjBuVzZJ4tW8S1iXaqIhPXp04fy8nK6dOlCp06d+MIXvsB1111Hfn4+/fv354ILLjjj8XfddRe33XYb/fr1o3///hQUFESlznPq9rlNVcmBo/yhcDvTFm9nx74jdEhuydhB2YwbnMN5GSmxLk8kpnT7XN0+t1nJapPIvaN6cPeI7ry9YQ/TFm3jmQWbmTJ/E0PO68D4glyu6ttRo3YROSMFehMSF2dc1jODy3pmUHrgKH9YEpprv/+FZbRPSuDGgdmMK8ile6ZG7SLyUQr0JiqzTSL3jOzOXZedzz827mXa4m387z+28NsFmyno1oGbw6P2xASN2iX43L1RVonE2sedAlegN3FxccYlPdK5pEc6ZeXHmLm0mGmLtzHxxWW0/Uto1D6+IIceWamxLlUkKhITE9m7dy9paWmBDnV3Z+/evSQmnv2zF3RStBk6dcpZuGkvzy/exuurdlNx0snv2p7xBblc06+TRu0SKBUVFRQXF9e5zjsIEhMTyc7OJiEh4bTtkZ4UVaA3c3sPfjBq387mPYdokxjPZwdm85kBXbigU6pOpIoEgAL9HOPuLNz0HtMWb+O1lbs5fvIULeKMvLQkenVMpUdmKr06ptIzK5W8tCTidU8ZkWZDyxbPMWbG0PPTGHp+Gu8dOs6CDXtYX1LO2t3lrN55gFdX7uaD390tW8RxXkZyZcCHvlLIaZ9EXFxw5yhFgk6BHkAdklsy5uLOp207cvwkG8sOsnZ3OetKy1m3u5zCLe/z52U7K9u0TmhBj6yU8Gg+pTLsO7VNDPTJKJGgUKCfI1q3bEHfLm3p26XtadvLj1awvvRgeDR/kPWl5by9voyZS4sr26S2iqdHVkq1EX0q6SktFfQiTYjm0KVG+w4fZ13JQdaWhEbz60pCX+8frqhs0yG5JT0yQ0HfIyuVXuGpm3ZJLWNYuUjwaA5dPpZ2SS0p6NaBgm4dKre5O2UHj7G+JDR1s740NEf/0tIdHDx2orJdZmqrKqP50NRNj6xUUlrpPzeRaNJPmETMzMhMTSQzNZFh3dMrt7s7u/YfZW1JeeXUzbqScqYu2srRilOV7bq0ax0ezaeER/OpdM9M0bp5kQYSyUOic4BngY7AKWCKuz9uZv0JPRg6ETgB3O3ui6NZrDRNZkbndq3p3K41I3tlVm4/ecopfv9weDQfPiFbEpqjrzgZmuqLM+iallw5dfPB/Hy39GQ9+EOkniIZoZ8AHnD3pWaWCiwxs1nAT4H/dPdXzezq8PcjoleqNDct4oyuacl0TUvmyj4fbq84eYqtew+F5uirzM+/uaaUk6dCQR8fZ5yXkXza3HzPrFS6piXTQksrRWoUyUOidwG7wq/LzawI6AI40CbcrC2ws+Z3EDldQos4umem0j0zlasv6lS5/diJk2wqO8S68Pr5dSUHWVG8n78t31XZplV8HOdnpHxkjr5Lu9ZaQy/nvHqtcjGzPGA+0JdQqL8OGBAHfNLdz/gcJq1ykbNx+PgJNpQe/MjUza79H97bI6lli/Bo/sP18706ppKZ2kpLK6XZa/BL/80sBZgH/Je7v2RmTwDz3H2mmd0ETHD3y2s4bgIwASA3N3dQXc/eE4nU/iMVbCj98CTsB197Dh6vbNMmMb7assrQqD4tpVUMKxepnwYNdDNLAF4GXnf3R8Pb9gPt3N0tNATa7+5tzvQ+GqFLY9h78BjrSg5WLqsMBf1B9h/5cA19ekrL0y6S6pf90YuuRJqKBluHHg7rp4GiD8I8bCdwGTAXGAWsP7tSRRpWWkorhqa0Yuj5aZXb3J3S8mNV5udDIf+Hwu0cOn4SgEt7pPOdT19An84Kdmme6hyhm9klwNvACkLLFgEeAg4AjxP6pXCU0LLFJWd6L43Qpak5dcrZse8Ir6/azZNvbeDA0Qo+078L37iyJ9ntk2Jdngig2+eK1Nv+IxU8NXcjz/x9MwBf/mQe94zoTtukhDqOFIkuBbrIWdq57wiPzlrHzKXFpLaK595R3fni0Dxd0SoxE2mg61I8kWo6t2vN/3zuYl6571IGdm3Pj15Zw+ifzWPmkuLKC59EmiIFukgtendqw//eVsDzt3+CDskteeAP/+LaJxcwb13Zx346u0g0KNBF6vDJ7un8+Z5hPDF+AAePVfClZxZzy9OLWLljf6xLEzmNAl0kAnFxxpiLOzP7G5fxH9deyOqdB7j2yQXc/8I/2f7e4ViXJwLopKjIWTlwtILJczfy9ILNuMOtQ7ty78jutE/Wwz2k4WmVi0gj2LX/CI/NWseMJcUkt4rn7hHduW2YVsRIw1KgizSitbvL+clra3hrTSmd2ibyjSt68tmB2brVrzQILVsUaUS9OqbyzJcH88KEIWSmtuKbM5ZzzRNvM2dtqVbESKNRoIs0oCHnpfGne4bxi5sHcKTiJLf97l1u/s0ilhfvi3Vpcg5QoIs0MDPj2n6dmTXpMh6+7kLWlpQz5hd/5+vT/sm2vVoRI9GjOXSRKCs/WsGU+Zv4zdubOHnKuWVIV74+qgcdtCJGIqSToiJNTMmBo/x89jpefHc7yS3juXPE+XxlWDdat9SKGDkzBbpIE7W+pJyfvLaW2UUldGyTyKQrejB2UI5WxEittMpFpInqkZXKb7+Uz/SvDaVj20S+PXMFn358Pm8WlWhFjHwsCnSRGCno1oE/3v1JnvrCQCpOOl/9fSGfn7KQZdu1IkbOjgJdJIbMjE9f1Ik3Jg3nB9f3YVPZQW745d+5Z+pStuw5FOvypJnRHLpIE3Lw2InQipj5m6g4eYovfCKXr4/uQXpKq1iXJjHUYCdFzSwHeBboSOiZolPc/XEzexHoFW7WDtjn7v3P9F4KdJHIlB44ys/fXM+L726ndUILvjb8PL56aTeSWtb5XHcJoIYM9E5AJ3dfamapwBLgBndfXaXNz4D97v79M72XAl2kfjaUHuSR19fw+qoSMlNbMemKnnxuUDbxLTRbei5psFUu7r7L3ZeGX5cDRUCXKh9kwE3AtLMvV0Rq0j0zhV/fms+MO4eS0yGJB19awVWPv82s1VoRIx9Vr1/zZpYHDAAWVdl8KVDi7usbriwRqSo/rwMz7hzKr28dxCl37ni2kJt+/Q5Lt70f69KkCYk40M0sBZgJTHT3A1V2jecMo3Mzm2BmhWZWWFZWdvaVipzjzIxP9enIGxOH81+f6cvmPYf57K/+wV3PLWFT2cFYlydNQESrXMwsAXgZeN3dH62yPR7YAQxy9+K63kdz6CIN59CxE/z27c38ev5Gjp84xfiCXO4b3YOMVK2ICZoGm0MPz5E/DRRVDfOwy4E1kYS5iDSs5Fbx3H95D+Z9cyTjC3KZtngbIx6Zw+Oz13Po2IlYlycxEMmUyzDgVmCUmS0Lf10d3jcOnQwViamM1Fb84Ia+vDFpOMN7ZvDY7HVc9shcnlu4lYqTp2JdnjQiXVgkEjBLtr7Pj18t4t0t73NeRjLf+tQFfKpPFqE/tqU50s25RM5Rg7q2Z/rXhvKbL+ZjwJ3PLWHs5HdYsvW9WJcmUaZAFwkgM+OKC7N4feJw/vuzF7H9vcPc+NQ7THi2kA2lWhETVJpyETkHHD5+gmcWbGbyvE0cqTjJ5wfnMPHyHmSmJsa6NImAHnAhIh+x9+AxnnxrA88t3ErL+Dhuv/Q8Jgw/j5RWukdMU6ZAF5FabdlziEfeWMvflu8iPaUl94/uwbiCXBJ0j5gmSSdFRaRWeenJ/PLmgfzpnmGcn5HCv/95FVc+Np9XV+zSPWKaMQW6yDmsf047XpgwhGe+nE9CC+OuqUv57FP/YPFmrYhpjhToIuc4M2PUBVm8ev9wfnpjP3buO8JNv36H239fyIbS8liXJ/WgOXQROc2R4yd55u+bmTx3I4eOnwiviOlJVhutiIkVnRQVkY/lvUPHefKt9Ty3cCvxcXHcfmk3Jgw/j9TEhFiXds5RoItIg9i29zD/88Za/vKvnaQlt+Tro7pz8ye60jJeM7aNRatcRKRB5KYl8cT4Afzl3mH0zErl4b+u5orH5rFq5/5YlybVKNBFJCL9stvx/B2f4He3DaZjm0Sy2yXFuiSpRpeHiUjEzIyRvTIZ2Ssz1qVIDTRCFxEJCAW6iEhAKNBFRAJCgS4iEhCRPCQ6x8zmmFmRma0ys/ur7Pu6ma0Nb/9pdEsVEZEziWSVywngAXdfamapwBIzmwVkAdcD/dz9mJnptLeISAzVGejuvgvYFX5dbmZFQBfgDuDH7n4svK80moWKiMiZ1WsO3czygAHAIqAncKmZLTKzeWY2uOHLExGRSEV8YZGZpQAzgYnufsDM4oH2wBBgMDDdzM7zajeHMbMJwASA3NzcBitcREROF9EI3cwSCIX5VHd/Kby5GHjJQxYDp4D06se6+xR3z3f3/IyMjIaqW0REqolklYsBTwNF7v5olV1/AkaF2/QEWgJ7olGkiIjULZIpl2HArcAKM1sW3vYQ8AzwjJmtBI4DX6o+3SIiIo0nklUuCwCrZfctDVuOiIicLV0pKiISEAp0EZGAUKCLiASEAl1EJCAU6CIiAaFAFxEJCAW6iEhAKNBFRAJCgS4iEhAKdBGRgFCgi4gEhAJdRCQgFOgiIgGhQBcRCQgFuohIQCjQRUQCQoEuIhIQCnQRkYCI5CHROWY2x8yKzGyVmd0f3v6wme0ws2Xhr6ujX66IiNQmkodEnwAecPelZpYKLDGzWeF9j7n7/0SvPBERiVQkD4neBewKvy43syKgS7QLExGR+qnXHLqZ5QEDgEXhTfea2XIze8bM2jdwbSIiUg8RB7qZpQAzgYnufgB4Cjgf6E9oBP+zWo6bYGaFZlZYVlbWACWLiEhNIgp0M0sgFOZT3f0lAHcvcfeT7n4K+A1QUNOx7j7F3fPdPT8jI6Oh6hYRkWoiWeViwNNAkbs/WmV7pyrNPgOsbPjyREQkUpGschkG3AqsMLNl4W0PAePNrD/gwBbga1GpUEREIhLJKpcFgNWw65WGL0dERM6WrhQVEQkIBbqISEAo0EVEAkKBLiISEAp0EZGAUKCLiASEAl1EJCAU6CIiAaFAFxEJCAW6iEhAKNBFRAJCgS4iEhAKdBGRgFCgi4gEhAJdRCQgFOgiIgGhQBcRCQgFuohIQETykOgcM5tjZkVmtsrM7q+2/9/MzM0sPXpliohIXSJ5SPQJ4AF3X2pmqcASM5vl7qvNLAe4AtgW1SpFRKROdY7Q3X2Xuy8Nvy4HioAu4d2PAd8CPGoViohIROo1h25mecAAYJGZjQF2uPu/olCXiIjUUyRTLgCYWQowE5hIaBrmu8CVERw3AZgAkJube3ZViohInSIaoZtZAqEwn+ruLwHnA92Af5nZFiAbWGpmHasf6+5T3D3f3fMzMjIarnIRETlNnSN0MzPgaaDI3R8FcPcVQGaVNluAfHffE6U6RUSkDpGM0IcBtwKjzGxZ+OvqKNclIiL1VOcI3d0XAFZHm7yGKkhERM6OrhQVEQkIBbqISEAo0EVEAkKBLiISEAp0EZGAUKCLiASEAl1EJCAU6CIiAaFAFxEJCAW6iEhAKNBFRAJCgS4iEhAKdBGRgFCgi4gEhAJdRCQgFOgiIgGhQBcRCQgFuohIQNQZ6GaWY2ZzzKzIzFaZ2f3h7T8ws+XhZ4y+YWado1+uiIjUJpIR+gngAXfvDQwB7jGzC4FH3L2fu/cHXgb+I4p1iohIHeoMdHff5e5Lw6/LgSKgi7sfqNIsGfDolCgiIpGIr09jM8sDBgCLwt//F/BFYD8wsoFrExGReoj4pKiZpQAzgYkfjM7d/bvungNMBe6t5bgJZlZoZoVlZWUNUbOIiNQgokA3swRCYT7V3V+qocnzwI01HevuU9w9393zMzIyzr5SERE5o0hWuRjwNFDk7o9W2d6jSrMxwJqGL09ERCIVyRz6MOBWYIWZLQtvewj4qpn1Ak4BW4E7o1OiiIhEos5Ad/cFgNWw65WGL0dERM6WrhQVEQkIBbqISEAo0EVEAkKBLiISEAp0EZGAUKCLiASEAl1EJCAU6CIiAaFAFxEJCAW6iEhAKNBFRAJCgS4iEhAKdBGRgFCgi4gEhAJdRCQgFOgiIgGhQBcRCQgFuohIQETykOgcM5tjZkVmtsrM7g9vf8TM1pjZcjP7o5m1i365IiJSm0hG6CeAB9y9NzAEuMfMLgRmAX3dvR+wDngwemWKiEhd6gx0d9/l7kvDr8uBIqCLu7/h7ifCzRYC2dErU0RE6lKvOXQzywMGAIuq7foK8Gotx0wws0IzKywrKzubGkVEJAIRB7qZpQAzgYnufqDK9u8SmpaZWtNx7j7F3fPdPT8jI+Pj1isiIrWIj6SRmSUQCvOp7v5Sle1fAq4FRru7R6dEERGJRJ2BbmYGPA0UufujVbZfBXwbuMzdD0evRBERiUQkI/RhwK3ACjNbFt72EPAE0AqYFcp8Frr7nVGpUkRE6lRnoLv7AsBq2PVKw5cjIiJnyxpz6tvMyoCtZ3l4OrCnActpKKqrflRX/aiu+mmqdcHHq62ru9e5qqRRA/3jMLNCd8+PdR3Vqa76UV31o7rqp6nWBY1Tm+7lIiISEAp0EZGAaE6BPiXWBdRCddWP6qof1VU/TbUuaITams0cuoiInFlzGqGLiMgZNKlAN7NnzKzUzFbWst/M7Akz2xC+D/vAJlLXCDPbb2bLwl//0Uh11Xiv+mptGr3PIqyr0fvMzBLNbLGZ/Stc13/W0KaVmb0Y7q9F4RvSNYW6vmxmZVX66/Zo11Xls1uY2T/N7OUa9jV6f0VYV0z6y8y2mNmK8GcW1rA/uj+P7t5kvoDhwEBgZS37ryZ0V0cjdG/2RU2krhHAyzHor07AwPDrVEL3pb8w1n0WYV2N3mfhPkgJv04gdNfQIdXa3A1MDr8eB7zYROr6MvCLxv5vLPzZ3wCer+n/r1j0V4R1xaS/gC1A+hn2R/XnsUmN0N19PvDeGZpcDzzrIQuBdmbWqQnUFRNey73qqzVr9D6LsK5GF+6Dg+FvE8Jf1U8iXQ/8Pvx6BjA6fD+jWNcVE2aWDVwD/LaWJo3eXxHW1VRF9eexSQV6BLoA26t8X0wTCIqwoeE/mV81sz6N/eFnuFd9TPvsDHVBDPos/Gf6MqAUmOXutfaXhx7gsh9IawJ1AdwY/jN9hpnlRLumsJ8D3wJO1bI/Jv0VQV0Qm/5y4A0zW2JmE2rYH9Wfx+YW6DX95m8KI5mlhC7NvRh4EvhTY3641XKv+g9213BIo/RZHXXFpM/c/aS79yf0hK0CM+tbrUlM+iuCuv4K5HnokY+z+XBUHDVmdi1Q6u5LztSshm1R7a8I62r0/gob5u4DgU8Telzn8Gr7o9pfzS3Qi4Gqv2mzgZ0xqqWSux/44E9md38FSDCz9Mb4bKvlXvVVxKTP6qorln0W/sx9wFzgqmq7KvvLzOKBtjTidFttdbn7Xnc/Fv72N8CgRihnGDDGzLYALwCjzOy5am1i0V911hWj/sLdd4b/txT4I1BQrUlUfx6bW6D/Bfhi+EzxEGC/u++KdVFm1vGDeUMzKyDUr3sb4XNrvFd9NY3eZ5HUFYs+M7MMM2sXft0auBxYU63ZX4AvhV+PBd7y8NmsWNZVbZ51DKHzElHl7g+6e7a75xE64fmWu99SrVmj91ckdcWiv8ws2cxSP3gNXAlUXxkX1Z/HiJ5Y1FjMbBqh1Q/pZlYMfI/QCSLcfTKhW/ZeDWwADgO3NZG6xgJ3mdkJ4AgwLtr/UYfVdq/63Cq1xaLPIqkrFn3WCfi9mbUg9Atkuru/bGY2B15MAAAAeElEQVTfBwrd/S+EfhH9n5ltIDTSHBflmiKt6z4zG0PocY/vEVrFERNNoL8iqSsW/ZUF/DE8TokHnnf318zsTmicn0ddKSoiEhDNbcpFRERqoUAXEQkIBbqISEAo0EVEAkKBLiISEAp0EZGAUKCLiASEAl1EJCD+P/Ah8y0j0MYTAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -2785,7 +2831,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.validate\" class=\"doc_header\"><code>Learner.validate</code><a href=\"__main__.py#L143\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.validate\" class=\"doc_header\"><code>Learner.validate</code><a href=\"__main__.py#L152\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>Learner.validate</code>(**`ds_idx`**=*`1`*, **`dl`**=*`None`*, **`cbs`**=*`None`*)\n",
        "\n",
@@ -2839,7 +2885,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.get_preds\" class=\"doc_header\"><code>Learner.get_preds</code><a href=\"__main__.py#L148\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.get_preds\" class=\"doc_header\"><code>Learner.get_preds</code><a href=\"__main__.py#L157\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>Learner.get_preds</code>(**`ds_idx`**=*`1`*, **`dl`**=*`None`*, **`with_input`**=*`False`*, **`with_decoded`**=*`False`*, **`with_loss`**=*`False`*, **`act`**=*`None`*, **`inner`**=*`False`*, **`reorder`**=*`True`*, **`cbs`**=*`None`*, **`save_preds`**=*`None`*, **`save_targs`**=*`None`*, **`concat_dim`**=*`0`*)\n",
        "\n",
@@ -3047,7 +3093,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.predict\" class=\"doc_header\"><code>Learner.predict</code><a href=\"__main__.py#L174\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.predict\" class=\"doc_header\"><code>Learner.predict</code><a href=\"__main__.py#L183\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>Learner.predict</code>(**`item`**, **`rm_type_tfms`**=*`None`*, **`with_input`**=*`False`*)\n",
        "\n",
@@ -3119,7 +3165,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.show_results\" class=\"doc_header\"><code>Learner.show_results</code><a href=\"__main__.py#L185\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.show_results\" class=\"doc_header\"><code>Learner.show_results</code><a href=\"__main__.py#L194\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>Learner.show_results</code>(**`ds_idx`**=*`1`*, **`dl`**=*`None`*, **`max_n`**=*`9`*, **`shuffle`**=*`True`*, **\\*\\*`kwargs`**)\n",
        "\n",
@@ -3161,7 +3207,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.no_logging\" class=\"doc_header\"><code>Learner.no_logging</code><a href=\"__main__.py#L198\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.no_logging\" class=\"doc_header\"><code>Learner.no_logging</code><a href=\"__main__.py#L207\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>Learner.no_logging</code>()\n",
        "\n",
@@ -3199,7 +3245,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Learner.loss_not_reduced\" class=\"doc_header\"><code>Learner.loss_not_reduced</code><a href=\"__main__.py#L203\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"Learner.loss_not_reduced\" class=\"doc_header\"><code>Learner.loss_not_reduced</code><a href=\"__main__.py#L212\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>Learner.loss_not_reduced</code>()\n",
        "\n",
@@ -3283,7 +3329,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[0, 7.539340496063232, 6.498353481292725, '00:00']\n"
+      "[0, 6.204502582550049, 4.0893754959106445, '00:00']\n"
      ]
     }
    ],
@@ -3325,9 +3371,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[0, 15.418253898620605, 11.340129852294922, '00:00']\n",
-      "[0, 13.123358726501465, 9.585997581481934, '00:00']\n",
-      "[0, 11.062408447265625, 8.10999870300293, '00:00']\n"
+      "[0, 7.3807878494262695, 6.851467132568359, '00:00']\n",
+      "[0, 5.96987247467041, 5.61495304107666, '00:00']\n",
+      "[0, 4.916624546051025, 4.603828430175781, '00:00']\n"
      ]
     }
    ],
@@ -3471,6 +3517,7 @@
       "Converted 21_vision.learner.ipynb.\n",
       "Converted 22_tutorial.imagenette.ipynb.\n",
       "Converted 23_tutorial.vision.ipynb.\n",
+      "Converted 24_tutorial.image_sequence.ipynb.\n",
       "Converted 24_tutorial.siamese.ipynb.\n",
       "Converted 24_vision.gan.ipynb.\n",
       "Converted 30_text.core.ipynb.\n",
@@ -3533,5 +3580,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This checks if the `opt_func` passed into `Learner` is a partial, and if so, it checks if `lr` was one of the arguments for the partial function and uses it for creating the optimizer. This would solve the issue where people try to pass `opt_func=partial(OptimWrapper, torch.optim.SGD, lr=3e-4`) and the `Learner` uses its own default learning rate rather than the learning rate used in the partial function instead. I guess this would work well if the user wants to provide the learning rate into any partial `opt_func`.

I also added a quick test for this partial `OptimWrapper` scenario.

Let me know if you see any unintended consequences of this feature. Nothing immediately obvious comes to mind...