### PR TITLE
send self.loss_func to device if it is an insatnce on nn.Module

### DIFF
--- a/fastai/callback/core.py
+++ b/fastai/callback/core.py
@@ -67,6 +67,7 @@ class TrainEvalCallback(Callback):
         self.learn.train_iter,self.learn.pct_train = 0,0.
         device = getattr(self.dls, 'device', default_device())
         self.model.to(device)
+        if isinstance(self.loss_func, nn.Module): self.loss_func.to(device)
         if hasattr(self.model, 'reset'): self.model.reset()
 
     def after_batch(self):

--- a/fastai/callback/core.py
+++ b/fastai/callback/core.py
@@ -7,6 +7,7 @@ __all__ = ['CancelStepException', 'CancelFitException', 'CancelEpochException', 
 # Cell
 from ..data.all import *
 from ..optimizer import *
+from ..losses import BaseLoss
 
 # Cell
 #nbdev_comment _all_ = ['CancelStepException','CancelFitException','CancelEpochException','CancelTrainException','CancelValidException','CancelBatchException']
@@ -67,7 +68,7 @@ class TrainEvalCallback(Callback):
         self.learn.train_iter,self.learn.pct_train = 0,0.
         device = getattr(self.dls, 'device', default_device())
         self.model.to(device)
-        if isinstance(self.loss_func, nn.Module): self.loss_func.to(device)
+        if isinstance(self.loss_func, (nn.Module, BaseLoss)): self.loss_func.to(device)
         if hasattr(self.model, 'reset'): self.model.reset()
 
     def after_batch(self):

--- a/fastai/losses.py
+++ b/fastai/losses.py
@@ -34,6 +34,9 @@ class BaseLoss():
         if self.flatten: inp = inp.view(-1,inp.shape[-1]) if self.is_2d else inp.view(-1)
         return self.func.__call__(inp, targ.view(-1) if self.flatten else targ, **kwargs)
 
+    def to(self, device):
+        if isinstance(self.func, nn.Module): self.func.to(device)
+
 # Cell
 @delegates()
 class CrossEntropyLossFlat(BaseLoss):

--- a/nbs/01a_losses.ipynb
+++ b/nbs/01a_losses.ipynb
@@ -81,7 +81,10 @@
     "        if self.floatify and targ.dtype!=torch.float16: targ = targ.float()\n",
     "        if targ.dtype in [torch.int8, torch.int16, torch.int32]: targ = targ.long()\n",
     "        if self.flatten: inp = inp.view(-1,inp.shape[-1]) if self.is_2d else inp.view(-1)\n",
-    "        return self.func.__call__(inp, targ.view(-1) if self.flatten else targ, **kwargs)"
+    "        return self.func.__call__(inp, targ.view(-1) if self.flatten else targ, **kwargs)\n",
+    "    \n",
+    "    def to(self, device):\n",
+    "        if isinstance(self.func, nn.Module): self.func.to(device)"
    ]
   },
   {
@@ -151,6 +154,22 @@
     "\n",
     "test_eq(tst.activation(output), F.softmax(output, dim=1))\n",
     "test_eq(tst.decodes(output), output.argmax(dim=1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#hide\n",
+    "#cuda\n",
+    "tst = CrossEntropyLossFlat(weight=torch.ones(10))\n",
+    "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
+    "tst.to(device)\n",
+    "output = torch.randn(32, 10, device=device)\n",
+    "target = torch.randint(0, 10, (32,), device=device)\n",
+    "_ = tst(output, target)"
    ]
   },
   {
@@ -521,9 +540,9 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.8.5 64-bit ('fastdev': conda)",
    "language": "python",
-   "name": "python3"
+   "name": "python385jvsc74a57bd0f33cfda8056e56fdb4f6a83cd5700571fefad39836c42b5143dfff57f27c84a3"
   }
  },
  "nbformat": 4,

