### PR TITLE
deleted unused add_vert arg in 08_vision.data:get_grid

### DIFF
--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -11,7 +11,7 @@ import types
 
 # Cell
 @delegates(subplots)
-def get_grid(n, nrows=None, ncols=None, add_vert=0, figsize=None, double=False, title=None, return_fig=False,
+def get_grid(n, nrows=None, ncols=None, figsize=None, double=False, title=None, return_fig=False,
              flatten=True, **kwargs):
     "Return a grid of `n` axes, `rows` by `cols`"
     if nrows:

--- a/nbs/08_vision.data.ipynb
+++ b/nbs/08_vision.data.ipynb
@@ -75,7 +75,7 @@
    "source": [
     "#export\n",
     "@delegates(subplots)\n",
-    "def get_grid(n, nrows=None, ncols=None, add_vert=0, figsize=None, double=False, title=None, return_fig=False,\n",
+    "def get_grid(n, nrows=None, ncols=None, figsize=None, double=False, title=None, return_fig=False,\n",
     "             flatten=True, **kwargs):\n",
     "    \"Return a grid of `n` axes, `rows` by `cols`\"\n",
     "    if nrows:\n",
@@ -1188,7 +1188,7 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   }


### PR DESCRIPTION
One thing to note as I look at the changes. There is this change in the notebook which I don't understand: 
```
   "display_name": "Python 3",
   "display_name": "Python 3 (ipykernel)",
```
I don't know if it matters, or if I can do anything about it. 