### PR TITLE
Fix #3277

### DIFF
--- a/nbs/60_medical.imaging.ipynb
+++ b/nbs/60_medical.imaging.ipynb
@@ -1634,10 +1634,16 @@
     "    if cls.__base__ == object: return x\n",
     "    return cls.__base__(x)\n",
     "\n",
-    "def _split_elem(res,k,v):\n",
-    "    if not isinstance(v,DcmMultiValue): return\n",
-    "    res[f'Multi{k}'] = 1\n",
-    "    for i,o in enumerate(v): res[f'{k}{\"\" if i==0 else i}']=o"
+    "def _split_elem(vals):\n",
+    "    res = dict()\n",
+    "    for val in vals:\n",
+    "        k, v = val.keyword, val.value\n",
+    "        if not isinstance(v,DcmMultiValue):\n",
+    "            res[k] = v\n",
+    "            continue\n",
+    "        res[f'Multi{k}'] = 1\n",
+    "        for i,o in enumerate(v): res[f'{k}{\"\" if i==0 else i}'] = o\n",
+    "    return {k: _cast_dicom_special(v) for k, v in res.items()}"
    ]
   },
   {
@@ -1652,10 +1658,8 @@
     "    \"Convert the header of a dicom into a dictionary\"\n",
     "    pxdata = (0x7fe0,0x0010)\n",
     "    vals = [self[o] for o in self.keys() if o != pxdata]\n",
-    "    its = [(v.keyword,v.value) for v in vals]\n",
-    "    res = dict(its)\n",
+    "    res = _split_elem(vals)\n",
     "    res['fname'] = self.filename\n",
-    "    for k,v in its: _split_elem(res,k,v)\n",
     "    if not px_summ: return res\n",
     "    stats = 'min','max','mean','std'\n",
     "    try:\n",
@@ -1665,7 +1669,6 @@
     "    except Exception as e:\n",
     "        for f in stats: res['img_'+f] = 0\n",
     "        print(res,e)\n",
-    "    for k in res: res[k] = _cast_dicom_special(res[k])\n",
     "    return res"
    ]
   },


### PR DESCRIPTION
`_split_elem` is supposed to strip all MultiValues, but fails for sequences of length 0 as the value is never overwritten by the for loop.