### PR TITLE
[Bugfix] Fix smoothloss on distributed

### DIFF
--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -456,7 +456,7 @@ class AvgSmoothLoss(Metric):
     def reset(self):               self.count,self.val = 0,tensor(0.)
     def accumulate(self, learn):
         self.count += 1
-        self.val = torch.lerp(to_detach(learn.loss.mean(), gather=False), self.val, self.beta)
+        self.val = torch.lerp(to_detach(learn.loss.mean()), self.val, self.beta)
     @property
     def value(self): return self.val/(1-self.beta**self.count)
 

--- a/nbs/13a_learner.ipynb
+++ b/nbs/13a_learner.ipynb
@@ -2272,7 +2272,7 @@
     "    def reset(self):               self.count,self.val = 0,tensor(0.)\n",
     "    def accumulate(self, learn):\n",
     "        self.count += 1\n",
-    "        self.val = torch.lerp(to_detach(learn.loss.mean(), gather=False), self.val, self.beta)\n",
+    "        self.val = torch.lerp(to_detach(learn.loss.mean()), self.val, self.beta)\n",
     "    @property\n",
     "    def value(self): return self.val/(1-self.beta**self.count)"
    ]


### PR DESCRIPTION
Currently smoothloss behaves differently than all the other metric calculators, as it does not gather all the tensors when calculating. As a result, if using fastai distributed the reported training loss is actually wrong, as it's only shown for worker 0.

cc @jph00 