### PR TITLE
changes DataLoaders.from_dsets

### DIFF
--- a/fastai/data/core.py
+++ b/fastai/data/core.py
@@ -187,7 +187,7 @@ class DataLoaders(GetAttr):
         val_kwargs={k[4:]:kwargs.pop(k) for k in list(kwargs.keys()) if k.startswith('val_')}
         def_kwargs = {'bs':bs,'shuffle':shuffle,'drop_last':drop_last,'device':device}
         dl = dl_type(ds[0], **merge(def_kwargs, kwargs))
-        def_kwargs = {'bs':bs if val_bs is None else val_bs,'shuffle':val_shuffle,'drop_last':False}
+        def_kwargs = {'bs':val_bs,'shuffle':val_shuffle,'drop_last':False}
         dls = [dl] + [dl.new(ds[i], **merge(def_kwargs,kwargs,val_kwargs))
                       for i in range(1,len(ds))]
         return cls(*dls, path=path, device=device)

--- a/nbs/03_data.core.ipynb
+++ b/nbs/03_data.core.ipynb
@@ -585,7 +585,7 @@
     "        val_kwargs={k[4:]:kwargs.pop(k) for k in list(kwargs.keys()) if k.startswith('val_')}\n",
     "        def_kwargs = {'bs':bs,'shuffle':shuffle,'drop_last':drop_last,'device':device}\n",
     "        dl = dl_type(ds[0], **merge(def_kwargs, kwargs))\n",
-    "        def_kwargs = {'bs':bs if val_bs is None else val_bs,'shuffle':val_shuffle,'drop_last':False}\n",
+    "        def_kwargs = {'bs':val_bs,'shuffle':val_shuffle,'drop_last':False}\n",
     "        dls = [dl] + [dl.new(ds[i], **merge(def_kwargs,kwargs,val_kwargs))\n",
     "                      for i in range(1,len(ds))]\n",
     "        return cls(*dls, path=path, device=device)\n",
@@ -683,23 +683,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(Pipeline: _TestTfm, Pipeline: _TestTfm)"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "dls3 = DataLoaders.from_dsets(start, start, bs=4, val_bs=8, after_item=[_TestTfm()], val_after_batch=[_TestTfm()])\n",
     "test_eq(len(dls3.train.after_batch.fs),0)\n",
     "test_eq(len(dls3.valid.after_batch.fs),1)\n",
-    "dls.train.after_item, dls.valid.after_item"
+    "test_eq(len(dls3.train.after_item.fs), len(dls3.valid.after_item.fs))"
    ]
   },
   {

--- a/nbs/03_data.core.ipynb
+++ b/nbs/03_data.core.ipynb
@@ -357,7 +357,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"DataLoader.one_batch\" class=\"doc_header\"><code>DataLoader.one_batch</code><a href=\"https://github.com/fastai/fastai/tree/master/fastai/data/load.py#L148\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"DataLoader.one_batch\" class=\"doc_header\"><code>DataLoader.one_batch</code><a href=\"https://github.com/fastai/fastai/tree/master/fastai/data/load.py#L146\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>DataLoader.one_batch</code>()\n",
        "\n",
@@ -577,14 +577,18 @@
     "    def cpu(self):  return self.to(device=torch.device('cpu'))\n",
     "\n",
     "    @classmethod\n",
-    "    def from_dsets(cls, *ds, path='.',  bs=64, device=None, dl_type=TfmdDL, **kwargs):\n",
-    "        default = (True,) + (False,) * (len(ds)-1)\n",
-    "        defaults = {'shuffle': default, 'drop_last': default}\n",
-    "        for nm in _batch_tfms:\n",
-    "            if nm in kwargs: kwargs[nm] = Pipeline(kwargs[nm])\n",
-    "        kwargs = merge(defaults, {k: tuplify(v, match=ds) for k,v in kwargs.items()})\n",
-    "        kwargs = [{k: v[i] for k,v in kwargs.items()} for i in range_of(ds)]\n",
-    "        return cls(*[dl_type(d, bs=bs, **k) for d,k in zip(ds, kwargs)], path=path, device=device)\n",
+    "    def from_dsets(cls, *ds, bs=64, val_bs=None, shuffle=True, val_shuffle=False, path='.',\n",
+    "                   dl_type=TfmdDL, device=None, **kwargs):\n",
+    "        if device is None: device=default_device()\n",
+    "        drop_last = kwargs.get('drop_last', shuffle)\n",
+    "        if val_bs is None: val_bs=bs\n",
+    "        val_kwargs={k[4:]:kwargs.pop(k) for k in list(kwargs.keys()) if k.startswith('val_')}\n",
+    "        def_kwargs = {'bs':bs,'shuffle':shuffle,'drop_last':drop_last,'device':device}\n",
+    "        dl = dl_type(ds[0], **merge(def_kwargs, kwargs))\n",
+    "        def_kwargs = {'bs':bs if val_bs is None else val_bs,'shuffle':val_shuffle,'drop_last':False}\n",
+    "        dls = [dl] + [dl.new(ds[i], **merge(def_kwargs,kwargs,val_kwargs))\n",
+    "                      for i in range(1,len(ds))]\n",
+    "        return cls(*dls, path=path, device=device)\n",
     "\n",
     "    @classmethod\n",
     "    def from_dblock(cls, dblock, source, path='.',  bs=64, val_bs=None, shuffle=True, device=None, **kwargs):\n",
@@ -600,6 +604,7 @@
     "               cuda=\"Use the gpu if available\",\n",
     "               cpu=\"Use the cpu\",\n",
     "               new_empty=\"Create a new empty version of `self` with the same transforms\",\n",
+    "               from_dsets=\"Create dataloaders from custom datasets `ds`\",\n",
     "               from_dblock=\"Create a dataloaders from a given `dblock`\")"
    ]
   },
@@ -672,6 +677,29 @@
     "test_eq(len(dls2.train.after_batch.fs),0)\n",
     "test_eq(len(dls2.valid.after_batch.fs),2)\n",
     "test_eq(next(iter(dls2.valid)),tensor([1,1,1,1]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(Pipeline: _TestTfm, Pipeline: _TestTfm)"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dls3 = DataLoaders.from_dsets(start, start, bs=4, val_bs=8, after_item=[_TestTfm()], val_after_batch=[_TestTfm()])\n",
+    "test_eq(len(dls3.train.after_batch.fs),0)\n",
+    "test_eq(len(dls3.valid.after_batch.fs),1)\n",
+    "dls.train.after_item, dls.valid.after_item"
    ]
   },
   {
@@ -2156,9 +2184,9 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.8.5 64-bit ('fastdev': conda)",
    "language": "python",
-   "name": "python3"
+   "name": "python385jvsc74a57bd0f33cfda8056e56fdb4f6a83cd5700571fefad39836c42b5143dfff57f27c84a3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Linked issues #3396 #3373 
@riven314 and myself came up with possible solution. This PR changes `DataLoaders.from_dsets` to resamble `Datasets.dataloaders` ([link](https://github.com/fastai/fastai/blob/301016c5d3de2bdb5269121bd0716538d85f7409/fastai/data/core.py#L221)). This resolves aforementioned issue and allows to pass custom arguments to valid dataloader (e.g. val_res for `SortedDL`).

Open questions:
- How do we deal with situation when only one dataset is passed to constructor. As of now it will trigger error when trying to access `dls.valid`?
- It's still not quite clear what exactly was causing the issue. It was not observed with `do_setup=False` so probably something went wrong when setting up `Pipeline`s. But `Pipeline.setup` in isolation doesn't seem to cause same effect.