### PR TITLE
plot_top_losses: fix its being limited to 9 items

### DIFF
--- a/fastai/interpret.py
+++ b/fastai/interpret.py
@@ -78,7 +78,7 @@ class Interpretation():
             losses, idx = self.top_losses(k, largest)
         inps, preds, targs, decoded, _ = self[idx]
         inps, targs, decoded = tuplify(inps), tuplify(targs), tuplify(decoded)
-        x, y, its = self.dl._pre_show_batch(inps+targs)
+        x, y, its = self.dl._pre_show_batch(inps+targs, max_n=len(idx))
         x1, y1, outs = self.dl._pre_show_batch(inps+decoded, max_n=len(idx))
         if its is not None:
             plot_top_losses(x, y, its, outs.itemgot(slice(len(inps), None)), preds, losses, **kwargs)

--- a/nbs/20_interpret.ipynb
+++ b/nbs/20_interpret.ipynb
@@ -155,7 +155,7 @@
     "            losses, idx = self.top_losses(k, largest)\n",
     "        inps, preds, targs, decoded, _ = self[idx]\n",
     "        inps, targs, decoded = tuplify(inps), tuplify(targs), tuplify(decoded)\n",
-    "        x, y, its = self.dl._pre_show_batch(inps+targs)\n",
+    "        x, y, its = self.dl._pre_show_batch(inps+targs, max_n=len(idx))\n",
     "        x1, y1, outs = self.dl._pre_show_batch(inps+decoded, max_n=len(idx))\n",
     "        if its is not None:\n",
     "            plot_top_losses(x, y, its, outs.itemgot(slice(len(inps), None)), preds, losses, **kwargs)\n",


### PR DESCRIPTION
A change in #3558 removed the `max_n` argument from one of the `_pre_show_batch` calls within `Interpretation.plot_top_losses` (probably by mistake?). This caused the number of items in `its` to default to 9 even if a different number `k` of losses to plot was set. This may lead to only 9 items being plotted even if more were requested.