### PR TITLE
Update 03_data.core.ipynb

### DIFF
--- a/fastai/data/core.py
+++ b/fastai/data/core.py
@@ -142,6 +142,7 @@ class DataLoaders(GetAttr):
         if device is not None or hasattr(loaders[0],'to'): self.device = device
 
     def __getitem__(self, i): return self.loaders[i]
+    def __len__(self): return len(self.loaders)
     def new_empty(self):
         loaders = [dl.new(dl.dataset.new_empty()) for dl in self.loaders]
         return type(self)(*loaders, path=self.path, device=self.device)

--- a/nbs/03_data.core.ipynb
+++ b/nbs/03_data.core.ipynb
@@ -540,6 +540,7 @@
     "        if device is not None or hasattr(loaders[0],'to'): self.device = device\n",
     "\n",
     "    def __getitem__(self, i): return self.loaders[i]\n",
+    "    def __len__(self): return len(self.loaders)\n",
     "    def new_empty(self):\n",
     "        loaders = [dl.new(dl.dataset.new_empty()) for dl in self.loaders]\n",
     "        return type(self)(*loaders, path=self.path, device=self.device)\n",


### PR DESCRIPTION
I often find myself wanting to know have many `loaders` are in `DataLoaders` but there is no `__len__` method currently. This seems counterintuitive to me because they have a `__getitem__` method so I can access individual loaders with, for example, `my_dataloader[0]`. I didn't see other comments about this in the forum but I thought I would make the suggestion.