### PR TITLE
Add latest TorchVision models on fastai

### DIFF
--- a/fastai/vision/models/tvm.py
+++ b/fastai/vision/models/tvm.py
@@ -1,4 +1,11 @@
-from torchvision.models import ResNet,resnet18,resnet34,resnet50,resnet101,resnet152
-from torchvision.models import SqueezeNet,squeezenet1_0,squeezenet1_1
-from torchvision.models import densenet121,densenet169,densenet201,densenet161
-from torchvision.models import vgg11_bn,vgg13_bn,vgg16_bn,vgg19_bn,alexnet
+from torchvision.models import *
+import types as _t
+
+_g = globals()
+for _k, _v in list(_g.items()):
+    if (
+        isinstance(_v, _t.ModuleType) and _v.__name__.startswith("torchvision.models")
+    ) or (callable(_v) and _v.__module__ == "torchvision.models._api"):
+        del _g[_k]
+
+del _k, _v, _g, _t


### PR DESCRIPTION
Fixes #3789

Implements a variation of option 2 as discussed on the issue:
- We remove automatically any submodule imported in `torchvision.models` such as `detection`, `video` etc.
- We remove any callable that is not a model such as `get_weights()`, `list_models()` etc
- Exposes only TorchVision's model builders, model classes and model weights. 
- Cleans up after itself to avoid exposing variables.
- Works across TorchVision versions and is compatible with static analysis / IDEs.

Here are all the imports using the latest TorchVision main:
```python
from fastai.vision.models.tvm import *

for a in list(globals().keys()):
    print(a)
```

<details><summary>Output</summary>

```
__name__
__doc__
__package__
__loader__
__spec__
__annotations__
__builtins__
__file__
__cached__
alexnet
AlexNet
AlexNet_Weights
ConvNeXt
ConvNeXt_Tiny_Weights
ConvNeXt_Small_Weights
ConvNeXt_Base_Weights
ConvNeXt_Large_Weights
convnext_tiny
convnext_small
convnext_base
convnext_large
DenseNet
DenseNet121_Weights
DenseNet161_Weights
DenseNet169_Weights
DenseNet201_Weights
densenet121
densenet161
densenet169
densenet201
EfficientNet
EfficientNet_B0_Weights
EfficientNet_B1_Weights
EfficientNet_B2_Weights
EfficientNet_B3_Weights
EfficientNet_B4_Weights
EfficientNet_B5_Weights
EfficientNet_B6_Weights
EfficientNet_B7_Weights
EfficientNet_V2_S_Weights
EfficientNet_V2_M_Weights
EfficientNet_V2_L_Weights
efficientnet_b0
efficientnet_b1
efficientnet_b2
efficientnet_b3
efficientnet_b4
efficientnet_b5
efficientnet_b6
efficientnet_b7
efficientnet_v2_s
efficientnet_v2_m
efficientnet_v2_l
googlenet
GoogLeNet
GoogLeNetOutputs
GoogLeNet_Weights
Inception3
InceptionOutputs
Inception_V3_Weights
inception_v3
MNASNet
MNASNet0_5_Weights
MNASNet0_75_Weights
MNASNet1_0_Weights
MNASNet1_3_Weights
mnasnet0_5
mnasnet0_75
mnasnet1_0
mnasnet1_3
MobileNetV2
MobileNet_V2_Weights
mobilenet_v2
MobileNetV3
MobileNet_V3_Large_Weights
MobileNet_V3_Small_Weights
mobilenet_v3_large
mobilenet_v3_small
RegNet
RegNet_Y_400MF_Weights
RegNet_Y_800MF_Weights
RegNet_Y_1_6GF_Weights
RegNet_Y_3_2GF_Weights
RegNet_Y_8GF_Weights
RegNet_Y_16GF_Weights
RegNet_Y_32GF_Weights
RegNet_Y_128GF_Weights
RegNet_X_400MF_Weights
RegNet_X_800MF_Weights
RegNet_X_1_6GF_Weights
RegNet_X_3_2GF_Weights
RegNet_X_8GF_Weights
RegNet_X_16GF_Weights
RegNet_X_32GF_Weights
regnet_y_400mf
regnet_y_800mf
regnet_y_1_6gf
regnet_y_3_2gf
regnet_y_8gf
regnet_y_16gf
regnet_y_32gf
regnet_y_128gf
regnet_x_400mf
regnet_x_800mf
regnet_x_1_6gf
regnet_x_3_2gf
regnet_x_8gf
regnet_x_16gf
regnet_x_32gf
ResNet
ResNet18_Weights
ResNet34_Weights
ResNet50_Weights
ResNet101_Weights
ResNet152_Weights
ResNeXt50_32X4D_Weights
ResNeXt101_32X8D_Weights
ResNeXt101_64X4D_Weights
Wide_ResNet50_2_Weights
Wide_ResNet101_2_Weights
resnet18
resnet34
resnet50
resnet101
resnet152
resnext50_32x4d
resnext101_32x8d
resnext101_64x4d
wide_resnet50_2
wide_resnet101_2
ShuffleNetV2
ShuffleNet_V2_X0_5_Weights
ShuffleNet_V2_X1_0_Weights
ShuffleNet_V2_X1_5_Weights
ShuffleNet_V2_X2_0_Weights
shufflenet_v2_x0_5
shufflenet_v2_x1_0
shufflenet_v2_x1_5
shufflenet_v2_x2_0
SqueezeNet
SqueezeNet1_0_Weights
SqueezeNet1_1_Weights
squeezenet1_0
squeezenet1_1
VGG
VGG11_Weights
VGG11_BN_Weights
VGG13_Weights
VGG13_BN_Weights
VGG16_Weights
VGG16_BN_Weights
VGG19_Weights
VGG19_BN_Weights
vgg11
vgg11_bn
vgg13
vgg13_bn
vgg16
vgg16_bn
vgg19
vgg19_bn
VisionTransformer
ViT_B_16_Weights
ViT_B_32_Weights
ViT_L_16_Weights
ViT_L_32_Weights
ViT_H_14_Weights
vit_b_16
vit_b_32
vit_l_16
vit_l_32
vit_h_14
SwinTransformer
Swin_T_Weights
Swin_S_Weights
Swin_B_Weights
Swin_V2_T_Weights
Swin_V2_S_Weights
Swin_V2_B_Weights
swin_t
swin_s
swin_b
swin_v2_t
swin_v2_s
swin_v2_b
```

</details>

Static analysis / IDE intelligence works:
<img width="633" alt="image" src="https://user-images.githubusercontent.com/5347466/189770913-22f56098-3fd5-4cfb-9bd1-b61df325c4a2.png">

Overall it's not the most elegant solution but it checks several of the boxes we discussed. Unfortunately, we are constrained by our Backwards compatibility guarantees and the fact that we can't pin fastai to the latest TorchVision version. If you would like to explore other ideas, I am happy to close this and send another PR.

cc @jph00 