### PR TITLE
Add verbose migrating pytorch tutorial [Documentation]

### DIFF
--- a/docs_src/sidebar.json
+++ b/docs_src/sidebar.json
@@ -33,6 +33,7 @@
         "empty3": {
             "Migrating from Other Libraries": {
                 "Plain PyTorch": "/migrating_pytorch.html",
+                "Plain PyTorch (Verbose)": "/migrating_pytorch_verbose.html",
                 "Ignite": "/migrating_ignite.html",
                 "Lightning": "/migrating_lightning.html",
                 "Catalyst": "/migrating_catalyst.html"

--- a/nbs/examples/migrating_pytorch_verbose.ipynb
+++ b/nbs/examples/migrating_pytorch_verbose.ipynb
@@ -1,0 +1,817 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#hide\n",
+    "#skip\n",
+    "! [ -e /content ] && pip install -Uqq fastai  # upgrade fastai on colab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#all_slow"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Migrating PyTorch - Verbose\n",
+    "\n",
+    "> Step by step integrating raw PyTorch into the fastai framework"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this tutorial we will be training MNIST (similar to the shortened tutorial [here](https://docs.fast.ai/migrating_pytorch.html)) from scratch using pure PyTorch and incrementally adding it to the fastai framework. What this entials is using:\n",
+    "- PyTorch DataLoaders\n",
+    "- PyTorch Model\n",
+    "- PyTorch Optimizer\n",
+    "\n",
+    "And with fastai we will simply use the Training Loop (or the `Learner` class)\n",
+    "\n",
+    "In this tutorial also since generally people are more used to explicit exports, we will use explicit exports within the fastai library, but also do understand you can get all of these imports automatically by doing `from fastai.vision.all import *`\n",
+    "\n",
+    "> Generally it is also recommend you do so because of monkey-patching throughout the library. You will see why later"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As mentioned in the title, we will  be loading in the dataset simply with the `torchvision` module. \n",
+    "\n",
+    "This includes both loading in the dataset, and preparing it for the DataLoaders (including transforms)\n",
+    "\n",
+    "First we will grab our imports:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch, torchvision\n",
+    "import torchvision.transforms as transforms"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next we can define some minimal transforms for converting the raw two-channel images into trainable tensors as well as normalize them:\n",
+    "\n",
+    "> The mean and standard deviation come from the MNIST dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tfms = transforms.Compose([transforms.ToTensor(),\n",
+    "                                 transforms.Normalize((0.1307,), (0.3081))\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before finally creating our train and test `DataLoaders` by downloading the dataset and applying our transforms."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torchvision import datasets\n",
+    "from torch.utils.data import DataLoader"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First let's download a train and test (or validation as it is reffered to in the fastai framework) dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_dset = datasets.MNIST('../data', train=True, download=True, transform=tfms)\n",
+    "valid_dset = datasets.MNIST('../data', train=False, transform=tfms)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next we'll define a few hyperparameters to pass to the individual `DataLoader`'s as they are being made.\n",
+    "\n",
+    "We'll set a batch size of 256 while training, and 512 during the validation set\n",
+    "\n",
+    "We'll also use a single worker and pin the memory:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_loader = DataLoader(train_dset, batch_size=256, \n",
+    "                          shuffle=True, num_workers=1, pin_memory=True)\n",
+    "\n",
+    "test_loader = DataLoader(valid_dset, batch_size=512,\n",
+    "                         shuffle=False, num_workers=1, pin_memory=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we have raw PyTorch `DataLoader`'s. To use them within the fastai framework all that is left is to wrap it in the fastai `DataLoaders` class, which just takes in any number of `DataLoader` objects and combines them into one:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastai.data.core import DataLoaders"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dls = DataLoaders(train_loader, test_loader)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We have now prepared the data for `fastai`! Next let's build a basic model to use"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This will be an extremely simplistic 2 layer convolutional neural network with an extra set of layers that mimics fastai's generated `head`. In each head includes a `Flatten` layer, which simply just adjusts the shape of the outputs. We will mimic it here"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torch import nn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Flatten(nn.Module):\n",
+    "    \"Flattens an input\"\n",
+    "    def forward(self, x): return x.view(x.size(0), -1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And then our actual model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Net(nn.Sequential):\n",
+    "    def __init__(self):\n",
+    "        super().__init__(\n",
+    "            nn.Conv2d(1, 32, 3, 1), nn.ReLU(),\n",
+    "            nn.Conv2d(32, 64, 3, 1), \n",
+    "            # A head to the model\n",
+    "            nn.MaxPool2d(2), nn.Dropout2d(0.25),\n",
+    "            Flatten(), nn.Linear(9216, 128), nn.ReLU(),\n",
+    "            nn.Dropout2d(0.5), nn.Linear(128, 10), nn.LogSoftmax(dim=1)\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Optimizer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using native PyTorch optimizers in the fastai framework is made extremely simple thanks to the `OptimWrapper` interface. \n",
+    "\n",
+    "Simply write a `partial` function specifying the `opt` as a torch optimizer. \n",
+    "\n",
+    "In our example we will use `Adam`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastai.optimizer import OptimWrapper\n",
+    "\n",
+    "from torch import optim\n",
+    "from functools import partial"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "opt_func = partial(OptimWrapper, opt=optim.Adam)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And that is all that's needed to make a working optimizer in the framework. You do not need to declare layer groups or any of the sort, that all occurs in the `Learner` class which we will do next!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Training"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Training in the fastai framework revolves around the `Learner` class. This class ties everything we declared earlier together and allows for quick training with many different schedulers and `Callback`'s quickly.\n",
+    "\n",
+    "Since we are using explicit exports in this tutorial, you will notice that we will import `Learner` three seperate times. This is because `Learner` is heavily monkey-patched throughout the library, so to utilize it best we need to get all of the existing patches"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastai.learner import Learner\n",
+    "from fastai.callback.schedule import Learner # To get `fit_one_cycle`, `lr_find`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Note: All `Callbacks` will still work, regardless of the type of dataloaders. It is recommended to use the `.all` import when wanting so, this way all callbacks are imported and anything related to the `Learne` is imported at once as well"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To build the Learner (minimally), we need to pass in the `DataLoaders`, our model, a loss function, potentially some metrics to use, and an optimizer function. \n",
+    "\n",
+    "Let's import the `accuracy` metric from fastai:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastai.metrics import accuracy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll use `nll_loss` as our loss function as well"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch.nn.functional as F"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And build our `Learner`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn = Learner(dls, Net(), loss_func=F.nll_loss, opt_func=opt_func, metrics=accuracy)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that everything is tied together, let's train our model with the One-Cycle policy through the `fit_one_cycle` function. We'll also use a learning rate of 1e-2 for a single epoch\n",
+    "\n",
+    "It would be noted that fastai's training loop will automatically take care of moving tensors to the proper devices during training, and will use the GPU by default if it is available. When using non-fastai native individual DataLoaders, it will look at the model's device for what device we want to train with."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To access any of the above parameters, we look in similarly-named properties such as `learn.dls`, `learn.model`, `learn.loss_func`, and so on. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's train:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: left;\">\n",
+       "      <th>epoch</th>\n",
+       "      <th>train_loss</th>\n",
+       "      <th>valid_loss</th>\n",
+       "      <th>accuracy</th>\n",
+       "      <th>time</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>0</td>\n",
+       "      <td>0.137776</td>\n",
+       "      <td>0.048324</td>\n",
+       "      <td>0.983600</td>\n",
+       "      <td>00:10</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.7/dist-packages/torch/nn/functional.py:718: UserWarning: Named tensors and all their associated APIs are an experimental feature and subject to change. Please do not use them for anything important until they are released as stable. (Triggered internally at  /pytorch/c10/core/TensorImpl.h:1156.)\n",
+      "  return torch.max_pool2d(input, kernel_size, stride, padding, dilation, ceil_mode)\n"
+     ]
+    }
+   ],
+   "source": [
+    "learn.fit_one_cycle(n_epoch=1, lr_max=1e-2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we have trained our model, let's simulate shipping off the model to be used on inference or various prediction methods."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exporting and Predicting"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To export your trained model, you can either use the `learn.export` method coupled with `load_learner` to load it back in, but it should be noted that none of the inference API will work, as we did not train with the fastai data API.\n",
+    "\n",
+    "Instead you should save the model weights, and perform raw PyTorch inference.\n",
+    "\n",
+    "We will walk through a quick example below.\n",
+    "\n",
+    "First let's save the model weights:\n",
+    "> Note: Generally when doing this approach you should also store the source code to build the model as well"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Path('models/myModel.pth')"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "learn.save('myModel', with_opt=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Note: `Learner.save` will save the optimizer state by default as well. When doing so the weights are located in the `model` key. We will set this to `false` for this tutorial"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can see that it showed us the location where our trained weights were stored. Next, let's load that in as a seperated PyTorch model not tied to the `Learner`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_net = Net()\n",
+    "net_dict = torch.load('models/myModel.pth') \n",
+    "new_net.load_state_dict(net_dict);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, let's predict on a single image using those `tfms` we declared earlier.\n",
+    "\n",
+    "When predicting in general we preprocess the dataset in the same form as the validation set, and this is how fastai does it as well with their `test_dl` and `test_set` methods.\n",
+    "\n",
+    "Since the downloaded dataset doesn't have individual files for us to work with, we will download a set of only 3's and 7's from fastai, and predict on one of those images:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastai.data.external import untar_data, URLs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <div>\n",
+       "        <style>\n",
+       "            /* Turns off some styling */\n",
+       "            progress {\n",
+       "                /* gets rid of default border in Firefox and Opera. */\n",
+       "                border: none;\n",
+       "                /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
+       "                background-size: auto;\n",
+       "            }\n",
+       "            .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
+       "                background: #F44336;\n",
+       "            }\n",
+       "        </style>\n",
+       "      <progress value='3219456' class='' max='3214948' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+       "      100.14% [3219456/3214948 00:00<00:00]\n",
+       "    </div>\n",
+       "    "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "data_path = untar_data(URLs.MNIST_SAMPLE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(#3) [Path('/root/.fastai/data/mnist_sample/labels.csv'),Path('/root/.fastai/data/mnist_sample/valid'),Path('/root/.fastai/data/mnist_sample/train')]"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_path.ls()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll grab one of the `valid` images"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "single_image = data_path/'valid'/'3'/'8483.png'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Open it in Pillow:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from PIL import Image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "im = Image.open(single_image)\n",
+    "im.load();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAABBElEQVR4nL2RMUsDQRSEJ5cY4haxMyIRsTApLRStLAz2YpM/YIK/wNpC7gdoJZh0Imhho/6CiIUWoqhdhCiksjHdId9qcRc87jZtppnHvH3zdnal8SMTcXa30pyUOo+vbZs61AAAC6f/ohfxgiTpvPWh+l5qMm+MMcbTYpfPuZGXaMBa0jaO+rDIxdVcIbCr0pXLsdDi7oaYbRz7YIGXomtnOaTBwDW5+dB77wa2P+9qasZIPpzknV1J6wFsJHdOlMKy8y3VEs3qdf9sWpIzpQ8clyRt/cBBJA5f6J6smiuXT0vLnt6OkqM7APwCHKZ8p2oX4WfzVXGE8LZvsTz7s6NSjgV/f9RkTrD3HWUAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28 at 0x7FB4F8979690>"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "im"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next we will apply the same transforms that we did to our validation set"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1, 28, 28])"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tfmd_im = tfms(im); tfmd_im.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll set it as a batch of 1:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tfmd_im = tfmd_im.unsqueeze(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1, 1, 28, 28])"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tfmd_im.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And then predict with our model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with torch.no_grad():\n",
+    "    new_net.cuda()\n",
+    "    tfmd_im = tfmd_im.cuda()\n",
+    "    preds = new_net(tfmd_im)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at the predictions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[-1.6179e+01, -1.0118e+01, -6.2008e+00, -4.2441e-03, -1.9511e+01,\n",
+       "         -8.5174e+00, -2.2341e+01, -1.0145e+01, -6.8038e+00, -7.1086e+00]],\n",
+       "       device='cuda:0')"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "preds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This isn't quite what fastai outputs, we need to convert this into a class label to make it similar. To do so, we simply take the argmax of the predictions over the first index.\n",
+    "\n",
+    "If we were using fastai DataLoaders, it would use this as an index into a list of class names. Since our labels are 0-9, the argmax *is* our label:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([3], device='cuda:0')"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "preds.argmax(dim=-1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And we can see it correctly predicted a label of 3!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Adds a new tutorial to the migration guides that mimics the original Pytorch tutorial, but is a bit more explicit in what is going on.

There is benefit in having both so I've added this as a (Verbose) example. 

Eg: this one is geared towards beginners who want hand-holding in what each part does and interact with the framework, while the other is a nice quick walkthrough and script for them to mimic