### PR TITLE
removing permissions change

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,4 +33,4 @@ services:
      && pip install .
      && nbdev_build_docs && cd docs
      && bundle i
-     && chmod -R u+rwx . && bundle exec jekyll serve --host 0.0.0.0"
+     && bundle exec jekyll serve --host 0.0.0.0"


### PR DESCRIPTION
Checking to see if it is possible to remove the `chmod -R u+rwx .` from the docker-compose.yml file.  This would be beneficial when using the docker-compose file locally to view docs or for development because currently using this will cause many permission changes and git thinks this is a difference.  If we are able to remove it, this is a pretty clean way to spin up a development environment locally and view the docs as changes are made. 