### PR TITLE
fix docs that were skipped leading to broken/outdated `show_doc` outputs

### DIFF
--- a/nbs/09c_vision.widgets.ipynb
+++ b/nbs/09c_vision.widgets.ipynb
@@ -5,7 +5,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/10b_tutorial.albumentations.ipynb
+++ b/nbs/10b_tutorial.albumentations.ipynb
@@ -16,7 +16,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/18_callback.fp16.ipynb
+++ b/nbs/18_callback.fp16.ipynb
@@ -16,7 +16,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/20b_tutorial.distributed.ipynb
+++ b/nbs/20b_tutorial.distributed.ipynb
@@ -26,7 +26,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/22_tutorial.imagenette.ipynb
+++ b/nbs/22_tutorial.imagenette.ipynb
@@ -25,7 +25,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/24_tutorial.image_sequence.ipynb
+++ b/nbs/24_tutorial.image_sequence.ipynb
@@ -16,7 +16,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/24_tutorial.siamese.ipynb
+++ b/nbs/24_tutorial.siamese.ipynb
@@ -25,7 +25,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/24_vision.gan.ipynb
+++ b/nbs/24_vision.gan.ipynb
@@ -16,7 +16,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/35_tutorial.wikitext.ipynb
+++ b/nbs/35_tutorial.wikitext.ipynb
@@ -27,7 +27,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/38_tutorial.text.ipynb
+++ b/nbs/38_tutorial.text.ipynb
@@ -25,7 +25,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/39_tutorial.transformers.ipynb
+++ b/nbs/39_tutorial.transformers.ipynb
@@ -25,7 +25,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]
@@ -1299,7 +1298,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.13 ('dev')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   }

--- a/nbs/46_tutorial.collab.ipynb
+++ b/nbs/46_tutorial.collab.ipynb
@@ -35,7 +35,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/50_tutorial.datablock.ipynb
+++ b/nbs/50_tutorial.datablock.ipynb
@@ -16,7 +16,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/60_medical.imaging.ipynb
+++ b/nbs/60_medical.imaging.ipynb
@@ -16,7 +16,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/61_tutorial.medical_imaging.ipynb
+++ b/nbs/61_tutorial.medical_imaging.ipynb
@@ -16,7 +16,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/70_callback.wandb.ipynb
+++ b/nbs/70_callback.wandb.ipynb
@@ -16,7 +16,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/70a_callback.tensorboard.ipynb
+++ b/nbs/70a_callback.tensorboard.ipynb
@@ -25,7 +25,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]
@@ -917,8 +916,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import GPT2LMHeadModel, GPT2TokenizerFast\n",
-    "\n",
+    "from transformers import GPT2LMHeadModel, GPT2TokenizerFast"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "tokenizer = GPT2TokenizerFast.from_pretrained('gpt2')\n",
     "model = GPT2LMHeadModel.from_pretrained('gpt2')\n",
     "layer = model.transformer.wte\n",
@@ -939,6 +945,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "from transformers import AutoTokenizer, AutoModel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -949,8 +964,6 @@
     }
    ],
    "source": [
-    "from transformers import AutoTokenizer, AutoModel\n",
-    "\n",
     "tokenizer = AutoTokenizer.from_pretrained(\"bert-base-uncased\")\n",
     "model = AutoModel.from_pretrained(\"bert-base-uncased\")\n",
     "\n",

--- a/nbs/70b_callback.neptune.ipynb
+++ b/nbs/70b_callback.neptune.ipynb
@@ -16,7 +16,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/70c_callback.captum.ipynb
+++ b/nbs/70c_callback.captum.ipynb
@@ -16,7 +16,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/70d_callback.comet.ipynb
+++ b/nbs/70d_callback.comet.ipynb
@@ -16,7 +16,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/74_huggingface.ipynb
+++ b/nbs/74_huggingface.ipynb
@@ -16,7 +16,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/dev-setup.ipynb
+++ b/nbs/dev-setup.ipynb
@@ -16,7 +16,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/examples/app_examples.ipynb
+++ b/nbs/examples/app_examples.ipynb
@@ -5,7 +5,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/examples/camvid.ipynb
+++ b/nbs/examples/camvid.ipynb
@@ -5,7 +5,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/examples/distributed_app_examples.ipynb
+++ b/nbs/examples/distributed_app_examples.ipynb
@@ -16,7 +16,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/examples/migrating_catalyst.ipynb
+++ b/nbs/examples/migrating_catalyst.ipynb
@@ -5,7 +5,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/examples/migrating_ignite.ipynb
+++ b/nbs/examples/migrating_ignite.ipynb
@@ -5,7 +5,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/examples/migrating_lightning.ipynb
+++ b/nbs/examples/migrating_lightning.ipynb
@@ -5,7 +5,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/examples/migrating_pytorch.ipynb
+++ b/nbs/examples/migrating_pytorch.ipynb
@@ -5,7 +5,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/examples/migrating_pytorch_verbose.ipynb
+++ b/nbs/examples/migrating_pytorch_verbose.ipynb
@@ -5,7 +5,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/examples/ulmfit.ipynb
+++ b/nbs/examples/ulmfit.ipynb
@@ -5,7 +5,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]

--- a/nbs/quick_start.ipynb
+++ b/nbs/quick_start.ipynb
@@ -16,7 +16,6 @@
    "metadata": {},
    "source": [
     "---\n",
-    "skip_showdoc: true\n",
     "skip_exec: true\n",
     "---"
    ]


### PR DESCRIPTION
- Removed `skip_showdoc: true` with `find . -name '*.ipynb' -exec perl -ni -e 'print unless /skip_showdoc: true/' {} +`
- Split some cells which were warning about mixed imports and code
- Tested locally with `rm -rf _proc && nbdev_preview` and clicked around a bit