### PR TITLE
Fix siamese tutorial

### DIFF
--- a/nbs/24_tutorial.siamese.ipynb
+++ b/nbs/24_tutorial.siamese.ipynb
@@ -1336,7 +1336,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It ends up with 512 features, so for our custom head, we will need to multiply this by 4 (i.e. 2*2): 2 because we have two images concatenated, and another 2 because of the fastai concat-pool trick (we concatenate the average pool and the max pool of the features). The `create_head` function will give us the head that is usually used in fastai's transfer learning models."
+    "It ends up with 512 features, so for our custom head, we will need to multiply this by 2 because we have two images concatenated. The `create_head` function will give us the head that is usually used in fastai's transfer learning models."
    ]
   },
   {


### PR DESCRIPTION
The `make_head` function changed in https://github.com/fastai/fastai/commit/870409f78df41e04a2be378197e41f8c2e1ab371

c56afb8d381b52ef69ef61ed4bd383b06eac2bef adjusted the code in the siamese tutorial, now I also adjusted the according text-block to match the code.