### PR TITLE
Bring in setup_cuda to `launch`

### DIFF
--- a/fastai/launch.py
+++ b/fastai/launch.py
@@ -1,6 +1,7 @@
 import subprocess,torch,os,sys
 from fastcore.basics import *
 from fastcore.script import *
+from fastai.torch_core import setup_cuda
 
 @call_parse
 def main(
@@ -9,6 +10,7 @@ def main(
     args:Param("Args to pass to script", nargs='...', opt=False)=''
 ):
     "PyTorch distributed training launch helper that spawns multiple distributed processes"
+    setup_cuda()
     current_env = os.environ.copy()
     gpus = list(range(torch.cuda.device_count())) if gpus=='all' else gpus.split(',')
     current_env["WORLD_SIZE"] = str(len(gpus))


### PR DESCRIPTION
In order for launch to run well, it needs `setup_cuda`, which is probably why this was added in the first place to always be run :)

cc @jph00 

Discovered this while trying to dive deeper into another issue. 