### PR TITLE
Modify HookCallBack to optionally include paramless layers like Relu

### DIFF
--- a/fastai/callback/hook.py
+++ b/fastai/callback/hook.py
@@ -107,13 +107,13 @@ class HookCallback(Callback):
     "`Callback` that can be used to register hooks on `modules`"
     _methods = ["hook"]
     hook = noops
-    def __init__(self, modules=None, every=None, remove_end=True, is_forward=True, detach=True, cpu=True, **kwargs):
-        store_attr('modules,every,remove_end,is_forward,detach,cpu')
+    def __init__(self, modules=None, every=None, remove_end=True, is_forward=True, detach=True, cpu=True, include_paramless=False , **kwargs):
+        store_attr('modules,every,remove_end,is_forward,detach,cpu, include_paramless')
         assert not kwargs
 
     def before_fit(self):
         "Register the `Hooks` on `self.modules`."
-        if self.modules is None: self.modules = [m for m in flatten_model(self.model) if has_params(m)]
+        if self.modules is None: self.modules = [m for m in flatten_model(self.model) if self.include_paramless or has_params(m)]
         if self.every is None: self._register()
 
     def before_batch(self):

--- a/nbs/15_callback.hook.ipynb
+++ b/nbs/15_callback.hook.ipynb
@@ -787,13 +787,13 @@
     "    \"`Callback` that can be used to register hooks on `modules`\"\n",
     "    _methods = [\"hook\"]\n",
     "    hook = noops\n",
-    "    def __init__(self, modules=None, every=None, remove_end=True, is_forward=True, detach=True, cpu=True, **kwargs):\n",
-    "        store_attr('modules,every,remove_end,is_forward,detach,cpu')\n",
+    "    def __init__(self, modules=None, every=None, remove_end=True, is_forward=True, detach=True, cpu=True, include_paramless=False , **kwargs):\n",
+    "        store_attr('modules,every,remove_end,is_forward,detach,cpu, include_paramless')\n",
     "        assert not kwargs\n",
     "\n",
     "    def before_fit(self):\n",
     "        \"Register the `Hooks` on `self.modules`.\"\n",
-    "        if self.modules is None: self.modules = [m for m in flatten_model(self.model) if has_params(m)]\n",
+    "        if self.modules is None: self.modules = [m for m in flatten_model(self.model) if self.include_paramless or has_params(m)]\n",
     "        if self.every is None: self._register()\n",
     "\n",
     "    def before_batch(self):\n",
@@ -821,7 +821,8 @@
    "source": [
     "You can either subclass and implement a `hook` function (along with any event you want) or pass that a `hook` function when initializing. Such a function needs to take three argument: a layer, input and output (for a backward hook, input means gradient with respect to the inputs, output, gradient with respect to the output) and can either modify them or update the state according to them.\n",
     "\n",
-    "If not provided, `modules` will default to the layers of `self.model` that have a `weight` attribute. Depending on `do_remove`, the hooks will be properly removed at the end of training (or in case of error). `is_forward` , `detach` and `cpu` are passed to `Hooks`.\n",
+    "If not provided, `modules` will default to the layers of `self.model` that have a `weight` attribute. (to include layers of `self.model` that *do not* have a `weight` attribute e.g `ReLU`, `Flatten` etc., set `include_paramless=True`)\n",
+    "Depending on `do_remove`, the hooks will be properly removed at the end of training (or in case of error). `is_forward` , `detach` and `cpu` are passed to `Hooks`.\n",
     "\n",
     "The function called at each forward (or backward) pass is `self.hook` and must be implemented when subclassing this callback."
    ]