--- a/nbs/13_callback.core.ipynb
+++ b/nbs/13_callback.core.ipynb
@@ -28,7 +28,8 @@
    "source": [
     "#export\n",
     "from fastai.data.all import *\n",
-    "from fastai.optimizer import *"
+    "from fastai.optimizer import *\n",
+    "from fastai.losses import BaseLoss"
    ]
   },
   {
@@ -107,8 +108,16 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": "<h3 id=\"event\" class=\"doc_header\"><code>class</code> <code>event</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h3>\n\n> <code>event</code>(**\\*`args`**, **\\*\\*`kwargs`**)\n\nAll possible events as attributes to get tab-completion and typo-proofing",
-      "text/plain": "<IPython.core.display.Markdown object>"
+      "text/markdown": [
+       "<h3 id=\"event\" class=\"doc_header\"><code>class</code> <code>event</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h3>\n",
+       "\n",
+       "> <code>event</code>(**\\*`args`**, **\\*\\*`kwargs`**)\n",
+       "\n",
+       "All possible events as attributes to get tab-completion and typo-proofing"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -225,8 +234,16 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": "<h4 id=\"Callback.__call__\" class=\"doc_header\"><code>Callback.__call__</code><a href=\"__main__.py#L11\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n\n> <code>Callback.__call__</code>(**`event_name`**)\n\nCall `self.{event_name}` if it's defined",
-      "text/plain": "<IPython.core.display.Markdown object>"
+      "text/markdown": [
+       "<h4 id=\"Callback.__call__\" class=\"doc_header\"><code>Callback.__call__</code><a href=\"__main__.py#L11\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "\n",
+       "> <code>Callback.__call__</code>(**`event_name`**)\n",
+       "\n",
+       "Call `self.{event_name}` if it's defined"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -331,7 +348,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<ipython-input-10-d52c7bdd898f>:22: UserWarning: You are shadowing an attribute (a) that exists in the learner. Use `self.learn.a` to avoid this\n  warn(f\"You are shadowing an attribute ({name}) that exists in the learner. Use `self.learn.{name}` to avoid this\")\n"
+      "<ipython-input-10-d52c7bdd898f>:22: UserWarning: You are shadowing an attribute (a) that exists in the learner. Use `self.learn.a` to avoid this\n",
+      "  warn(f\"You are shadowing an attribute ({name}) that exists in the learner. Use `self.learn.{name}` to avoid this\")\n"
      ]
     }
    ],
@@ -375,8 +393,14 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": "<h4 id=\"Callback.name\" class=\"doc_header\"><code>Callback.name</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n\nName of the [`Callback`](/callback.core.html#Callback), camel-cased and with '*Callback*' removed",
-      "text/plain": "<IPython.core.display.Markdown object>"
+      "text/markdown": [
+       "<h4 id=\"Callback.name\" class=\"doc_header\"><code>Callback.name</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "\n",
+       "Name of the [`Callback`](/callback.core.html#Callback), camel-cased and with '*Callback*' removed"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -422,7 +446,7 @@
     "        self.learn.train_iter,self.learn.pct_train = 0,0.\n",
     "        device = getattr(self.dls, 'device', default_device())\n",
     "        self.model.to(device)\n",
-    "        if isinstance(self.loss_func, nn.Module): self.loss_func.to(device)\n",
+    "        if isinstance(self.loss_func, (nn.Module, BaseLoss)): self.loss_func.to(device)\n",
     "        if hasattr(self.model, 'reset'): self.model.reset()\n",
     "\n",
     "    def after_batch(self):\n",
@@ -449,8 +473,16 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": "<h3 id=\"TrainEvalCallback\" class=\"doc_header\"><code>class</code> <code>TrainEvalCallback</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h3>\n\n> <code>TrainEvalCallback</code>(**`after_create`**=*`None`*, **`before_fit`**=*`None`*, **`before_epoch`**=*`None`*, **`before_train`**=*`None`*, **`before_batch`**=*`None`*, **`after_pred`**=*`None`*, **`after_loss`**=*`None`*, **`before_backward`**=*`None`*, **`before_step`**=*`None`*, **`after_cancel_step`**=*`None`*, **`after_step`**=*`None`*, **`after_cancel_batch`**=*`None`*, **`after_batch`**=*`None`*, **`after_cancel_train`**=*`None`*, **`after_train`**=*`None`*, **`before_validate`**=*`None`*, **`after_cancel_validate`**=*`None`*, **`after_validate`**=*`None`*, **`after_cancel_epoch`**=*`None`*, **`after_epoch`**=*`None`*, **`after_cancel_fit`**=*`None`*, **`after_fit`**=*`None`*) :: [`Callback`](/callback.core.html#Callback)\n\n[`Callback`](/callback.core.html#Callback) that tracks the number of iterations done and properly sets training/eval mode",
-      "text/plain": "<IPython.core.display.Markdown object>"
+      "text/markdown": [
+       "<h3 id=\"TrainEvalCallback\" class=\"doc_header\"><code>class</code> <code>TrainEvalCallback</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h3>\n",
+       "\n",
+       "> <code>TrainEvalCallback</code>(**`after_create`**=*`None`*, **`before_fit`**=*`None`*, **`before_epoch`**=*`None`*, **`before_train`**=*`None`*, **`before_batch`**=*`None`*, **`after_pred`**=*`None`*, **`after_loss`**=*`None`*, **`before_backward`**=*`None`*, **`before_step`**=*`None`*, **`after_cancel_step`**=*`None`*, **`after_step`**=*`None`*, **`after_cancel_batch`**=*`None`*, **`after_batch`**=*`None`*, **`after_cancel_train`**=*`None`*, **`after_train`**=*`None`*, **`before_validate`**=*`None`*, **`after_cancel_validate`**=*`None`*, **`after_validate`**=*`None`*, **`after_cancel_epoch`**=*`None`*, **`after_epoch`**=*`None`*, **`after_cancel_fit`**=*`None`*, **`after_fit`**=*`None`*) :: [`Callback`](/callback.core.html#Callback)\n",
+       "\n",
+       "[`Callback`](/callback.core.html#Callback) that tracks the number of iterations done and properly sets training/eval mode"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -967,6 +999,7 @@
   },
   "kernelspec": {
    "display_name": "Python 3.8.5 64-bit ('fastdev': conda)",
+   "language": "python",
    "name": "python385jvsc74a57bd0f33cfda8056e56fdb4f6a83cd5700571fefad39836c42b5143dfff57f27c84a3"
   }
  },

--- a/nbs/13_callback.core.ipynb
+++ b/nbs/13_callback.core.ipynb
@@ -107,16 +107,8 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": [
-       "<h3 id=\"event\" class=\"doc_header\"><code>class</code> <code>event</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h3>\n",
-       "\n",
-       "> <code>event</code>(**\\*`args`**, **\\*\\*`kwargs`**)\n",
-       "\n",
-       "All possible events as attributes to get tab-completion and typo-proofing"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
+      "text/markdown": "<h3 id=\"event\" class=\"doc_header\"><code>class</code> <code>event</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h3>\n\n> <code>event</code>(**\\*`args`**, **\\*\\*`kwargs`**)\n\nAll possible events as attributes to get tab-completion and typo-proofing",
+      "text/plain": "<IPython.core.display.Markdown object>"
      },
      "metadata": {},
      "output_type": "display_data"
