### PR TITLE
Remove redundant color specification

### DIFF
--- a/fastai/callback/schedule.py
+++ b/fastai/callback/schedule.py
@@ -269,7 +269,7 @@ def plot_lr_find(self:Recorder, skip_end=5, return_fig=True, suggestions=None, n
     if suggestions:
         colors = plt.rcParams['axes.prop_cycle'].by_key()['color'][1:]
         for (val, idx), nm, color in zip(suggestions, nms, colors):
-            ax.plot(val, idx, 'ro', label=nm, c=color)
+            ax.plot(val, idx, 'o', label=nm, c=color)
         ax.legend(loc='best')
 
 # Cell

--- a/nbs/14_callback.schedule.ipynb
+++ b/nbs/14_callback.schedule.ipynb
@@ -1629,7 +1629,7 @@
     "    if suggestions:\n",
     "        colors = plt.rcParams['axes.prop_cycle'].by_key()['color'][1:]\n",
     "        for (val, idx), nm, color in zip(suggestions, nms, colors):\n",
-    "            ax.plot(val, idx, 'ro', label=nm, c=color)\n",
+    "            ax.plot(val, idx, 'o', label=nm, c=color)\n",
     "        ax.legend(loc='best')"
    ]
   },


### PR DESCRIPTION
Remove redundant color specification on `plot_lr_find`, it was causing warning messages from matplotlib.