### PR TITLE
Missing shapes for activations and Flatten in learner.summary

### DIFF
--- a/fastai/callback/hook.py
+++ b/fastai/callback/hook.py
@@ -147,9 +147,9 @@ def layer_info(learn, *xb):
     def _track(m, i, o):
         params, trainable, shape = '', '', ''
         same = any((isinstance(x[0], torch.Tensor) and x[0].shape[1:] == x[1].shape for x in zip(i, o)))
+        shape = apply(lambda x: x.shape, o)
         if hasattr(m, 'weight'): # non activation layer
             params, trainable = total_params(m)
-            shape = apply(lambda x: x.shape, o)
         return (type(m).__name__, params, trainable, shape, same)
 
     with Hooks(flatten_model(learn.model), _track) as h:

--- a/nbs/15_callback.hook.ipynb
+++ b/nbs/15_callback.hook.ipynb
@@ -983,9 +983,9 @@
     "    def _track(m, i, o): \n",
     "        params, trainable, shape = '', '', ''\n",
     "        same = any((isinstance(x[0], torch.Tensor) and x[0].shape[1:] == x[1].shape for x in zip(i, o)))\n",
+    "        shape = apply(lambda x: x.shape, o)\n",
     "        if hasattr(m, 'weight'): # non activation layer\n",
     "            params, trainable = total_params(m)\n",
-    "            shape = apply(lambda x: x.shape, o)\n",
     "        return (type(m).__name__, params, trainable, shape, same)\n",
     "            \n",
     "    with Hooks(flatten_model(learn.model), _track) as h:\n",
@@ -1000,12 +1000,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The output of `_track` is expected to be a `type`, the number of parameters, the shape of the layer, whether it is trainable, what layer group it belongs to, and whether or not the size changed. There are three potential groups that can show:\n",
+    "The output of `_track` is expected to be a `tuple` of module name, the number of parameters, the shape of the layer, whether it is trainable, what layer group it belongs to, and whether or not the size changed. There are three potential groups that can show:\n",
     "* A non-activation layer (Linear, Conv, etc)\n",
     "* An activation layer\n",
     "* A pooling layer\n",
     "\n",
-    "Depending on which only part of the output is really returned, otherwise it is `''`. For non-activation layers everything is returned. Activation layers only return a name and `False` for `same`. Pooling layers will return the name, the new shape, and `False` for `same`"
+    "Depending on which only part of the output is really returned, otherwise it is `''`. For non-activation layers everything is returned. Activation layers only return a name, the shape and `False` for `same`. Pooling layers will return the name, the new shape, and `False` for `same`"
    ]
   },
   {
@@ -1018,7 +1018,37 @@
     "sample_input = torch.randn((16, 1))\n",
     "test_eq(layer_info(synth_learner(model=_m()), sample_input), [\n",
     "    ('Linear', 100, True, [1, 50], False),\n",
-    "    ('ReLU', '', '', '', True),\n",
+    "    ('ReLU', '', '', [1,50], True),\n",
+    "    ('BatchNorm1d', 100, True, [1, 50], True),\n",
+    "    ('Linear', 51, True, [1, 1], False)\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#hide\n",
+    "# Test for Flatten\n",
+    "def _tst_m(): return nn.Sequential(\n",
+    "    nn.Conv2d(1, 2, kernel_size=3, padding=1, stride=2),\n",
+    "    nn.ReLU(),\n",
+    "    nn.Flatten(),\n",
+    "    nn.Linear(8,50), \n",
+    "    nn.ReLU(), \n",
+    "    nn.BatchNorm1d(50), \n",
+    "    nn.Linear(50, 1)\n",
+    ")\n",
+    "                                                              \n",
+    "sample_input = torch.randn((1,1,4,4))\n",
+    "test_eq(layer_info(synth_learner(model=_tst_m()), sample_input), [\n",
+    "    ('Conv2d', 20, True, [1, 2, 2, 2], False),\n",
+    "    ('ReLU', '', '', [1, 2, 2, 2], True),\n",
+    "    ('Flatten', '', '', [1, 8], False),\n",
+    "    ('Linear', 450, True, [1, 50], False),\n",
+    "    ('ReLU', '', '', [1,50], True),\n",
     "    ('BatchNorm1d', 100, True, [1, 50], True),\n",
     "    ('Linear', 51, True, [1, 1], False)\n",
     "])"
@@ -1045,7 +1075,7 @@
     "learn.dls.n_inp = 2\n",
     "test_eq(layer_info(learn, *sample_inputs), [\n",
     "    ('Linear', 150, True, [1, 50], False),\n",
-    "    ('ReLU', '', '', '', True),\n",
+    "    ('ReLU', '', '', [1,50], True),\n",
     "    ('BatchNorm1d', 100, True, [1, 50], True),\n",
     "    ('Linear', 51, True, [1, 1], False)\n",
     "])"


### PR DESCRIPTION
When I was going from fastbook `13_convolutions.ipynb` notebook I found that the `learn.summary()` method was printing out the shapes for activation functions. The one that was really useful for myself was the output shape of the `Flatten()` module. 
![image](https://user-images.githubusercontent.com/4218395/136545594-e023360d-b6d9-461b-b066-1dfa746fdb04.png)

However, going through the notebook with the latest fastai, i found out that output shape of the Flatten module is empty, what I found misleading. I found that the format of the summary is changed which is not a problem, but I found that missing shapes of non-trainable modules (like flatten) might be misleading.

Here is my attempt to fix that situation. Apparently, shapes wasn't calculated for non-trainable modules.
