### PR TITLE
Add explicit links to the migrating scripts [Documentation]

### DIFF
--- a/nbs/examples/migrating_catalyst.ipynb
+++ b/nbs/examples/migrating_catalyst.ipynb
@@ -40,7 +40,7 @@
    "source": [
     "We're going to use the MNIST training code from Catalyst's README (as at August 2020), converted to a module.\n",
     "\n",
-    "> Note: The `migrating_catalyst` script is available [here](https://github.com/fastai/fastai/blob/master/nbs/examples/migrating_catalyst.py)"
+    "> Note: The source script for `migrating_catalyst` is in the `examples` subdirectory of this folder if you checked out the `fastai` repo from git, or can be downloaded from [here](https://github.com/fastai/fastai/blob/master/nbs/examples/migrating_catalyst.py) if you're using an online viewer such as Colab. "
    ]
   },
   {

--- a/nbs/examples/migrating_catalyst.ipynb
+++ b/nbs/examples/migrating_catalyst.ipynb
@@ -38,7 +38,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We're going to use the MNIST training code from Catalyst's README (as at August 2020), converted to a module."
+    "We're going to use the MNIST training code from Catalyst's README (as at August 2020), converted to a module.\n",
+    "\n",
+    "> Note: The `migrating_catalyst` script is available [here](https://github.com/fastai/fastai/blob/master/nbs/examples/migrating_catalyst.py)"
    ]
   },
   {

--- a/nbs/examples/migrating_ignite.ipynb
+++ b/nbs/examples/migrating_ignite.ipynb
@@ -22,7 +22,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We're going to use the MNIST training code from Ignite's examples directory (as at August 2020), converted to a module."
+    "We're going to use the MNIST training code from Ignite's examples directory (as at August 2020), converted to a module.\n",
+    "\n",
+    "> Note: The `migrating_ignite` script is available [here](https://github.com/fastai/fastai/blob/master/nbs/examples/migrating_ignite.py)"
    ]
   },
   {

--- a/nbs/examples/migrating_ignite.ipynb
+++ b/nbs/examples/migrating_ignite.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "We're going to use the MNIST training code from Ignite's examples directory (as at August 2020), converted to a module.\n",
     "\n",
-    "> Note: The `migrating_ignite` script is available [here](https://github.com/fastai/fastai/blob/master/nbs/examples/migrating_ignite.py)"
+    "> Note: The source script for `migrating_ignite` is in the `examples` subdirectory of this folder if you checked out the `fastai` repo from git, or can be downloaded from [here](https://github.com/fastai/fastai/blob/master/nbs/examples/migrating_ignite.py) if you're using an online viewer such as Colab. "
    ]
   },
   {

--- a/nbs/examples/migrating_lightning.ipynb
+++ b/nbs/examples/migrating_lightning.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "We're going to use the MNIST training code from Lightning's 'Quick Start' (as at August 2020), converted to a module.\n",
     "\n",
-    "> Note: The `migrating_lightning` script is available [here](https://github.com/fastai/fastai/blob/master/nbs/examples/migrating_lightning.py)"
+    "> Note: The source script for `migrating_lightning` is in the `examples` subdirectory of this folder if you checked out the `fastai` repo from git, or can be downloaded from [here](https://github.com/fastai/fastai/blob/master/nbs/examples/migrating_lightning.py) if you're using an online viewer such as Colab. "
    ]
   },
   {

--- a/nbs/examples/migrating_lightning.ipynb
+++ b/nbs/examples/migrating_lightning.ipynb
@@ -22,7 +22,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We're going to use the MNIST training code from Lightning's 'Quick Start' (as at August 2020), converted to a module. See `migrating_lightning.py` for the Lightning code we are importing here."
+    "We're going to use the MNIST training code from Lightning's 'Quick Start' (as at August 2020), converted to a module.\n",
+    "\n",
+    "> Note: The `migrating_catalyst` script is available [here](https://github.com/fastai/fastai/blob/master/nbs/examples/migrating_lightning.py)"
    ]
   },
   {

--- a/nbs/examples/migrating_lightning.ipynb
+++ b/nbs/examples/migrating_lightning.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "We're going to use the MNIST training code from Lightning's 'Quick Start' (as at August 2020), converted to a module.\n",
     "\n",
-    "> Note: The `migrating_catalyst` script is available [here](https://github.com/fastai/fastai/blob/master/nbs/examples/migrating_lightning.py)"
+    "> Note: The `migrating_lightning` script is available [here](https://github.com/fastai/fastai/blob/master/nbs/examples/migrating_lightning.py)"
    ]
   },
   {

--- a/nbs/examples/migrating_pytorch.ipynb
+++ b/nbs/examples/migrating_pytorch.ipynb
@@ -31,7 +31,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We're going to use the MNIST training code from the official PyTorch examples, slightly reformatted for space, updated from AdaDelta to AdamW, and converted from a script to a module. There's a lot of code, so we've put it into migrating_pytorch.py!"
+    "We're going to use the MNIST training code from the official PyTorch examples, slightly reformatted for space, updated from AdaDelta to AdamW, and converted from a script to a module. There's a lot of code, so we've put it into migrating_pytorch.py!\n",
+    "\n",
+    "> Note: The `migrating_pytorch` script is available [here](https://github.com/fastai/fastai/blob/master/nbs/examples/migrating_pytorch.py)"
    ]
   },
   {

--- a/nbs/examples/migrating_pytorch.ipynb
+++ b/nbs/examples/migrating_pytorch.ipynb
@@ -33,7 +33,7 @@
    "source": [
     "We're going to use the MNIST training code from the official PyTorch examples, slightly reformatted for space, updated from AdaDelta to AdamW, and converted from a script to a module. There's a lot of code, so we've put it into migrating_pytorch.py!\n",
     "\n",
-    "> Note: The `migrating_pytorch` script is available [here](https://github.com/fastai/fastai/blob/master/nbs/examples/migrating_pytorch.py)"
+    "> Note: The source script for `migrating_pytorch` is in the `examples` subdirectory of this folder if you checked out the `fastai` repo from git, or can be downloaded from [here](https://github.com/fastai/fastai/blob/master/nbs/examples/migrating_pytorch.py) if you're using an online viewer such as Colab. "
    ]
   },
   {


### PR DESCRIPTION
Makes sure that each Migrating* tutorial has an explicit link to the various script they utilize