### PR TITLE
Solve hanging `load_model` and let LRFind be ran in a distributed setup

### DIFF
--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -46,7 +46,6 @@ def save_model(file, model, opt, with_opt=True, pickle_protocol=2):
 # Cell
 def load_model(file, model, opt, with_opt=True, device=None, strict=True):
     "Load `model` from `file` along with `opt` (if available, and if `with_opt`)"
-    distrib_barrier()
     if isinstance(device, int): device = torch.device('cuda', device)
     elif device is None: device = 'cpu'
     state = torch.load(file, map_location=device)
@@ -385,6 +384,7 @@ def load(self:Learner, file, device=None, **kwargs):
     if self.opt is None: self.create_opt()
     file = join_path_file(file, self.path/self.model_dir, ext='.pth')
     load_model(file, self.model, self.opt, device=device, **kwargs)
+    nested_attr(self, "accelerator.wait_for_everyone", noop)()
     return self
 
 # Cell

--- a/nbs/13a_learner.ipynb
+++ b/nbs/13a_learner.ipynb
@@ -212,7 +212,6 @@
     "#|export\n",
     "def load_model(file, model, opt, with_opt=True, device=None, strict=True):\n",
     "    \"Load `model` from `file` along with `opt` (if available, and if `with_opt`)\"\n",
-    "    distrib_barrier()\n",
     "    if isinstance(device, int): device = torch.device('cuda', device)\n",
     "    elif device is None: device = 'cpu'\n",
     "    state = torch.load(file, map_location=device)\n",
@@ -1811,6 +1810,7 @@
     "    if self.opt is None: self.create_opt()\n",
     "    file = join_path_file(file, self.path/self.model_dir, ext='.pth')\n",
     "    load_model(file, self.model, self.opt, device=device, **kwargs)\n",
+    "    nested_attr(self, \"accelerator.wait_for_everyone\", noop)()\n",
     "    return self"
    ]
   },


### PR DESCRIPTION
# Solve `load_model` hanging in distributed setup

## What does this add?

This PR guts some of the distributed logic in `load_model` and replaces it with better Accelerate logic for loading the Learner

## Who is it for?

Closes https://github.com/fastai/fastai/issues/3688 and https://github.com/fastai/fastai/issues/3132

## Why is it needed?

Currently we have a `distrib_barrier` inside of `load_model`, which one would consider to be enough to avoid deadlocks but its not. Instead we need to have all model weights loaded in first before moving on with whatever we are about to do, causing a deadlock hang when calling `Learn.lr_find()` in a distributed situation.

## What parts of the API does this impact?

### User-facing:

Nothing

### Internal structure:

Since in distributed setups we assume that Accelerate will always be used, Learner has a `learn.accelerator` attribute. We can then call Accelerator's [wait_for_everyone](https://huggingface.co/docs/accelerate/v0.9.0/en/accelerator#accelerate.Accelerator.wait_for_everyone) method to ensure that all models are loaded before moving on, avoiding the deadlock.

## When would I use it, and when wouldn't I?

When would you: A distributed run
When wouldn't you: When you're not (which is why it's a `nested_attr` + `noop`

I've tested this on my own 2gpu system and lr find ran to completion without issue.

cc @jph00 