### PR TITLE
PyTorch 1.13 Compatibility

### DIFF
--- a/fastai/optimizer.py
+++ b/fastai/optimizer.py
@@ -370,9 +370,6 @@ def set_item_pg(pg, k, v):
 # %% ../nbs/12_optimizer.ipynb 118
 pytorch_hp_map = {'momentum': 'mom', 'weight_decay': 'wd', 'alpha': 'sqr_mom', 'betas__0': 'mom',
                   'betas__1': 'sqr_mom'}
-if ismin_torch('1.12'):
-    # Torch>=1.12 has a foreach param
-    pytorch_hp_map = merge(*(pytorch_hp_map,{'foreach': 'foreach'}))
 
 # %% ../nbs/12_optimizer.ipynb 119
 def _convert_params(o:list) -> list:

--- a/fastai/torch_core.py
+++ b/fastai/torch_core.py
@@ -41,13 +41,13 @@ def setup_cuda(benchmark=defaults.benchmark):
 def subplots(
     nrows:int=1, # Number of rows in returned axes grid
     ncols:int=1, # Number of columns in returned axes grid
-    figsize:tuple=None, # Width, height in inches of the returned figure 
+    figsize:tuple=None, # Width, height in inches of the returned figure
     imsize:int=3, # Size (in inches) of images that will be displayed in the returned figure
     suptitle:str=None, # Title to be set to returned figure
     **kwargs
-) -> (plt.Figure, plt.Axes): # Returns both fig and ax as a tuple 
+) -> (plt.Figure, plt.Axes): # Returns both fig and ax as a tuple
     "Returns a figure and set of subplots to display images of `imsize` inches"
-    if figsize is None: 
+    if figsize is None:
         h=nrows*imsize if suptitle is None or imsize>2 else nrows*imsize+0.6 #https://github.com/matplotlib/matplotlib/issues/5355
         figsize=(ncols*imsize, h)
     fig,ax = plt.subplots(nrows, ncols, figsize=figsize, **kwargs)
@@ -343,7 +343,7 @@ def _rebuild_from_type(func, type, args, dict):
     return ret
 
 # %% ../nbs/00_torch_core.ipynb 92
-def _find_args(x):   
+def _find_args(x):
     x0 = x[0] if is_listy(x[0]) and x[0] else x
     return [a for a in x0 if hasattr(a,'__dict__')]
 
@@ -393,7 +393,7 @@ class TensorBase(Tensor):
         cls = type(self)
         res = self.as_subclass(Tensor).new() if x is None else self.as_subclass(Tensor).new(x)
         return res.as_subclass(cls)
-    
+
     def requires_grad_(self, requires_grad=True):
         # Workaround https://github.com/pytorch/pytorch/issues/50219
         self.requires_grad = requires_grad
@@ -864,3 +864,16 @@ def ismin_torch(min_version):
 def notmax_torch(max_version):
     "Check if `torch.__version__` < `max_version` using packaging.version"
     return parse(torch.__version__) < parse(max_version)
+
+# %% ../nbs/00_torch_core.ipynb 228
+# PyTorch 1.13 introduced a Tensor Subclass string formatting bug
+# Workaround from pending PyTorch PR: https://github.com/pytorch/pytorch/pull/82766
+if ismin_torch('1.13') and notmax_torch('1.14'):
+    from torch.overrides import has_torch_function_unary, handle_torch_function
+    @patch
+    def __format__(self:Tensor, format_spec):
+        if has_torch_function_unary(self):
+            return handle_torch_function(Tensor.__format__, (self,), self, format_spec)
+        if self.dim() == 0 and not self.is_meta and issubclass(type(self), Tensor):
+            return self.item().__format__(format_spec)
+        return object.__format__(self, format_spec)

--- a/nbs/00_torch_core.ipynb
+++ b/nbs/00_torch_core.ipynb
@@ -3266,6 +3266,33 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## PyTorch 1.13 `__format__` workaround -"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#|export\n",
+    "# PyTorch 1.13 introduced a Tensor Subclass string formatting bug\n",
+    "# Workaround from pending PyTorch PR: https://github.com/pytorch/pytorch/pull/82766\n",
+    "if ismin_torch('1.13') and notmax_torch('1.14'):\n",
+    "    from torch.overrides import has_torch_function_unary, handle_torch_function\n",
+    "    @patch\n",
+    "    def __format__(self:Tensor, format_spec):\n",
+    "        if has_torch_function_unary(self):\n",
+    "            return handle_torch_function(Tensor.__format__, (self,), self, format_spec)\n",
+    "        if self.dim() == 0 and not self.is_meta and issubclass(type(self), Tensor):\n",
+    "            return self.item().__format__(format_spec)\n",
+    "        return object.__format__(self, format_spec)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Export -"
    ]
   },

