### PR TITLE
Add torch_[(save)|(load)]_kwargs to fastai.[(save)|(load)]_model

### DIFF
--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -34,13 +34,13 @@ def mk_metric(m):
     return m if isinstance(m, Metric) else AvgMetric(m)
 
 # %% ../nbs/13a_learner.ipynb 15
-def save_model(file, model, opt, with_opt=True, pickle_protocol=2):
+def save_model(file, model, opt, with_opt=True, pickle_protocol=2, **torch_save_kwargs):
     "Save `model` to `file` along with `opt` (if available, and if `with_opt`)"
     if rank_distrib(): return # don't save if child proc
     if opt is None: with_opt=False
     state = get_model(model).state_dict()
     if with_opt: state = {'model': state, 'opt':opt.state_dict()}
-    torch.save(state, file, pickle_protocol=pickle_protocol)
+    torch.save(state, file, pickle_protocol=pickle_protocol, **torch_save_kwargs)
 
 # %% ../nbs/13a_learner.ipynb 17
 def load_model(file, model, opt, with_opt=True, device=None, strict=True):

--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -43,11 +43,11 @@ def save_model(file, model, opt, with_opt=True, pickle_protocol=2, **torch_save_
     torch.save(state, file, pickle_protocol=pickle_protocol, **torch_save_kwargs)
 
 # %% ../nbs/13a_learner.ipynb 17
-def load_model(file, model, opt, with_opt=True, device=None, strict=True):
+def load_model(file, model, opt, with_opt=True, device=None, strict=True, **torch_load_kwargs):
     "Load `model` from `file` along with `opt` (if available, and if `with_opt`)"
     if isinstance(device, int): device = torch.device('cuda', device)
     elif device is None: device = 'cpu'
-    state = torch.load(file, map_location=device)
+    state = torch.load(file, map_location=device, **torch_load_kwargs)
     hasopt = set(state)=={'model', 'opt'}
     model_state = state['model'] if hasopt else state
     get_model(model).load_state_dict(model_state, strict=strict)


### PR DESCRIPTION
This lets us do nice things like set `pickle_module` to `cloudpickle`.

I went with `**kwargs` approach so that any updates to `torch.save` or `load` are automatically supported.
However, I decided to keep the existing pass through kwargs as is in case someone is relying on them as positional arguments. We can make this a breaking change if that is preferred, though.

(btw thank you for the excellent library and lectures!)