### PR TITLE
Improvements to AzureMLCallback

### DIFF
--- a/fastai/callback/azureml.py
+++ b/fastai/callback/azureml.py
@@ -8,21 +8,33 @@ from ..learner import Callback
 
 # Cell
 from azureml.core.run import Run
+from azureml.exceptions import RunEnvironmentException
+import warnings
 
 # Cell
 class AzureMLCallback(Callback):
-    "Log losses, metrics, model architecture summary to AzureML"
+    """
+    Log losses, metrics, model architecture summary to AzureML.
+
+    If `log_offline` is False, will only log if actually running on AzureML.
+    A custom AzureML `Run` class can be passed as `azurerun`.
+    """
     order = Recorder.order+1
 
     def __init__(self, azurerun=None):
         if azurerun:
             self.azurerun = azurerun
         else:
-            self.azurerun = Run.get_context()
+            try:
+                self.azurerun = Run.get_context(allow_offline=False)
+            except RunEnvironmentException:
+                # running locally
+                self.azurerun = None
+                warnings.warn("Not running on AzureML and no azurerun passed, AzureMLCallback will be disabled.")
 
     def before_fit(self):
-        self.azurerun.log("n_epoch", self.learn.n_epoch)
-        self.azurerun.log("model_class", str(type(self.learn.model)))
+        self._log("n_epoch", self.learn.n_epoch)
+        self._log("model_class", str(type(self.learn.model)))
 
         try:
             summary_file = Path("outputs") / 'model_summary.txt'
@@ -34,19 +46,23 @@ class AzureMLCallback(Callback):
     def after_batch(self):
         # log loss and opt.hypers
         if self.learn.training:
-            self.azurerun.log('batch__loss', self.learn.loss.item())
-            self.azurerun.log('batch__train_iter', self.learn.train_iter)
+            self._log('batch__loss', self.learn.loss.item())
+            self._log('batch__train_iter', self.learn.train_iter)
             for i, h in enumerate(self.learn.opt.hypers):
                 for k, v in h.items():
-                    self.azurerun.log(f'batch__opt.hypers.{k}', v)
+                    self._log(f'batch__opt.hypers.{k}', v)
 
     def after_epoch(self):
         # log metrics
         for n, v in zip(self.learn.recorder.metric_names, self.learn.recorder.log):
             if n not in ['epoch', 'time']:
-                self.azurerun.log(f'epoch__{n}', v)
+                self._log(f'epoch__{n}', v)
             if n == 'time':
                 # split elapsed time string, then convert into 'seconds' to log
                 m, s = str(v).split(':')
                 elapsed = int(m)*60 + int(s)
-                self.azurerun.log(f'epoch__{n}', elapsed)
+                self._log(f'epoch__{n}', elapsed)
+
+    def _log(self, metric, value):
+        if self.azurerun is not None:
+            self.azurerun.log(metric, value)

--- a/fastai/callback/azureml.py
+++ b/fastai/callback/azureml.py
@@ -18,10 +18,11 @@ class AzureMLCallback(Callback):
 
     If `log_offline` is False, will only log if actually running on AzureML.
     A custom AzureML `Run` class can be passed as `azurerun`.