--- a/nbs/12_optimizer.ipynb
+++ b/nbs/12_optimizer.ipynb
@@ -1773,10 +1773,7 @@
    "source": [
     "#|export\n",
     "pytorch_hp_map = {'momentum': 'mom', 'weight_decay': 'wd', 'alpha': 'sqr_mom', 'betas__0': 'mom',\n",
-    "                  'betas__1': 'sqr_mom'}\n",
-    "if ismin_torch('1.12'):\n",
-    "    # Torch>=1.12 has a foreach param\n",
-    "    pytorch_hp_map = merge(*(pytorch_hp_map,{'foreach': 'foreach'}))"
+    "                  'betas__1': 'sqr_mom'}"
    ]
   },
   {
@@ -1849,6 +1846,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#|hide\n",
+    "def test_dict_in(a,b):\n",
+    "    \"Test that dictionary a is in b\"\n",
+    "    if is_listy(a) or is_listy(b):\n",
+    "        for i,j in zip(a,b):\n",
+    "            test_dict_in(i,j)\n",
+    "    else:\n",
+    "        for k,v in zip(a.keys(),a.values()):\n",
+    "            test_eq(b[k], v)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "sgd = SGD([tensor([1,2,3])], lr=1e-3, mom=0.9, wd=1e-2)\n",
     "tst_sgd = OptimWrapper([tensor([1,2,3])], torch.optim.SGD, lr=1e-3, momentum=0.9, weight_decay=1e-2)\n",
     "#Access to param_groups\n",
@@ -1857,12 +1871,7 @@
     "tst_sgd.param_lists = [[tensor([4,5,6])]]\n",
     "test_eq(tst_sgd.opt.param_groups[0]['params'], [tensor(4,5,6)])\n",
     "#Access to hypers\n",
-    "_xtra_hypers = dict(dampening=0., nesterov=False, maximize=False)\n",
-    "\n",
-    "if ismin_torch('1.12'):\n",
-    "    _xtra_hypers = merge(*(_xtra_hypers,dict(foreach=None)))\n",
-    "                         \n",
-    "test_eq(tst_sgd.hypers, [{**sgd.hypers[0], **_xtra_hypers}])\n",
+    "test_dict_in(sgd.hypers, tst_sgd.hypers)\n",
     "#Set hypers\n",
     "tst_sgd.set_hyper('mom', 0.95)\n",
     "test_eq(tst_sgd.opt.param_groups[0]['momentum'], 0.95)"
@@ -1884,7 +1893,7 @@
     "test_eq(tst_sgd.opt.param_groups[0]['params'], [tensor(4,5,6)])\n",
     "test_eq(tst_sgd.opt.param_groups[1]['params'], [tensor(1,2,3)])\n",
     "#Access to hypers\n",
-    "test_eq(tst_sgd.hypers, [{**sgd.hypers[i], **_xtra_hypers} for i in range(2)])\n",
+    "test_dict_in(sgd.hypers, tst_sgd.hypers)\n",
     "#Set hypers\n",
     "tst_sgd.set_hyper('mom', 0.95)\n",
     "test_eq([pg['momentum'] for pg in tst_sgd.opt.param_groups], [0.95,0.95])\n",
@@ -1910,7 +1919,7 @@
     "test_eq(tst_sgd.opt.param_groups[0]['params'], [tensor(4,5,6)])\n",
     "test_eq(tst_sgd.opt.param_groups[1]['params'], [tensor(1,2,3)])\n",
     "#Access to hypers\n",
-    "test_eq(tst_sgd.hypers, [{**sgd.hypers[i], **_xtra_hypers} for i in range(2)])\n",
+    "test_dict_in(sgd.hypers, tst_sgd.hypers)\n",
     "#Set hypers\n",
     "tst_sgd.set_hyper('mom', 0.95)\n",
     "test_eq([pg['momentum'] for pg in tst_sgd.opt.param_groups], [0.95,0.95])\n",
@@ -1929,10 +1938,8 @@
     "tst_adam = OptimWrapper([tensor([1,2,3])], torch.optim.Adam, lr=1e-2, betas=(0.9, 0.99))\n",
     "\n",
     "tst_hypers = {'lr': 0.01, 'mom': 0.9, 'sqr_mom': 0.99, 'eps': 1e-08, 'wd': 0, 'amsgrad': False, 'maximize':False}\n",
-    "if ismin_torch('1.12'):\n",
-    "    tst_hypers = merge(*(tst_hypers,dict(foreach=None, capturable=False)))\n",
     "\n",
-    "test_eq(tst_adam.hypers, [tst_hypers])\n",
+    "test_dict_in([tst_hypers], tst_adam.hypers)\n",
     "tst_adam.set_hyper('mom', 0.95)\n",
     "test_eq(tst_adam.opt.param_groups[0]['betas'], (0.95, 0.99))\n",
     "tst_adam.set_hyper('sqr_mom', 0.9)\n",
@@ -1941,10 +1948,7 @@
     "tst_adam = torch.optim.Adam([tensor([1,2,3])], lr=1e-2, betas=(0.9, 0.99))\n",
     "tst_adam = OptimWrapper(opt=tst_adam)\n",
     "\n",
-    "if ismin_torch('1.12'):\n",
-    "    tst_hypers = merge(*(tst_hypers,dict(foreach=None, capturable=False)))\n",
-    "\n",
-    "test_eq(tst_adam.hypers, [tst_hypers])\n",
+    "test_dict_in([tst_hypers], tst_adam.hypers)\n",
     "tst_adam.set_hyper('mom', 0.95)\n",
     "test_eq(tst_adam.opt.param_groups[0]['betas'], (0.95, 0.99))\n",
     "tst_adam.set_hyper('sqr_mom', 0.9)\n",


### PR DESCRIPTION
PyTorch 1.13 introduced a subclassed Tensor formatting issue. A potential workaround is pytorch/pytorch#82766 which I use for the fastai `TensorBase` compatibility patch in `torch_core`.

PyTorch 1.13 also adds "differentiable" as another `optim` hyperparameter and it looks like PyTorch 1.14 will add "fused" for at least a subset of optimizers. Since I modified `OptimWrapper` not to error out in #3821, I changed the `OptimWrapper` tests to only check for the subset of hyperparameters fastai cares about.

Tested locally running the cuda and slow flags without issue.