### PR TITLE
Fixed showing the model input shape

### DIFF
--- a/fastai/callback/hook.py
+++ b/fastai/callback/hook.py
@@ -160,8 +160,10 @@ def layer_info(learn, *xb):
         return h.stored
 
 # Cell
+def _get_shapes(o, bs): return ' x '.join([str(bs)] + [str(t) for t in o[1:]])
 def _print_shapes(o, bs):
-    if isinstance(o, (torch.Size,tuple)): return ' x '.join([str(bs)] + [str(t) for t in o[1:]])
+    if isinstance(o, torch.Size): return _get_shapes(o, bs)
+    elif isinstance(o, tuple): return _get_shapes(o[0], bs)
     else: return str([_print_shapes(x, bs) for x in o])
 
 # Cell

--- a/nbs/15_callback.hook.ipynb
+++ b/nbs/15_callback.hook.ipynb
@@ -1088,8 +1088,10 @@
    "outputs": [],
    "source": [
     "#export\n",
+    "def _get_shapes(o, bs): return ' x '.join([str(bs)] + [str(t) for t in o[1:]])\n",
     "def _print_shapes(o, bs):\n",
-    "    if isinstance(o, (torch.Size,tuple)): return ' x '.join([str(bs)] + [str(t) for t in o[1:]])\n",
+    "    if isinstance(o, torch.Size): return _get_shapes(o, bs)\n",
+    "    elif isinstance(o, tuple): return _get_shapes(o[0], bs)\n",
     "    else: return str([_print_shapes(x, bs) for x in o])"
    ]
   },


### PR DESCRIPTION
I've noticed that the Learner `summary` method doesn't print out out input shape. Instead only batch size, as on the screen below

![image](https://user-images.githubusercontent.com/4218395/138099532-009443ac-b4fb-4304-a956-2bd91f39ccab.png)

The issue I found was in the `_print_shapes` method that was checking the `o` object if it is an instance of `tuple` or `torch.Size`. However, torch.Size is in fact already a subclass of `tuple` according to the [docs](https://pytorch.org/docs/stable/generated/torch.Tensor.size.html). And we have two situations here:
1. The input `o` can be `(torch.Size,)` (a tuple with first element being a torch.Size object)
2. The input `o` can be simply a `torch.Size`

In the first scenario, the method failed to print out anything except the batch size, as the `o[1:]` returns everything from the 1st index of the given tuple which is None.

Due to the `torch.Size` being a `tuple` I had to split the checks so if it's really a tuple then we're taking the first element which is the `torch.Size`. That way we will end up with shapes as follows:

![image](https://user-images.githubusercontent.com/4218395/138099447-9f4103c2-c7a6-4429-8162-640a04d026d0.png)
