### PR TITLE
Add Open in Kaggle Badge 

### DIFF
--- a/dev_nbs/course/lesson3-head-pose.ipynb
+++ b/dev_nbs/course/lesson3-head-pose.ipynb
@@ -13,6 +13,7 @@
    "source": [
     "<a href=\"https://kaggle.com/kernels/welcome?src=https://github.com/fastai/fastai/blob/master/dev_nbs/course/lesson3-head-pose.ipynb\"><img align=\"left\" alt=\"Kaggle\" title=\"Open in Kaggle\" src=\"https://kaggle.com/static/images/open-in-kaggle.svg\"></a>&nbsp;",
     "<br></br>",
+    "<br></br>",
     "This is a more advanced example to show how to create custom datasets and do regression with images. Our task is to find the center of the head in each image. The data comes from the [BIWI head pose dataset](https://data.vision.ee.ethz.ch/cvl/gfanelli/head_pose/head_forest.html#db), thanks to Gabriele Fanelli et al. We have converted the images to jpeg format, so you should download the converted dataset from [this link](https://s3.amazonaws.com/fast-ai-imagelocal/biwi_head_pose.tgz)."
    ]
   },

--- a/dev_nbs/course/lesson3-head-pose.ipynb
+++ b/dev_nbs/course/lesson3-head-pose.ipynb
@@ -11,6 +11,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<a href=\"https://kaggle.com/kernels/welcome?src=https://github.com/fastai/fastai/blob/master/dev_nbs/course/lesson3-head-pose.ipynb\"><img align=\"left\" alt=\"Kaggle\" title=\"Open in Kaggle\" src=\"https://kaggle.com/static/images/open-in-kaggle.svg\"></a>&nbsp;",
+    "<br></br>",
     "This is a more advanced example to show how to create custom datasets and do regression with images. Our task is to find the center of the head in each image. The data comes from the [BIWI head pose dataset](https://data.vision.ee.ethz.ch/cvl/gfanelli/head_pose/head_forest.html#db), thanks to Gabriele Fanelli et al. We have converted the images to jpeg format, so you should download the converted dataset from [this link](https://s3.amazonaws.com/fast-ai-imagelocal/biwi_head_pose.tgz)."
    ]
   },

--- a/nbs/examples/migrating_catalyst.ipynb
+++ b/nbs/examples/migrating_catalyst.ipynb
@@ -1,5 +1,12 @@
 {
  "cells": [
+    {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://kaggle.com/kernels/welcome?src=https://github.com/fastai/fastai/blob/master/nbs/examples/migrating_catalyst.ipynb\"><img align=\"left\" alt=\"Kaggle\" title=\"Open in Kaggle\" src=\"https://kaggle.com/static/images/open-in-kaggle.svg\"></a>"
+   ]
+  },
   {
    "cell_type": "code",
    "execution_count": null,


### PR DESCRIPTION
This is an example of what adding a Kaggle Badge (that allows for opening the .ipynb as a Kaggle Notebook as seen here https://www.kaggle.com/product-feedback/152480) would look like.

If it makes sense I can submit a further PR adding it to other notebooks in the repo.