### PR TITLE
Fix tabular_learner to accept custom embedding sizes

### DIFF
--- a/fastai/tabular/learner.py
+++ b/fastai/tabular/learner.py
@@ -26,7 +26,7 @@ def tabular_learner(dls, layers=None, emb_szs=None, config=None, n_out=None, y_r
     if config is None: config = tabular_config()
     if layers is None: layers = [200,100]
     to = dls.train_ds
-    emb_szs = get_emb_sz(dls.train_ds, {} if emb_szs is None else emb_szs)
+    emb_szs = get_emb_sz(dls.train_ds, {}) if emb_szs is None else emb_szs
     if n_out is None: n_out = get_c(dls)
     assert n_out, "`n_out` is not defined, and could not be inferred from data, set `dls.c` or pass `n_out`"
     if y_range is None and 'y_range' in config: y_range = config.pop('y_range')

--- a/nbs/43_tabular.learner.ipynb
+++ b/nbs/43_tabular.learner.ipynb
@@ -139,7 +139,7 @@
     "    if config is None: config = tabular_config()\n",
     "    if layers is None: layers = [200,100]\n",
     "    to = dls.train_ds\n",
-    "    emb_szs = get_emb_sz(dls.train_ds, {} if emb_szs is None else emb_szs)\n",
+    "    emb_szs = get_emb_sz(dls.train_ds, {}) if emb_szs is None else emb_szs\n",
     "    if n_out is None: n_out = get_c(dls)\n",
     "    assert n_out, \"`n_out` is not defined, and could not be inferred from data, set `dls.c` or pass `n_out`\"\n",
     "    if y_range is None and 'y_range' in config: y_range = config.pop('y_range')\n",
@@ -425,7 +425,7 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   }


### PR DESCRIPTION
There is a typo in tabular_learner, which makes it impossible to set custom embedding sizes.