### PR TITLE
bugfix for learner summary

### DIFF
--- a/fastai/callback/hook.py
+++ b/fastai/callback/hook.py
@@ -201,7 +201,7 @@ def module_summary(learn, *xb):
 @patch
 def summary(self:Learner):
     "Print a summary of the model, optimizer and loss function."
-    xb = self.dls.train.one_batch()[:self.dls.train.n_inp]
+    xb = self.dls.train.one_batch()[:getattr(self.dls.train, "n_inp", 1)]
     res = module_summary(self, *xb)
     res += f"Optimizer used: {self.opt_func}\nLoss function: {self.loss_func}\n\n"
     if self.opt is not None:

--- a/nbs/15_callback.hook.ipynb
+++ b/nbs/15_callback.hook.ipynb
@@ -1113,7 +1113,7 @@
     "@patch\n",
     "def summary(self:Learner):\n",
     "    \"Print a summary of the model, optimizer and loss function.\"\n",
-    "    xb = self.dls.train.one_batch()[:self.dls.train.n_inp]\n",
+    "    xb = self.dls.train.one_batch()[:getattr(self.dls.train, \"n_inp\", 1)]\n",
     "    res = module_summary(self, *xb)\n",
     "    res += f\"Optimizer used: {self.opt_func}\\nLoss function: {self.loss_func}\\n\\n\"\n",
     "    if self.opt is not None:\n",
@@ -1254,6 +1254,37 @@
     "\n",
     "learn = synth_learner(model = _NOutModel())\n",
     "learn.summary() # Output Shape should be (50, 16, 256), (1, 16, 256)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#hide\n",
+    "# Test for the case (as in Book) when learn.dls.train_ds is a list not fastai.data.core.Datasets\n",
+    "train_x = torch.rand((100, 4))\n",
+    "train_y = torch.rand((100, 1))\n",
+    "\n",
+    "valid_x = torch.rand((100, 4))\n",
+    "valid_y = torch.rand((100,1))\n",
+    "\n",
+    "dset = list(zip(train_x,train_y))\n",
+    "valid_dset = list(zip(valid_x,valid_y))\n",
+    "\n",
+    "dl = DataLoader(dset, batch_size=16)\n",
+    "val_dl = DataLoader(valid_dset, batch_size=16)\n",
+    "\n",
+    "dls = DataLoaders(dl, val_dl)\n",
+    "\n",
+    "simple_net = nn.Sequential(\n",
+    "    nn.Linear(4, 2),\n",
+    "    nn.ReLU(),\n",
+    "    nn.Linear(2,1)\n",
+    ")\n",
+    "learn = Learner(dls, simple_net, loss_func=F.l1_loss)\n",
+    "learn.summary()"
    ]
   },
   {


### PR DESCRIPTION
In Chapter 4: Under the Hood: Training a Digit Classifier (04_mnist_basics.ipynb) Jeremy creates Dataloaders from lists:

```python
train_x = torch.cat([stacked_threes, stacked_sevens]).view(-1, 28*28)
train_y = tensor([1]*len(threes) + [0]*len(sevens)).unsqueeze(1)
dset = list(zip(train_x,train_y))
dl = DataLoader(dset, batch_size=256)
```

as a result, there is no Dataset object and we can't use `summary` method of a learner

Here is a fix (and a test) that works the same for objects that have "n_inp" attribute and work with lists if there is no.