### PR TITLE
Fix Classification Interpretation

### DIFF
--- a/fastai/interpret.py
+++ b/fastai/interpret.py
@@ -75,15 +75,17 @@ class Interpretation():
 class ClassificationInterpretation(Interpretation):
     "Interpretation methods for classification models."
 
-    def __init__(self, dl, inputs, preds, targs, decoded, losses):
-        super().__init__(dl, inputs, preds, targs, decoded, losses)
+    def __init__(self, learn, dl, losses, act=None):
+        super().__init__(learn, dl, losses, act)
         self.vocab = self.dl.vocab
         if is_listy(self.vocab): self.vocab = self.vocab[-1]
 
     def confusion_matrix(self):
         "Confusion matrix as an `np.ndarray`."
         x = torch.arange(0, len(self.vocab))
-        d,t = flatten_check(self.decoded, self.targs)
+        _,targs,decoded = self.learn.get_preds(dl=self.dl, with_decoded=True, with_preds=True,
+                                               with_targs=True, act=self.act)
+        d,t = flatten_check(decoded, targs)
         cm = ((d==x[:,None]) & (t==x[:,None,None])).long().sum(2)
         return to_np(cm)
 
@@ -124,7 +126,9 @@ class ClassificationInterpretation(Interpretation):
 
     def print_classification_report(self):
         "Print scikit-learn classification report"
-        d,t = flatten_check(self.decoded, self.targs)
+        _,targs,decoded = self.learn.get_preds(dl=self.dl, with_decoded=True, with_preds=True,
+                                               with_targs=True, act=self.act)
+        d,t = flatten_check(decoded, targs)
         print(skm.classification_report(t, d, labels=list(self.vocab.o2i.values()), target_names=[str(v) for v in self.vocab]))
 
 # Cell

--- a/nbs/20_interpret.ipynb
+++ b/nbs/20_interpret.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "#hide\n",
     "#skip\n",
-    "! [ -e /content ] && pip install -Uqq fastai  # upgrade fastai on colab"
+    "# ! [ -e /content ] && pip install -Uqq fastai  # upgrade fastai on colab"
    ]
   },
   {
@@ -446,15 +446,17 @@
     "class ClassificationInterpretation(Interpretation):\n",
     "    \"Interpretation methods for classification models.\"\n",
     "\n",
-    "    def __init__(self, dl, inputs, preds, targs, decoded, losses):\n",
-    "        super().__init__(dl, inputs, preds, targs, decoded, losses)\n",
+    "    def __init__(self, learn, dl, losses, act=None):\n",
+    "        super().__init__(learn, dl, losses, act)\n",
     "        self.vocab = self.dl.vocab\n",
     "        if is_listy(self.vocab): self.vocab = self.vocab[-1]\n",
     "\n",
     "    def confusion_matrix(self):\n",
     "        \"Confusion matrix as an `np.ndarray`.\"\n",
     "        x = torch.arange(0, len(self.vocab))\n",
-    "        d,t = flatten_check(self.decoded, self.targs)\n",
+    "        _,targs,decoded = self.learn.get_preds(dl=self.dl, with_decoded=True, with_preds=True, \n",
+    "                                               with_targs=True, act=self.act)\n",
+    "        d,t = flatten_check(decoded, targs)\n",
     "        cm = ((d==x[:,None]) & (t==x[:,None,None])).long().sum(2)\n",
     "        return to_np(cm)\n",
     "\n",
@@ -495,8 +497,43 @@
     "\n",
     "    def print_classification_report(self):\n",
     "        \"Print scikit-learn classification report\"\n",
-    "        d,t = flatten_check(self.decoded, self.targs)\n",
+    "        _,targs,decoded = self.learn.get_preds(dl=self.dl, with_decoded=True, with_preds=True, \n",
+    "                                               with_targs=True, act=self.act)\n",
+    "        d,t = flatten_check(decoded, targs)\n",
     "        print(skm.classification_report(t, d, labels=list(self.vocab.o2i.values()), target_names=[str(v) for v in self.vocab]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#hide\n",
+    "# simple test to make sure ClassificationInterpretation works\n",
+    "interp = ClassificationInterpretation.from_learner(test_learner)\n",
+    "cm = interp.confusion_matrix()"
    ]
   },
   {

--- a/nbs/20_interpret.ipynb
+++ b/nbs/20_interpret.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "#hide\n",
     "#skip\n",
-    "# ! [ -e /content ] && pip install -Uqq fastai  # upgrade fastai on colab"
+    "! [ -e /content ] && pip install -Uqq fastai  # upgrade fastai on colab"
    ]
   },
   {


### PR DESCRIPTION
Resolves #3562 and adds simple test to make sure `ClassificationInterpretation` doesn't fall through the cracks again.

Implementation does generate the entire datasets' worth of predictions, targets, and decoded predictions, which is required for the confusion matrix. It might be possible to make this more memory efficient, but the labels and predictions for classification problems are not usually that large.