### PR TITLE
Fixes 50_tutorial.datablock.ipynb issue

### DIFF
--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -54,7 +54,7 @@ def clip_remove_empty(
 # Cell
 def bb_pad(
     samples:list, # List of 3-tuples like (image, bounding_boxes, labels)
-    pad_idx:int=0 # Label that will be used to pad each list of labels
+    pad_idx=0 # Label that will be used to pad each list of labels
 ):
     "Function that collects `samples` of labelled bboxes and adds padding with `pad_idx`."
     samples = [(s[0], *clip_remove_empty(*s[1:])) for s in samples]

--- a/nbs/08_vision.data.ipynb
+++ b/nbs/08_vision.data.ipynb
@@ -154,7 +154,7 @@
     "#|export\n",
     "def bb_pad(\n",
     "    samples:list, # List of 3-tuples like (image, bounding_boxes, labels)\n",
-    "    pad_idx:int=0 # Label that will be used to pad each list of labels\n",
+    "    pad_idx=0 # Label that will be used to pad each list of labels\n",
     "):\n",
     "    \"Function that collects `samples` of labelled bboxes and adds padding with `pad_idx`.\"\n",
     "    samples = [(s[0], *clip_remove_empty(*s[1:])) for s in samples]\n",


### PR DESCRIPTION
Fixed very strange issue where int type is breaking things

- Notebook 50_tutorial.datablock.ipynb was broken due to this:
At:
```
	dls = coco.dataloaders(coco_source)
	dls.show_batch(max_n=9)
```