### PR TITLE
Update CI to match GitHub Security Requirements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Install libraries
       run: |
-        pip install git+git://github.com/fastai/fastcore.git
+        pip install git+https://github.com/fastai/fastcore.git
         pip install -Uq fastprogress
         pip install -Uqe .[dev]
     


### PR DESCRIPTION
Update CI workflow to install fastcore from source per [Improving Git protocol security on GitHub](https://github.blog/2021-09-01-improving-git-protocol-security-github/).