### PR TITLE
Add built-in integration to Comet

### DIFF
--- a/docs_src/sidebar.json
+++ b/docs_src/sidebar.json
@@ -118,6 +118,7 @@
         "Captum": "/callback.captum.html",
         "Weights & Biases": "/callback.wandb.html",
         "Neptune": "/callback.neptune.html",
+        "Comet": "/callback.comet.html",
         "TensorBoard": "/callback.tensorboard.html",
         "Hugging Face Hub": "/huggingface.html"
     },

--- a/nbs/72_callback.comet.ipynb
+++ b/nbs/72_callback.comet.ipynb
@@ -1,0 +1,240 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# |hide\n",
+    "# |skip\n",
+    "! [ -e /content ] && pip install -Uqq fastai  # upgrade fastai on colab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# |all_slow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# |export\n",
+    "from __future__ import annotations\n",
+    "\n",
+    "import tempfile\n",
+    "\n",
+    "from fastai.basics import *\n",
+    "from fastai.learner import Callback"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# |hide\n",
+    "from nbdev.showdoc import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# |default_exp callback.neptune"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Comet.ml\n",
+    "\n",
+    "> Integration with [Comet.ml](https://www.comet.ml/)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Registration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "1. Create account: [comet.ml/signup](https://www.comet.ml/signup).\n",
+    "2. Export API key to the environment variable (more help [here](https://www.comet.ml/docs/v2/guides/getting-started/quickstart/#get-an-api-key)). In your terminal run:\n",
+    "\n",
+    "```\n",
+    "export COMET_API_KEY='YOUR_LONG_API_TOKEN'\n",
+    "```\n",
+    "\n",
+    "or include it in your `./comet.config` file (**recommended**). More help is [here](https://www.comet.ml/docs/v2/guides/tracking-ml-training/jupyter-notebooks/#set-your-api-key-and-project-name)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Installation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "1. You need to install neptune-client. In your terminal run:\n",
+    "\n",
+    "```\n",
+    "pip install comet_ml\n",
+    "```\n",
+    "\n",
+    "or (alternative installation using conda). In your terminal run:\n",
+    "\n",
+    "```\n",
+    "conda install -c anaconda -c conda-forge -c comet_ml comet_ml\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## How to use?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Key is to create the callback `CometMLCallback` before you create `Learner()` like this:\n",
+    "\n",
+    "```\n",
+    "from fastai.callback.comet import CometMLCallback\n",
+    "\n",
+    "comet_ml_callback = CometCallback('PROJECT_NAME')  # specify project\n",
+    "\n",
+    "learn = Learner(dls, model,\n",
+    "                cbs=comet_ml_callback\n",
+    "                )\n",
+    "\n",
+    "learn.fit_one_cycle(1)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# |export\n",
+    "import comet_ml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# |export\n",
+    "class CometCallback(Callback):\n",
+    "    \"Log losses, metrics, model weights, model architecture summary to neptune\"\n",
+    "    order = Recorder.order + 1\n",
+    "\n",
+    "    def __init__(self, project_name, log_model_weights=True):\n",
+    "        self.log_model_weights = log_model_weights\n",
+    "        self.keep_experiment_running = keep_experiment_running\n",
+    "        self.project_name = project_name\n",
+    "        self.experiment = None\n",
+    "\n",
+    "    def before_fit(self):\n",
+    "        try:\n",
+    "            self.experiment = comet_ml.Experiment(project_name=self.project_name)\n",
+    "        except ValueError:\n",
+    "            print(\"No active experiment\")\n",
+    "\n",
+    "        try:\n",
+    "            self.experiment.log_parameter(\"n_epoch\", str(self.learn.n_epoch))\n",
+    "            self.experiment.log_parameter(\"model_class\", str(type(self.learn.model)))\n",
+    "        except:\n",
+    "            print(f\"Did not log all properties.\")\n",
+    "\n",
+    "        try:\n",
+    "            with tempfile.NamedTemporaryFile(mode=\"w\") as f:\n",
+    "                with open(f.name, \"w\") as g:\n",
+    "                    g.write(repr(self.learn.model))\n",
+    "                self.experiment.log_asset(f.name, \"model_summary.txt\")\n",
+    "        except:\n",
+    "            print(\"Did not log model summary. Check if your model is PyTorch model.\")\n",
+    "\n",
+    "        if self.log_model_weights and not hasattr(self.learn, \"save_model\"):\n",
+    "            print(\n",
+    "                \"Unable to log model to Comet.\\n\",\n",
+    "            )\n",
+    "\n",
+    "    def after_batch(self):\n",
+    "        # log loss and opt.hypers\n",
+    "        if self.learn.training:\n",
+    "            self.experiment.log_metric(\"batch__smooth_loss\", self.learn.smooth_loss)\n",
+    "            self.experiment.log_metric(\"batch__loss\", self.learn.loss)\n",
+    "            self.experiment.log_metric(\"batch__train_iter\", self.learn.train_iter)\n",
+    "            for i, h in enumerate(self.learn.opt.hypers):\n",
+    "                for k, v in h.items():\n",
+    "                    self.experiment.log_metric(f\"batch__opt.hypers.{k}\", v)\n",
+    "\n",
+    "    def after_epoch(self):\n",
+    "        # log metrics\n",
+    "        for n, v in zip(self.learn.recorder.metric_names, self.learn.recorder.log):\n",
+    "            if n not in [\"epoch\", \"time\"]:\n",
+    "                self.experiment.log_metric(f\"epoch__{n}\", v)\n",
+    "            if n == \"time\":\n",
+    "                self.experiment.log_text(f\"epoch__{n}\", str(v))\n",
+    "\n",
+    "        # log model weights\n",
+    "        if self.log_model_weights and hasattr(self.learn, \"save_model\"):\n",
+    "            if self.learn.save_model.every_epoch:\n",
+    "                _file = join_path_file(\n",
+    "                    f\"{self.learn.save_model.fname}_{self.learn.save_model.epoch}\",\n",
+    "                    self.learn.path / self.learn.model_dir,\n",
+    "                    ext=\".pth\",\n",
+    "                )\n",
+    "            else:\n",
+    "                _file = join_path_file(\n",
+    "                    self.learn.save_model.fname,\n",
+    "                    self.learn.path / self.learn.model_dir,\n",
+    "                    ext=\".pth\",\n",
+    "                )\n",
+    "            self.experiment.log_asset(_file)\n",
+    "\n",
+    "    def after_fit(self):\n",
+    "        try:\n",
+    "            self.experiment.end()\n",
+    "        except:\n",
+    "            print(\"No neptune experiment to stop.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:fastai]",
+   "language": "python",
+   "name": "conda-env-fastai-py"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/settings.ini
+++ b/settings.ini
@@ -16,7 +16,7 @@ language = English
 requirements = fastdownload>=0.0.5,<2 fastcore>=1.3.27,<1.5 torchvision>=0.8.2 matplotlib pandas requests pyyaml fastprogress>=0.2.4 pillow>6.0.0 scikit-learn scipy spacy<4 packaging
 pip_requirements = torch>=1.7.0,<1.12
 conda_requirements = pytorch>=1.7.0,<1.12
-dev_requirements = nbdev>=1.0.22,<2 ipywidgets pytorch-lightning pytorch-ignite transformers sentencepiece tensorboard pydicom catalyst flask_compress captum>=0.3 flask wandb kornia scikit-image neptune-client albumentations opencv-python pyarrow catalyst ninja timm>=0.6.2.dev #azureml-sdk
+dev_requirements = nbdev>=1.0.22,<2 ipywidgets pytorch-lightning pytorch-ignite transformers sentencepiece tensorboard pydicom catalyst flask_compress captum>=0.3 flask wandb kornia scikit-image neptune-client comet_ml albumentations opencv-python pyarrow catalyst ninja timm>=0.6.2.dev #azureml-sdk
 nbs_path = nbs
 doc_path = docs
 doc_src_path = docs_src


### PR DESCRIPTION
Fastai has built-in integration with Neptune, see https://docs.fast.ai/callback.neptune.html.

I use [Comet.ml](https://www.comet.ml/) instead of Netpune and I want to have Comet available from Fastai similar to Neptune.

Is this contribution welcome?