@@ -1452,20 +1453,29 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[0, 17.679288864135742, 14.008296966552734, '00:00']\n",
-      "[0, 10.259830474853516, 7.18204402923584, '00:00']\n",
-      "[0, 6.888329982757568, 6.546466827392578, '00:00']\n",
-      "[0, 0.7978436350822449, 0.763887882232666, '00:00']\n",
-      "[0, 11.21524429321289, 10.462451934814453, '00:00']\n",
-      "[0, 8.768335342407227, 6.789102554321289, '00:00']\n"
-     ]
-    }
-   ],
+   "outputs": [],
+   "source": [
+    "#hide\n",
+    "def test_activation_stats_include_paramless(include_paramless=False):\n",
+    "    \"create a learner, fit, then check number of layers\"\n",
+    "    modl = nn.Sequential(nn.Linear(1,50), nn.ReLU(), nn.BatchNorm1d(50), nn.Linear(50, 1), nn.Flatten())\n",
+    "\n",
+    "    learn = synth_learner(model=modl, cbs=ActivationStats(every=4, include_paramless=include_paramless))\n",
+    "    learn.fit(1)\n",
+    "    \n",
+    "    expected_stats_len = 3  \n",
+    "    if include_paramless: expected_stats_len = 5 # includes Relu & Flatten\n",
+    "    test_eq(expected_stats_len, len(learn.activation_stats.modules))\n",
+    "\n",
+    "test_activation_stats_include_paramless(include_paramless=True)\n",
+    "test_activation_stats_include_paramless(include_paramless=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def test_every(n_tr, every):\n",
     "    \"create a learner, fit, then check number of stats collected\"\n",
@@ -1619,11 +1629,11 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Motivation: 
Currently in Fastbook Chapter_13 convolutions there is an exploration of the activation layers. 
This has prompted some queries as to why negative values are shown in the book examples, as the expectation is that Relu should not have allowed them. 

However only the trainable layers (or layers with params) are returned. Thus layers like RELU and Flatten are not seen in ActivationStats. 
Upon investigation, this comes down to a filter operation in hooks.callback that only copies layers to modules where has_params(). 

Proposing a change (as implemented in this PR), controlling the filter via a flag on the function but leaving the current behaviour as default. `include_paramless=False`. 
To include the paramless layers when required, we can now use `include_paramless=True` .

Documentation for HookCallback has also been updated.


```
#example use case.

from fastai.vision.all import *
from fastai.callback.hook import *

path = untar_data(URLs.MNIST)
Path.BASE_PATH = path

def get_dls(bs=128):
    return DataBlock(
        blocks=(ImageBlock(cls=PILImageBW), CategoryBlock), 
        get_items=get_image_files, 
        splitter=GrandparentSplitter('training','testing'),
        get_y=parent_label,
        batch_tfms=Normalize()
    ).dataloaders(path, bs=bs)

def plot_title(title="title goes here"):
    text_kwargs = dict(ha='left', va='center', fontsize=22, color='C1')
    plt.subplots(figsize=(5, .4))
    plt.text(0.01, 0.1, title,**text_kwargs)
    plt.axis('off')
    plt.show()


def conv(ni, nf, ks=3, act=True):
    layers = [nn.Conv2d(ni, nf, stride=2, kernel_size=ks, padding=ks//2)]
    if act: layers.append(nn.ReLU())
    layers.append(nn.BatchNorm2d(nf))
    return nn.Sequential(*layers)

def simple_cnn():
    return sequential(
        conv(1 ,8, ks=5),        #14x14
        conv(8 ,16),             #7x7
        conv(16,32),             #4x4
        conv(32,64),             #2x2
        conv(64,10, act=False),  #1x1
        Flatten(),
)
   

def demo(epochs=1, include_paramless=False ):
    learn = Learner(get_dls(), simple_cnn(), loss_func=F.cross_entropy,
                    metrics=accuracy, cbs=ActivationStats(every=4, with_hist=True, include_paramless=include_paramless))
    learn.fit(epochs, 0.06)
    return learn


#learn = demo(1, include_paramless=False) #default behaviour - excludes relu and flatten
learn = demo(1, include_paramless=True)   #new option - includes relu and flatten

print(f'Module Count {len(learn.activation_stats.modules)}')
for idx, mod in enumerate(learn.activation_stats.modules):
    plot_title(learn.activation_stats.modules[idx])
    learn.activation_stats.plot_layer_stats(idx)
    learn.activation_stats.color_dim(idx)
```