@@ -233,16 +225,8 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": [
-       "<h4 id=\"Callback.__call__\" class=\"doc_header\"><code>Callback.__call__</code><a href=\"__main__.py#L11\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
-       "\n",
-       "> <code>Callback.__call__</code>(**`event_name`**)\n",
-       "\n",
-       "Call `self.{event_name}` if it's defined"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
+      "text/markdown": "<h4 id=\"Callback.__call__\" class=\"doc_header\"><code>Callback.__call__</code><a href=\"__main__.py#L11\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n\n> <code>Callback.__call__</code>(**`event_name`**)\n\nCall `self.{event_name}` if it's defined",
+      "text/plain": "<IPython.core.display.Markdown object>"
      },
      "metadata": {},
      "output_type": "display_data"
@@ -347,7 +331,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/mnt/d/lib/python3.7/site-packages/ipykernel_launcher.py:22: UserWarning: You are shadowing an attribute (a) that exists in the learner. Use `self.learn.a` to avoid this\n"
+      "<ipython-input-10-d52c7bdd898f>:22: UserWarning: You are shadowing an attribute (a) that exists in the learner. Use `self.learn.a` to avoid this\n  warn(f\"You are shadowing an attribute ({name}) that exists in the learner. Use `self.learn.{name}` to avoid this\")\n"
      ]
     }
    ],
@@ -391,14 +375,8 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": [
-       "<h4 id=\"Callback.name\" class=\"doc_header\"><code>Callback.name</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
-       "\n",
-       "Name of the [`Callback`](/callback.core.html#Callback), camel-cased and with '*Callback*' removed"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
+      "text/markdown": "<h4 id=\"Callback.name\" class=\"doc_header\"><code>Callback.name</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n\nName of the [`Callback`](/callback.core.html#Callback), camel-cased and with '*Callback*' removed",
+      "text/plain": "<IPython.core.display.Markdown object>"
      },
      "metadata": {},
      "output_type": "display_data"
@@ -444,6 +422,7 @@
     "        self.learn.train_iter,self.learn.pct_train = 0,0.\n",
     "        device = getattr(self.dls, 'device', default_device())\n",
     "        self.model.to(device)\n",
+    "        if isinstance(self.loss_func, nn.Module): self.loss_func.to(device)\n",
     "        if hasattr(self.model, 'reset'): self.model.reset()\n",
     "\n",
     "    def after_batch(self):\n",
