### PR TITLE
Add torch save and load kwargs

### DIFF
--- a/fastai/layers.py
+++ b/fastai/layers.py
@@ -73,7 +73,7 @@ def Flatten(self, x):
 # %% ../nbs/01_layers.ipynb 15
 @module(tensor_cls=TensorBase)
 def ToTensorBase(self, x):
-    "Remove `tensor_cls` to x"
+    "Convert x to TensorBase class"
     return self.tensor_cls(x)
 
 # %% ../nbs/01_layers.ipynb 17

--- a/fastai/torch_core.py
+++ b/fastai/torch_core.py
@@ -251,7 +251,7 @@ def to_half(b):
 # %% ../nbs/00_torch_core.ipynb 69
 def to_float(b):
     "Recursively map lists of int tensors in `b ` to float."
-    return apply(lambda x: x.float() if torch.is_floating_point(x) else x, b)
+    return apply(lambda x: x.float() if not torch.is_floating_point(x) else x, b)
 
 # %% ../nbs/00_torch_core.ipynb 70
 # None: True if available; True: error if not available; False: use CPU
@@ -758,7 +758,7 @@ def nested_reorder(t, idxs):
 
 # %% ../nbs/00_torch_core.ipynb 199
 def flatten_check(inp, targ):
-    "Check that `out` and `targ` have the same number of elements and flatten them."
+    "Check that `inp` and `targ` have the same number of elements and flatten them."
     inp,targ = TensorBase(inp.contiguous()).view(-1),TensorBase(targ.contiguous()).view(-1)
     test_eq(len(inp), len(targ))
     return inp,targ

--- a/nbs/13a_learner.ipynb
+++ b/nbs/13a_learner.ipynb
@@ -187,20 +187,20 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "def save_model(file, model, opt, with_opt=True, pickle_protocol=2):\n",
+    "def save_model(file, model, opt, with_opt=True, pickle_protocol=2, **torch_save_kwargs):\n",
     "    \"Save `model` to `file` along with `opt` (if available, and if `with_opt`)\"\n",
     "    if rank_distrib(): return # don't save if child proc\n",
     "    if opt is None: with_opt=False\n",
     "    state = get_model(model).state_dict()\n",
     "    if with_opt: state = {'model': state, 'opt':opt.state_dict()}\n",
-    "    torch.save(state, file, pickle_protocol=pickle_protocol)"
+    "    torch.save(state, file, pickle_protocol=pickle_protocol, **torch_save_kwargs)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`file` can be a `Path` object, a string or an opened file object. `pickle_protocol` is passed along to `torch.save`"
+    "`file` can be a `Path` object, a string or an opened file object. `pickle_protocol` and `torch_save_kwargs` is passed along to `torch.save`"
    ]
   },
   {
@@ -210,11 +210,11 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "def load_model(file, model, opt, with_opt=True, device=None, strict=True):\n",
+    "def load_model(file, model, opt, with_opt=True, device=None, strict=True, **torch_load_kwargs):\n",
     "    \"Load `model` from `file` along with `opt` (if available, and if `with_opt`)\"\n",
     "    if isinstance(device, int): device = torch.device('cuda', device)\n",
     "    elif device is None: device = 'cpu'\n",
-    "    state = torch.load(file, map_location=device)\n",
+    "    state = torch.load(file, map_location=device, **torch_load_kwargs)\n",
     "    hasopt = set(state)=={'model', 'opt'}\n",
     "    model_state = state['model'] if hasopt else state\n",
     "    get_model(model).load_state_dict(model_state, strict=strict)\n",
@@ -231,7 +231,9 @@
    "source": [
     "`file` can be a `Path` object, a string or an opened file object. If a `device` is passed, the model is loaded on it, otherwise it's loaded on the CPU. \n",
     "\n",
-    "If `strict` is `True`, the file must exactly contain weights for every parameter key in `model`, if `strict` is `False`, only the keys that are in the saved model are loaded in `model`."
+    "If `strict` is `True`, the file must exactly contain weights for every parameter key in `model`, if `strict` is `False`, only the keys that are in the saved model are loaded in `model`.",
+    "\n",
+    "You can pass in other kwargs to `torch.load` through `torch_load_kwargs`."
    ]
   },
   {


### PR DESCRIPTION
This lets us do nice things like set pickle_module to cloudpickle.

I went with **kwargs approach so that any updates to torch.save or load are automatically supported.
However, I decided to keep the existing pass through kwargs as is in case someone is relying on them as positional arguments. We can make this a breaking change if that is preferred, though.

(btw thank you for the excellent library and lectures!)
