### PR TITLE
Fix bug in URLs.path() in 04_data.external

### DIFF
--- a/fastai/data/external.py
+++ b/fastai/data/external.py
@@ -113,7 +113,7 @@ class URLs():
     def path(url='.', c_key='archive'):
         "Return local path where to download based on `c_key`"
         fname = url.split('/')[-1]
-        local_path = URLs.LOCAL_PATH/('models' if c_key=='models' else 'data')/fname
+        local_path = URLs.LOCAL_PATH/('models' if c_key=='model' else 'data')/fname
         if local_path.exists(): return local_path
         return fastai_path(c_key)/fname
 

--- a/nbs/04_data.external.ipynb
+++ b/nbs/04_data.external.ipynb
@@ -431,7 +431,7 @@
     "    def path(url='.', c_key='archive'):\n",
     "        \"Return local path where to download based on `c_key`\"\n",
     "        fname = url.split('/')[-1]\n",
-    "        local_path = URLs.LOCAL_PATH/('models' if c_key=='models' else 'data')/fname\n",
+    "        local_path = URLs.LOCAL_PATH/('models' if c_key=='model' else 'data')/fname\n",
     "        if local_path.exists(): return local_path\n",
     "        return fastai_path(c_key)/fname"
    ]


### PR DESCRIPTION
In `URLs.path()`, there is a check to see if the file to download exists in folders `data` or `models` in `URLs.LOCAL_PATH`.

The key to the `Config` is set to `models` instead of `model` when forming the local path. The key should be one of ['archive', 'data', 'model', 'storage'] according to  [URLs docs](https://docs.fast.ai/data.external.html#URLs)

I have tried the following:

1. Current working director is empty (path pointed by LOCAL_PATH = Path.cwd())
2. Run URLs.path() with different values for c_key ['data', 'archive', 'storage', 'model']

```python
for k in ['data', 'archive', 'storage', 'model']:
    print(URLs.path(URLs.MNIST_TINY,c_key=k))

"""
Output:

/root/.fastai/data/mnist_tiny.tgz
/root/.fastai/archive/mnist_tiny.tgz
/root/.fastai/tmp/mnist_tiny.tgz
/root/.fastai/models/mnist_tiny.tgz
"""
```

Then, 

1. Copied `mnist_tiny.tgz` to my current directory under folders `data` and `models`
2. Ran the same code as above
```python
for k in ['data', 'archive', 'storage', 'model']:
    print(URLs.path(URLs.MNIST_TINY,c_key=k))

"""
Output:

/content/data/mnist_tiny.tgz
/content/data/mnist_tiny.tgz
/content/data/mnist_tiny.tgz
/content/data/mnist_tiny.tgz  # <---
"""
```
I was expecting the last output line in the second run (marked by `<---`) to be `/content/models/mnist_tiny.tgz`. 

So I have changed the key value that is compared