### PR TITLE
Recursive copying of attribute dictionaries for TensorImage subclass

### DIFF
--- a/fastai/torch_core.py
+++ b/fastai/torch_core.py
@@ -378,6 +378,7 @@ class TensorBase(Tensor):
         res = super().__torch_function__(func, types, args, ifnone(kwargs, {}))
         dict_objs = _find_args(args) if args else _find_args(list(kwargs.values()))
         if issubclass(type(res),TensorBase) and dict_objs: res.set_meta(dict_objs[0],as_copy=True)
+        elif dict_objs and is_listy(res) and len(args) < len(res) : [r.set_meta(dict_objs[0],as_copy=True) for r in res if issubclass(type(r),TensorBase)]
         return res
 
     def new_tensor(self, size, dtype=None, device=None, requires_grad=False):

--- a/fastai/torch_core.py
+++ b/fastai/torch_core.py
@@ -378,7 +378,7 @@ class TensorBase(Tensor):
         res = super().__torch_function__(func, types, args, ifnone(kwargs, {}))
         dict_objs = _find_args(args) if args else _find_args(list(kwargs.values()))
         if issubclass(type(res),TensorBase) and dict_objs: res.set_meta(dict_objs[0],as_copy=True)
-        elif dict_objs and is_listy(res) and len(args) < len(res) : [r.set_meta(dict_objs[0],as_copy=True) for r in res if issubclass(type(r),TensorBase)]
+        elif dict_objs and is_listy(res): [r.set_meta(dict_objs[0],as_copy=True) for r in res if issubclass(type(r),TensorBase)]
         return res
 
     def new_tensor(self, size, dtype=None, device=None, requires_grad=False):

--- a/nbs/00_torch_core.ipynb
+++ b/nbs/00_torch_core.ipynb
@@ -1276,7 +1276,7 @@
     "        res = super().__torch_function__(func, types, args, ifnone(kwargs, {}))\n",
     "        dict_objs = _find_args(args) if args else _find_args(list(kwargs.values()))\n",
     "        if issubclass(type(res),TensorBase) and dict_objs: res.set_meta(dict_objs[0],as_copy=True)\n",
-    "        elif dict_objs and is_listy(res) and len(args) < len(res) : [r.set_meta(dict_objs[0],as_copy=True) for r in res if issubclass(type(r),TensorBase)]\n",
+    "        elif dict_objs and is_listy(res): [r.set_meta(dict_objs[0],as_copy=True) for r in res if issubclass(type(r),TensorBase)]\n",
     "        return res\n",
     "\n",
     "    def new_tensor(self, size, dtype=None, device=None, requires_grad=False):\n",

--- a/nbs/00_torch_core.ipynb
+++ b/nbs/00_torch_core.ipynb
@@ -1276,6 +1276,7 @@
     "        res = super().__torch_function__(func, types, args, ifnone(kwargs, {}))\n",
     "        dict_objs = _find_args(args) if args else _find_args(list(kwargs.values()))\n",
     "        if issubclass(type(res),TensorBase) and dict_objs: res.set_meta(dict_objs[0],as_copy=True)\n",
+    "        elif dict_objs and is_listy(res) and len(args) < len(res) : [r.set_meta(dict_objs[0],as_copy=True) for r in res if issubclass(type(r),TensorBase)]\n",
     "        return res\n",
     "\n",
     "    def new_tensor(self, size, dtype=None, device=None, requires_grad=False):\n",


### PR DESCRIPTION
I ran into a problem with `batch_to_sample` when I was trying to apply it to multi-spectral images. I simplified the problematic code to the following

```
import torch
import fastai
from fastai.vision.all import *

class _T(TensorImage):
    pass

t = _T([[1.,2.],[3.,4.],[5.,6.]], kw=1)

test_eq(t.__dict__,{'kw': 1})

l = torch.unbind(t)
```

Basically I was expecting this to be true
```
test_eq(l[0].__dict__,{'kw': 1})
```

Instead I was getting
```
test_eq(l[0].__dict__,{})
```

If what I was expecting is the desired behaviour, then this branch contains my proposed fix. I'm a relative newbie to both python and fastai, so apologies if I'm missing something obvious.

I was also unable to get `nbdev_test` running properly on the fastai repo on my mac (lots of seemingly spurious test failures). Presumably the CI will run as part of this PR.

I would like to add my appreciation and admiration for Jeremy and the other incredible people who have helped create this community and movement. Well done!!!