### PR TITLE
Fix nested tensors predictions compatibility with fp16

### DIFF
--- a/fastai/callback/fp16.py
+++ b/fastai/callback/fp16.py
@@ -19,7 +19,7 @@ class MixedPrecision(Callback):
     def before_fit(self): self.learn.scaler,self.scales = GradScaler(**self.kwargs),L()
     def before_batch(self): self.autocast.__enter__()
     def after_pred(self):
-        if listify(flatten(self.pred))[0].dtype==torch.float16: self.learn.pred = to_float(self.pred)
+        if next(flatten(self.pred)).dtype==torch.float16: self.learn.pred = to_float(self.pred)
     def after_loss(self): self.autocast.__exit__(None, None, None)
     def before_backward(self): self.learn.loss_grad = self.scaler.scale(self.loss_grad)
     def before_step(self):

--- a/fastai/callback/fp16.py
+++ b/fastai/callback/fp16.py
@@ -19,7 +19,7 @@ class MixedPrecision(Callback):
     def before_fit(self): self.learn.scaler,self.scales = GradScaler(**self.kwargs),L()
     def before_batch(self): self.autocast.__enter__()
     def after_pred(self):
-        if listify(self.pred)[0].dtype==torch.float16: self.learn.pred = to_float(self.pred)
+        if listify(flatten(self.pred))[0].dtype==torch.float16: self.learn.pred = to_float(self.pred)
     def after_loss(self): self.autocast.__exit__(None, None, None)
     def before_backward(self): self.learn.loss_grad = self.scaler.scale(self.loss_grad)
     def before_step(self):
@@ -37,7 +37,7 @@ class MixedPrecision(Callback):
 class FP16TestCallback(Callback):
     "Asserts that predictions are `float16` values"
     order = 9
-    def after_pred(self): assert listify(self.pred)[0].dtype==torch.float16
+    def after_pred(self): assert listify(flatten(self.pred))[0].dtype==torch.float16
 
 # Cell
 @patch

--- a/nbs/18_callback.fp16.ipynb
+++ b/nbs/18_callback.fp16.ipynb
@@ -197,7 +197,7 @@
     "    def before_fit(self): self.learn.scaler,self.scales = GradScaler(**self.kwargs),L()\n",
     "    def before_batch(self): self.autocast.__enter__()\n",
     "    def after_pred(self):\n",
-    "        if listify(self.pred)[0].dtype==torch.float16: self.learn.pred = to_float(self.pred)\n",
+    "        if listify(flatten(self.pred))[0].dtype==torch.float16: self.learn.pred = to_float(self.pred)\n",
     "    def after_loss(self): self.autocast.__exit__(None, None, None)\n",
     "    def before_backward(self): self.learn.loss_grad = self.scaler.scale(self.loss_grad)\n",
     "    def before_step(self):\n",
@@ -222,7 +222,7 @@
     "class FP16TestCallback(Callback):\n",
     "    \"Asserts that predictions are `float16` values\"\n",
     "    order = 9\n",
-    "    def after_pred(self): assert listify(self.pred)[0].dtype==torch.float16"
+    "    def after_pred(self): assert listify(flatten(self.pred))[0].dtype==torch.float16"
    ]
   },
   {
@@ -1239,6 +1239,7 @@
       "Converted migrating_ignite.ipynb.\n",
       "Converted migrating_lightning.ipynb.\n",
       "Converted migrating_pytorch.ipynb.\n",
+      "Converted migrating_pytorch_verbose.ipynb.\n",
       "Converted ulmfit.ipynb.\n",
       "Converted index.ipynb.\n",
       "Converted quick_start.ipynb.\n",

--- a/nbs/18_callback.fp16.ipynb
+++ b/nbs/18_callback.fp16.ipynb
@@ -197,7 +197,7 @@
     "    def before_fit(self): self.learn.scaler,self.scales = GradScaler(**self.kwargs),L()\n",
     "    def before_batch(self): self.autocast.__enter__()\n",
     "    def after_pred(self):\n",
-    "        if listify(flatten(self.pred))[0].dtype==torch.float16: self.learn.pred = to_float(self.pred)\n",
+    "        if next(flatten(self.pred)).dtype==torch.float16: self.learn.pred = to_float(self.pred)\n",
     "    def after_loss(self): self.autocast.__exit__(None, None, None)\n",
     "    def before_backward(self): self.learn.loss_grad = self.scaler.scale(self.loss_grad)\n",
     "    def before_step(self):\n",


### PR DESCRIPTION
Modifies retrieving first tensor to check float16 dtype to support nested tensors.
> Warning: This PR needs the flatten function that is added in this other [PR](https://github.com/fastai/fastcore/pull/375).