@@ -470,16 +449,8 @@
    "outputs": [
     {
      "data": {
-      "text/markdown": [
-       "<h3 id=\"TrainEvalCallback\" class=\"doc_header\"><code>class</code> <code>TrainEvalCallback</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h3>\n",
-       "\n",
-       "> <code>TrainEvalCallback</code>(**`after_create`**=*`None`*, **`before_fit`**=*`None`*, **`before_epoch`**=*`None`*, **`before_train`**=*`None`*, **`before_batch`**=*`None`*, **`after_pred`**=*`None`*, **`after_loss`**=*`None`*, **`before_backward`**=*`None`*, **`before_step`**=*`None`*, **`after_cancel_step`**=*`None`*, **`after_step`**=*`None`*, **`after_cancel_batch`**=*`None`*, **`after_batch`**=*`None`*, **`after_cancel_train`**=*`None`*, **`after_train`**=*`None`*, **`before_validate`**=*`None`*, **`after_cancel_validate`**=*`None`*, **`after_validate`**=*`None`*, **`after_cancel_epoch`**=*`None`*, **`after_epoch`**=*`None`*, **`after_cancel_fit`**=*`None`*, **`after_fit`**=*`None`*) :: [`Callback`](/callback.core.html#Callback)\n",
-       "\n",
-       "[`Callback`](/callback.core.html#Callback) that tracks the number of iterations done and properly sets training/eval mode"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
+      "text/markdown": "<h3 id=\"TrainEvalCallback\" class=\"doc_header\"><code>class</code> <code>TrainEvalCallback</code><a href=\"\" class=\"source_link\" style=\"float:right\">[source]</a></h3>\n\n> <code>TrainEvalCallback</code>(**`after_create`**=*`None`*, **`before_fit`**=*`None`*, **`before_epoch`**=*`None`*, **`before_train`**=*`None`*, **`before_batch`**=*`None`*, **`after_pred`**=*`None`*, **`after_loss`**=*`None`*, **`before_backward`**=*`None`*, **`before_step`**=*`None`*, **`after_cancel_step`**=*`None`*, **`after_step`**=*`None`*, **`after_cancel_batch`**=*`None`*, **`after_batch`**=*`None`*, **`after_cancel_train`**=*`None`*, **`after_train`**=*`None`*, **`before_validate`**=*`None`*, **`after_cancel_validate`**=*`None`*, **`after_validate`**=*`None`*, **`after_cancel_epoch`**=*`None`*, **`after_epoch`**=*`None`*, **`after_cancel_fit`**=*`None`*, **`after_fit`**=*`None`*) :: [`Callback`](/callback.core.html#Callback)\n\n[`Callback`](/callback.core.html#Callback) that tracks the number of iterations done and properly sets training/eval mode",
+      "text/plain": "<IPython.core.display.Markdown object>"
      },
      "metadata": {},
      "output_type": "display_data"
@@ -538,7 +509,8 @@
     "- `x`/`xb`: last input drawn from `self.dl` (potentially modified by callbacks). `xb` is always a tuple (potentially with one element) and `x` is detuplified. You can only assign to `xb`.\n",
     "- `y`/`yb`: last target drawn from `self.dl` (potentially modified by callbacks). `yb` is always a tuple (potentially with one element) and `y` is detuplified. You can only assign to `yb`.\n",
     "- `pred`: last predictions from `self.model` (potentially modified by callbacks)\n",
-    "- `loss`: last computed loss (potentially modified by callbacks)\n",
+    "- `loss_grad`: last computed loss (potentially modified by callbacks)\n",
+    "- `loss`: clone of `loss_grad` used for logging\n",
     "- `n_epoch`: the number of epochs in this training\n",
     "- `n_iter`: the number of iterations in the current `self.dl`\n",
     "- `epoch`: the current epoch index (from 0 to `n_epoch-1`)\n",
@@ -994,9 +966,8 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
+   "display_name": "Python 3.8.5 64-bit ('fastdev': conda)",
+   "name": "python385jvsc74a57bd0f33cfda8056e56fdb4f6a83cd5700571fefad39836c42b5143dfff57f27c84a3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
If `loss_func` has assoicated parameters or buffers on other device it triggers error. This PR adds a line to send `loss_func` to device in `TrainEvalCallback` is it's an instance of `nn.Module`. 
Minimal example gist: https://gist.github.com/arampacha/ae6299a7b577da3d2d18e88bec2e39e2

If this makes sense it's possible to add `BaseLoss.to` method and have similar behavior for it