### PR TITLE
remove residual FetchPredsCallback when WandbCallback gets into exception

### DIFF
--- a/fastai/callback/wandb.py
+++ b/fastai/callback/wandb.py
@@ -108,6 +108,7 @@ class WandbCallback(Callback):
                 self.log_predictions(self.learn.fetch_preds.preds)
             except Exception as e:
                 self.log_preds = False
+                self.remove_cb(FetchPredsCallback)
                 print(f'WandbCallback was not able to get prediction samples -> {e}')
         wandb.log({n:s for n,s in zip(self.recorder.metric_names, self.recorder.log) if n not in ['train_loss', 'epoch', 'time']}, step=self._wandb_step)
 

--- a/nbs/70_callback.wandb.ipynb
+++ b/nbs/70_callback.wandb.ipynb
@@ -189,6 +189,7 @@
     "                self.log_predictions(self.learn.fetch_preds.preds)\n",
     "            except Exception as e:\n",
     "                self.log_preds = False\n",
+    "                self.remove_cb(FetchPredsCallback)\n",
     "                print(f'WandbCallback was not able to get prediction samples -> {e}')\n",
     "        wandb.log({n:s for n,s in zip(self.recorder.metric_names, self.recorder.log) if n not in ['train_loss', 'epoch', 'time']}, step=self._wandb_step)\n",
     "\n",


### PR DESCRIPTION
This fix aims to remove `FetchPredsCallback` from Learner when `WandbCallback` get into exception. 
`WandbCallback` adds `FetchPredsCallback` at the beginning of fit and then remove it at the end of fit. However, `WandbCallback` is left after fit when `WandbCallback` get into exception. In my experience, `learner.get_preds` crashed when `FetchPredsCallback` remained. 

A note on notebook cleaning, I tried to run the following before the commit
```
$ nbdev_install_git_hooks
$ nbdev_update_lib
$ nbdev_clean_nbs
```
But after that I found it induced changes in several notebooks, some of them seems not related to my change (as attached):
![Screenshot from 2021-05-16 22-32-41](https://user-images.githubusercontent.com/21143399/118401229-75f15800-b697-11eb-97cd-631b00d2a96d.png)
I am not sure if they are the right changes, so I didnt commit those notebook changes. If they are necessary, I can commit those changes as follows.