### PR TITLE
Migrate callouts to Quarto format

### DIFF
--- a/nbs/01_layers.ipynb
+++ b/nbs/01_layers.ipynb
@@ -1328,7 +1328,11 @@
    "source": [
     "ICNR init was introduced in [this article](https://arxiv.org/abs/1707.02937). It suggests to initialize the convolution that will be used in PixelShuffle so that each of the `r**2` channels get the same weight (so that in the picture above, the 9 colors in a 3 by 3 window are initially the same).\n",
     "\n",
-    "> Note: This is done on the first dimension because PyTorch stores the weights of a convolutional layer in this format: `ch_out x ch_in x ks x ks`. "
+    ":::{.callout-note}\n",
+    "\n",
+    "This is done on the first dimension because PyTorch stores the weights of a convolutional layer in this format: `ch_out x ch_in x ks x ks`.\n",
+    "\n",
+    ":::"
    ]
   },
   {

--- a/nbs/07_vision.core.ipynb
+++ b/nbs/07_vision.core.ipynb
@@ -813,7 +813,11 @@
    "source": [
     "Points are expected to come as an array/tensor of shape `(n,2)` or as a list of lists with two elements. Unless you change the defaults in `PointScaler` (see later on), coordinates should go from 0 to width/height, with the first one being the column index (so from 0 to width) and the second one being the row index (so from 0 to height).\n",
     "\n",
-    "> Note: This is different from the usual indexing convention for arrays in numpy or in PyTorch, but it's the way points are expected by matplotlib or the internal functions in PyTorch like `F.grid_sample`."
+    ":::{.callout-note}\n",
+    "\n",
+    "This is different from the usual indexing convention for arrays in numpy or in PyTorch, but it's the way points are expected by matplotlib or the internal functions in PyTorch like `F.grid_sample`.\n",
+    "\n",
+    ":::"
    ]
   },
   {
@@ -968,7 +972,11 @@
    "source": [
     "Bounding boxes are expected to come as tuple with an array/tensor of shape `(n,4)` or as a list of lists with four elements and a list of corresponding labels. Unless you change the defaults in `PointScaler` (see later on), coordinates for each bounding box should go from 0 to width/height, with the following convention: x1, y1, x2, y2 where (x1,y1) is your top-left corner and (x2,y2) is your bottom-right corner.\n",
     "\n",
-    "> Note: We use the same convention as for points with x going from 0 to width and y going from 0 to height."
+    ":::{.callout-note}\n",
+    "\n",
+    "We use the same convention as for points with x going from 0 to width and y going from 0 to height.\n",
+    "\n",
+    ":::"
    ]
   },
   {
@@ -1173,7 +1181,11 @@
    "source": [
     "To work with data augmentation, and in particular the `grid_sample` method, points need to be represented with coordinates going from -1 to 1 (-1 being top or left, 1 bottom or right), which will be done unless you pass `do_scale=False`. We also need to make sure they are following our convention of points being x,y coordinates, so pass along `y_first=True` if you have your data in an y,x format to add a flip.\n",
     "\n",
-    "> Warning: This transform needs to run on the tuple level, before any transform that changes the image size."
+    ":::{.callout-warning}\n",
+    "\n",
+    "This transform needs to run on the tuple level, before any transform that changes the image size.\n",
+    "\n",
+    ":::"
    ]
   },
   {
@@ -1225,7 +1237,11 @@
    "source": [
     "To work with data augmentation, and in particular the `grid_sample` method, points need to be represented with coordinates going from -1 to 1 (-1 being top or left, 1 bottom or right), which will be done unless you pass `do_scale=False`. We also need to make sure they are following our convention of points being x,y coordinates, so pass along `y_first=True` if you have your data in an y,x format to add a flip.\n",
     "\n",
-    "> Note: This transform automatically grabs the sizes of the images it sees before a <code>TensorPoint</code> object and embeds it in them. For this to work, those images need to be before any points in the order of your final tuple. If you don't have such images, you need to embed the size of the corresponding image when creating a <code>TensorPoint</code> by passing it with `sz=...`."
+    ":::{.callout-note}\n",
+    "\n",
+    "This transform automatically grabs the sizes of the images it sees before a <code>TensorPoint</code> object and embeds it in them. For this to work, those images need to be before any points in the order of your final tuple. If you don't have such images, you need to embed the size of the corresponding image when creating a <code>TensorPoint</code> by passing it with `sz=...`.\n",
+    "\n",
+    ":::"
    ]
   },
   {

--- a/nbs/10b_tutorial.albumentations.ipynb
+++ b/nbs/10b_tutorial.albumentations.ipynb
@@ -792,7 +792,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> Note: We used fastai's crop first as some padding is needed due to some image sizes being too small."
+    ":::{.callout-note}\n",
+    "\n",
+    "We used fastai's crop first as some padding is needed due to some image sizes being too small.\n",
+    "\n",
+    ":::"
    ]
   },
   {

--- a/nbs/12_optimizer.ipynb
+++ b/nbs/12_optimizer.ipynb
@@ -243,7 +243,11 @@
    "source": [
     "`params` will be used to create the `param_groups` of the optimizer. If it's a collection (or a generator) of parameters, it will be a `L` containing one `L` with all the parameters. To define multiple parameter groups `params` should be passed as a collection (or a generator) of `L`s.\n",
     "\n",
-    "> Note: In PyTorch, <code>model.parameters()</code> returns a generator with all the parameters, that you can directly pass to <code>Optimizer</code>."
+    ":::{.callout-note}\n",
+    "\n",
+    "In PyTorch, <code>model.parameters()</code> returns a generator with all the parameters, that you can directly pass to <code>Optimizer</code>.\n",
+    "\n",
+    ":::"
    ]
   },
   {
@@ -429,7 +433,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> Warning: Weight decay and L2 regularization is the same thing for basic SGD, but for more complex optimizers, they are very different."
+    ":::{.callout-warning}\n",
+    "\n",
+    "Weight decay and L2 regularization is the same thing for basic SGD, but for more complex optimizers, they are very different.\n",
+    "\n",
+    ":::"
    ]
   },
   {
@@ -1236,7 +1244,11 @@
     "\n",
     "Optional weight decay of `wd` is applied, as true weight decay (decay the weights directly) if `decouple_wd=True` else as L2 regularization (add the decay to the gradients).\n",
     "\n",
-    "> Note: Don't forget that `eps` is an hyper-parameter you can change. Some models won't train without a very high `eps` like 0.1 (intuitively, the higher `eps` is, the closer we are to normal SGD). The usual default of 1e-8 is often too extreme in the sense we don't manage to get as good results as with SGD. "
+    ":::{.callout-note}\n",
+    "\n",
+    "Don't forget that `eps` is an hyper-parameter you can change. Some models won't train without a very high `eps` like 0.1 (intuitively, the higher `eps` is, the closer we are to normal SGD). The usual default of 1e-8 is often too extreme in the sense we don't manage to get as good results as with SGD.\n",
+    "\n",
+    ":::"
    ]
   },
   {

--- a/nbs/13a_learner.ipynb
+++ b/nbs/13a_learner.ipynb
@@ -2167,7 +2167,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> Warning: `load_learner` requires all your custom code be in the exact same place as when exporting your `Learner` (the main script, or the module you imported it from)."
+    ":::{.callout-warning}\n",
+    "\n",
+    "`load_learner` requires all your custom code be in the exact same place as when exporting your `Learner` (the main script, or the module you imported it from).\n",
+    "\n",
+    ":::"
    ]
   },
   {
@@ -2319,7 +2323,11 @@
    "source": [
     "Metrics can be simple averages (like accuracy) but sometimes their computation is a little bit more complex and can't be averaged over batches (like precision or recall), which is why we need a special class for them. For simple functions that can be computed as averages over batches, we can use the class `AvgMetric`, otherwise you'll need to implement the following methods.\n",
     "\n",
-    "> Note: If your <code>Metric</code> has state depending on tensors, don't forget to store it on the CPU to avoid any potential memory leaks."
+    ":::{.callout-note}\n",
+    "\n",
+    "If your <code>Metric</code> has state depending on tensors, don't forget to store it on the CPU to avoid any potential memory leaks.\n",
+    "\n",
+    ":::"
    ]
   },
   {
@@ -3581,7 +3589,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> Note: If you want to use the option `with_loss=True` on a custom loss function, make sure you have implemented a `reduction` attribute that supports 'none' "
+    ":::{.callout-note}\n",
+    "\n",
+    "If you want to use the option `with_loss=True` on a custom loss function, make sure you have implemented a `reduction` attribute that supports 'none'\n",
+    "\n",
+    ":::"
    ]
   },
   {

--- a/nbs/13b_metrics.ipynb
+++ b/nbs/13b_metrics.ipynb
@@ -352,14 +352,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> Warning: All functions defined in this section are intended for single-label classification and targets that are not one-hot encoded. For multi-label problems or one-hot encoded targets, use the version suffixed with multi."
+    ":::{.callout-warning}\n",
+    "\n",
+    "All functions defined in this section are intended for single-label classification and targets that are not one-hot encoded. For multi-label problems or one-hot encoded targets, use the version suffixed with multi.\n",
+    "\n",
+    ":::"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> Warning: Many metrics in fastai are thin wrappers around sklearn functionality. However, sklearn metrics can handle python list strings, amongst other things, whereas fastai metrics work with PyTorch, and thus require tensors. The arguments that are passed to metrics are after all transformations, such as categories being converted to indices, have occurred. This means that when you pass a label of a metric, for instance, that you must pass indices, not strings. This can be converted with `vocab.map_obj`."
+    ":::{.callout-warning}\n",
+    "\n",
+    "Many metrics in fastai are thin wrappers around sklearn functionality. However, sklearn metrics can handle python list strings, amongst other things, whereas fastai metrics work with PyTorch, and thus require tensors. The arguments that are passed to metrics are after all transformations, such as categories being converted to indices, have occurred. This means that when you pass a label of a metric, for instance, that you must pass indices, not strings. This can be converted with `vocab.map_obj`.\n",
+    "\n",
+    ":::"
    ]
   },
   {

--- a/nbs/15_callback.hook.ipynb
+++ b/nbs/15_callback.hook.ipynb
@@ -275,7 +275,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> Note: It's important to properly remove your hooks for your model when you're done to avoid them being called again next time your model is applied to some inputs, and to free the memory that go with their state."
+    ":::{.callout-note}\n",
+    "\n",
+    "It's important to properly remove your hooks for your model when you're done to avoid them being called again next time your model is applied to some inputs, and to free the memory that go with their state.\n",
+    "\n",
+    ":::"
    ]
   },
   {

--- a/nbs/17_callback.tracker.ipynb
+++ b/nbs/17_callback.tracker.ipynb
@@ -1019,7 +1019,11 @@
    "source": [
     "Each of these three derived `TrackerCallback`s (`SaveModelCallback`, `ReduceLROnPlateu`, and `EarlyStoppingCallback`) all have an adjusted order so they can each run with each other without interference. That order is as follows:\n",
     "\n",
-    "> Note: in parenthesis is the actual `Callback` order number\n",
+    ":::{.callout-note}\n",
+    "\n",
+    "in parenthesis is the actual `Callback` order number\n",
+    "\n",
+    ":::\n",
     "\n",
     "1. `TrackerCallback` (60)\n",
     "2. `SaveModelCallback` (61)\n",

--- a/nbs/18a_callback.training.ipynb
+++ b/nbs/18a_callback.training.ipynb
@@ -1085,7 +1085,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> Note: It works with most `timm` models"
+    ":::{.callout-note}\n",
+    "\n",
+    "It works with most `timm` models\n",
+    "\n",
+    ":::"
    ]
   },
   {

--- a/nbs/20_interpret.ipynb
+++ b/nbs/20_interpret.ipynb
@@ -223,7 +223,11 @@
    "source": [
     "`Interpretation` is a helper base class for exploring predictions from trained models. It can be inherited for task specific interpretation classes, such as `ClassificationInterpretation`. `Interpretation` is memory efficient and should be able to process any sized dataset, provided the hardware could train the same model.\n",
     "\n",
-    "> Note: `Interpretation` is memory efficient due to generating inputs, predictions, targets, decoded outputs, and losses for each item on the fly, using batch processing where possible."
+    ":::{.callout-note}\n",
+    "\n",
+    "`Interpretation` is memory efficient due to generating inputs, predictions, targets, decoded outputs, and losses for each item on the fly, using batch processing where possible.\n",
+    "\n",
+    ":::"
    ]
   },
   {

--- a/nbs/20b_tutorial.distributed.ipynb
+++ b/nbs/20b_tutorial.distributed.ipynb
@@ -97,7 +97,11 @@
    "source": [
     "We need to setup `Accelerate` to use all of our GPUs. We can do so quickly with `write_basic_config ()`:\n",
     "\n",
-    "> Note: Since this checks `torch.cuda.device_count`, you will need to restart your notebook and skip calling this again to continue. It only needs to be ran once! Also if you choose not to use this run `accelerate config` from the terminal and set `mixed_precision` to `no`"
+    ":::{.callout-note}\n",
+    "\n",
+    "Since this checks `torch.cuda.device_count`, you will need to restart your notebook and skip calling this again to continue. It only needs to be ran once! Also if you choose not to use this run `accelerate config` from the terminal and set `mixed_precision` to `no`\n",
+    "\n",
+    ":::"
    ]
   },
   {
@@ -136,7 +140,11 @@
    "source": [
     "We wrap the creation of the `DataLoaders`, our `vision_learner`, and call to `fine_tune` inside of a `train` function. \n",
     "\n",
-    "> Note: It is important to **not** build the `DataLoaders` outside of the function, as absolutely *nothing* can be loaded onto CUDA beforehand."
+    ":::{.callout-note}\n",
+    "\n",
+    "It is important to **not** build the `DataLoaders` outside of the function, as absolutely *nothing* can be loaded onto CUDA beforehand.\n",
+    "\n",
+    ":::"
    ]
   },
   {
@@ -162,7 +170,11 @@
    "source": [
     "The last addition to the `train` function needed is to use our context manager before calling `fine_tune` and setting `in_notebook` to `True`:\n",
     "\n",
-    "> Note: for this example `sync_bn` is disabled for compatibility purposes with `torchvision`'s resnet34"
+    ":::{.callout-note}\n",
+    "\n",
+    "for this example `sync_bn` is disabled for compatibility purposes with `torchvision`'s resnet34\n",
+    "\n",
+    ":::"
    ]
   },
   {

--- a/nbs/24_tutorial.image_sequence.ipynb
+++ b/nbs/24_tutorial.image_sequence.ipynb
@@ -208,7 +208,11 @@
    "metadata": {},
    "source": [
     "inside, you will find  one video per instance, the videos are in `.avi` format. We will need to convert each video to a sequence of images to able to work with our fastai vision toolset.\n",
-    "> Note: torchvision has a built-in video reader that may be capable of simplifying this task"
+    ":::{.callout-note}\n",
+    "\n",
+    "torchvision has a built-in video reader that may be capable of simplifying this task\n",
+    "\n",
+    ":::"
    ]
   },
   {
@@ -1073,7 +1077,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> Note: We don't need to put a `sigmoid` layer at the end, as the loss function will fuse the Entropy with the sigmoid to get more numerical stability. Our models will output one value per category. you can recover the predicted class using `torch.sigmoid` and `argmax`."
+    ":::{.callout-note}\n",
+    "\n",
+    "We don't need to put a `sigmoid` layer at the end, as the loss function will fuse the Entropy with the sigmoid to get more numerical stability. Our models will output one value per category. you can recover the predicted class using `torch.sigmoid` and `argmax`.\n",
+    "\n",
+    ":::"
    ]
   },
   {
@@ -1153,7 +1161,11 @@
    "metadata": {},
    "source": [
     "We will make use of the `MixedPrecision` callback to speed up our training (by calling `to_fp16` on the learner object).\n",
-    "> Note: The `TimeDistributed` layer is memory hungry (it pivots the image sequence to the batch dimesion) so if you get OOM errors, try reducing the batchsize.\n",
+    ":::{.callout-note}\n",
+    "\n",
+    "The `TimeDistributed` layer is memory hungry (it pivots the image sequence to the batch dimesion) so if you get OOM errors, try reducing the batchsize.\n",
+    "\n",
+    ":::\n",
     "\n",
     "As this is a classification problem, we will monitor classification `accuracy`. You can pass the model splitter directly when creating the learner."
    ]

--- a/nbs/24_vision.gan.ipynb
+++ b/nbs/24_vision.gan.ipynb
@@ -88,7 +88,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> Note: The fastai library provides support for training GANs through the GANTrainer, but doesn't include more than basic models."
+    ":::{.callout-note}\n",
+    "\n",
+    "The fastai library provides support for training GANs through the GANTrainer, but doesn't include more than basic models.\n",
+    "\n",
+    ":::"
    ]
   },
   {
@@ -582,7 +586,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> Warning: The GANTrainer is useless on its own, you need to complete it with one of the following switchers"
+    ":::{.callout-warning}\n",
+    "\n",
+    "The GANTrainer is useless on its own, you need to complete it with one of the following switchers\n",
+    "\n",
+    ":::"
    ]
   },
   {

--- a/nbs/31_text.data.ipynb
+++ b/nbs/31_text.data.ipynb
@@ -121,7 +121,11 @@
    "source": [
     "If there are more than `max_vocab` tokens, the ones kept are the most frequent.\n",
     "\n",
-    "> Note: For performance when using mixed precision, the vocabulary is always made of size a multiple of 8, potentially by adding `xxfake` tokens."
+    ":::{.callout-note}\n",
+    "\n",
+    "For performance when using mixed precision, the vocabulary is always made of size a multiple of 8, potentially by adding `xxfake` tokens.\n",
+    "\n",
+    ":::"
    ]
   },
   {

--- a/nbs/33_text.models.core.ipynb
+++ b/nbs/33_text.models.core.ipynb
@@ -288,7 +288,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> Warning: This module expects the inputs padded with most of the padding first, with the sequence beginning at a round multiple of `bptt` (and the rest of the padding at the end). Use `pad_input_chunk` to get your data in a suitable format."
+    ":::{.callout-warning}\n",
+    "\n",
+    "This module expects the inputs padded with most of the padding first, with the sequence beginning at a round multiple of `bptt` (and the rest of the padding at the end). Use `pad_input_chunk` to get your data in a suitable format.\n",
+    "\n",
+    ":::"
    ]
   },
   {

--- a/nbs/40_tabular.core.ipynb
+++ b/nbs/40_tabular.core.ipynb
@@ -2561,7 +2561,11 @@
    "metadata": {},
    "source": [
     "We can make new test datasets based on the training data with the `to.new()`\n",
-    "> Note: Since machine learning models can't magically understand categories it was never trained on, the data should reflect this. If there are different missing values in your test data you should address this before training"
+    ":::{.callout-note}\n",
+    "\n",
+    "Since machine learning models can't magically understand categories it was never trained on, the data should reflect this. If there are different missing values in your test data you should address this before training\n",
+    "\n",
+    ":::"
    ]
   },
   {

--- a/nbs/44_tutorial.tabular.ipynb
+++ b/nbs/44_tutorial.tabular.ipynb
@@ -1035,7 +1035,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> Note: Since machine learning models can't magically understand categories it was never trained on, the data should reflect this. If there are different missing values in your test data you should address this before training"
+    ":::{.callout-note}\n",
+    "\n",
+    "Since machine learning models can't magically understand categories it was never trained on, the data should reflect this. If there are different missing values in your test data you should address this before training\n",
+    "\n",
+    ":::"
    ]
   },
   {

--- a/nbs/50_tutorial.datablock.ipynb
+++ b/nbs/50_tutorial.datablock.ipynb
@@ -1535,7 +1535,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> Warning: You need to make sure to use the same `seq_len` in `TextBlock` and the `Learner` you will define later on."
+    ":::{.callout-warning}\n",
+    "\n",
+    "You need to make sure to use the same `seq_len` in `TextBlock` and the `Learner` you will define later on.\n",
+    "\n",
+    ":::"
    ]
   },
   {

--- a/nbs/examples/distributed_app_examples.ipynb
+++ b/nbs/examples/distributed_app_examples.ipynb
@@ -42,7 +42,11 @@
    "id": "5499ff72",
    "metadata": {},
    "source": [
-    "> Important: Before running, ensure that Accelerate has been configured through either `accelerate config` in the command line or by running `write_basic_config`"
+    ":::{.callout-important}\n",
+    "\n",
+    "Before running, ensure that Accelerate has been configured through either `accelerate config` in the command line or by running `write_basic_config`\n",
+    "\n",
+    ":::"
    ]
   },
   {

--- a/nbs/examples/migrating_catalyst.ipynb
+++ b/nbs/examples/migrating_catalyst.ipynb
@@ -41,7 +41,11 @@
    "source": [
     "We're going to use the MNIST training code from Catalyst's README (as at August 2020), converted to a module.\n",
     "\n",
-    "> Note: The source script for `migrating_catalyst` is in the `examples` subdirectory of this folder if you checked out the `fastai` repo from git, or can be downloaded from [here](https://github.com/fastai/fastai/blob/master/nbs/examples/migrating_catalyst.py) if you're using an online viewer such as Colab. "
+    ":::{.callout-note}\n",
+    "\n",
+    "The source script for `migrating_catalyst` is in the `examples` subdirectory of this folder if you checked out the `fastai` repo from git, or can be downloaded from [here](https://github.com/fastai/fastai/blob/master/nbs/examples/migrating_catalyst.py) if you're using an online viewer such as Colab.\n",
+    "\n",
+    ":::"
    ]
   },
   {

--- a/nbs/examples/migrating_ignite.ipynb
+++ b/nbs/examples/migrating_ignite.ipynb
@@ -25,7 +25,11 @@
    "source": [
     "We're going to use the MNIST training code from Ignite's examples directory (as at August 2020), converted to a module.\n",
     "\n",
-    "> Note: The source script for `migrating_ignite` is in the `examples` subdirectory of this folder if you checked out the `fastai` repo from git, or can be downloaded from [here](https://github.com/fastai/fastai/blob/master/nbs/examples/migrating_ignite.py) if you're using an online viewer such as Colab. "
+    ":::{.callout-note}\n",
+    "\n",
+    "The source script for `migrating_ignite` is in the `examples` subdirectory of this folder if you checked out the `fastai` repo from git, or can be downloaded from [here](https://github.com/fastai/fastai/blob/master/nbs/examples/migrating_ignite.py) if you're using an online viewer such as Colab.\n",
+    "\n",
+    ":::"
    ]
   },
   {

--- a/nbs/examples/migrating_lightning.ipynb
+++ b/nbs/examples/migrating_lightning.ipynb
@@ -25,7 +25,11 @@
    "source": [
     "We're going to use the MNIST training code from Lightning's 'Quick Start' (as at August 2020), converted to a module.\n",
     "\n",
-    "> Note: The source script for `migrating_lightning` is in the `examples` subdirectory of this folder if you checked out the `fastai` repo from git, or can be downloaded from [here](https://github.com/fastai/fastai/blob/master/nbs/examples/migrating_lightning.py) if you're using an online viewer such as Colab. "
+    ":::{.callout-note}\n",
+    "\n",
+    "The source script for `migrating_lightning` is in the `examples` subdirectory of this folder if you checked out the `fastai` repo from git, or can be downloaded from [here](https://github.com/fastai/fastai/blob/master/nbs/examples/migrating_lightning.py) if you're using an online viewer such as Colab.\n",
+    "\n",
+    ":::"
    ]
   },
   {

--- a/nbs/examples/migrating_pytorch.ipynb
+++ b/nbs/examples/migrating_pytorch.ipynb
@@ -34,7 +34,11 @@
    "source": [
     "We're going to use the MNIST training code from the official PyTorch examples, slightly reformatted for space, updated from AdaDelta to AdamW, and converted from a script to a module. There's a lot of code, so we've put it into migrating_pytorch.py!\n",
     "\n",
-    "> Note: The source script for `migrating_pytorch` is in the `examples` subdirectory of this folder if you checked out the `fastai` repo from git, or can be downloaded from [here](https://github.com/fastai/fastai/blob/master/nbs/examples/migrating_pytorch.py) if you're using an online viewer such as Colab. "
+    ":::{.callout-note}\n",
+    "\n",
+    "The source script for `migrating_pytorch` is in the `examples` subdirectory of this folder if you checked out the `fastai` repo from git, or can be downloaded from [here](https://github.com/fastai/fastai/blob/master/nbs/examples/migrating_pytorch.py) if you're using an online viewer such as Colab.\n",
+    "\n",
+    ":::"
    ]
   },
   {

--- a/nbs/examples/migrating_pytorch_verbose.ipynb
+++ b/nbs/examples/migrating_pytorch_verbose.ipynb
@@ -320,7 +320,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> Note: All `Callbacks` will still work, regardless of the type of dataloaders. It is recommended to use the `.all` import when wanting so, this way all callbacks are imported and anything related to the `Learner` is imported at once as well"
+    ":::{.callout-note}\n",
+    "\n",
+    "All `Callbacks` will still work, regardless of the type of dataloaders. It is recommended to use the `.all` import when wanting so, this way all callbacks are imported and anything related to the `Learner` is imported at once as well\n",
+    "\n",
+    ":::"
    ]
   },
   {
@@ -470,7 +474,11 @@
     "We will walk through a quick example below.\n",
     "\n",
     "First let's save the model weights:\n",
-    "> Note: Generally when doing this approach you should also store the source code to build the model as well"
+    ":::{.callout-note}\n",
+    "\n",
+    "Generally when doing this approach you should also store the source code to build the model as well\n",
+    "\n",
+    ":::"
    ]
   },
   {
@@ -497,7 +505,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> Note: `Learner.save` will save the optimizer state by default as well. When doing so the weights are located in the `model` key. We will set this to `false` for this tutorial"
+    ":::{.callout-note}\n",
+    "\n",
+    "`Learner.save` will save the optimizer state by default as well. When doing so the weights are located in the `model` key. We will set this to `false` for this tutorial\n",
+    "\n",
+    ":::"
    ]
   },
   {


### PR DESCRIPTION
I migrated callouts from nbdev v1 to Quarto format. Docs appear to render correctly using `nbdev_preview`.