+    If `log_to_parent` is True, will also log to the parent run, if exists (e.g. in AzureML pipelines).
     """
     order = Recorder.order+1
 
-    def __init__(self, azurerun=None):
+    def __init__(self, azurerun=None, log_to_parent=True):
         if azurerun:
             self.azurerun = azurerun
         else:
@@ -31,6 +32,7 @@ class AzureMLCallback(Callback):
                 # running locally
                 self.azurerun = None
                 warnings.warn("Not running on AzureML and no azurerun passed, AzureMLCallback will be disabled.")
+        self.log_to_parent = log_to_parent
 
     def before_fit(self):
         self._log("n_epoch", self.learn.n_epoch)
@@ -66,3 +68,5 @@ class AzureMLCallback(Callback):
     def _log(self, metric, value):
         if self.azurerun is not None:
             self.azurerun.log(metric, value)
+            if self.log_to_parent and self.azurerun.parent is not None:
+                self.azurerun.parent.log(metric, value)

--- a/nbs/74_callback.azureml.ipynb
+++ b/nbs/74_callback.azureml.ipynb
@@ -90,6 +90,8 @@
     "\n",
     "If you are running an experiment on your local machine (i.e. not using `ScriptRunConfig` and not passing an `run` into the callback), it will recognize that there is no AzureML run to log to, and produce no logging output.\n",
     "\n",
+    "If you are using [AzureML pipelines](https://docs.microsoft.com/en-us/azure/machine-learning/concept-ml-pipelines), the `AzureMLCallback` will by default also send the same logging output to the parent run, so that metrics can easily be plotted. If you do not want this (e.g. because you have multiple training steps in a pipeline), you can disable it by setting `log_to_parent`to `False`.\n",
+    "\n",
     "To save the model weights, use the usual fastai methods and save the model to the `outputs` folder, which is a \"special\" (for Azure) folder that is automatically tracked in AzureML.\n",
     "\n",
     "As it stands, note that if you pass the callback into your `Learner` directly, e.g.:\n",
@@ -124,10 +126,11 @@
     "\n",
     "    If `log_offline` is False, will only log if actually running on AzureML.\n",
     "    A custom AzureML `Run` class can be passed as `azurerun`.\n",
+    "    If `log_to_parent` is True, will also log to the parent run, if exists (e.g. in AzureML pipelines).\n",
     "    \"\"\"\n",
     "    order = Recorder.order+1\n",
     "\n",
-    "    def __init__(self, azurerun=None):\n",
+    "    def __init__(self, azurerun=None, log_to_parent=True):\n",
     "        if azurerun:\n",
     "            self.azurerun = azurerun\n",
     "        else:\n",
@@ -137,6 +140,7 @@
     "                # running locally\n",
     "                self.azurerun = None\n",
     "                warnings.warn(\"Not running on AzureML and no azurerun passed, AzureMLCallback will be disabled.\")\n",
+    "        self.log_to_parent = log_to_parent\n",
     "\n",
     "    def before_fit(self):\n",
     "        self._log(\"n_epoch\", self.learn.n_epoch)\n",
@@ -171,7 +175,9 @@
     "\n",
     "    def _log(self, metric, value):\n",
     "        if self.azurerun is not None:\n",
-    "            self.azurerun.log(metric, value)"
+    "            self.azurerun.log(metric, value)\n",
+    "            if self.log_to_parent and self.azurerun.parent is not None:\n",
+    "                self.azurerun.parent.log(metric, value)"
    ]
   },
   {

--- a/nbs/74_callback.azureml.ipynb
+++ b/nbs/74_callback.azureml.ipynb
@@ -88,7 +88,7 @@
     "learn.fit_one_cycle(epoch, lr, cbs=AzureMLCallback(run))\n",
     "```\n",
     "\n",
-    "If you are running an experiment on your local machine (i.e. not using `ScriptRunConfig` and not passing an azureml `run` into the callback), it will recognize that there is no AzureML run to log to, and print the log attempts instead.\n",
+    "If you are running an experiment on your local machine (i.e. not using `ScriptRunConfig` and not passing an `run` into the callback), it will recognize that there is no AzureML run to log to, and produce no logging output.\n",
     "\n",
     "To save the model weights, use the usual fastai methods and save the model to the `outputs` folder, which is a \"special\" (for Azure) folder that is automatically tracked in AzureML.\n",
     "\n",
@@ -106,7 +106,9 @@
    "outputs": [],
    "source": [
     "#export\n",
-    "from azureml.core.run import Run"
+    "from azureml.core.run import Run\n",
+    "from azureml.exceptions import RunEnvironmentException\n",
+    "import warnings"
    ]
   },
   {
@@ -117,18 +119,28 @@
    "source": [
     "# export\n",
     "class AzureMLCallback(Callback):\n",
-    "    \"Log losses, metrics, model architecture summary to AzureML\"\n",
+    "    \"\"\"\n",
+    "    Log losses, metrics, model architecture summary to AzureML.\n",
+    "\n",
+    "    If `log_offline` is False, will only log if actually running on AzureML.\n",
+    "    A custom AzureML `Run` class can be passed as `azurerun`.\n",
+    "    \"\"\"\n",
     "    order = Recorder.order+1\n",
     "\n",
     "    def __init__(self, azurerun=None):\n",
     "        if azurerun:\n",
     "            self.azurerun = azurerun\n",
     "        else:\n",
-    "            self.azurerun = Run.get_context()\n",
+    "            try:\n",
+    "                self.azurerun = Run.get_context(allow_offline=False)\n",
+    "            except RunEnvironmentException:\n",
+    "                # running locally\n",
+    "                self.azurerun = None\n",
+    "                warnings.warn(\"Not running on AzureML and no azurerun passed, AzureMLCallback will be disabled.\")\n",
     "\n",
     "    def before_fit(self):\n",
-    "        self.azurerun.log(\"n_epoch\", self.learn.n_epoch)\n",
-    "        self.azurerun.log(\"model_class\", str(type(self.learn.model)))\n",
+    "        self._log(\"n_epoch\", self.learn.n_epoch)\n",
+    "        self._log(\"model_class\", str(type(self.learn.model)))\n",
     "\n",
     "        try:\n",
     "            summary_file = Path(\"outputs\") / 'model_summary.txt'\n",
@@ -140,22 +152,26 @@
     "    def after_batch(self):\n",
     "        # log loss and opt.hypers\n",
     "        if self.learn.training:\n",
-    "            self.azurerun.log('batch__loss', self.learn.loss.item())\n",
-    "            self.azurerun.log('batch__train_iter', self.learn.train_iter)\n",
+    "            self._log('batch__loss', self.learn.loss.item())\n",
+    "            self._log('batch__train_iter', self.learn.train_iter)\n",
     "            for i, h in enumerate(self.learn.opt.hypers):\n",
     "                for k, v in h.items():\n",
-    "                    self.azurerun.log(f'batch__opt.hypers.{k}', v)\n",
+    "                    self._log(f'batch__opt.hypers.{k}', v)\n",
     "\n",
     "    def after_epoch(self):\n",
     "        # log metrics\n",
     "        for n, v in zip(self.learn.recorder.metric_names, self.learn.recorder.log):\n",
     "            if n not in ['epoch', 'time']:\n",
-    "                self.azurerun.log(f'epoch__{n}', v)\n",
+    "                self._log(f'epoch__{n}', v)\n",
     "            if n == 'time':\n",
     "                # split elapsed time string, then convert into 'seconds' to log\n",
     "                m, s = str(v).split(':')\n",
     "                elapsed = int(m)*60 + int(s)\n",
-    "                self.azurerun.log(f'epoch__{n}', elapsed)"
+    "                self._log(f'epoch__{n}', elapsed)\n",
+    "\n",
+    "    def _log(self, metric, value):\n",
+    "        if self.azurerun is not None:\n",
+    "            self.azurerun.log(metric, value)"
    ]
   },
   {
@@ -168,7 +184,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   }

--- a/settings.ini
+++ b/settings.ini
@@ -16,7 +16,7 @@ language = English
 requirements = fastdownload>=0.0.5,<2 fastcore>=1.3.22,<1.4 torchvision>=0.8.2 matplotlib pandas requests pyyaml fastprogress>=0.2.4 pillow>6.0.0 scikit-learn scipy spacy<4
 pip_requirements = torch>=1.7.0,<1.10
 conda_requirements = pytorch>=1.7.0,<1.10
-dev_requirements = nbdev>=1.0.22,<2 ipywidgets pytorch-lightning pytorch-ignite transformers sentencepiece tensorboard pydicom catalyst captum>=0.3 flask wandb kornia scikit-image neptune-client albumentations opencv-python pyarrow catalyst ninja
+dev_requirements = nbdev>=1.0.22,<2 ipywidgets pytorch-lightning pytorch-ignite transformers sentencepiece tensorboard pydicom catalyst captum>=0.3 flask wandb azureml-sdk kornia scikit-image neptune-client albumentations opencv-python pyarrow catalyst ninja
 nbs_path = nbs
 doc_path = docs
 doc_src_path = docs_src


### PR DESCRIPTION
This adds two small improvements to the AzureMLCallback:
- Do not print unsuccessful log attempts when running locally
- Also log to the parent run when using Azure ML pipelines (can be disabled with the `log_to_parent` parameter)

It also seems like the Azure ML integration is not showing up in the docs website next to the other [integrations](https://docs.fast.ai/callback.neptune.html). This is probably because the Azure ML SDK is not installed during docs build time, so I added `azureml-sdk` to the `dev_requirements` to hopefully fix this.