### PR TITLE
Update 05_data.transforms.ipynb

### DIFF
--- a/nbs/05_data.transforms.ipynb
+++ b/nbs/05_data.transforms.ipynb
@@ -460,7 +460,7 @@
     "test_size = 0.2\n",
     "\n",
     "f = TrainTestSplitter(test_size=test_size, random_state=42, stratify=labels)\n",
-    "trn,val = _test_splitter(f)\n",
+    "trn,val = _test_splitter(f, items=src)\n",
     "\n",
     "# test labels distribution consistency\n",
     "# there should be test_size % of zeroes and ones respectively in the validation set\n",


### PR DESCRIPTION
While _test_splitter(f) works in this example,  _test_splitter(f, items=src) is better, because it doesn't break the example when changing the number of list items and labels.