### PR TITLE
[Enhancement] Let optimizer use built torch opt

### DIFF
--- a/nbs/12_optimizer.ipynb
+++ b/nbs/12_optimizer.ipynb
@@ -24,20 +24,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/lib/python3.9/site-packages/torch/cuda/__init__.py:145: UserWarning: \n",
-      "NVIDIA GeForce RTX 3070 Laptop GPU with CUDA capability sm_86 is not compatible with the current PyTorch installation.\n",
-      "The current PyTorch install supports CUDA capabilities sm_37 sm_50 sm_60 sm_70.\n",
-      "If you want to use the NVIDIA GeForce RTX 3070 Laptop GPU GPU with PyTorch, please check the instructions at https://pytorch.org/get-started/locally/\n",
-      "\n",
-      "  warnings.warn(incompatible_device_warn.format(device_name, capability, \" \".join(arch_list), device_name))\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#|export\n",
     "from __future__ import annotations\n",

--- a/nbs/12_optimizer.ipynb
+++ b/nbs/12_optimizer.ipynb
@@ -24,7 +24,20 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/conda/lib/python3.9/site-packages/torch/cuda/__init__.py:145: UserWarning: \n",
+      "NVIDIA GeForce RTX 3070 Laptop GPU with CUDA capability sm_86 is not compatible with the current PyTorch installation.\n",
+      "The current PyTorch install supports CUDA capabilities sm_37 sm_50 sm_60 sm_70.\n",
+      "If you want to use the NVIDIA GeForce RTX 3070 Laptop GPU GPU with PyTorch, please check the instructions at https://pytorch.org/get-started/locally/\n",
+      "\n",
+      "  warnings.warn(incompatible_device_warn.format(device_name, capability, \" \".join(arch_list), device_name))\n"
+     ]
+    }
+   ],
    "source": [
     "#|export\n",
     "from __future__ import annotations\n",
@@ -200,7 +213,8 @@
     "            p.grad.detach_()\n",
     "            p.grad.zero_()\n",
     "\n",
-    "    def step(self):\n",
+    "    def step(self, closure=None):\n",
+    "        if closure is not None: raise NotImplementedError(\"fastai optimizers currently do not support closure\")\n",
     "        for p,pg,state,hyper in self.all_params(with_grad=True):\n",
     "            for cb in self.cbs: state = _update(state, cb(p, **{**state, **hyper}))\n",
     "            self.state[p] = state\n",
@@ -731,7 +745,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Optimizer.freeze\" class=\"doc_header\"><code>Optimizer.freeze</code><a href=\"__main__.py#L27\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"Optimizer.freeze\" class=\"doc_header\"><code>Optimizer.freeze</code><a href=\"__main__.py#L28\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>Optimizer.freeze</code>()\n",
        "\n",
@@ -757,11 +771,15 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Optimizer.freeze_to\" class=\"doc_header\"><code>Optimizer.freeze_to</code><a href=\"__main__.py#L18\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"Optimizer.freeze_to\" class=\"doc_header\"><code>Optimizer.freeze_to</code><a href=\"__main__.py#L19\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
-       "> <code>Optimizer.freeze_to</code>(**`n`**)\n",
+       "> <code>Optimizer.freeze_to</code>(**`n`**:`int`)\n",
        "\n",
-       "Freeze parameter groups up to `n`"
+       "Freeze parameter groups up to `n`\n",
+       "\n",
+       "||Type|Default|Details|\n",
+       "|---|---|---|---|\n",
+       "|**`n`**|`int`||Freeze up to `n` layers|\n"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -783,7 +801,7 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Optimizer.unfreeze\" class=\"doc_header\"><code>Optimizer.unfreeze</code><a href=\"__main__.py#L38\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "<h4 id=\"Optimizer.unfreeze\" class=\"doc_header\"><code>Optimizer.unfreeze</code><a href=\"__main__.py#L57\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
        "> <code>Optimizer.unfreeze</code>()\n",
        "\n",
@@ -888,9 +906,13 @@
       "text/markdown": [
        "<h4 id=\"Optimizer.load_state_dict\" class=\"doc_header\"><code>Optimizer.load_state_dict</code><a href=\"__main__.py#L37\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
        "\n",
-       "> <code>Optimizer.load_state_dict</code>(**`sd`**)\n",
+       "> <code>Optimizer.load_state_dict</code>(**`sd`**:`dict`)\n",
        "\n",
-       "Load the content of `sd`"
+       "Load the content of `sd`\n",
+       "\n",
+       "||Type|Default|Details|\n",
+       "|---|---|---|---|\n",
+       "|**`sd`**|`dict`||State dict with `hypers` and `state` to load on the optimizer|\n"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -1321,7 +1343,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAD4CAYAAAD8Zh1EAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8/fFQqAAAACXBIWXMAAAsTAAALEwEAmpwYAAAev0lEQVR4nO3deXhV1b3/8feXjGSETEwJhCGMCioBHKriCA5V29pWrdrai1xtaX8db21729v+eu/Twd62t/dWrT+l1utAtWqLFqu2zlqZZIwQCARICCEJIfN8zvr9kQPGGCDACTtnn8/rec6TPeWc7zo8fFisvfbe5pxDREQi3xCvCxARkfBQoIuI+IQCXUTEJxToIiI+oUAXEfGJWK8+OCsry+Xn53v18SIiEWnt2rU1zrnsvvZ5Fuj5+fmsWbPGq48XEYlIZrb7SPs05CIi4hPHDHQzW2pmVWa2+Qj7zcx+bWYlZrbRzM4Kf5kiInIs/emhPwQsPMr+K4CC0GsxcO/JlyUiIsfrmIHunHsdqD3KIdcCD7tu7wDDzGxUuAoUEZH+CccY+higrMd6eWibiIicQuEIdOtjW593/DKzxWa2xszWVFdXh+GjRUTkkHAEejmQ12M9F6jo60Dn3P3OuULnXGF2dp/TKEVE5ASFYx76cmCJmS0D5gH1zrl9YXhfEZGIEgg6mju6aGrroqm9i8bQz+71zsPrs8cN5/yC8HdqjxnoZvY4MB/IMrNy4N+AOADn3H3ACuBKoARoAW4Le5UiIqdAZyBIfWvnB14Nh5Zb3t/W1P5+YDe2dR4O7eaOQL8+5875E70JdOfcjcfY74Avhq0iEZGT5Jyjoa2Lg80dHGjuoLa5o8dyO3UtfYf2sQI5KT6G9KFxpCbGkpIQS9rQOMYMG0pKQiwpoW2H9n1wPe7wenJ8DLExA3NNp2eX/ouIHI+2zgBVDe1UNbZR3dhOTVM7tc2d1Da3Hw7tQ6+DLR10Bvp+GltC7BCGJ8WTPjSO9KFx5A5PYtiYuMPrPV9pvdbjYwf3xfUKdBHxjHOOupZOqhrbqW7sDuv3l9upamijuqmd6oZ2Gtu7+nyPtMRYMlMSyEiOJy8jiVm5w8hIiSczOZ7hSfGHlzNCr6R4/8aef1smIp5raOtkX10bFfWt7KtrY199KxWhn/vqu3+2dQY/9HtJ8THkpCaQnZrAtJFpXFDQvZyTmkBOWiLZKQlkpXYHdtwADV9EIgW6iJwQ5xy1zR3sqW2h7GArZbUtlB9sYW9dG/vqugO7qVeveojBiLRERqUnMn10GpdOy2Fk+tDuoD4U1qkJpCQomk6EvjUROaK2zgBltS3doV3bwp7aVsoOdi+X1bZ86CRiZnI8o4cNZXxWMudNymJUeiKjhw1l9LBERoWCe6BOCIoCXSTqBYKOirpWdtY0s7O6idKaZnZWN1Na08zeutYPHDs0Loa8jKGMzUji7AmZjM1IYmxGEnkZSeRlDPX1+HQk0LcvEiVaOrooqWpi2/4mdlQ3UVrdzM6aJnYdaKGj6/1x7NSEWMZnJzMnfzifysojPyuJ3OHdwZ2VEo9ZX3f7kMFAgS7iM+1dAXZWN7NtfyPb9jdSXNnEtv2NlB1swYVm8sUOMcZmJjEhK4X5U3KYkJXM+KxkJmSnKLQjmAJdJEI556hqbKeoop6ivQ1sqWyguLKRXQdaCAS7kzt2iDE+K5nTc9O5fnYuk0ekUDAilXEZSRrL9iEFukgECAYde2pbKKpooKiins0VDbxXUU9NU8fhY8ZlJjFlRCpXnDaKySNTmTIilfFZyYP+YhgJHwW6yCDjnGNvXSsbyupZX3aQDeX1vFfRcHgKYOwQo2BEKvOn5DBjdBozRqczbVQqqYlxHlcuXlOgi3issa2TjeX1rC+rY92eOtaX1VHT1A5AfOwQZoxO42Nnjjkc3pNHppAQG+Nx1TIYKdBFTiHnHOUHW1lVWsvqXbWs3X2QkuqmwycrJ2Qlc0FBFmeMHcYZecOYOjJNQybSbwp0kQEUDDpKqptYWVrL6lCI76tvAyA1MZbZ44Zz1cxRnDl2OLNy0xmWFO9xxRLJFOgiYRQMOor3N/JWSQ3v7Kxlze5a6lo6AchJTWDO+Azm5mcwJz+DKSNTiRmi6YESPgp0kZNUfrCFt0pqeLPkAG+X1HCguXvmybjMJC6bNuJwiI/LTNL8bhlQCnSR41Tf2snbJTW8WVLDWyU17DrQAkB2agIXTM7m3ImZnDcpi9HDhnpcqUQbBbrIMTjn2La/iZe3VvFKcRVrdx8kEHQkx8dw9oRMbj0nn48UZFGQk6IeuHhKgS7Sh9aOAG/vqOHlrVW8Wlx9+CZV00elcceFE5g/JYcz8obpXtwyqCjQRUJqmzv425b9vLC5kjdKaujoCpIUH8NHJmXxpYsnMX9KDiPTE70uU+SIFOgS1fbVt/Ji0X5eKKpkZWktgaBjzLChfGbeWC6ZOoI544frIh6JGAp0iTp7DrSwYvM+/rq5kvVldQAU5KRw54UTWXjaSGaMTtNYuEQkBbpEhaqGNp7buI/lGyoOh/jM3HS+uWAKC2aMZFJOircFioSBAl18q76lk78WdYf4P3YcIOi6T2redcVUrp45itzhSV6XKBJWCnTxlc5AkFeLq3lyTRmvFlfTEQiSn5nEkosmcc0Zo5mUk+p1iSIDRoEuvrBtfyNPrinjmXV7qWnqICslgZvPHse1Z4xmZm66xsQlKijQJWLVt3by7IYKnlxbzoayOmKHGBdPzeFThXlcOCVbc8Ql6ijQJeJsKKvjf9/ZzbMbKmjvCjJ1ZCr/etU0rjtzDFkpCV6XJ+IZBbpEhNaOAM9uqOB/39nNpr31JMfHcP3sXD49J4/Tx2hIRQQU6DLI7axu4tGVe3hyTRkNbV1MHpHCj66dwXVnjtEj10R6UaDLoOOc443tNTzwZimvb6smdoix8LSR3HL2OOaOz1BvXOQIFOgyaLR3BVi+voIH3yxla2Uj2akJfO2yydwwN4+cVN1DReRYFOjiuYPNHTy2ag8Pvb2L6sZ2poxI5e7rZ3LNGaN1HxWR46BAF89U1rfx29d3sGxVGa2dAc4vyOI/PzmL8wuyNKwicgL6FehmthD4LyAGeMA595Ne+9OBR4Cxoff8uXPud2GuVXyirLaFe1/bwR/XlBNwjuvOGMPtF4xn6sg0r0sTiWjHDHQziwF+A1wGlAOrzWy5c+69Hod9EXjPOfdRM8sGis3sUedcx4BULRFpZ3UT97y6g2fW7SXGjE8W5nLHhRPJy9A9VUTCoT899LlAiXNuJ4CZLQOuBXoGugNSrfv/ySlALdAV5lolQpVUNfHrv2/nuY0VxMUM4dZzxrH4ggmMStczN0XCqT+BPgYo67FeDszrdcz/AMuBCiAV+LRzLtj7jcxsMbAYYOzYsSdSr0SQ8oMt/NfftvPUu+UkxsVw+wUTWPSRCWSn6mpOkYHQn0Dv6+yU67W+AFgPXAxMBF4yszeccw0f+CXn7gfuBygsLOz9HuITVY1t3PPKDh5duRsz4/PnjefO+RPJ1GX5IgOqP4FeDuT1WM+luyfe023AT5xzDigxs1JgKrAqLFVKRKhv7eS3r+3gd2/toiMQ5FOFeXz5kkkaWhE5RfoT6KuBAjMbD+wFbgBu6nXMHuAS4A0zGwFMAXaGs1AZvDoDQR5buYdf/W0bda2dXDNrNF+9dDL5WclelyYSVY4Z6M65LjNbArxA97TFpc65IjO7I7T/PuBHwENmtonuIZpvOedqBrBuGQScc7y8tYr/WLGFndXNnDsxk+9eNY0Zo9O9Lk0kKvVrHrpzbgWwote2+3osVwCXh7c0Gczeq2jgP1a8x1slB5iQlcwDtxZyybQcXRAk4iFdKSrH5WBzBz97oZhlq/eQPjSOH3x0Op85e5weJiEyCCjQpV+CQceTa8v4yfNbaWjr4nPn5vOVSyaTnqRb2IoMFgp0Oaaiinq+96fNvLunjjn5w/m/157GtFG6TF9ksFGgyxE1tHXyixe38fA/djE8KZ6ff3IWnzhrjMbJRQYpBbr06cWiSv71T5upbmrn5nnj+MblUzS8IjLIKdDlA2qa2vnB8iKe27iPqSNTeeCzhczMHeZ1WSLSDwp0AbrnlP95fQU/fLaI5vYAX79sMnfMn6jZKyIRRIEu7G9o49tPb+LlrVWcOXYYP/vETApGpHpdlogcJwV6lPvLxn1855lNtHcF+N7V0/ncufnEDNFJT5FIpECPUvWtnfxgeRHPrNvLrLxh/PJTs5iQneJ1WSJyEhToUejtHTV844kN7G9s56uXTuaLF00kVmPlIhFPgR5FOrqC/PzFYv7fGzvJz0zmqTvP5Yy8YV6XJSJhokCPEmW1LSx5fB0byur4zLyxfPeqaSTF649fxE/0NzoKvFBUyTef3IBzcO9nzuKK00d5XZKIDAAFuo91dAX58fNb+N1bu5iZm87/3HgWYzOTvC5LRAaIAt2nympb+OJj77KxvJ7bzsvnriumkhAb43VZIjKAFOg+9Ob2GpY8/i6BoOO3t8xmwYyRXpckIqeAAt1HnHM88EYpP35+C5NyUrj/lkI911MkiijQfaK1I8C3ntrI8g0VXHn6SO6+fhbJCfrjFYkm+hvvA+UHW7j94bVsrWzgmwum8IX5E3XPcpEopECPcOv2HOT2h9fQ3hVk6efmcNGUHK9LEhGPKNAj2F827uNrT6xnRFoiyxbPYVKO7sUiEs0U6BHIOcc9r+7g7heKmT1uOPffMpvMlASvyxIRjynQI0xnIMh3nt7Ek2vLuWbWaH52/UwS4zS/XEQU6BGlpaOLOx95l9e2VfPlSwr46qUFOvkpIocp0CPEweYObntoNRvL6/jJx0/nhrljvS5JRAYZBXoEqKhr5dalq9hT28K9N+vKTxHpmwJ9kCupauSWB1fR1NbFw5+fy9kTMr0uSUQGKQX6ILapvJ5bl64kZsgQlv3z2cwYne51SSIyiCnQB6l1ew5y69JVpCXG8djt8xiXqXuyiMjRKdAHobW7a/ns0tVkJMfz+OKzGTNsqNcliUgE0JOBB5mVOw9w64OryE5N4A//rDAXkf5ToA8ib5fU8LnfrWZkeiLLFp/NqHSFuYj0nwJ9kPjHjgPc9tBq8jKGsmzxOYxIS/S6JBGJMP0KdDNbaGbFZlZiZncd4Zj5ZrbezIrM7LXwlulv6/YcZNHvV5OXkcRjt59NdqruyyIix++YJ0XNLAb4DXAZUA6sNrPlzrn3ehwzDLgHWOic22NmuodrP71X0cBnl64iKzWBRxfNI0s32RKRE9SfHvpcoMQ5t9M51wEsA67tdcxNwNPOuT0Azrmq8JbpTyVVTdzy4EpSEmJ5dNE8DbOIyEnpT6CPAcp6rJeHtvU0GRhuZq+a2Vozu7WvNzKzxWa2xszWVFdXn1jFPlFW28LND6zEzHhk0Txyhyd5XZKIRLj+BHpft/NzvdZjgdnAVcAC4HtmNvlDv+Tc/c65QudcYXZ29nEX6xe1zR3cunQVrZ0BHlk0lwnZejCFiJy8/lxYVA7k9VjPBSr6OKbGOdcMNJvZ68AsYFtYqvSRlo4uPv/QairqWnl00TymjkzzuiQR8Yn+9NBXAwVmNt7M4oEbgOW9jvkzcL6ZxZpZEjAP2BLeUiNfVyDIlx5bx8byOn5945kU5md4XZKI+Mgxe+jOuS4zWwK8AMQAS51zRWZ2R2j/fc65LWb2V2AjEAQecM5tHsjCI41zju/9eTN/31rFv193mm6BKyJh1697uTjnVgArem27r9f63cDd4SvNX/775RIeX1XGkosmcfPZ47wuR0R8SFeKngLPbazgFy9t4+NnjuHrl3/oXLGISFgo0AfYpvJ6vvHkBgrHDefHnzhdzwAVkQGjQB9A+xvaWPTwajKTE7jvltkkxMZ4XZKI+Jjuhz5A2joDLH54DY1tXTx157m6pF9EBpwCfQA45/iXP25k4956fnvzbKaN0lxzERl4GnIZAA++WcryDRV84/IpXK7piSJyiijQw2xVaS0/fn4rl08fwRfmT/S6HBGJIgr0MKpqbGPJY++SN3woP//ULM1oEZFTSmPoYXLosv6Gtk5+//m5pCXGeV2SiEQZBXqY/PzFbawsreWXn56lk6Ai4gkNuYTB69uque+1Hdw0bywfOzPX63JEJEop0E9STVM7X3tiA5NHpPD9q6d7XY6IRDENuZyEYNDxjSc30NDWySOL5pIYpytBRcQ76qGfhN+9vYtXi6v516um6UEVIuI5BfoJKqqo56fPb+XSaSO4RbfDFZFBQIF+Ajq6gnz9iQ2kJ8Xxs+tnar65iAwKGkM/Ab/++3a2VjbywK2FZCTHe12OiAigHvpx21BWx72v7eATZ+Vy6fQRXpcjInKYAv04tHUG+MaTG8hOSeD7H9UURREZXDTkchx+9bftbK9q4qHb5pA+VJf2i8jgoh56P20sr+P+13dww5w85k/J8bocEZEPUaD3Q1cgyHee2URmSgLfuWqa1+WIiPRJgd4PD/9jN5v3NvD9q6frLooiMmgp0I+hsr6N/3yxmAsmZ3P1zFFelyMickQK9GP44bNFdAUd/37tabqASEQGNQX6Uby8dT/Pb67ky5cUMDYzyetyRESOSoF+BG2dAf5teRGTclK4/fwJXpcjInJMmod+BA++WUpZbSuPLZpHfKz+3RORwU9J1YeqhjbueaWEy6aP4NxJWV6XIyLSLwr0Ptz9QjEdgSDfvVJzzkUkcijQe9lUXs8f3y3ntvPGk5+V7HU5IiL9pkDvwTnHj557j4ykeJZcPMnrckREjosCvYeXt1axalctX7lssq4IFZGI069AN7OFZlZsZiVmdtdRjptjZgEzuz58JZ4awaDj7heKGZeZxA1z8rwuR0TkuB0z0M0sBvgNcAUwHbjRzD50M/DQcT8FXgh3kafCsxsr2FrZyNcum0xcjP7jIiKRpz/JNRcocc7tdM51AMuAa/s47kvAU0BVGOs7JToDQX7x0jamjUrjozNHe12OiMgJ6U+gjwHKeqyXh7YdZmZjgI8B9x3tjcxssZmtMbM11dXVx1vrgPnD6jJ2H2jhmwsmM2SI7tciIpGpP4HeV8K5Xuu/Ar7lnAsc7Y2cc/c75wqdc4XZ2dn9LHFgtXUG+O+Xt1M4bjgX6cEVIhLB+nPpfznQ8yxhLlDR65hCYFnoboRZwJVm1uWc+1M4ihxIT64pY39DO7/89Bm6m6KIRLT+BPpqoMDMxgN7gRuAm3oe4Jwbf2jZzB4CnouEMO8MBLnvtZ3MHjeccyZkel2OiMhJOeaQi3OuC1hC9+yVLcATzrkiM7vDzO4Y6AIH0jPr9rK3rpUlF09S71xEIl6/7rbonFsBrOi1rc8ToM65z518WQMvEHTc++oOThuTxvzJg2M8X0TkZETthOu/bNpHaU0zX5yv3rmI+ENUBnow6LjnlRIm5aSwYMZIr8sREQmLqAz017ZXs7WykS/Mn6h55yLiG1EZ6EvfLCUnNYGrdVWoiPhI1AX6tv2NvLG9hlvPGadHy4mIr0Rdoi19s5SE2CHcNG+c16WIiIRVVAX6gaZ2nl63l4+flUtGcrzX5YiIhFVUBfrjq/bQ0RXk8+fle12KiEjYRU2gB4KOx1eVce7ETApGpHpdjohI2EVNoL++vZq9da3cNG+s16WIiAyIqAn0x1buITM5nsun60IiEfGnqAj0yvo2Xt5axfWFuZqqKCK+FRXp9sSaMgJBx41zNNwiIv7l+0APBh1/WF3GRyZlkZ+V7HU5IiIDxveB/k7pAfbWtfLJwlyvSxERGVC+D/Q/rdtLcnyMToaKiO/5OtDbOgM8v6mShaeNYmh8jNfliIgMKF8H+stbq2hs7+JjZ47xuhQRkQHn60B/Zt1eclITOGeiHgAtIv7n20A/2NzBq8VVXDNrNDF6iIWIRAHfBvqKzfvoDDiu03CLiEQJ3wb6XzdXMj4rmRmj07wuRUTklPBloNe1dPCPHQdYeNpIzDTcIiLRwZeB/vctVXQFHQtnaO65iEQPXwb6X4sqGZWeyMzcdK9LERE5ZXwX6M3tXby+rZoFMzTcIiLRxXeB/sb2atq7gizQcIuIRBnfBforW6tJS4xlTv5wr0sRETmlfBXozjle21bN+QXZxMb4qmkiIsfkq9TbWtlIZUMbF07O9roUEZFTzleB/mpxNQAXTlGgi0j08VmgVzFtVBoj0hK9LkVE5JTzTaA3tnWydvdB5qt3LiJRyjeBvqq0lq6g4/yCLK9LERHxRL8C3cwWmlmxmZWY2V197P+MmW0Mvd42s1nhL/XoVpbWEh8zhLPGarqiiESnYwa6mcUAvwGuAKYDN5rZ9F6HlQIXOudmAj8C7g93oceysrSWWXnpJMbpUXMiEp3600OfC5Q453Y65zqAZcC1PQ9wzr3tnDsYWn0HyA1vmUfX1N7F5r31zBuvJxOJSPTqT6CPAcp6rJeHth3JPwHP97XDzBab2RozW1NdXd3/Ko9h7e6DBIKOeRMywvaeIiKRpj+B3tcdrlyfB5pdRHegf6uv/c65+51zhc65wuzs8M1GWbnzALFDjNnjNH4uItErth/HlAN5PdZzgYreB5nZTOAB4Arn3IHwlNc/K0trOT03naT4/jRHRMSf+tNDXw0UmNl4M4sHbgCW9zzAzMYCTwO3OOe2hb/MI2vrDLCxvE7j5yIS9Y7ZpXXOdZnZEuAFIAZY6pwrMrM7QvvvA74PZAL3hO5B3uWcKxy4st9XVNFAZ8Bx1thhp+LjREQGrX6NUTjnVgArem27r8fyImBReEvrnw1ldQCckTfMi48XERk0Iv5K0Q3ldYxKTyRH928RkSgX+YFeVses3GFelyEi4rmIDvS6lg52HWhhZp4eBi0iEtGBvmlvPYB66CIiRHigb93XCMC0UWkeVyIi4r2IDvQtlQ3kpCaQkRzvdSkiIp6L6EAvrmxkqnrnIiJABAd6VyDI9v1NTBuZ6nUpIiKDQsQGemlNMx2BIFMU6CIiQAQH+tbK7hOiU0dqyEVEBCI40Lfvb2SIwcScZK9LEREZFCI20HcdaCF3eBIJsXrknIgIRHSgNzMuM8nrMkREBo2IDHTnHKU1zeRnarhFROSQiAz0upZOGtu61EMXEekhIgN914FmAPXQRUR6iMhA332gBYD8LPXQRUQOichA33WgGTPIHa5AFxE5JCIDffeBFkanDyUxTlMWRUQOichAL6ttIXf4UK/LEBEZVCIy0Csb2hiVrmeIioj0FHGB7pyjqqGdEQp0EZEPiLhAr23uoCMQZGSaAl1EpKeIC/TKhjYABbqISC+RF+j13YGuIRcRkQ+KuEBPHxrHghkjNMtFRKSXWK8LOF6F+RkU5md4XYaIyKATcT10ERHpmwJdRMQnFOgiIj6hQBcR8QkFuoiITyjQRUR8QoEuIuITCnQREZ8w55w3H2xWDew+wV/PAmrCWE6kULujRzS2GaKz3cfb5nHOuey+dngW6CfDzNY45wq9ruNUU7ujRzS2GaKz3eFss4ZcRER8QoEuIuITkRro93tdgEfU7ugRjW2G6Gx32NockWPoIiLyYZHaQxcRkV4U6CIiPhFxgW5mC82s2MxKzOwur+sJJzNbamZVZra5x7YMM3vJzLaHfg7vse/boe+h2MwWeFP1yTGzPDN7xcy2mFmRmf2f0HbfttvMEs1slZltCLX5h6Htvm1zT2YWY2brzOy50Lrv221mu8xsk5mtN7M1oW3hb7dzLmJeQAywA5gAxAMbgOle1xXG9l0AnAVs7rHtZ8BdoeW7gJ+GlqeH2p8AjA99LzFet+EE2jwKOCu0nApsC7XNt+0GDEgJLccBK4Gz/dzmXu3/GvAY8Fxo3fftBnYBWb22hb3dkdZDnwuUOOd2Ouc6gGXAtR7XFDbOudeB2l6brwV+H1r+PXBdj+3LnHPtzrlSoITu7yeiOOf2OefeDS03AluAMfi43a5bU2g1LvRy+LjNh5hZLnAV8ECPzb5v9xGEvd2RFuhjgLIe6+WhbX42wjm3D7rDD8gJbffdd2Fm+cCZdPdYfd3u0LDDeqAKeMk55/s2h/wK+Bcg2GNbNLTbAS+a2VozWxzaFvZ2R9pDoq2PbdE679JX34WZpQBPAV9xzjWY9dW87kP72BZx7XbOBYAzzGwY8IyZnXaUw33RZjO7Gqhyzq01s/n9+ZU+tkVcu0POc85VmFkO8JKZbT3KsSfc7kjroZcDeT3Wc4EKj2o5Vfab2SiA0M+q0HbffBdmFkd3mD/qnHs6tNn37QZwztUBrwIL8X+bzwOuMbNddA+XXmxmj+D/duOcqwj9rAKeoXsIJeztjrRAXw0UmNl4M4sHbgCWe1zTQFsOfDa0/Fngzz2232BmCWY2HigAVnlQ30mx7q74g8AW59wveuzybbvNLDvUM8fMhgKXAlvxcZsBnHPfds7lOufy6f67+7Jz7mZ83m4zSzaz1EPLwOXAZgai3V6f/T2Bs8VX0j0TYgfwXa/rCXPbHgf2AZ10/yv9T0Am8Hdge+hnRo/jvxv6HoqBK7yu/wTb/BG6/zu5EVgfel3p53YDM4F1oTZvBr4f2u7bNvfxHczn/Vkuvm433bPyNoReRYdyayDarUv/RUR8ItKGXERE5AgU6CIiPqFAFxHxCQW6iIhPKNBFRHxCgS4i4hMKdBERn/j/PMyNWsqWzZcAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAD4CAYAAAD8Zh1EAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAAe9UlEQVR4nO3deXxV9Z3/8deH7PtCFgIJJCxhX8QAWq37grbFLtZR21ErLfoYmdrpMup0xmntPk73n792tCqDFa3WqpTi0rp0rCgQdghEAgGykpBA9j3f+SMXJiJIgJuc3Hvfz8fjPnLP93zJ/Xwvl7dfv+ece8w5h4iIBL4RXhcgIiL+oUAXEQkSCnQRkSChQBcRCRIKdBGRIBHu1QunpaW53Nxcr15eRCQgbdiw4ZBzLv1E+zwL9NzcXAoLC716eRGRgGRm+0+2T0suIiJB4pSBbmaPmVmNmW0/yX4zs1+YWYmZbTWzuf4vU0RETmUgM/RlwMIP2X8NMMn3WAL86uzLEhGR03XKQHfO/Q9Q/yFdrgOWuz7vAslmluWvAkVEZGD8sYY+Bijrt13uaxMRkSE0pAdFzWyJmRWaWWFtbe1QvrSISNDzR6BXADn9trN9bR/gnHvYOVfgnCtITz/haZQiInKG/HEe+kpgqZk9DSwAGpxzVX74vSIiAaWn19Hc0d33aO+muaOLpvb+2900tXdz+dQMZmUn+/31TxnoZvYUcAmQZmblwL8DEQDOuV8Dq4FrgRKgFfiC36sUERkCHd09NLR10djWRUP/R2sXDW3dx7abO7qOhXRTv7Bu7ewZ0OukJ0R5E+jOuZtOsd8Bd/mtIhGRs9Tb62hs76KupZP6EzyOtHadMLjbuj48kOOjwkmKiSAhOpz4qHBS4iLJSY09th0fFUF8dDgJUeHE+9riosL/b390OHGR4YSNsEEZt2eX/ouInI6Wjm5qmjqoaWyntrmDuuZOX2B3cLili7qWjmOBfbi1i57eE9+NLTYyjOSYCBJjIkiKiSA3LZYk3/Ojj8TjtpNjI0mMDic8bHhfXK9AFxHP9PY66ls7qWnsoLa5L6xrmjqo9T1qmtp9PztOuJxhBskxEaTGRZIaF0leWhznjktlZFwkKXGRjPS1939ER4R5MNKhoUAXkUHhnONIaxeVDW1UHWmnqqGNyoZ2qo74fja0cbChg86e3g/82YSocNITo0iPj2JmdjIZCVGkJ0SRkRBFRkI06QlRpMVHkhwbOWjLF4FIgS4iZ8Q5R21TBwfqWyk73MqBujbKD7dS1dB+LMSPX5MOH2FkJkYzOjmac3JSyJoZTVZiNBmJ0e8L65jI4J1FDyYFuoicVHNHN2X1rX2h7Xv0BXgbZfWtdHS/f3adkRDF6OQYpoxK4NLJGWQlRTM6OebYz7T4KM2oB5ECXSTEdfX0UlbfSumhFvbWtrD3UAt7a5spPdRCTVPH+/rGR4WTkxrLhPQ4Lp2cTk5qLDmpsYxNjWVMckxQr08HAgW6SIhobO9i98Fmdh9sOhbaew+1cKCule5+Z4SkxEaQlxbHRfnp5KXFMW5kX2DnpMSSHBuBmWbYw5UCXSTItHX2UFLTTPHBJt47+qhuorKh/VifyPAR5I2MIz8jgYXTR5GXFsf49HjGp8WREhfpYfVyNhToIgHKOUf54TZ2VDayo7KBXdV94X2gvhXnm3BHho9gYno88/NSyR+VwOTMBPIzExidHKO17CCkQBcJAD29jr21zeyobGR7RQM7Khspqmqkoa0LgBEG49PjmTE6iU+fk83kUfFMykxgXGrssL8YRvxHgS4yzDjn2FfXyuayw2w+cIQt5Q3sqm6kvavvjJLI8BFMHZXAtTOzmD46kemjE5kyKlGn+okCXcRrh1s62Vx2hE1lR9hcdoQtZUeOzbxjI8OYMSaJm+ePY/roRGaMSWJCepxm3XJCCnSRIeScY09tC+v31bO+tJ6NBw6zr64V6Fs2yc9M4JoZo5iTk8ycsclMykjQWrcMmAJdZBB19/Sys6qJdfvqWVdaR+G+w9S1dAIwMi6Sc8elcMO8HObkJDMrO5n4KP2TlDOnT4+IH3X39LKtooE1e+p4d28dG/cfpsX3pVLZKTFcPDmd+bmpzMtLZXxanM7pFr9SoIucBeccew+18HbJIf62+xDv7K2jqb0bgPzMeD41dwzzclOZn5dKVlKMx9VKsFOgi5ym2qaOvgAvOcTbJYeo8l2wMyY5ho/NzOKCiWl8ZMJIRsZHeVyphBoFusgp9PY6tlU08PquGt4ormFreQMAybERXDAhjQsmpnHBxJGMTY3VEop4SoEucgINbV28tbuWN3bV8tf3ajjU3IkZnJOTzNevyufi/Aymj05khM5AkWFEgS7iU93QzqtF1by8vZq1pfX09DqSYiK4OD+dy6ZkcFF+Oqn6nhMZxhToEtL2HWrh5R19Ib657AgAEzPiueOi8Vw2JYM5Ocm6iEcChgJdQk5xdROrt1Xxyo5qdlU3ATArO4lvXD2Zq6ePYmJGvMcVipwZBbqEhLL6VlZuqWTl5kqKDzZhBvNyU7n/49O4anom2SmxXpcoctYU6BK0apra+dPWKlZuqWTTgSMAFIxL4YHrpnPNjCzSE3RaoQQXBboElfauHl7eXs3vN5SzZs8heh1MzUrknoVT+MTsLM3EJagp0CXgOefYXHaEZzeU88ctlTS1d5OdEsNdl05k0ezRTMpM8LpEkSGhQJeAVdvUwfObynm2sJzdNc1ER4zg2hlZXF+QzXl5I3WOuIQcBboEFOcca/bU8cQ7+/nzzoP09Drmjk3mB5+eycdmZZEYHeF1iSKeUaBLQGho6+K5DeX8du1+9ta2kBIbweIL87ihIEenGYr4KNBlWNte0cBv393PC5sraO/q5ZyxyfzkhtlcOzOL6Ajdck2kPwW6DDs9vY5XdlTzm7f2svHAEaIjRvDJOWP4/HnjmDEmyevyRIYtBboMG80d3TyzvozH15RSVt/G2NRY/u3j07j+3GySYrQ2LnIqCnTxXFVDG8vW7GPF2gM0tXdz7rgUvnntVK6cNkr30xQ5DQp08cye2mb+/xt7eHFzBb3Occ2MLBZ/NI+5Y1O8Lk0kIA0o0M1sIfBzIAz4jXPuh8ftHwv8N5Ds63Ovc261f0uVYLGrupGH3tjDqq2VRIWP4PPnjWPxhXnkpOoqTpGzccpAN7Mw4CHgSqAcWG9mK51zRf26/SvwjHPuV2Y2DVgN5A5CvRLAtpU38MvXd/Nq0UHiIsO446IJfPGjeaTpVm0ifjGQGfp8oMQ5txfAzJ4GrgP6B7oDEn3Pk4BKfxYpgW1L2RF++pf3eLO4lsTocO6+fBJfuCCX5FjdLELEnwYS6GOAsn7b5cCC4/p8C3jVzP4RiAOuONEvMrMlwBKAsWPHnm6tEmCKq5v48avFvFp0kJTYCL5x9WT+/vxxuppTZJD466DoTcAy59yPzex84Akzm+Gc6+3fyTn3MPAwQEFBgfPTa8sws7+uhZ/9ZTcvbK4gPjKcr16Zz+0X5hEfpWPwIoNpIP/CKoCcftvZvrb+FgMLAZxz75hZNJAG1PijSAkMNY3t/Py13fxufRnhYcaSi8Zz50UTSNF9OEWGxEACfT0wyczy6AvyG4Gbj+tzALgcWGZmU4FooNafhcrw1drZzSP/U8qv/7qH7t5ebl4wlqWXTiQjMdrr0kRCyikD3TnXbWZLgVfoOyXxMefcDjN7ACh0zq0EvgY8Ymb/RN8B0tucc1pSCXK9vY7nN1Xw4CvFVDe2c+3MUdyzcArjRsZ5XZpISBrQoqbvnPLVx7Xd3+95EXCBf0uT4ezdvXV8909FbK9oZHZ2Er+8+Rzm5aZ6XZZISNNRKjktlUfa+M6qIl7aXk1WUjQ/+7s5LJo9WjeTEBkGFOgyIJ3dvTz6t1J+8dpuHI6vXpnPlz46nphIfYWtyHChQJdTemdPHf/24nZKapq5Ymom//6JabpMX2QYUqDLSdU0tvO91Tt5cXMlOakxPHprAZdPzfS6LBE5CQW6fIBzjmcKy/jun3bS0dXLly+fxD9cMkF3CBIZ5hTo8j4H6lq57/mtvF1Sx4K8VH74mVnkpek0RJFAoEAXoO+2b8vW7OM/XykmbITxvU/N4KZ5Y3X2ikgAUaALJTXNfOP3W9h04AiXTk7ne5+ayejkGK/LEpHTpEAPYc45lr+zn++v3klMZBg/+7s5XDdnNGaalYsEIgV6iDrY2M7Xn93CW7sPccnkdP7jM7P03SsiAU6BHoL+tLWKf3l+G53dvXz3kzP43IKxmpWLBAEFeghp7ujm/he284dNFczOSeanN8xmfHq812WJiJ8o0ENEUWUjS1dsZF9dC3dfPomll00kImyE12WJiB8p0IOcc44V6w7w7T8WkRIbwVNfOo8F40d6XZaIDAIFehBrau/ivj9sY9XWKi7KT+enN8xmZHyU12WJyCBRoAepHZUN3PXkRsoOt/HPCydz50UTdJGQSJBToAehFzdXcM9zW0mOieTpJefpxhMiIUKBHkS6e3r54Uu7+M3fSpmfl8pDN88lPUFLLCKhQoEeJOpbOlm6YiNr9tRx20dy+ebHpuosFpEQo0APAkWVjXxpeSG1zR08eP0sPluQ43VJIuIBBXqAe33XQZau2ERidATP3nE+s3OSvS5JRDyiQA9QzvV93e13VhUxfXQSj95aoO9iEQlxCvQA1N3TywOrilj+zn6umpbJz26cQ2yk/ipFQp1SIMA0d3SzdMVG3iyuZclF47l34RSdXy4igAI9oBxq7uALj6+nqKqR739qJjcvGOt1SSIyjCjQA0RZfSu3PLaOqoY2HrnlXC6bkul1SSIyzCjQA8Cu6kZueXQdHd29PPnFBZw7Tld+isgHKdCHufX76lm8bD2xkeE8e+f55GcmeF2SiAxTCvRh7M3iGu54YgNjkmNYvng+2SmxXpckIsOYAn2Y+kvRQf7hyY1Myoxn+e3z9bW3InJKCvRh6OXt1SxdsZHpoxNZfvsCkmIjvC5JRAKAAn2YWbW1kruf3sys7CT++/b5JEYrzEVkYPR1fMPIC5sq+PJTm5g7NpnlCnMROU2aoQ8TL26u4J+e2cyCvFQevXUecVH6qxGR0zOgGbqZLTSzYjMrMbN7T9LnBjMrMrMdZrbCv2UGt1d3VPPVZ7YwLzeVx2+brzAXkTNyyuQwszDgIeBKoBxYb2YrnXNF/fpMAu4DLnDOHTazjMEqONi8tbuWpSs2MWNMEo/dNo+YyDCvSxKRADWQGfp8oMQ5t9c51wk8DVx3XJ8vAQ855w4DOOdq/FtmcFpXWs+XlhcyISOe5V+YT7xm5iJyFgYS6GOAsn7b5b62/vKBfDN728zeNbOFJ/pFZrbEzArNrLC2tvbMKg4SW8uPcPuy9YxOjuGJxfN1aqKInDV/neUSDkwCLgFuAh4xs+TjOznnHnbOFTjnCtLT0/300oFn36EWvvD4epJjI1jxxfNI00VDIuIHAwn0CqD/TSqzfW39lQMrnXNdzrlS4D36Al6Oc6i5g1sfX0evcyy/fT6jknSXIRHxj4EE+npgkpnlmVkkcCOw8rg+L9A3O8fM0uhbgtnrvzKDQ0tHN7cvW8/BxnYeu20e49PjvS5JRILIKQPdOdcNLAVeAXYCzzjndpjZA2a2yNftFaDOzIqAN4BvOOfqBqvoQNTV08tdKzayvaKBh26eyzljU7wuSUSCjDnnPHnhgoICV1hY6MlrDzXnHPc8t5VnCsv5wadnctN83WlIRM6MmW1wzhWcaJ8u/R8Cj7y1l2cKy/nyZRMV5iIyaBTog+y1nQf5wUu7+NjMLL5yRb7X5YhIEFOgD6Li6ia+/NQmpo9O5D8/O5sRI8zrkkQkiCnQB0l9SydfXL6euKhwHrmlQJf0i8ig07Xmg6Czu5c7f7uBg40dPHPH+WQlxXhdkoiEAM3QB8H3V+9kXWk9D14/izk5yV6XIyIhQoHuZyu3VLJszT5uvyCP6+Yc/5U3IiKDR4HuR7sPNnHvc1spGJfCfddO8bocEQkxCnQ/ae7o5s7fbiA2Moz/d/NcIsL01orI0NJBUT9wznHvc1spPdTCk188T1+4JSKe0DTSD363voxVW6v4+tWTOX/CSK/LEZEQpUA/SyU1zXz7j0VcODGNOy+a4HU5IhLCFOhnob2rh398ahMxkWH85AZdCSoi3tIa+ln40cu72FnVyKO3FpCRqHVzEfGWZuhn6I3iGh5/ex+3fSSXy6dmel2OiIgC/Uwcae3knt9vZXJmAvdeo/PNRWR40JLLGfjWyh3Ut3Ty2G3ziI7Ql26JyPCgGfppenl7NS9sruSuSycyY0yS1+WIiByjQD8N9S2d/OsL25iWlcjSyyZ6XY6IyPtoyeU03P/idhraunhi8QJd2i8iw45SaYBe3l7Nqq1V3H35JKZmJXpdjojIByjQB6C5o5tvrdzBlFEJ3HGxrgYVkeFJSy4D8JNX3+NgUzsPfU7foigiw5fS6RS2VzSwbE0pN80fy7njUrwuR0TkpBToH6Kn1/HN57eRGhfJPVfrAiIRGd4U6B/iybX72VLewL99fBpJsRFelyMi8qEU6CdxqLmDB18u5sKJaSyaPdrrckRETkmBfhI/fvU92rp6+Nai6Zjpa3FFZPhToJ9AUWUjv1t/gL8/fxwTM+K9LkdEZEAU6MdxzvGdVUUkxkTwlcvzvS5HRGTAFOjHebXoIO/sreOrV+brQKiIBBQFej+d3b18f/VOJmXEc/P8sV6XIyJyWhTo/Ty17gD761r5l49NJVxXhIpIgBlQapnZQjMrNrMSM7v3Q/p9xsycmRX4r8Sh0drZzS9fL2F+XiqX5Kd7XY6IyGk7ZaCbWRjwEHANMA24ycymnaBfAnA3sNbfRQ6Fx9/ex6HmDu5ZOFmnKYpIQBrIDH0+UOKc2+uc6wSeBq47Qb/vAD8C2v1Y35A40trJr/+6hyumZnDuuFSvyxEROSMDCfQxQFm/7XJf2zFmNhfIcc796cN+kZktMbNCMyusra097WIHy6//upfmjm6+fvVkr0sRETljZ33kz8xGAD8Bvnaqvs65h51zBc65gvT04bFOXdPUzrI1pVw3ezRTRunGFSISuAYS6BVATr/tbF/bUQnADOBNM9sHnAesDJQDo4++VUpndy9fuUIXEYlIYBtIoK8HJplZnplFAjcCK4/udM41OOfSnHO5zrlc4F1gkXOucFAq9qPDLZ389t39fGL2aHLT4rwuR0TkrJwy0J1z3cBS4BVgJ/CMc26HmT1gZosGu8DB9PiafbR09nDXpRO9LkVE5KwN6BZ0zrnVwOrj2u4/Sd9Lzr6swdfU3sWyt0u5enom+ZkJXpcjInLWQvZyyCfe3U9jezdLL53kdSkiIn4RkoHe1tnDo2+VcnF+OjOzk7wuR0TEL0Iy0H+/sZy6lk6tnYtIUAm5QO/tdTz+dimzspOYl5vidTkiIn4TcoH+1/dq2Vvbwu0X5Ok7W0QkqIRcoD/6t1IyE6O4dmaW16WIiPhVSAV6cXUTfys5xC3n5xIZHlJDF5EQEFKp9vjbpURHjNDdiEQkKIVMoDe2d/Hi5koWzR5NSlyk1+WIiPhdyAT6i5sraevq4eYF47wuRURkUIREoDvnWLH2ANOyEpmtC4lEJEiFRKBvKW9gZ1UjNy0Yq1MVRSRohUSgr1i7n9jIMD45Z7TXpYiIDJqgD/Sm9i7+uKWKRbNHkxAd4XU5IiKDJugD/aXt1bR19fDZgpxTdxYRCWBBH+gvbKpg3MhY5o5N9roUEZFBFdSBXt3Qzjt76/jknDE6GCoiQS+oA33llgqcg0+eM8brUkREBl1QB/rzmyqZk5NMnm4ALSIhIGgDfVd1IzurGnWqooiEjKAN9Bc3VxI2wvj4bAW6iISGoAx05xwvbaviIxNGkhYf5XU5IiJDIigD/b2Dzeyra2XhjFFelyIiMmSCMtBf3l6NGVw5LdPrUkREhkxwBvqOagrGpZCREO11KSIiQyboAn1/XQs7qxq5erqWW0QktARdoP+56CCAAl1EQk7QBfobxTVMzkwgJzXW61JERIZUUAV6S0c360sPc8nkdK9LEREZckEV6Gv21NHZ08vF+Qp0EQk9QRXobxbXEBcZRkFuqteliIgMuaAJdOccbxbX8pGJaUSGB82wREQGLGiSb09tMxVH2rR+LiIhK2gC/e2SOgAumqRAF5HQNKBAN7OFZlZsZiVmdu8J9n/VzIrMbKuZvWZm4/xf6odbW1rHmOQYna4oIiHrlIFuZmHAQ8A1wDTgJjObdly3TUCBc24W8HvgP/xd6IdxzrGutJ75eToYKiKhayAz9PlAiXNur3OuE3gauK5/B+fcG865Vt/mu0C2f8v8cHtqWzjU3MkCBbqIhLCBBPoYoKzfdrmv7WQWAy+daIeZLTGzQjMrrK2tHXiVp7C2tG/9fMH4kX77nSIigcavB0XN7PNAAfDgifY75x52zhU45wrS0/138HLt3noyEqLIHan1cxEJXeED6FMB5PTbzva1vY+ZXQF8E7jYOdfhn/JOzTnH2tI6FowfiZkN1cuKiAw7A5mhrwcmmVmemUUCNwIr+3cws3OA/wIWOedq/F/myZXVt3GwsUPr5yIS8k4Z6M65bmAp8AqwE3jGObfDzB4ws0W+bg8C8cCzZrbZzFae5Nf53aaywwDMHZsyVC8pIjIsDWTJBefcamD1cW3393t+hZ/rGrAtZQ1ER4wgPzPeqxJERIaFgL9SdEv5EWaOSSI8LOCHIiJyVgI6Bbt6etle0cDs7GSvSxER8VxAB3pxdRMd3b3Mykn2uhQREc8FdKBvq2gAYHZ2kseViIh4L6ADfVdVI/FR4eSk6IIiEZGADvSd1U3kZ8YzYoQuKBIRCdhAd85RXN3ElKxEr0sRERkWAjbQqxvbaWjrYuqoBK9LEREZFgI20HdVNQEweZRm6CIiEMiBXn000DVDFxGBAA703QebyEqKJikmwutSRESGhYAN9H11LeSlxXldhojIsBHAgd7KuJEKdBGRowIy0Bvauqhv6dQdikRE+gnIQD9Q13c/as3QRUT+T0AG+r66FgBy0zRDFxE5KiADfb8v0MemKtBFRI4KyEDfV9dKZmIUsZEDuuGSiEhICMhA31/XQq7Wz0VE3icgA72svo1sfWWuiMj7BFyg9/Q6aps7yEqK9roUEZFhJeAC/VBzBz29jkwFuojI+wRcoFc3tAMwKlGBLiLSX+AFeqMCXUTkRAIv0H0z9MykKI8rEREZXgIu0LOSorlyWiZpcQp0EZH+Au7KnKumj+Kq6aO8LkNEZNgJuBm6iIicmAJdRCRIKNBFRIKEAl1EJEgo0EVEgoQCXUQkSCjQRUSChAJdRCRImHPOmxc2qwX2n+EfTwMO+bGcQKFxh45QHDOE5rhPd8zjnHPpJ9rhWaCfDTMrdM4VeF3HUNO4Q0cojhlCc9z+HLOWXEREgoQCXUQkSARqoD/sdQEe0bhDRyiOGUJz3H4bc0CuoYuIyAcF6gxdRESOo0AXEQkSARfoZrbQzIrNrMTM7vW6Hn8ys8fMrMbMtvdrSzWzP5vZbt/PFF+7mdkvfO/DVjOb613lZ87McszsDTMrMrMdZna3rz1ox21m0Wa2zsy2+Mb8bV97npmt9Y3td2YW6WuP8m2X+PbnejqAs2RmYWa2ycxW+baDftxmts/MtpnZZjMr9LX5/TMeUIFuZmHAQ8A1wDTgJjOb5m1VfrUMWHhc273Aa865ScBrvm3oew8m+R5LgF8NUY3+1g18zTk3DTgPuMv3dxrM4+4ALnPOzQbmAAvN7DzgR8BPnXMTgcPAYl//xcBhX/tPff0C2d3Azn7boTLuS51zc/qdc+7/z7hzLmAewPnAK/227wPu87ouP48xF9jeb7sYyPI9zwKKfc//C7jpRP0C+QG8CFwZKuMGYoGNwAL6rhYM97Uf+6wDrwDn+56H+/qZ17Wf4XizfeF1GbAKsBAZ9z4g7bg2v3/GA2qGDowByvptl/vaglmmc67K97wayPQ9D7r3wve/1OcAawnycfuWHTYDNcCfgT3AEedct69L/3EdG7NvfwMwckgL9p+fAf8M9Pq2RxIa43bAq2a2wcyW+Nr8/hkPuJtEhzLnnDOzoDzP1MzigeeArzjnGs3s2L5gHLdzrgeYY2bJwPPAFG8rGnxm9nGgxjm3wcwu8bicoXahc67CzDKAP5vZrv47/fUZD7QZegWQ028729cWzA6aWRaA72eNrz1o3gszi6AvzJ90zv3B1xz04wZwzh0B3qBvqSHZzI5OsvqP69iYffuTgLqhrdQvLgAWmdk+4Gn6ll1+TvCPG+dche9nDX3/AZ/PIHzGAy3Q1wOTfEfFI4EbgZUe1zTYVgK3+p7fSt8a89H2W3xHxM8DGvr971vAsL6p+KPATufcT/rtCtpxm1m6b2aOmcXQd8xgJ33Bfr2v2/FjPvpeXA+87nyLq4HEOXefcy7bOZdL37/d151znyPIx21mcWaWcPQ5cBWwncH4jHt9sOAMDi5cC7xH35rjN72ux89jewqoArroWzdbTN+a4WvAbuAvQKqvr9F3xs8eYBtQ4HX9ZzjmC+lbX9wKbPY9rg3mcQOzgE2+MW8H7ve1jwfWASXAs0CUrz3at13i2z/e6zH44T24BFgVCuP2jW+L77HjaG4Nxmdcl/6LiASJQFtyERGRk1Cgi4gECQW6iEiQUKCLiAQJBbqISJBQoIuIBAkFuohIkPhfd1Nr97f1m5EAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -1787,8 +1809,19 @@
     "    \"A wrapper class for existing PyTorch optimizers\"\n",
     "    _xtra=['zero_grad', 'step', 'state_dict', 'load_state_dict']\n",
     "    _default='opt'\n",
-    "    def __init__(self, params, opt, hp_map=None, convert_groups=True, **kwargs):\n",
-    "        self.opt = opt(_convert_params(params), **kwargs) if convert_groups else opt(params, **kwargs)\n",
+    "    def __init__(self, \n",
+    "         params:list|dict=None, # Model parameters to pass to `opt`. If using an already built `opt`\n",
+    "         opt:callable|torch.optim.Optimizer=None, # A torch optimizer constructor, or an already built optimizer \n",
+    "         hp_map:dict=None, # A dictionary converting the keys of a built `opt` to the keys of fastai's Optimizer\n",
+    "         convert_groups=True, # Whether to convert parameter groups\n",
+    "         **kwargs\n",
+    "    ):\n",
+    "        if params is None and opt is None: raise ValueError(\"Both `params` and `opt` cannot be None.\")\n",
+    "        if callable(opt):\n",
+    "            self.opt = opt(_convert_params(params), **kwargs) if convert_groups else opt(params, **kwargs)\n",
+    "        else:\n",
+    "            if params is not None: raise ValueError(\"Tried using both `params` and a built optimizer. Just pass in `opt`.\")\n",
+    "            self.opt = opt\n",
     "        if hp_map is None: hp_map = pytorch_hp_map\n",
     "        self.fwd_map = {k: hp_map[k] if k in hp_map else k for k in detuplify_pg(self.opt.param_groups[0]).keys()}\n",
     "        self.bwd_map = {v:k for k,v in self.fwd_map.items()}\n",
@@ -1862,9 +1895,44 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Ensure we can use an already made optimizer\n",
+    "tst_sgd = torch.optim.SGD([{'params': [tensor([1,2,3])], 'lr': 1e-3}, \n",
+    "                                        {'params': [tensor([4,5,6])], 'lr': 1e-2}])\n",
+    "tst_sgd = OptimWrapper(opt = tst_sgd)\n",
+    "sgd = SGD([[tensor([1,2,3])], [tensor([4,5,6])]], lr=[1e-3, 1e-2])\n",
+    "#Access to param_groups\n",
+    "test_eq(tst_sgd.param_lists, sgd.param_lists)\n",
+    "#Set param_groups\n",
+    "tst_sgd.param_lists = [[tensor([4,5,6])], [tensor([1,2,3])]]\n",
+    "test_eq(tst_sgd.opt.param_groups[0]['params'], [tensor(4,5,6)])\n",
+    "test_eq(tst_sgd.opt.param_groups[1]['params'], [tensor(1,2,3)])\n",
+    "#Access to hypers\n",
+    "test_eq(tst_sgd.hypers, [{**sgd.hypers[i], **_xtra_hypers} for i in range(2)])\n",
+    "#Set hypers\n",
+    "tst_sgd.set_hyper('mom', 0.95)\n",
+    "test_eq([pg['momentum'] for pg in tst_sgd.opt.param_groups], [0.95,0.95])\n",
+    "tst_sgd.set_hyper('lr', [1e-4,1e-3])\n",
+    "test_eq([pg['lr'] for pg in tst_sgd.opt.param_groups], [1e-4,1e-3])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "#|hide\n",
     "#check it works with tuply hp names like in Adam\n",
     "tst_adam = OptimWrapper([tensor([1,2,3])], torch.optim.Adam, lr=1e-2, betas=(0.9, 0.99))\n",
+    "test_eq(tst_adam.hypers, [{\n",
+    "    'lr': 0.01, 'mom': 0.9, 'sqr_mom': 0.99, 'eps': 1e-08, 'wd': 0, 'amsgrad': False, 'maximize':False}])\n",
+    "tst_adam.set_hyper('mom', 0.95)\n",
+    "test_eq(tst_adam.opt.param_groups[0]['betas'], (0.95, 0.99))\n",
+    "tst_adam.set_hyper('sqr_mom', 0.9)\n",
+    "test_eq(tst_adam.opt.param_groups[0]['betas'], (0.95, 0.9))\n",
+    "\n",
+    "tst_adam = torch.optim.Adam([tensor([1,2,3])], lr=1e-2, betas=(0.9, 0.99))\n",
+    "tst_adam = OptimWrapper(opt=tst_adam)\n",
     "test_eq(tst_adam.hypers, [{\n",
     "    'lr': 0.01, 'mom': 0.9, 'sqr_mom': 0.99, 'eps': 1e-08, 'wd': 0, 'amsgrad': False, 'maximize':False}])\n",
     "tst_adam.set_hyper('mom', 0.95)\n",
@@ -1923,6 +1991,36 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#hide\n",
+    "m = nn.Linear(4,5)\n",
+    "x = torch.randn(100, 3, 4)\n",
+    "y = torch.randn(100, 3, 5)\n",
+    "try:\n",
+    "    torch.save(m.state_dict(), 'tmp.pth')\n",
+    "    wgt,bias = m.weight.data.clone(),m.bias.data.clone()\n",
+    "\n",
+    "    m.load_state_dict(torch.load('tmp.pth'))\n",
+    "    opt1 = torch.optim.AdamW(m.parameters(), betas=(0.9, 0.99), eps=1e-5, weight_decay=1e-2)\n",
+    "    opt1 = OptimWrapper(opt=opt1)\n",
+    "    _mock_train(m, x.clone(), y.clone(), opt1)\n",
+    "    wgt1,bias1 = m.weight.data.clone(),m.bias.data.clone()\n",
+    "\n",
+    "    m.load_state_dict(torch.load('tmp.pth'))\n",
+    "    opt2 = Adam(m.parameters(), 1e-3, wd=1e-2)\n",
+    "    _mock_train(m, x.clone(), y.clone(), opt2)\n",
+    "    wgt2,bias2 = m.weight.data.clone(),m.bias.data.clone()\n",
+    "    \n",
+    "    test_close(wgt1,wgt2,eps=1e-3)\n",
+    "    test_close(bias1,bias2,eps=1e-3)\n",
+    "finally: os.remove('tmp.pth')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "m = nn.Linear(4,5)\n",
     "x = torch.randn(100, 3, 4)\n",
     "y = torch.randn(100, 3, 5)\n",
@@ -1932,6 +2030,36 @@
     "\n",
     "    m.load_state_dict(torch.load('tmp.pth'))\n",
     "    opt1 = OptimWrapper(m.parameters(), torch.optim.Adam, betas=(0.9, 0.99), eps=1e-5, weight_decay=1e-2)\n",
+    "    _mock_train(m, x.clone(), y.clone(), opt1)\n",
+    "    wgt1,bias1 = m.weight.data.clone(),m.bias.data.clone()\n",
+    "\n",
+    "    m.load_state_dict(torch.load('tmp.pth'))\n",
+    "    opt2 = Adam(m.parameters(), 1e-3, wd=1e-2, decouple_wd=False)\n",
+    "    _mock_train(m, x.clone(), y.clone(), opt2)\n",
+    "    wgt2,bias2 = m.weight.data.clone(),m.bias.data.clone()\n",
+    "    \n",
+    "    test_close(wgt1,wgt2,eps=1e-3)\n",
+    "    test_close(bias1,bias2,eps=1e-3)\n",
+    "finally: os.remove('tmp.pth')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#hide\n",
+    "m = nn.Linear(4,5)\n",
+    "x = torch.randn(100, 3, 4)\n",
+    "y = torch.randn(100, 3, 5)\n",
+    "try:\n",
+    "    torch.save(m.state_dict(), 'tmp.pth')\n",
+    "    wgt,bias = m.weight.data.clone(),m.bias.data.clone()\n",
+    "\n",
+    "    m.load_state_dict(torch.load('tmp.pth'))\n",
+    "    opt1 = torch.optim.Adam(m.parameters(), betas=(0.9, 0.99), eps=1e-5, weight_decay=1e-2)\n",
+    "    opt1 = OptimWrapper(opt=opt1)\n",
     "    _mock_train(m, x.clone(), y.clone(), opt1)\n",
     "    wgt1,bias1 = m.weight.data.clone(),m.bias.data.clone()\n",
     "\n",
@@ -1959,6 +2087,23 @@
    "outputs": [],
    "source": [
     "opt_func = partial(OptimWrapper, opt=torch.optim.SGD)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or if you already have an existing one, pass in only `opt`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "opt = torch.optim.SGD([tensor([1,2,3])], lr=1e-2)\n",
+    "opt_func = OptimWrapper(opt=opt)"
    ]
   },
   {
@@ -2039,6 +2184,7 @@
       "Converted 71_callback.tensorboard.ipynb.\n",
       "Converted 72_callback.neptune.ipynb.\n",
       "Converted 73_callback.captum.ipynb.\n",
+      "Converted 74_huggingface.ipynb.\n",
       "Converted 97_test_utils.ipynb.\n",
       "Converted 99_pytorch_doc.ipynb.\n",
       "Converted dev-setup.ipynb.\n",
@@ -2051,7 +2197,6 @@
       "Converted migrating_pytorch_verbose.ipynb.\n",
       "Converted ulmfit.ipynb.\n",
       "Converted index.ipynb.\n",
-      "Converted index_original.ipynb.\n",
       "Converted quick_start.ipynb.\n",
       "Converted tutorial.ipynb.\n"
      ]


### PR DESCRIPTION
This PR slightly tweaks the constructor for `OptimWrapper`, by allowing it to use an already built pytorch optimizer. This is beneficial for when other libraries need to use a built optimizer directly to work with it. Prime need is Accelerate can prepare an optimizer, but it converts it back to pytorch. We then need to wrap it again in `OptimWrapper`.

Example use case:

```python
# some func to build a learner
learn = get_learner(...)
opt = accelerator.prepare_optimizer(learn.opt)
# Rewrap the optimizer
learn.opt = OptimWrapper(opt=opt)
```

To also have it be compatible with Accelerate, `step` takes in a closure param, but will raise an error if it's anything but `None`. This keeps it compatible with regular torch optimizers as well, though the implementation is not there (which @tmabraham is working on I believe)
cc @jph00 