### PR TITLE
Fix AttributeError with PIL

### DIFF
--- a/dev_nbs/course/lesson7-superres.ipynb
+++ b/dev_nbs/course/lesson7-superres.ipynb
@@ -1335,31 +1335,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.10"
-  },
-  "toc": {
-   "base_numbering": 1,
-   "nav_menu": {},
-   "number_sections": false,
-   "sideBar": true,
-   "skip_h1_title": false,
-   "title_cell": "Table of Contents",
-   "title_sidebar": "Contents",
-   "toc_cell": false,
-   "toc_position": {},
-   "toc_section_display": true,
-   "toc_window_display": false
   }
  },
  "nbformat": 4,

--- a/fastai/vision/core.py
+++ b/fastai/vision/core.py
@@ -16,7 +16,7 @@ from ..data.all import *
 
 from PIL import Image
 try: BILINEAR,NEAREST = Image.Resampling.BILINEAR,Image.Resampling.NEAREST
-except ModuleNotFoundError: from PIL.Image import BILINEAR,NEAREST
+except AttributeError: from PIL.Image import BILINEAR,NEAREST
 
 # Cell
 #nbdev_comment _all_ = ['BILINEAR','NEAREST']

--- a/nbs/07_vision.core.ipynb
+++ b/nbs/07_vision.core.ipynb
@@ -34,7 +34,7 @@
     "\n",
     "from PIL import Image\n",
     "try: BILINEAR,NEAREST = Image.Resampling.BILINEAR,Image.Resampling.NEAREST\n",
-    "except ModuleNotFoundError: from PIL.Image import BILINEAR,NEAREST"
+    "except AttributeError: from PIL.Image import BILINEAR,NEAREST"
    ]
   },
   {


### PR DESCRIPTION
Makes the try/catch use an `AttributeError` rather than a ModuleNotFound error, which actually catches it.

Would recommend another release as currently installing in colab raises this error still.

Closes https://github.com/fastai/fastai/issues/3698

cc @jph00 