### PR TITLE
opens README.md with utf-8 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if cfg.get('requirements'): requirements += cfg.get('requirements','').split()
 if cfg.get('pip_requirements'): requirements += cfg.get('pip_requirements','').split()
 dev_requirements = (cfg.get('dev_requirements') or '').split()
 
-long_description = open('README.md').read()
+long_description = open('README.md', encoding='utf8').read()
 # ![png](docs/images/output_13_0.png)
 for ext in ['png', 'svg']:
     long_description = re.sub(r'!\['+ext+'\]\((.*)\)', '!['+ext+']('+'https://raw.githubusercontent.com/{}/{}'.format(cfg['user'],cfg['lib_name'])+'/'+cfg['branch']+'/\\1)', long_description)


### PR DESCRIPTION
When this previously wasn't the case, running `pip install -e"fastai[dev]"` gave me the following error on Windows:

```
Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "D:\Code\VSCode_Workspaces\Python\fastai\setup.py", line 34, in <module>
          long_description = open('README.md').read()
        File "C:\Users\saada\AppData\Local\Programs\Python\Python310\lib\encodings\cp1252.py", line 23, in decode
          return codecs.charmap_decode(input,self.errors,decoding_table)[0]
      UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 918: character maps to <undefined>
```
Explicitly speciying it to open README.md with the utf8 encoding fixes the issue.