### PR TITLE
Add `log_freq` param to WandbCallback

### DIFF
--- a/nbs/70_callback.wandb.ipynb
+++ b/nbs/70_callback.wandb.ipynb
@@ -100,14 +100,14 @@
     "    # Record if watch has been called previously (even in another instance)\n",
     "    _wandb_watch_called = False\n",
     "\n",
-    "    def __init__(self, log=\"gradients\", log_preds=True, log_model=True, log_dataset=False, dataset_name=None, valid_dl=None, n_preds=36, seed=12345, reorder=True):\n",
+    "    def __init__(self, log=\"gradients\", log_preds=True, log_model=True, log_dataset=False, dataset_name=None, valid_dl=None, n_preds=36, seed=12345, reorder=True, log_freq=1000):\n",
     "        # Check if wandb.init has been called\n",
     "        if wandb.run is None:\n",
     "            raise ValueError('You must call wandb.init() before WandbCallback()')\n",
     "        # W&B log step\n",
     "        self._wandb_step = wandb.run.step - 1  # -1 except if the run has previously logged data (incremented at each batch)\n",
     "        self._wandb_epoch = 0 if not(wandb.run.step) else math.ceil(wandb.run.summary['epoch']) # continue to next epoch\n",
-    "        store_attr('log,log_preds,log_model,log_dataset,dataset_name,valid_dl,n_preds,seed,reorder')\n",
+    "        store_attr('log,log_preds,log_model,log_dataset,dataset_name,valid_dl,n_preds,seed,reorder,log_freq')\n",
     "\n",
     "    def before_fit(self):\n",
     "        \"Call watch method to log model topology, gradients & weights\"\n",
@@ -125,7 +125,7 @@
     "        if not WandbCallback._wandb_watch_called:\n",
     "            WandbCallback._wandb_watch_called = True\n",
     "            # Logs model topology and optionally gradients and weights\n",
-    "            wandb.watch(self.learn.model, log=self.log)\n",
+    "            wandb.watch(self.learn.model, log=self.log, log_freq=self.log_freq)\n",
     "\n",
     "        # log dataset\n",
     "        assert isinstance(self.log_dataset, (str, Path, bool)), 'log_dataset must be a path or a boolean'\n",
@@ -873,13 +873,19 @@
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "10951ab8608296a5a0cdeec1a18304ecb3d7c26209d7d704833d6e1ee4f84e7e"
+  },
   "jupytext": {
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
+   "display_name": "Python 3.9.5 64-bit ('fastaidev': conda)",
    "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": ""
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Previously, `WandbCallback` used the default `log_freq=1000`, which may prevent any grads or params from being logged if there are too few steps.