### PR TITLE
Fix 04_data.external.ipynb copy-paste issue

### DIFF
--- a/nbs/04_data.external.ipynb
+++ b/nbs/04_data.external.ipynb
@@ -57,7 +57,7 @@
     "\n",
     "To download model pretrained weights: \n",
     "```python \n",
-    "path = untar_data(URLs.PETS)\n",
+    "path = untar_data(URLs.WT103_BWD)\n",
     "path.ls()\n",
     "\n",
     ">> (#2) [Path('/home/ubuntu/.fastai/data/wt103-bwd/itos_wt103.pkl'),Path('/home/ubuntu/.fastai/data/wt103-bwd/lstm_bwd.pth')]\n",


### PR DESCRIPTION
While reading [the docs](https://docs.fast.ai/data.external.html), that was very confusing that running the same piece of code lead to different results.

But I believe it's just a copy-paste typo.