### PR TITLE
Custom name for metrics

### DIFF
--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -25,8 +25,9 @@ mk_class('ActivationType', **{o:o.lower() for o in ['No', 'Sigmoid', 'Softmax', 
 class AccumMetric(Metric):
     "Stores predictions and targets on CPU in accumulate to perform final calculations with `func`."
     def __init__(self, func, dim_argmax=None, activation=ActivationType.No, thresh=None, to_np=False,
-                 invert_arg=False, flatten=True, **kwargs):
+                 invert_arg=False, flatten=True, name=None, **kwargs):
         store_attr('func,dim_argmax,activation,thresh,flatten')
+        self._name = ifnone(name, self.func.func.__name__ if hasattr(self.func, 'func') else  self.func.__name__)
         self.to_np,self.invert_args,self.kwargs = to_np,invert_arg,kwargs
 
     def reset(self):
@@ -67,7 +68,10 @@ class AccumMetric(Metric):
         return self.func(targs, preds, **self.kwargs) if self.invert_args else self.func(preds, targs, **self.kwargs)
 
     @property
-    def name(self):  return self.func.func.__name__ if hasattr(self.func, 'func') else  self.func.__name__
+    def name(self):  return self._name
+
+    @name.setter
+    def name(self, value): self._name = name
 
 # Cell
 def skm_to_fastai(func, is_class=True, thresh=None, axis=-1, activation=None, **kwargs):

--- a/nbs/13b_metrics.ipynb
+++ b/nbs/13b_metrics.ipynb
@@ -126,8 +126,9 @@
     "class AccumMetric(Metric):\n",
     "    \"Stores predictions and targets on CPU in accumulate to perform final calculations with `func`.\"\n",
     "    def __init__(self, func, dim_argmax=None, activation=ActivationType.No, thresh=None, to_np=False,\n",
-    "                 invert_arg=False, flatten=True, **kwargs):\n",
+    "                 invert_arg=False, flatten=True, name=None, **kwargs):\n",
     "        store_attr('func,dim_argmax,activation,thresh,flatten')\n",
+    "        self._name = ifnone(name, self.func.func.__name__ if hasattr(self.func, 'func') else  self.func.__name__)\n",
     "        self.to_np,self.invert_args,self.kwargs = to_np,invert_arg,kwargs\n",
     "\n",
     "    def reset(self):\n",
@@ -168,7 +169,10 @@
     "        return self.func(targs, preds, **self.kwargs) if self.invert_args else self.func(preds, targs, **self.kwargs)\n",
     "\n",
     "    @property\n",
-    "    def name(self):  return self.func.func.__name__ if hasattr(self.func, 'func') else  self.func.__name__"
+    "    def name(self):  return self._name\n",
+    "\n",
+    "    @name.setter\n",
+    "    def name(self, value): self._name = name"
    ]
   },
   {


### PR DESCRIPTION
This PR adds a setter to the name property of AccumMetric so that we can give a custom name for a metric. This is useful when we want to use the same metric type with different arguments, such as threshold or average arguments. For instance, 
in multi-label classification, when we want to have F1 scores with `macro` and `samples` averaging, this is what we currently have:
![metrics-without-custom-name](https://user-images.githubusercontent.com/9764782/152947908-0f9a31eb-79d6-45ff-b4c6-68baf2c0e44e.png)
In epoch results, both F1 scores are named as `f1_scores`.

With this PR, we'll able to distinguish them:
![metrics-with-custom-name](https://user-images.githubusercontent.com/9764782/152948089-6cd52d88-6034-40b1-b18e-9f80813aa168.png)