### PR TITLE
[WIP] Revamp WandbCallback

### DIFF
--- a/nbs/70_callback.wandb.ipynb
+++ b/nbs/70_callback.wandb.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 81,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +176,7 @@
     "        inp,preds,targs,out = preds\n",
     "        b = tuplify(inp) + tuplify(targs)\n",
     "        x,y,its,outs = self.valid_dl.show_results(b, out, show=False, max_n=self.n_preds)\n",
-    "        wandb.log(wandb_process(x, y, its, outs), step=self._wandb_step)\n",
+    "        wandb.log(wandb_process(x, y, its, outs, preds), step=self._wandb_step)\n",
     "\n",
     "    def after_epoch(self):\n",
     "        \"Log validation loss and custom metrics & log prediction samples\"\n",
@@ -225,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 82,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,7 +260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 83,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,7 +280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 84,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -295,7 +295,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 85,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,7 +312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 86,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,7 +324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 87,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -350,7 +350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 88,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -372,13 +372,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 89,
    "metadata": {},
    "outputs": [],
    "source": [
     "#export\n",
     "@typedispatch\n",
-    "def wandb_process(x:TensorImage, y, samples, outs):\n",
+    "def wandb_process(x:TensorImage, y, samples, outs, preds):\n",
     "    \"Process `sample` and `out` depending on the type of `x/y`\"\n",
     "    res_input, res_pred, res_label = [],[],[]\n",
     "    for s,o in zip(samples, outs):\n",
@@ -396,61 +396,80 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [],
    "source": [
     "#export\n",
-    "@typedispatch\n",
-    "def wandb_process(x:TensorImage, y:(TensorCategory,TensorMultiCategory), samples, outs):\n",
-    "    return {\"Prediction Samples\": [wandb.Image(s[0].permute(1,2,0), caption=f'Ground Truth: {s[1]}\\nPrediction: {o[0]}')\n",
-    "            for s,o in zip(samples,outs)]}"
+    "def _unlist(l):\n",
+    "    \"get element of lists of lenght 1\"\n",
+    "    if isinstance(l, (list, tuple)):\n",
+    "        if len(l) == 1: return l[0]\n",
+    "    else: return l"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 65,
    "metadata": {},
    "outputs": [],
    "source": [
     "#export\n",
     "@typedispatch\n",
-    "def wandb_process(x:TensorImage, y:TensorMask, samples, outs):\n",
+    "def wandb_process(x:TensorImage, y:(TensorCategory,TensorMultiCategory), samples, outs, preds):\n",
+    "    table = wandb.Table(columns=[\"Input image\", \"Ground Truth\", \"Predictions\"])\n",
+    "    for (image, label), pred_label in zip(samples,outs):\n",
+    "        table.add_data(wandb.Image(image.permute(1,2,0)), label, _unlist(pred_label))\n",
+    "    return {\"Prediction Samples\": table}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#export\n",
+    "@typedispatch\n",
+    "def wandb_process(x:TensorImage, y:TensorMask, samples, outs, preds):\n",
     "    res = []\n",
-    "    codes = getattr(y, 'codes', None)\n",
-    "    class_labels = {i:f'{c}' for i,c in enumerate(codes)} if codes is not None else None\n",
-    "    for s,o in zip(samples, outs):\n",
-    "        img = s[0].permute(1,2,0)\n",
-    "        masks = {}\n",
-    "        for t, capt in ((o[0], \"Prediction\"), (s[1], \"Ground Truth\")):\n",
-    "            masks[capt] = {'mask_data':t.numpy().astype(np.uint8)}\n",
-    "            if class_labels: masks[capt]['class_labels'] = class_labels\n",
-    "        res.append(wandb.Image(img, masks=masks))\n",
-    "    return {\"Prediction Samples\":res}"
+    "    codes = getattr(outs[0][0], 'codes', None)\n",
+    "    if codes is not None:\n",
+    "        class_labels = [{'name': name, 'id': id}  for id, name in enumerate(codes)] \n",
+    "    else:\n",
+    "        class_labels = [{'name': i, 'id': i} for i in range(preds.shape[1])]\n",
+    "    table = wandb.Table(columns=[\"Input Image\", \"Ground Truth\", \"Predictions\"])\n",
+    "    for (image, label), pred_label in zip(samples, outs):\n",
+    "        img = image.permute(1,2,0)\n",
+    "        table.add_data(wandb.Image(img),\n",
+    "                       wandb.Image(img, masks={\"Ground Truth\": {'mask_data': label.numpy().astype(np.uint8)}}, classes=class_labels), \n",
+    "                       wandb.Image(img, masks={\"Prediction\":   {'mask_data': pred_label[0].numpy().astype(np.uint8)}}, classes=class_labels) \n",
+    "                      )\n",
+    "    return {\"Prediction Samples\": table}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 73,
    "metadata": {},
    "outputs": [],
    "source": [
     "#export\n",
     "@typedispatch\n",
-    "def wandb_process(x:TensorText, y:(TensorCategory,TensorMultiCategory), samples, outs):\n",
+    "def wandb_process(x:TensorText, y:(TensorCategory,TensorMultiCategory), samples, outs, preds):\n",
     "    data = [[s[0], s[1], o[0]] for s,o in zip(samples,outs)]\n",
     "    return {\"Prediction Samples\": wandb.Table(data=data, columns=[\"Text\", \"Target\", \"Prediction\"])}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [],
    "source": [
     "#export\n",
     "@typedispatch\n",
-    "def wandb_process(x:Tabular, y:Tabular, samples, outs):\n",
+    "def wandb_process(x:Tabular, y:Tabular, samples, outs, preds):\n",
     "    df = x.all_cols\n",
     "    for n in x.y_names: df[n+'_pred'] = y[n].values\n",
     "    return {\"Prediction Samples\": wandb.Table(dataframe=df)}"
@@ -486,15 +505,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Failed to detect the name of this notebook, you can set it manually with the WANDB_NOTEBOOK_NAME environment variable to enable code saving.\n"
-     ]
+     "data": {
+      "text/html": [
+       "\n",
+       "    <div>\n",
+       "        <style>\n",
+       "            /* Turns off some styling */\n",
+       "            progress {\n",
+       "                /* gets rid of default border in Firefox and Opera. */\n",
+       "                border: none;\n",
+       "                /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
+       "                background-size: auto;\n",
+       "            }\n",
+       "            .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
+       "                background: #F44336;\n",
+       "            }\n",
+       "        </style>\n",
+       "      <progress value='344064' class='' max='342207' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+       "      100.54% [344064/342207 00:16<00:00]\n",
+       "    </div>\n",
+       "    "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "data": {
@@ -510,29 +551,21 @@
      "output_type": "display_data"
     },
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Downloading: \"https://download.pytorch.org/models/resnet18-f37072fd.pth\" to /Users/tcapelle/.cache/torch/hub/checkpoints/resnet18-f37072fd.pth\n"
+     ]
+    },
+    {
      "data": {
-      "text/html": [
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: left;\">\n",
-       "      <th>epoch</th>\n",
-       "      <th>train_loss</th>\n",
-       "      <th>valid_loss</th>\n",
-       "      <th>time</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <td>0</td>\n",
-       "      <td>0.831425</td>\n",
-       "      <td>0.334918</td>\n",
-       "      <td>00:02</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>"
-      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "eb1b8493e39a4b46822cfbfad5a7d523",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "<IPython.core.display.HTML object>"
+       "  0%|          | 0.00/44.7M [00:00<?, ?B/s]"
       ]
      },
      "metadata": {},
@@ -553,9 +586,9 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>0</td>\n",
-       "      <td>0.654261</td>\n",
-       "      <td>0.124091</td>\n",
-       "      <td>00:01</td>\n",
+       "      <td>0.698428</td>\n",
+       "      <td>0.219071</td>\n",
+       "      <td>00:14</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>"
@@ -568,9 +601,136 @@
      "output_type": "display_data"
     },
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WandbCallback was not able to get prediction samples -> wandb.log must be passed a dictionary\n"
+     ]
+    },
+    {
      "data": {
       "text/html": [
-       "<br/>Waiting for W&B process to finish, PID 19610... <strong style=\"color:green\">(success).</strong>"
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: left;\">\n",
+       "      <th>epoch</th>\n",
+       "      <th>train_loss</th>\n",
+       "      <th>valid_loss</th>\n",
+       "      <th>time</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>0</td>\n",
+       "      <td>0.704247</td>\n",
+       "      <td>0.213689</td>\n",
+       "      <td>00:14</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n",
+      "WARNING:root:add_row is deprecated, use add_data\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WandbCallback was not able to get prediction samples -> wandb.log must be passed a dictionary\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<br/>Waiting for W&B process to finish, PID 65236... <strong style=\"color:green\">(success).</strong>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -588,12 +748,12 @@
        "    .wandb-col { display: flex; flex-direction: column; flex-basis: 100%; flex: 1; padding: 10px; }\n",
        "    </style>\n",
        "<div class=\"wandb-row\"><div class=\"wandb-col\">\n",
-       "<h3>Run history:</h3><br/><table class=\"wandb\"><tr><td>epoch</td><td>▁▁▂▂▂▃▃▃▄▄▄▅▅▅▆▆▆▇▇▇██</td></tr><tr><td>eps_0</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>eps_1</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>eps_2</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>lr_0</td><td>███████████▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>lr_1</td><td>███████████▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>lr_2</td><td>▁▁▁▁▁▁▁▁▁▁▁███████████</td></tr><tr><td>mom_0</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>mom_1</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>mom_2</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>raw_loss</td><td>█▇▄▄▅▃▄▂▂▂▃▇▂▄▅▂▃▁▁▃▃▁</td></tr><tr><td>sqr_mom_0</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>sqr_mom_1</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>sqr_mom_2</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>train_loss</td><td>█▇▆▅▅▄▄▃▃▃▃▆▃▃▃▂▂▂▁▁▁▁</td></tr><tr><td>valid_loss</td><td>█▁</td></tr><tr><td>wd_0</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>wd_1</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>wd_2</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr></table><br/></div><div class=\"wandb-col\">\n",
-       "<h3>Run summary:</h3><br/><table class=\"wandb\"><tr><td>epoch</td><td>2</td></tr><tr><td>eps_0</td><td>1e-05</td></tr><tr><td>eps_1</td><td>1e-05</td></tr><tr><td>eps_2</td><td>1e-05</td></tr><tr><td>lr_0</td><td>0.0005</td></tr><tr><td>lr_1</td><td>0.0005</td></tr><tr><td>lr_2</td><td>0.005</td></tr><tr><td>mom_0</td><td>0.9</td></tr><tr><td>mom_1</td><td>0.9</td></tr><tr><td>mom_2</td><td>0.9</td></tr><tr><td>raw_loss</td><td>0.44433</td></tr><tr><td>sqr_mom_0</td><td>0.99</td></tr><tr><td>sqr_mom_1</td><td>0.99</td></tr><tr><td>sqr_mom_2</td><td>0.99</td></tr><tr><td>train_loss</td><td>0.65426</td></tr><tr><td>valid_loss</td><td>0.12409</td></tr><tr><td>wd_0</td><td>0.01</td></tr><tr><td>wd_1</td><td>0.01</td></tr><tr><td>wd_2</td><td>0.01</td></tr></table>\n",
+       "<h3>Run history:</h3><br/><table class=\"wandb\"><tr><td>epoch</td><td>▁▁▂▂▂▃▃▃▄▄▄▅▅▅▆▆▆▇▇▇██</td></tr><tr><td>eps_0</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>eps_1</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>eps_2</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>lr_0</td><td>███████████▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>lr_1</td><td>███████████▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>lr_2</td><td>▁▁▁▁▁▁▁▁▁▁▁███████████</td></tr><tr><td>mom_0</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>mom_1</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>mom_2</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>raw_loss</td><td>▇▅▆▅▆▄▃▃▁▃▃█▃▃▂▆▆▄▁▃▄▅</td></tr><tr><td>sqr_mom_0</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>sqr_mom_1</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>sqr_mom_2</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>train_loss</td><td>▇▅▅▄▄▄▃▂▂▁▁█▄▃▁▂▂▂▁▁▁▁</td></tr><tr><td>valid_loss</td><td>█▁</td></tr><tr><td>wd_0</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>wd_1</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>wd_2</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr></table><br/></div><div class=\"wandb-col\">\n",
+       "<h3>Run summary:</h3><br/><table class=\"wandb\"><tr><td>epoch</td><td>2</td></tr><tr><td>eps_0</td><td>1e-05</td></tr><tr><td>eps_1</td><td>1e-05</td></tr><tr><td>eps_2</td><td>1e-05</td></tr><tr><td>lr_0</td><td>0.0005</td></tr><tr><td>lr_1</td><td>0.0005</td></tr><tr><td>lr_2</td><td>0.005</td></tr><tr><td>mom_0</td><td>0.9</td></tr><tr><td>mom_1</td><td>0.9</td></tr><tr><td>mom_2</td><td>0.9</td></tr><tr><td>raw_loss</td><td>0.78661</td></tr><tr><td>sqr_mom_0</td><td>0.99</td></tr><tr><td>sqr_mom_1</td><td>0.99</td></tr><tr><td>sqr_mom_2</td><td>0.99</td></tr><tr><td>train_loss</td><td>0.70425</td></tr><tr><td>valid_loss</td><td>0.21369</td></tr><tr><td>wd_0</td><td>0.01</td></tr><tr><td>wd_1</td><td>0.01</td></tr><tr><td>wd_2</td><td>0.01</td></tr></table>\n",
        "</div></div>\n",
        "You can sync this run to the cloud by running:<br/>\n",
-       "\u001b[33mwandb sync /tmp/tmp30p4uhjw/wandb/offline-run-20211026_233240-1gyph0w0<br/>\n",
-       "\u001b[0mFind logs at: <code>/tmp/tmp30p4uhjw/wandb/offline-run-20211026_233240-1gyph0w0/logs</code><br/>\n"
+       "\u001b[33mwandb sync /var/folders/sf/tgv7vcv96x557p38bvvp1ms40000gn/T/tmpl6yqn0oq/wandb/offline-run-20211126_104502-1a6mgtpk<br/>\n",
+       "\u001b[0mFind logs at: <code>/var/folders/sf/tgv7vcv96x557p38bvvp1ms40000gn/T/tmpl6yqn0oq/wandb/offline-run-20211126_104502-1a6mgtpk/logs</code><br/>\n"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -630,7 +790,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -647,7 +807,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 90,
    "metadata": {},
    "outputs": [
     {
@@ -739,13 +899,6 @@
     "from nbdev.export import *\n",
     "notebook2script()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -756,6 +909,18 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/nbs/70_callback.wandb.ipynb
+++ b/nbs/70_callback.wandb.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,15 +100,26 @@
     "    # Record if watch has been called previously (even in another instance)\n",
     "    _wandb_watch_called = False\n",
     "\n",
-    "    def __init__(self, log=\"gradients\", log_preds=True, log_model=True, log_dataset=False, dataset_name=None, valid_dl=None, n_preds=36, seed=12345, reorder=True):\n",
+    "    def __init__(self, log=\"gradients\", log_preds=True, log_model=False, model_name=None, log_dataset=False, dataset_name=None, valid_dl=None, n_preds=36, seed=12345, reorder=True):\n",
     "        # Check if wandb.init has been called\n",
     "        if wandb.run is None:\n",
     "            raise ValueError('You must call wandb.init() before WandbCallback()')\n",
     "        # W&B log step\n",
     "        self._wandb_step = wandb.run.step - 1  # -1 except if the run has previously logged data (incremented at each batch)\n",
     "        self._wandb_epoch = 0 if not(wandb.run.step) else math.ceil(wandb.run.summary['epoch']) # continue to next epoch\n",
-    "        store_attr('log,log_preds,log_model,log_dataset,dataset_name,valid_dl,n_preds,seed,reorder')\n",
-    "\n",
+    "        store_attr()\n",
+    "    \n",
+    "    def after_create(self):\n",
+    "        # log model\n",
+    "        if self.log_model:\n",
+    "            if not hasattr(self, 'save_model'):\n",
+    "                # does not have the SaveModelCallback\n",
+    "                self.learn.add_cb(SaveModelCallback(fname=ifnone(self.model_name, 'model')))\n",
+    "            else:\n",
+    "                # override SaveModelCallback\n",
+    "                if self.model_name is not None:\n",
+    "                    self.save_model.fname = self.model_name\n",
+    "            \n",
     "    def before_fit(self):\n",
     "        \"Call watch method to log model topology, gradients & weights\"\n",
     "        self.run = not hasattr(self.learn, 'lr_finder') and not hasattr(self, \"gather_preds\") and rank_distrib()==0\n",
@@ -141,11 +152,6 @@
     "            metadata = {'path relative to learner': os.path.relpath(self.log_dataset, self.learn.path)}\n",
     "            log_dataset(path=self.log_dataset, name=self.dataset_name, metadata=metadata)\n",
     "\n",
-    "        # log model\n",
-    "        if self.log_model and not hasattr(self, 'save_model'):\n",
-    "            print('WandbCallback requires use of \"SaveModelCallback\" to log best model')\n",
-    "            self.log_model = False\n",
-    "\n",
     "        if self.log_preds:\n",
     "            try:\n",
     "                if not self.valid_dl:\n",
@@ -163,7 +169,8 @@
     "            except Exception as e:\n",
     "                self.log_preds = False\n",
     "                print(f'WandbCallback was not able to prepare a DataLoader for logging prediction samples -> {e}')\n",
-    "\n",
+    "        self.ti = time.perf_counter()\n",
+    "        x\n",
     "    def after_batch(self):\n",
     "        \"Log hyper-parameters and training loss\"\n",
     "        if self.training:\n",
@@ -194,16 +201,19 @@
     "        wandb.log({n:s for n,s in zip(self.recorder.metric_names, self.recorder.log) if n not in ['train_loss', 'epoch', 'time']}, step=self._wandb_step)\n",
     "\n",
     "    def after_fit(self):\n",
+    "        wandb.log({\"fit_time\":time.perf_counter() - self.ti})\n",
     "        if self.log_model:\n",
     "            if self.save_model.last_saved_path is None:\n",
     "                print('WandbCallback could not retrieve a model to upload')\n",
     "            else:\n",
     "                metadata = {n:s for n,s in zip(self.recorder.metric_names, self.recorder.log) if n not in ['train_loss', 'epoch', 'time']}\n",
-    "                log_model(self.save_model.last_saved_path, metadata=metadata)                \n",
+    "                log_model(self.save_model.last_saved_path, name=self.save_model.fname, metadata=metadata)                \n",
     "        self.run = True\n",
     "        if self.log_preds: self.remove_cb(FetchPredsCallback)\n",
+    "        \n",
     "        wandb.log({})  # ensure sync of last step\n",
-    "        self._wandb_step += 1"
+    "        self._wandb_step += 1\n",
+    "        "
    ]
   },
   {
@@ -225,7 +235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,7 +270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,7 +290,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -295,7 +305,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,7 +322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,7 +334,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -350,7 +360,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -372,7 +382,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -383,20 +393,20 @@
     "    res_input, res_pred, res_label = [],[],[]\n",
     "    for s,o in zip(samples, outs):\n",
     "        img = s[0].permute(1,2,0)\n",
-    "        res_input.append(wandb.Image(img, caption='Input data'))\n",
-    "        for t, capt, res in ((o[0], \"Prediction\", res_pred), (s[1], \"Ground Truth\", res_label)):\n",
+    "        res_input.append(wandb.Image(img, caption='Input_data'))\n",
+    "        for t, capt, res in ((o[0], \"Prediction\", res_pred), (s[1], \"Ground_Truth\", res_label)):\n",
     "            fig, ax = _make_plt(img)\n",
     "            # Superimpose label or prediction to input image\n",
     "            ax = img.show(ctx=ax)\n",
     "            ax = t.show(ctx=ax)\n",
     "            res.append(wandb.Image(fig, caption=capt))\n",
     "            plt.close(fig)\n",
-    "    return {\"Inputs\":res_input, \"Predictions\":res_pred, \"Ground Truth\":res_label}"
+    "    return {\"Inputs\":res_input, \"Predictions\":res_pred, \"Ground_Truth\":res_label}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -410,22 +420,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
     "#export\n",
     "@typedispatch\n",
     "def wandb_process(x:TensorImage, y:(TensorCategory,TensorMultiCategory), samples, outs, preds):\n",
-    "    table = wandb.Table(columns=[\"Input image\", \"Ground Truth\", \"Predictions\"])\n",
+    "    table = wandb.Table(columns=[\"Input image\", \"Ground_Truth\", \"Predictions\"])\n",
     "    for (image, label), pred_label in zip(samples,outs):\n",
     "        table.add_data(wandb.Image(image.permute(1,2,0)), label, _unlist(pred_label))\n",
-    "    return {\"Prediction Samples\": table}"
+    "    return {\"Prediction_Samples\": table}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -438,19 +448,19 @@
     "        class_labels = [{'name': name, 'id': id}  for id, name in enumerate(codes)] \n",
     "    else:\n",
     "        class_labels = [{'name': i, 'id': i} for i in range(preds.shape[1])]\n",
-    "    table = wandb.Table(columns=[\"Input Image\", \"Ground Truth\", \"Predictions\"])\n",
+    "    table = wandb.Table(columns=[\"Input Image\", \"Ground_Truth\", \"Predictions\"])\n",
     "    for (image, label), pred_label in zip(samples, outs):\n",
     "        img = image.permute(1,2,0)\n",
     "        table.add_data(wandb.Image(img),\n",
-    "                       wandb.Image(img, masks={\"Ground Truth\": {'mask_data': label.numpy().astype(np.uint8)}}, classes=class_labels), \n",
+    "                       wandb.Image(img, masks={\"Ground_Truth\": {'mask_data': label.numpy().astype(np.uint8)}}, classes=class_labels), \n",
     "                       wandb.Image(img, masks={\"Prediction\":   {'mask_data': pred_label[0].numpy().astype(np.uint8)}}, classes=class_labels) \n",
     "                      )\n",
-    "    return {\"Prediction Samples\": table}"
+    "    return {\"Prediction_Samples\": table}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -458,12 +468,12 @@
     "@typedispatch\n",
     "def wandb_process(x:TensorText, y:(TensorCategory,TensorMultiCategory), samples, outs, preds):\n",
     "    data = [[s[0], s[1], o[0]] for s,o in zip(samples,outs)]\n",
-    "    return {\"Prediction Samples\": wandb.Table(data=data, columns=[\"Text\", \"Target\", \"Prediction\"])}"
+    "    return {\"Prediction_Samples\": wandb.Table(data=data, columns=[\"Text\", \"Target\", \"Prediction\"])}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -472,7 +482,7 @@
     "def wandb_process(x:Tabular, y:Tabular, samples, outs, preds):\n",
     "    df = x.all_cols\n",
     "    for n in x.y_names: df[n+'_pred'] = y[n].values\n",
-    "    return {\"Prediction Samples\": wandb.Table(dataframe=df)}"
+    "    return {\"Prediction_Samples\": wandb.Table(dataframe=df)}"
    ]
   },
   {
@@ -511,24 +521,7 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "    <div>\n",
-       "        <style>\n",
-       "            /* Turns off some styling */\n",
-       "            progress {\n",
-       "                /* gets rid of default border in Firefox and Opera. */\n",
-       "                border: none;\n",
-       "                /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
-       "                background-size: auto;\n",
-       "            }\n",
-       "            .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
-       "                background: #F44336;\n",
-       "            }\n",
-       "        </style>\n",
-       "      <progress value='344064' class='' max='342207' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
-       "      100.54% [344064/342207 00:16<00:00]\n",
-       "    </div>\n",
-       "    "
+       "Tracking run with wandb version 0.12.17"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -540,8 +533,7 @@
     {
      "data": {
       "text/html": [
-       "W&B syncing is set to `offline` in this directory.  <br/>\n",
-       "Run `wandb online` or set WANDB_MODE=online to enable cloud syncing."
+       "W&B syncing is set to <code>`offline`<code> in this directory.  <br/>Run <code>`wandb online`<code> or set <code>WANDB_MODE=online<code> to enable cloud syncing."
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -551,189 +543,252 @@
      "output_type": "display_data"
     },
     {
-     "name": "stderr",
+     "data": {
+      "text/html": [
+       "\n",
+       "<style>\n",
+       "    /* Turns off some styling */\n",
+       "    progress {\n",
+       "        /* gets rid of default border in Firefox and Opera. */\n",
+       "        border: none;\n",
+       "        /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
+       "        background-size: auto;\n",
+       "    }\n",
+       "    .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
+       "        background: #F44336;\n",
+       "    }\n",
+       "</style>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: left;\">\n",
+       "      <th>epoch</th>\n",
+       "      <th>train_loss</th>\n",
+       "      <th>valid_loss</th>\n",
+       "      <th>time</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>0</td>\n",
+       "      <td>0.704093</td>\n",
+       "      <td>0.208393</td>\n",
+       "      <td>00:01</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<style>\n",
+       "    /* Turns off some styling */\n",
+       "    progress {\n",
+       "        /* gets rid of default border in Firefox and Opera. */\n",
+       "        border: none;\n",
+       "        /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
+       "        background-size: auto;\n",
+       "    }\n",
+       "    .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
+       "        background: #F44336;\n",
+       "    }\n",
+       "</style>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: left;\">\n",
+       "      <th>epoch</th>\n",
+       "      <th>train_loss</th>\n",
+       "      <th>valid_loss</th>\n",
+       "      <th>time</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>0</td>\n",
+       "      <td>0.887358</td>\n",
+       "      <td>0.267755</td>\n",
+       "      <td>00:01</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<style>\n",
+       "    /* Turns off some styling */\n",
+       "    progress {\n",
+       "        /* gets rid of default border in Firefox and Opera. */\n",
+       "        border: none;\n",
+       "        /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
+       "        background-size: auto;\n",
+       "    }\n",
+       "    .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
+       "        background: #F44336;\n",
+       "    }\n",
+       "</style>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: left;\">\n",
+       "      <th>epoch</th>\n",
+       "      <th>train_loss</th>\n",
+       "      <th>valid_loss</th>\n",
+       "      <th>time</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>0</td>\n",
+       "      <td>0.737858</td>\n",
+       "      <td>0.368810</td>\n",
+       "      <td>00:01</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Downloading: \"https://download.pytorch.org/models/resnet18-f37072fd.pth\" to /Users/tcapelle/.cache/torch/hub/checkpoints/resnet18-f37072fd.pth\n"
+      "Better model found at epoch 0 with valid_loss value: 0.3688099980354309.\n"
      ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<style>\n",
+       "    /* Turns off some styling */\n",
+       "    progress {\n",
+       "        /* gets rid of default border in Firefox and Opera. */\n",
+       "        border: none;\n",
+       "        /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
+       "        background-size: auto;\n",
+       "    }\n",
+       "    .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
+       "        background: #F44336;\n",
+       "    }\n",
+       "</style>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: left;\">\n",
+       "      <th>epoch</th>\n",
+       "      <th>train_loss</th>\n",
+       "      <th>valid_loss</th>\n",
+       "      <th>time</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>0</td>\n",
+       "      <td>0.826742</td>\n",
+       "      <td>0.350351</td>\n",
+       "      <td>00:01</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Better model found at epoch 0 with valid_loss value: 0.35035112500190735.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "Waiting for W&B process to finish... <strong style=\"color:green\">(success).</strong>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "eb1b8493e39a4b46822cfbfad5a7d523",
+       "model_id": "121ff6cfa27543f68cdae9f8775d994e",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "  0%|          | 0.00/44.7M [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: left;\">\n",
-       "      <th>epoch</th>\n",
-       "      <th>train_loss</th>\n",
-       "      <th>valid_loss</th>\n",
-       "      <th>time</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <td>0</td>\n",
-       "      <td>0.698428</td>\n",
-       "      <td>0.219071</td>\n",
-       "      <td>00:14</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WandbCallback was not able to get prediction samples -> wandb.log must be passed a dictionary\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: left;\">\n",
-       "      <th>epoch</th>\n",
-       "      <th>train_loss</th>\n",
-       "      <th>valid_loss</th>\n",
-       "      <th>time</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <td>0</td>\n",
-       "      <td>0.704247</td>\n",
-       "      <td>0.213689</td>\n",
-       "      <td>00:14</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n",
-      "WARNING:root:add_row is deprecated, use add_data\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WandbCallback was not able to get prediction samples -> wandb.log must be passed a dictionary\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<br/>Waiting for W&B process to finish, PID 65236... <strong style=\"color:green\">(success).</strong>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+       "VBox(children=(Label(value='0.000 MB of 0.000 MB uploaded (0.000 MB deduped)\\r'), FloatProgress(value=1.0, max…"
       ]
      },
      "metadata": {},
@@ -743,17 +798,35 @@
      "data": {
       "text/html": [
        "<style>\n",
-       "    table.wandb td:nth-child(1) { padding: 0 10px; text-align: right }\n",
-       "    .wandb-row { display: flex; flex-direction: row; flex-wrap: wrap; width: 100% }\n",
+       "    table.wandb td:nth-child(1) { padding: 0 10px; text-align: left ; width: auto;} td:nth-child(2) {text-align: left ; width: 100%}\n",
+       "    .wandb-row { display: flex; flex-direction: row; flex-wrap: wrap; justify-content: flex-start; width: 100% }\n",
        "    .wandb-col { display: flex; flex-direction: column; flex-basis: 100%; flex: 1; padding: 10px; }\n",
        "    </style>\n",
-       "<div class=\"wandb-row\"><div class=\"wandb-col\">\n",
-       "<h3>Run history:</h3><br/><table class=\"wandb\"><tr><td>epoch</td><td>▁▁▂▂▂▃▃▃▄▄▄▅▅▅▆▆▆▇▇▇██</td></tr><tr><td>eps_0</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>eps_1</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>eps_2</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>lr_0</td><td>███████████▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>lr_1</td><td>███████████▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>lr_2</td><td>▁▁▁▁▁▁▁▁▁▁▁███████████</td></tr><tr><td>mom_0</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>mom_1</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>mom_2</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>raw_loss</td><td>▇▅▆▅▆▄▃▃▁▃▃█▃▃▂▆▆▄▁▃▄▅</td></tr><tr><td>sqr_mom_0</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>sqr_mom_1</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>sqr_mom_2</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>train_loss</td><td>▇▅▅▄▄▄▃▂▂▁▁█▄▃▁▂▂▂▁▁▁▁</td></tr><tr><td>valid_loss</td><td>█▁</td></tr><tr><td>wd_0</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>wd_1</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>wd_2</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr></table><br/></div><div class=\"wandb-col\">\n",
-       "<h3>Run summary:</h3><br/><table class=\"wandb\"><tr><td>epoch</td><td>2</td></tr><tr><td>eps_0</td><td>1e-05</td></tr><tr><td>eps_1</td><td>1e-05</td></tr><tr><td>eps_2</td><td>1e-05</td></tr><tr><td>lr_0</td><td>0.0005</td></tr><tr><td>lr_1</td><td>0.0005</td></tr><tr><td>lr_2</td><td>0.005</td></tr><tr><td>mom_0</td><td>0.9</td></tr><tr><td>mom_1</td><td>0.9</td></tr><tr><td>mom_2</td><td>0.9</td></tr><tr><td>raw_loss</td><td>0.78661</td></tr><tr><td>sqr_mom_0</td><td>0.99</td></tr><tr><td>sqr_mom_1</td><td>0.99</td></tr><tr><td>sqr_mom_2</td><td>0.99</td></tr><tr><td>train_loss</td><td>0.70425</td></tr><tr><td>valid_loss</td><td>0.21369</td></tr><tr><td>wd_0</td><td>0.01</td></tr><tr><td>wd_1</td><td>0.01</td></tr><tr><td>wd_2</td><td>0.01</td></tr></table>\n",
-       "</div></div>\n",
-       "You can sync this run to the cloud by running:<br/>\n",
-       "\u001b[33mwandb sync /var/folders/sf/tgv7vcv96x557p38bvvp1ms40000gn/T/tmpl6yqn0oq/wandb/offline-run-20211126_104502-1a6mgtpk<br/>\n",
-       "\u001b[0mFind logs at: <code>/var/folders/sf/tgv7vcv96x557p38bvvp1ms40000gn/T/tmpl6yqn0oq/wandb/offline-run-20211126_104502-1a6mgtpk/logs</code><br/>\n"
+       "<div class=\"wandb-row\"><div class=\"wandb-col\"><h3>Run history:</h3><br/><table class=\"wandb\"><tr><td>epoch</td><td>▁▁▁▁▂▂▂▂▂▂▃▃▃▃▃▄▄▄▄▄▅▅▅▅▅▅▆▆▆▆▆▇▇▇▇▇▇███</td></tr><tr><td>eps_0</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>eps_1</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>eps_2</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>lr_0</td><td>██████████▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>lr_1</td><td>██████████▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>lr_2</td><td>▁▁▁▁▁▁▁▁▁▁██████████████████████████████</td></tr><tr><td>mom_0</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>mom_1</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>mom_2</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>raw_loss</td><td>▅▄▃▄▃▂▂▁▂▃▇█▃▆▃▂▃▂▂▂▄▅▄▂▂▂▄▄▁▂▅▃▄▁▃▃▅▃▃▁</td></tr><tr><td>sqr_mom_0</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>sqr_mom_1</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>sqr_mom_2</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>train_loss</td><td>▄▃▃▃▃▂▂▁▁▁▇█▆▆▅▄▄▃▃▂▂▃▃▂▂▁▂▂▁▁▅▃▃▂▂▂▂▂▂▂</td></tr><tr><td>valid_loss</td><td>▁▄█▇</td></tr><tr><td>wd_0</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>wd_1</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>wd_2</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr></table><br/></div><div class=\"wandb-col\"><h3>Run summary:</h3><br/><table class=\"wandb\"><tr><td>epoch</td><td>4</td></tr><tr><td>eps_0</td><td>1e-05</td></tr><tr><td>eps_1</td><td>1e-05</td></tr><tr><td>eps_2</td><td>1e-05</td></tr><tr><td>lr_0</td><td>0.0005</td></tr><tr><td>lr_1</td><td>0.0005</td></tr><tr><td>lr_2</td><td>0.005</td></tr><tr><td>mom_0</td><td>0.9</td></tr><tr><td>mom_1</td><td>0.9</td></tr><tr><td>mom_2</td><td>0.9</td></tr><tr><td>raw_loss</td><td>0.31697</td></tr><tr><td>sqr_mom_0</td><td>0.99</td></tr><tr><td>sqr_mom_1</td><td>0.99</td></tr><tr><td>sqr_mom_2</td><td>0.99</td></tr><tr><td>train_loss</td><td>0.82674</td></tr><tr><td>valid_loss</td><td>0.35035</td></tr><tr><td>wd_0</td><td>0.01</td></tr><tr><td>wd_1</td><td>0.01</td></tr><tr><td>wd_2</td><td>0.01</td></tr></table><br/></div></div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "You can sync this run to the cloud by running:<br/><code>wandb sync /tmp/tmp6io1pso4/wandb/offline-run-20220531_160806-2gchgzj0<code>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "Find logs at: <code>/tmp/tmp6io1pso4/wandb/offline-run-20220531_160806-2gchgzj0/logs</code>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -784,13 +857,21 @@
     "    learn = cnn_learner(dls, resnet18, loss_func=CrossEntropyLossFlat(), cbs=WandbCallback(log_model=False))\n",
     "    learn.fit(1, lr=slice(0.005))\n",
     "    \n",
+    "    # save model\n",
+    "    learn = cnn_learner(dls, resnet18, loss_func=CrossEntropyLossFlat(), cbs=WandbCallback(log_model=True))\n",
+    "    learn.fit(1, lr=slice(0.005))\n",
+    "    \n",
+    "    # save model override name\n",
+    "    learn = cnn_learner(dls, resnet18, loss_func=CrossEntropyLossFlat(), cbs=[WandbCallback(log_model=True, model_name=\"good_name\"), SaveModelCallback(fname=\"bad_name\")])\n",
+    "    learn.fit(1, lr=slice(0.005))\n",
+    "    \n",
     "    # finish writing files to temporary folder\n",
     "    wandb.finish()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -807,7 +888,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -920,7 +1001,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR adds `wandb.Table` support for image object. This enables easier model comparison and evaluation.
What do you think @borisdayma about something like this?
- We could log the table only after fit and log to the media panel every epoch?
- Should we add a param to the callback to enable/disable this feature?
- Should we automatically infer metrics to log, and logits (like the Keras CB?)
- I would also like that the dashboard is organised automatically, with the `train_loss`, `val_loss` as first graphs to show, instead of obscure `eps_mom_2`...
Runs are available [here](https://wandb.ai/tcapelle/test_fastai?workspace=user-tcapelle)