### PR TITLE
Quick-Start Guide - Unhide Imports

### DIFF
--- a/nbs/quick_start.ipynb
+++ b/nbs/quick_start.ipynb
@@ -26,7 +26,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#hide\n",
     "from fastai.vision.all import *\n",
     "from fastai.text.all import *\n",
     "from fastai.collab import *\n",


### PR DESCRIPTION
Import statements for fastai modules are hidden in the quick start guide.  This leads to new user confusion (ie import fastai.vision vs fastai.vision.all vs fastai).  In order to see it they would need to click through to the source notebook or to open in colab.  Because it's not visible on that page, new users end up doing a google search to use the quick-start guide.

Since this is a quick-start guide I believe they should be visible to allow users looking to start to copy/paste 100% of what they need to start quickly from the quick-start guide doc page with no additional need to click through/search.