### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ on:
 
 jobs: 
   debug:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
 
@@ -30,6 +32,8 @@ jobs:
         path: ${{ github.event_path }}
         
   filter:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
       - run: |


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
