### PR TITLE
Update nbdev_install_hooks in dev-setup docs

### DIFF
--- a/nbs/dev-setup.ipynb
+++ b/nbs/dev-setup.ipynb
@@ -603,18 +603,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/nbs/dev-setup.ipynb
+++ b/nbs/dev-setup.ipynb
@@ -265,7 +265,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Because all fast.ai libraries use nbdev, we need to run [nbdev_install_git_hooks](https://nbdev.fast.ai/cli#Git-hooks) the first time after we clone a repo; this ensures that our notebooks are automatically cleaned and trusted whenever we push to GitHub:"
+    "Because all fast.ai libraries use nbdev, we need to run [nbdev_install_hooks](https://nbdev.fast.ai/tutorials/git_friendly_jupyter.html#what-are-nbdev-hooks) the first time after we clone a repo; this ensures that our notebooks are automatically cleaned and trusted whenever we push to GitHub:"
    ]
   },
   {
@@ -603,6 +603,18 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In the [setup fastcore](https://docs.fast.ai/dev-setup.html#set-up-fastcore),
I updated the docs to read, `nbdev_install_hooks` instead of `nbdev_install_git_hooks`
 and updated the link to point to the [new nbdev hooks docs](https://nbdev.fast.ai/tutorials/git_friendly_jupyter.html#what-are-nbdev-hooks)
 instead of what was being shown.
