### PR TITLE
removal of trailing query string following image file in URL

### DIFF
--- a/dev_nbs/course/lesson2-download.ipynb
+++ b/dev_nbs/course/lesson2-download.ipynb
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "hide_input": false
    },
@@ -1343,18 +1343,6 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/dev_nbs/course/lesson2-download.ipynb
+++ b/dev_nbs/course/lesson2-download.ipynb
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "hide_input": false
    },
@@ -1343,6 +1343,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/fastai/vision/utils.py
+++ b/fastai/vision/utils.py
@@ -22,6 +22,7 @@ def _get_downloaded_image_filename(dest, name, suffix):
 # Cell
 def _download_image_inner(dest, inp, timeout=4, preserve_filename=False):
     i,url = inp
+    url = url.split("?")[0]
     url_path = Path(url)
     suffix = url_path.suffix if url_path.suffix else '.jpg'
     name = _get_downloaded_image_filename(dest, url_path.stem, suffix) if preserve_filename else f"{i:08d}"

--- a/nbs/09b_vision.utils.ipynb
+++ b/nbs/09b_vision.utils.ipynb
@@ -80,6 +80,7 @@
     "#export\n",
     "def _download_image_inner(dest, inp, timeout=4, preserve_filename=False):\n",
     "    i,url = inp\n",
+    "    url = url.split(\"?\")[0]\n",
     "    url_path = Path(url)\n",
     "    suffix = url_path.suffix if url_path.suffix else '.jpg'\n",
     "    name = _get_downloaded_image_filename(dest, url_path.stem, suffix) if preserve_filename else f\"{i:08d}\"\n",


### PR DESCRIPTION
PR as requested by @jph00 in the Discord chat for current course (lesson 3 channel). The change removes any trailing query string in the URL which is currently carried over into the file name (extension) thus meaning the file in not used thereafter.

I ended up using the .split() string method instead of additionally importing urllib. 

Note I only made changes to to the nbs/09b_vision.utils.ipynb and nbdev_build_lib them into fastai/vision/utils.py and added these 2 files.

Not sure why dev_nbs/course/lesson2-download.ipynb was included in the commit?

i.e. should I not do a git add in this context?