### PR TITLE
Update HF Hub integration docs to new release of huggingface_hub

### DIFF
--- a/nbs/74_huggingface.ipynb
+++ b/nbs/74_huggingface.ipynb
@@ -26,7 +26,7 @@
    "source": [
     "# Using the Hugging Face Hub to share and load models\n",
     "\n",
-    "> Integration with the Hugging Face Hub"
+    "> Integration with the [Hugging Face Hub](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.from_pretrained_fastai)"
    ]
   },
   {
@@ -42,14 +42,19 @@
    "source": [
     "The Hub is a central platform where anyone can share and explore models, datasets, and ML demos. It aims to build the most extensive collection of Open Source models, datasets, and demos. \n",
     "\n",
-    "Sharing to the Hub could amplify the impact of a fastai Learner by making it available for others to download and explore.\n",
+    "Sharing to the Hub could amplify the impact of a fastai `Learner`  by making it available for others to download and explore.\n",
     "\n",
     "Anyone can access all the fastai models in the Hub by filtering the [huggingface.co/models](https://huggingface.co/models) webpage by the fastai library, as in the image below.\n",
     "\n",
-    "To know more about the Hub, refer to [this introduction](https://github.com/huggingface/education-toolkit/blob/main/01_huggingface-hub-tour.md).\n",
-    "\n",
     "\n",
     "<img src=\"images/hf_hub_fastai.png\" alt=\"hf_hub_fastai\" width=\"800\" />"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Hub has built-in [version control based on git](https://huggingface.co/docs/transformers/model_sharing#repository-features) (git-lfs, for large files), discussions, [pull requests](https://huggingface.co/blog/community-update), and [model cards](https://huggingface.co/docs/hub/model-repos#what-are-model-cards-and-why-are-they-useful) for discoverability and reproducibility. For more information on navigating the Hub, see [this introduction](https://github.com/huggingface/education-toolkit/blob/main/01_huggingface-hub-tour.md)."
    ]
   },
   {
@@ -74,33 +79,29 @@
     "pip install huggingface_hub[\"fastai\"]\n",
     "```\n",
     "\n",
-    "Note: As of May 5, 2022, there has not been a release that includes the fastai+hub features so that you can install from `main`:\n",
-    "\n",
-    "```\n",
-    "!pip install git+https://github.com/huggingface/huggingface_hub#egg=huggingface-hub[\"fastai\"]\n",
-    "```\n",
-    "\n",
-    "To share models in the Hub, you will need to have a user. Create it on the [Hugging Face website](https://huggingface.co/).\n"
+    "To share models in the Hub, you will need to have a user. Create it on the [Hugging Face website](https://huggingface.co/join)."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Sharing a Learner to the Hub\n"
+    "## Sharing a `Learner` to the Hub\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are three options to login to the Hugging Face Hub; your token will be available in your Account Settings:\n",
+    "First, log in to the Hugging Face Hub. You will need to create a `write` token in your [Account Settings](http://hf.co/settings/tokens). Then there are three options to log in:\n",
+    "\n",
     "1. Type `huggingface-cli login` in your terminal and enter your token.\n",
     "\n",
     "2. If in a python notebook, you can use `notebook_login`.\n",
     "\n",
     "```\n",
     "from huggingface_hub import notebook_login\n",
+    "\n",
     "notebook_login()\n",
     "```\n",
     "\n",
@@ -112,19 +113,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Input `push_to_hub_fastai` (refer to the [Hub Client documentation](https://huggingface.co/docs/huggingface_hub/main/en/package_reference/mixins#huggingface_hub.push_to_hub_fastai)) with the Learner you want to upload and the repository id for the Hub in the format of \"namespace/repo_name\". The namespace can be an individual account or an organization you have write access to (for example, 'fastai/stanza-de'). For more details, refer to the [Hub Client documentation](https://huggingface.co/docs/huggingface_hub/main/en/package_reference/mixins#huggingface_hub.push_to_hub_fastai).\n",
+    "Input `push_to_hub_fastai` with the `Learner` you want to upload and the repository id for the Hub in the format of \"namespace/repo_name\". The namespace can be an individual account or an organization you have write access to (for example, 'fastai/stanza-de'). For more details, refer to the [Hub Client documentation](https://huggingface.co/docs/huggingface_hub/main/en/package_reference/mixins#huggingface_hub.push_to_hub_fastai).\n",
     "\n",
-    "```\n",
+    "```py\n",
     "from huggingface_hub import push_to_hub_fastai\n",
-    "push_to_hub_fastai(learner=learn, repo_id=\"espejelomar/cool_learner\")\n",
+    "\n",
+    "# repo_id = \"YOUR_USERNAME/YOUR_LEARNER_NAME\"\n",
+    "repo_id = \"espejelomar/identify-my-cat\"\n",
+    "\n",
+    "push_to_hub_fastai(learner=learn, repo_id=repo_id)\n",
     "```\n",
     "\n",
-    "The Learner is now in the Hub with the id `espejelomar/cool_learner`.\n",
-    "\n",
-    "When uploading a fastai Learner (or any other model) to the Hub, it is helpful to edit its model card (image below) so that others better understand your work (refer to the [Hugging Face documentation](https://huggingface.co/docs/hub/model-repos#what-are-model-cards-and-why-are-they-useful)).\n",
+    "The `Learner` is now in the Hub in the repo named [`espejelomar/identify-my-cat`](https://huggingface.co/espejelomar/identify-my-cat). An automatic model card is created with some links and next steps. When uploading a fastai `Learner` (or any other model) to the Hub, it is helpful to edit its model card (image below) so that others better understand your work (refer to the [Hugging Face documentation](https://huggingface.co/docs/hub/model-repos#what-are-model-cards-and-why-are-they-useful)).\n",
     "\n",
     "<img src=\"images/hf_model_card.png\" alt=\"hf_model_card\" width=\"800\" />\n",
-    "\n"
+    "\n",
+    "`push_to_hub_fastai` has additional arguments that could be of interest; refer to the [Hub Client Documentation](https://huggingface.co/docs/huggingface_hub/main/en/package_reference/mixins#huggingface_hub.from_pretrained_fastai). The model is a [Git repository](https://huggingface.co/docs/transformers/model_sharing#repository-features) with all the advantages that this entails: version control, commits, branches, [discussions and pull requests](https://huggingface.co/blog/community-update).\n"
    ]
   },
   {
@@ -138,11 +142,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To load a model in the Hub with the id `ITESM/fastai_model`:\n",
+    "Load the `Learner` we just shared in the Hub.\n",
     "\n",
-    "```\n",
+    "```py\n",
     "from huggingface_hub import from_pretrained_fastai\n",
-    "learner = from_pretrained_fastai(\"ITESM/fastai_model\")\n",
+    "\n",
+    "# repo_id = \"YOUR_USERNAME/YOUR_LEARNER_NAME\"\n",
+    "repo_id = \"espejelomar/identify-my-cat\"\n",
+    "\n",
+    "learner = from_pretrained_fastai(repo_id)\n",
     "```\n",
     "\n",
     "The [Hub Client documentation](https://huggingface.co/docs/huggingface_hub/main/en/package_reference/mixins#huggingface_hub.from_pretrained_fastai) includes addtional details on `from_pretrained_fastai`.\n"


### PR DESCRIPTION
## Description
This PR updates the HF Hub integration doc for new HF releases.

## New releases in this PR
- The new [`huggingface_hub`](https://github.com/huggingface/huggingface_hub/releases/tag/v0.6.0) 0.6.0 release includes the fastai integration. 
- The Hub now provides the ability for users to do [Pull Requests and open Discussions](https://huggingface.co/blog/community-update) in the shared models. 