### PR TITLE
add LIB_INSTALL_TYPE env file to docker-compose 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,12 @@ services:
     tty: true
     volumes:
       - .:/data/
+    environment:
+      - LIB_INSTALL_TYPE=. #optionally change this locally to .[dev] to install dev packages as well
 
   notebook:
     <<: *fastai
-    command: bash -c "pip install -e . && jupyter notebook --allow-root --no-browser --ip=0.0.0.0 --port=8080 --NotebookApp.token='' --NotebookApp.password=''"
+    command: bash -c "pip install -e $$LIB_INSTALL_TYPE && jupyter notebook --allow-root --no-browser --ip=0.0.0.0 --port=8080 --NotebookApp.token='' --NotebookApp.password=''"
     ports:
       - "8080:8080"
 
@@ -30,7 +32,7 @@ services:
      - "4000:4000"
     command: >
      bash -c "cp -r docs_src docs
-     && pip install .
+     && pip install $$LIB_INSTALL_TYPE
      && nbdev_build_docs && cd docs
      && bundle i
      && bundle exec jekyll serve --host 0.0.0.0"


### PR DESCRIPTION
Wanted to throw this idea out based on some conversations in discord.  This would allow users to fairly quickly switch from the normal `pip install -e .` and `pip install -e .[dev]` by changing a new environment variable (LIB_INSTALL_TYPE) that I am proposing is set in docker-compose.yml. 