### PR TITLE
Sync notebooks with library and rollback `to_float` change

### DIFF
--- a/fastai/layers.py
+++ b/fastai/layers.py
@@ -73,7 +73,7 @@ def Flatten(self, x):
 # %% ../nbs/01_layers.ipynb 15
 @module(tensor_cls=TensorBase)
 def ToTensorBase(self, x):
-    "Remove `tensor_cls` to x"
+    "Convert x to TensorBase class"
     return self.tensor_cls(x)
 
 # %% ../nbs/01_layers.ipynb 17

--- a/fastai/torch_core.py
+++ b/fastai/torch_core.py
@@ -245,12 +245,12 @@ def to_detach(b, cpu=True, gather=True):
 
 # %% ../nbs/00_torch_core.ipynb 68
 def to_half(b):
-    "Recursively map lists of tensors in `b ` to FP16."
+    "Recursively map floating point tensors in `b ` to FP16."
     return apply(lambda x: x.half() if torch.is_floating_point(x) else x, b)
 
 # %% ../nbs/00_torch_core.ipynb 69
 def to_float(b):
-    "Recursively map lists of int tensors in `b ` to float."
+    "Recursively map floating point tensors in `b ` to float."
     return apply(lambda x: x.float() if torch.is_floating_point(x) else x, b)
 
 # %% ../nbs/00_torch_core.ipynb 70
@@ -292,7 +292,7 @@ def to_device(b, device=None, non_blocking=False):
 
 # %% ../nbs/00_torch_core.ipynb 77
 def to_cpu(b):
-    "Recursively map lists of tensors in `b ` to the cpu."
+    "Recursively map tensors in `b ` to the cpu."
     return to_device(b,'cpu')
 
 # %% ../nbs/00_torch_core.ipynb 79
@@ -758,7 +758,7 @@ def nested_reorder(t, idxs):
 
 # %% ../nbs/00_torch_core.ipynb 199
 def flatten_check(inp, targ):
-    "Check that `out` and `targ` have the same number of elements and flatten them."
+    "Check that `inp` and `targ` have the same number of elements and flatten them."
     inp,targ = TensorBase(inp.contiguous()).view(-1),TensorBase(targ.contiguous()).view(-1)
     test_eq(len(inp), len(targ))
     return inp,targ

--- a/nbs/00_torch_core.ipynb
+++ b/nbs/00_torch_core.ipynb
@@ -115,13 +115,13 @@
     "def subplots(\n",
     "    nrows:int=1, # Number of rows in returned axes grid\n",
     "    ncols:int=1, # Number of columns in returned axes grid\n",
-    "    figsize:tuple=None, # Width, height in inches of the returned figure \n",
+    "    figsize:tuple=None, # Width, height in inches of the returned figure\n",
     "    imsize:int=3, # Size (in inches) of images that will be displayed in the returned figure\n",
     "    suptitle:str=None, # Title to be set to returned figure\n",
     "    **kwargs\n",
-    ") -> (plt.Figure, plt.Axes): # Returns both fig and ax as a tuple \n",
+    ") -> (plt.Figure, plt.Axes): # Returns both fig and ax as a tuple\n",
     "    \"Returns a figure and set of subplots to display images of `imsize` inches\"\n",
-    "    if figsize is None: \n",
+    "    if figsize is None:\n",
     "        h=nrows*imsize if suptitle is None or imsize>2 else nrows*imsize+0.6 #https://github.com/matplotlib/matplotlib/issues/5355\n",
     "        figsize=(ncols*imsize, h)\n",
     "    fig,ax = plt.subplots(nrows, ncols, figsize=figsize, **kwargs)\n",
@@ -924,7 +924,7 @@
    "source": [
     "#|export\n",
     "def to_half(b):\n",
-    "    \"Recursively map lists of tensors in `b ` to FP16.\"\n",
+    "    \"Recursively map floating point tensors in `b ` to FP16.\"\n",
     "    return apply(lambda x: x.half() if torch.is_floating_point(x) else x, b)"
    ]
   },
@@ -936,8 +936,8 @@
    "source": [
     "#|export\n",
     "def to_float(b):\n",
-    "    \"Recursively map lists of int tensors in `b ` to float.\"\n",
-    "    return apply(lambda x: x.float() if not torch.is_floating_point(x) else x, b)"
+    "    \"Recursively map floating point tensors in `b ` to float.\"\n",
+    "    return apply(lambda x: x.float() if torch.is_floating_point(x) else x, b)"
    ]
   },
   {
@@ -1052,7 +1052,7 @@
    "source": [
     "#|export\n",
     "def to_cpu(b):\n",
-    "    \"Recursively map lists of tensors in `b ` to the cpu.\"\n",
+    "    \"Recursively map tensors in `b ` to the cpu.\"\n",
     "    return to_device(b,'cpu')"
    ]
   },
@@ -1234,7 +1234,7 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "def _find_args(x):   \n",
+    "def _find_args(x):\n",
     "    x0 = x[0] if is_listy(x[0]) and x[0] else x\n",
     "    return [a for a in x0 if hasattr(a,'__dict__')]"
    ]
@@ -1291,7 +1291,7 @@
     "        cls = type(self)\n",
     "        res = self.as_subclass(Tensor).new() if x is None else self.as_subclass(Tensor).new(x)\n",
     "        return res.as_subclass(cls)\n",
-    "    \n",
+    "\n",
     "    def requires_grad_(self, requires_grad=True):\n",
     "        # Workaround https://github.com/pytorch/pytorch/issues/50219\n",
     "        self.requires_grad = requires_grad\n",


### PR DESCRIPTION
This PR resolves the out of sync issue with fastai notebooks and library.

It also rolls back the issue unintentionally introduced in #3823 to `to_float`. fastai uses `to_float` to convert fp16 to fp32 in mixed precision training, so the unsynced change of the function to match the doc string would have resulted in `NonNativeMixedPrecision` not convert fp16 predictions to fp32 predictions as expected.

I also clarified a few doc strings, as `to_half` and `to_float` only modify [floating point](https://pytorch.org/docs/stable/generated/torch.is_floating_point.html) Tensors, and both along with `to_cpu` recursively apply to more than just lists of tensors, so I removed the doc string reference to lists. 