### PR TITLE
add missing `id` invocation for Image.Image

### DIFF
--- a/nbs/07_vision.core.ipynb
+++ b/nbs/07_vision.core.ipynb
@@ -86,7 +86,7 @@
     "#|exporti\n",
     "@patch\n",
     "def __repr__(x:Image.Image):\n",
-    "    return \"<%s.%s image mode=%s size=%dx%d at 0x%X>\" % (x.__class__.__module__, x.__class__.__name__, x.mode, x.size[0], x.size[1])"
+    "    return \"<%s.%s image mode=%s size=%dx%d at 0x%X>\" % (x.__class__.__module__, x.__class__.__name__, x.mode, x.size[0], x.size[1], id(x))"
    ]
   },
   {


### PR DESCRIPTION
Add a parameter to the `__repr__` method for `Image.Image` which fills the last placeholder in the format string with the internal id.

---

I was going through the first notebook of the fastai course (thanks for the course!!) [1] and got an error in one of the cells:
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
/opt/conda/lib/python3.7/site-packages/IPython/core/formatters.py in __call__(self, obj)
    700                 type_pprinters=self.type_printers,
    701                 deferred_pprinters=self.deferred_printers)
--> 702             printer.pretty(obj)
    703             printer.flush()
    704             return stream.getvalue()

/opt/conda/lib/python3.7/site-packages/IPython/lib/pretty.py in pretty(self, obj)
    392                         if cls is not object \
    393                                 and callable(cls.__dict__.get('__repr__')):
--> 394                             return _repr_pprint(obj, self, cycle)
    395 
    396             return _default_pprint(obj, self, cycle)

/opt/conda/lib/python3.7/site-packages/IPython/lib/pretty.py in _repr_pprint(obj, p, cycle)
    698     """A pprint that just redirects to the normal repr function."""
    699     # Find newlines and replace them with p.break_()
--> 700     output = repr(obj)
    701     lines = output.splitlines()
    702     with p.group():

/opt/conda/lib/python3.7/site-packages/fastai/vision/core.py in __repr__(x)
     26 @patch
     27 def __repr__(x:Image.Image):
---> 28     return "<%s.%s image mode=%s size=%dx%d at 0x%X>" % (x.__class__.__module__, x.__class__.__name__, x.mode, x.size[0], x.size[1])
     29 
     30 # %% ../nbs/07_vision.core.ipynb 11

TypeError: not enough arguments for format string
```

I think release 2.7.8 which includes 0454367 introduced this bug, as rolling back to 2.7.7 fixes the issue. 

I'm not sure how the auto generation works as I couldn't get `nbenv` to work correctly for me. Is there an alternate command I can run to generate the build artifacts?

[1] https://www.kaggle.com/code/jhoward/is-it-a-bird-creating-a-model-from-your-own-data