### PR TITLE
Fix typos in LR finder suggestion methods docs

### DIFF
--- a/nbs/14_callback.schedule.ipynb
+++ b/nbs/14_callback.schedule.ipynb
@@ -1337,7 +1337,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are a few methodologies for suggesting a learning rate automatically and these as we will see can further be passed into `lr_find`. Currently four methods are supported, however to write your own you should it should look like a function that can accept `LRFinder`'s returned `lrs`, `losses`, as well as the `num_it`. \n",
+    "There are a few methodologies for suggesting a learning rate automatically and these as we will see can further be passed into `lr_find`. Currently four methods are supported, however to write your own it should look like a function that can accept `LRFinder`'s returned `lrs`, `losses`, as well as the `num_it`. \n",
     "Your function should return an `x,y` coordinate that can be plotted, such as below:\n",
     "\n",
     "\n",
@@ -1672,7 +1672,7 @@
    "source": [
     "First introduced by Leslie N. Smith in [Cyclical Learning Rates for Training Neural Networks](https://arxiv.org/pdf/1506.01186.pdf), the LR Finder trains the model with exponentially growing learning rates from `start_lr` to `end_lr` for `num_it` and stops in case of divergence (unless `stop_div=False`) then plots the losses vs the learning rates with a log scale. \n",
     "\n",
-    "A variety of learning rate suggestion algorithms can be passed into the function, by default we use the `steep` paradigm."
+    "A variety of learning rate suggestion algorithms can be passed into the function, by default we use the `valley` paradigm."
    ]
   },
   {


### PR DESCRIPTION
This PR fixes the default algorithm for `Learner.lr_find` in the docs from `steep` to `valley`, and removes a little typo.