### PR TITLE
Optimizer documentation pass & small fixes

### DIFF
--- a/fastai/imports.py
+++ b/fastai/imports.py
@@ -20,6 +20,7 @@ from enum import Enum,IntEnum
 from textwrap import TextWrapper
 from operator import itemgetter,attrgetter,methodcaller
 from urllib.request import urlopen
+from numbers import Number, Real
 
 # External modules
 import requests,yaml,matplotlib.pyplot as plt,pandas as pd,scipy

--- a/fastai/optimizer.py
+++ b/fastai/optimizer.py
@@ -85,13 +85,15 @@ class Optimizer(_BaseOptimizer):
     "Base optimizer class for the fastai library, updating `params` with `cbs`"
     _keep_on_clear = ['force_train', 'do_wd']
     def __init__(self,
-        params:Tensor, # Parameters and hyper parameters
-        cbs:list, # `Optimizer` callbacks
-        train_bn:bool=True, # Batch normalization is always trained
-        **defaults # Default values to set on hyper parameters
+        params:Tensor|Iterable, # Model parameters
+        cbs:callable|MutableSequence, # `Optimizer` step callbacks
+        **defaults # Hyper parameters default values
     ):
+        if 'train_bn' in defaults.keys():
+            _ = defaults.pop('train_bn') 
+            warn('Setting `train_bn` in `Optimizer` has no effect. Set `train_bn` on `Learner` init instead')
         params = L(params)
-        self.cbs,self.state,self.train_bn = L(cbs),defaultdict(dict),train_bn
+        self.cbs,self.state = L(cbs),defaultdict(dict)
         defaults = merge(*self.cbs.attrgot('defaults'), defaults)
         self.param_lists = L(L(p) for p in params) if isinstance(params[0], (L,list)) else L([params])
         self.hypers = L({} for _ in range_of(self.param_lists))
@@ -168,8 +170,14 @@ def momentum_step(p, lr, grad_avg, **kwargs):
     p.data.add_(grad_avg, alpha=-lr)
 
 # %% ../nbs/12_optimizer.ipynb 63
-def SGD(params, lr, mom=0., wd=0., decouple_wd=True):
-    "A `Optimizer` for SGD with `lr` and `mom` and `params`"
+def SGD(
+    params:Tensor|Iterable, # Model parameters
+    lr:float|slice, # Default learning rate
+    mom:float=0., # Gradient moving average (β1) coefficient
+    wd:Real=0., # Optional weight decay (true or L2)
+    decouple_wd:bool=True # Apply true weight decay or L2 regularization (SGD)
+) -> Optimizer:
+    "A SGD `Optimizer`"
     cbs = [weight_decay] if decouple_wd else [l2_reg]
     if mom != 0: cbs.append(average_grad)
     cbs.append(sgd_step if mom==0 else momentum_step)
@@ -177,15 +185,23 @@ def SGD(params, lr, mom=0., wd=0., decouple_wd=True):
 
 # %% ../nbs/12_optimizer.ipynb 70
 def rms_prop_step(p, lr, sqr_avg, eps, grad_avg=None, **kwargs):
-    "Step for SGD with momentum with `lr`"
+    "Step for RMSProp with momentum with `lr`"
     denom = sqr_avg.sqrt().add_(eps)
     p.data.addcdiv_((grad_avg if grad_avg is not None else p.grad), denom, value=-lr)
 
 rms_prop_step.defaults = dict(eps=1e-8)
 
 # %% ../nbs/12_optimizer.ipynb 71
-def RMSProp(params, lr, sqr_mom=0.99, mom=0., wd=0., decouple_wd=True):
-    "A `Optimizer` for RMSProp with `lr`, `sqr_mom`, `mom` and `params`"
+def RMSProp(
+    params:Tensor|Iterable, # Model parameters
+    lr:float|slice, # Default learning rate
+    mom:float=0., # Gradient moving average (β1) coefficient
+    sqr_mom:float=0.99, # Gradient squared moving average (β2) coefficient
+    eps:float=1e-8, # Added for numerical stability
+    wd:Real=0., # Optional weight decay (true or L2)
+    decouple_wd:bool=True # Apply true weight decay or L2 regularization (RMSProp)
+) -> Optimizer:
+    "A RMSProp `Optimizer`"
     cbs = [weight_decay] if decouple_wd else [l2_reg]
     cbs += ([average_sqr_grad] if mom==0. else [average_grad, average_sqr_grad])
     cbs.append(rms_prop_step)
@@ -211,8 +227,16 @@ def adam_step(p, lr, mom, step, sqr_mom, grad_avg, sqr_avg, eps, **kwargs):
 adam_step._defaults = dict(eps=1e-5)
 
 # %% ../nbs/12_optimizer.ipynb 80
-def Adam(params, lr, mom=0.9, sqr_mom=0.99, eps=1e-5, wd=0.01, decouple_wd=True):
-    "A `Optimizer` for Adam with `lr`, `mom`, `sqr_mom`, `eps` and `params`"
+def Adam(
+    params:Tensor|Iterable, # Model parameters
+    lr:float|slice, # Default learning rate
+    mom:float=0.9, # Gradient moving average (β1) coefficient
+    sqr_mom:float=0.99, # Gradient squared moving average (β2) coefficient
+    eps:float=1e-5, # Added for numerical stability
+    wd:Real=0.01, # Optional weight decay (true or L2)
+    decouple_wd:bool=True # Apply true weight decay (AdamW) or L2 regularization (Adam)
+) -> Optimizer:
+    "A Adam/AdamW `Optimizer`"
     cbs = [weight_decay] if decouple_wd else [l2_reg]
     cbs += [partial(average_grad, dampening=True), average_sqr_grad, step_stat, adam_step]
     return Optimizer(params, cbs, lr=lr, mom=mom, sqr_mom=sqr_mom, eps=eps, wd=wd)
@@ -236,8 +260,17 @@ def radam_step(p, lr, mom, step, sqr_mom, grad_avg, sqr_avg, eps, beta, **kwargs
 radam_step._defaults = dict(eps=1e-5)
 
 # %% ../nbs/12_optimizer.ipynb 86
-def RAdam(params, lr, mom=0.9, sqr_mom=0.99, eps=1e-5, wd=0., beta=0., decouple_wd=True):
-    "A `Optimizer` for Adam with `lr`, `mom`, `sqr_mom`, `eps` and `params`"
+def RAdam(
+    params:Tensor|Iterable, # Model parameters
+    lr:float|slice, # Default learning rate
+    mom:float=0.9, # Gradient moving average (β1) coefficient
+    sqr_mom:float=0.99, # Gradient squared moving average (β2) coefficient
+    eps:float=1e-5, # Added for numerical stability
+    wd:Real=0., # Optional weight decay (true or L2)
+    beta:float=0., # Set to enable SAdam
+    decouple_wd:bool=True # Apply true weight decay (RAdamW) or L2 regularization (RAdam)
+) -> Optimizer:
+    "A RAdam/RAdamW `Optimizer`"
     cbs = [weight_decay] if decouple_wd else [l2_reg]
     cbs += [partial(average_grad, dampening=True), average_sqr_grad, step_stat, radam_step]
     return Optimizer(params, cbs, lr=lr, mom=mom, sqr_mom=sqr_mom, eps=eps, wd=wd, beta=beta)
@@ -254,8 +287,18 @@ def qhadam_step(p, lr, mom, sqr_mom, sqr_avg, nu_1, nu_2, step, grad_avg, eps, *
 qhadam_step._defaults = dict(eps=1e-8)
 
 # %% ../nbs/12_optimizer.ipynb 93
-def QHAdam(params, lr, mom=0.999, sqr_mom=0.999, nu_1=0.7, nu_2 = 1.0, eps=1e-8, wd=0., decouple_wd=True):
-    "An `Optimizer` for Adam with `lr`, `mom`, `sqr_mom`, `nus`, eps` and `params`"
+def QHAdam(
+    params:Tensor|Iterable, # Model parameters
+    lr:float|slice, # Default learning rate
+    mom:float=0.999, # Gradient moving average (β1) coefficient
+    sqr_mom:float=0.999, # Gradient squared moving average (β2) coefficient
+    nu_1:float=0.7, # QH immediate discount factor
+    nu_2:float=1.0, # QH momentum discount factor
+    eps:float=1e-8, # Added for numerical stability
+    wd:Real=0., # Optional weight decay (true or L2)
+    decouple_wd:bool=True, # Apply true weight decay (QHAdamW) or L2 regularization (QHAdam)
+) -> Optimizer:
+    "A QHAdam/QHAdamW `Optimizer`"
     cbs = [weight_decay] if decouple_wd else [l2_reg]
     cbs += [partial(average_grad, dampening=True), partial(average_sqr_grad, dampening=True), step_stat, qhadam_step]
     return Optimizer(params, cbs, lr=lr, nu_1=nu_1, nu_2=nu_2 ,
@@ -276,8 +319,17 @@ def larc_step(p, local_lr, grad_avg=None, **kwargs):
     p.data.add_(p.grad.data if grad_avg is None else grad_avg, alpha = -local_lr)
 
 # %% ../nbs/12_optimizer.ipynb 98
-def Larc(params, lr, mom=0.9, clip=True, trust_coeff=0.02, eps=1e-8, wd=0., decouple_wd=True):
-    "A `Optimizer` for Adam with `lr`, `mom`, `sqr_mom`, `eps` and `params`"
+def Larc(
+    params:Tensor|Iterable, # Model parameters
+    lr:float|slice, # Default learning rate
+    mom:float=0.9, # Gradient moving average (β1) coefficient
+    clip:bool=True, # LARC if clip=True, LARS if clip=False
+    trust_coeff:float=0.02, # Trust coeffiecnet for calculating layerwise LR
+    eps:float=1e-8, # Added for numerical stability
+    wd:Real=0., # Optional weight decay (true or L2)
+    decouple_wd:bool=True # Apply true weight decay or L2 regularization
+) -> Optimizer:
+    "A LARC/LARS `Optimizer`"
     cbs = [weight_decay] if decouple_wd else [l2_reg]
     if mom!=0.: cbs.append(average_grad)
     cbs += [partial(larc_layer_lr, clip=clip), larc_step]
@@ -297,8 +349,16 @@ def lamb_step(p, lr, mom, step, sqr_mom, grad_avg, sqr_avg, eps, **kwargs):
 lamb_step._defaults = dict(eps=1e-6, wd=0.)
 
 # %% ../nbs/12_optimizer.ipynb 104
-def Lamb(params, lr, mom=0.9, sqr_mom=0.99, eps=1e-5, wd=0., decouple_wd=True):
-    "A `Optimizer` for Adam with `lr`, `mom`, `sqr_mom`, `eps` and `params`"
+def Lamb(
+    params:Tensor|Iterable, # Model parameters
+    lr:float|slice, # Default learning rate
+    mom:float=0.9, # Gradient moving average (β1) coefficient
+    sqr_mom:float=0.99, # Gradient squared moving average (β2) coefficient
+    eps:float=1e-5, # Added for numerical stability
+    wd:Real=0., # Optional weight decay (true or L2)
+    decouple_wd:bool=True # Apply true weight decay or L2 regularization
+) -> Optimizer:
+    "A LAMB `Optimizer`"
     cbs = [weight_decay] if decouple_wd else [l2_reg]
     cbs += [partial(average_grad, dampening=True), average_sqr_grad, step_stat, lamb_step]
     return Optimizer(params, cbs, lr=lr, mom=mom, sqr_mom=sqr_mom, eps=eps, wd=wd)
@@ -307,7 +367,11 @@ def Lamb(params, lr, mom=0.9, sqr_mom=0.99, eps=1e-5, wd=0., decouple_wd=True):
 class Lookahead(Optimizer, GetAttr):
     "Wrap `opt` in a lookahead optimizer"
     _default='opt'
-    def __init__(self, opt, k=6, alpha=0.5):
+    def __init__(self, 
+        opt:Optimizer, # `Optimizer` to wrap with Lookahead
+        k:int=6, # How often to conduct Lookahead step
+        alpha:float=0.5, # Slow weight moving average coefficient
+    ):
         store_attr('opt,k,alpha')
         self._init_state()
 
@@ -346,9 +410,18 @@ class Lookahead(Optimizer, GetAttr):
 
 # %% ../nbs/12_optimizer.ipynb 111
 @delegates(RAdam)
-def ranger(p, lr, mom=0.95, wd=0.01, eps=1e-6, **kwargs):
+def ranger(
+    params:Tensor|Iterable, # Model parameters
+    lr:float|slice, # Default learning rate
+    mom:float=0.95, # Gradient moving average (β1) coefficient
+    wd:Real=0.01, # Optional weight decay (true or L2)
+    eps:float=1e-6, # Added for numerical stability
+    k:int=6, # How often to conduct Lookahead step
+    alpha:float=0.5, # Slow weight moving average coefficient 
+    **kwargs
+) -> Lookahead:
     "Convenience method for `Lookahead` with `RAdam`"
-    return Lookahead(RAdam(p, lr=lr, mom=mom, wd=wd, eps=eps, **kwargs))
+    return Lookahead(RAdam(params, lr=lr, mom=mom, wd=wd, eps=eps, **kwargs), k=k, alpha=alpha)
 
 # %% ../nbs/12_optimizer.ipynb 114
 def detuplify_pg(d):
@@ -385,9 +458,9 @@ class OptimWrapper(_BaseOptimizer, GetAttr):
     _xtra=['zero_grad', 'step', 'state_dict', 'load_state_dict']
     _default='opt'
     def __init__(self, 
-         params:MutableSequence|dict=None, # Model parameters to pass to `opt`. If using an already built `opt`
+         params:Tensor|Iterable=None, # Model parameters. Don't set if using a built optimizer
          opt:callable|torch.optim.Optimizer=None, # A torch optimizer constructor, or an already built optimizer 
-         hp_map:dict=None, # A dictionary converting the keys of a built `opt` to the keys of fastai's Optimizer
+         hp_map:dict=None, # A dictionary converting PyTorch optimizer keys to fastai's `Optimizer` keys. Defaults to `pytorch_hp_map`
          convert_groups:bool=True, # Convert parameter groups from splitter or pass unaltered to `opt`
          **kwargs
     ):

--- a/nbs/12_optimizer.ipynb
+++ b/nbs/12_optimizer.ipynb
@@ -174,13 +174,15 @@
     "    \"Base optimizer class for the fastai library, updating `params` with `cbs`\"\n",
     "    _keep_on_clear = ['force_train', 'do_wd']\n",
     "    def __init__(self,\n",
-    "        params:Tensor, # Parameters and hyper parameters\n",
-    "        cbs:list, # `Optimizer` callbacks\n",
-    "        train_bn:bool=True, # Batch normalization is always trained\n",
-    "        **defaults # Default values to set on hyper parameters\n",
+    "        params:Tensor|Iterable, # Model parameters\n",
+    "        cbs:callable|MutableSequence, # `Optimizer` step callbacks\n",
+    "        **defaults # Hyper parameters default values\n",
     "    ):\n",
+    "        if 'train_bn' in defaults.keys():\n",
+    "            _ = defaults.pop('train_bn') \n",
+    "            warn('Setting `train_bn` in `Optimizer` has no effect. Set `train_bn` on `Learner` init instead')\n",
     "        params = L(params)\n",
-    "        self.cbs,self.state,self.train_bn = L(cbs),defaultdict(dict),train_bn\n",
+    "        self.cbs,self.state = L(cbs),defaultdict(dict)\n",
     "        defaults = merge(*self.cbs.attrgot('defaults'), defaults)\n",
     "        self.param_lists = L(L(p) for p in params) if isinstance(params[0], (L,list)) else L([params])\n",
     "        self.hypers = L({} for _ in range_of(self.param_lists))\n",
@@ -943,18 +945,31 @@
     {
      "data": {
       "text/markdown": [
-       "<h4 id=\"Optimizer.clear_state\" class=\"doc_header\"><code>Optimizer.clear_state</code><a href=\"__main__.py#L30\" class=\"source_link\" style=\"float:right\">[source]</a></h4>\n",
+       "---\n",
        "\n",
-       "> <code>Optimizer.clear_state</code>()\n",
+       "[source](https://github.com/fastai/fastai/blob/master/fastai/optimizer.py#L114){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### Optimizer.clear_state\n",
+       "\n",
+       ">      Optimizer.clear_state ()\n",
        "\n",
        "Reset the state of the optimizer"
       ],
       "text/plain": [
-       "<IPython.core.display.Markdown object>"
+       "---\n",
+       "\n",
+       "[source](https://github.com/fastai/fastai/blob/master/fastai/optimizer.py#L114){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### Optimizer.clear_state\n",
+       "\n",
+       ">      Optimizer.clear_state ()\n",
+       "\n",
+       "Reset the state of the optimizer"
       ]
      },
+     "execution_count": null,
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -1010,8 +1025,14 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "def SGD(params, lr, mom=0., wd=0., decouple_wd=True):\n",
-    "    \"A `Optimizer` for SGD with `lr` and `mom` and `params`\"\n",
+    "def SGD(\n",
+    "    params:Tensor|Iterable, # Model parameters\n",
+    "    lr:float|slice, # Default learning rate\n",
+    "    mom:float=0., # Gradient moving average (β1) coefficient\n",
+    "    wd:Real=0., # Optional weight decay (true or L2)\n",
+    "    decouple_wd:bool=True # Apply true weight decay or L2 regularization (SGD)\n",
+    ") -> Optimizer:\n",
+    "    \"A SGD `Optimizer`\"\n",
     "    cbs = [weight_decay] if decouple_wd else [l2_reg]\n",
     "    if mom != 0: cbs.append(average_grad)\n",
     "    cbs.append(sgd_step if mom==0 else momentum_step)\n",
@@ -1037,7 +1058,6 @@
     "opt.step()\n",
     "test_close([p.item() for p in params], [i*0.99 for i in range(4)])\n",
     "opt.step()\n",
-    "[p.item() for p in params]\n",
     "test_close([p.item() for p in params], [i*0.98 for i in range(4)])"
    ]
   },
@@ -1054,7 +1074,6 @@
     "opt.step()\n",
     "test_close([p.item() for p in params], [i*0.99 for i in range(4)])\n",
     "opt.step()\n",
-    "[p.item() for p in params]\n",
     "test_close([p.item() for p in params], [i*(1 - 0.1 * (0.1 + 0.1*1.9)) for i in range(4)])\n",
     "for i,p in enumerate(params): test_close(opt.state[p]['grad_avg'].item(), i*0.19)"
    ]
@@ -1099,7 +1118,7 @@
    "source": [
     "#|export\n",
     "def rms_prop_step(p, lr, sqr_avg, eps, grad_avg=None, **kwargs):\n",
-    "    \"Step for SGD with momentum with `lr`\"\n",
+    "    \"Step for RMSProp with momentum with `lr`\"\n",
     "    denom = sqr_avg.sqrt().add_(eps)\n",
     "    p.data.addcdiv_((grad_avg if grad_avg is not None else p.grad), denom, value=-lr)\n",
     "\n",
@@ -1113,8 +1132,16 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "def RMSProp(params, lr, sqr_mom=0.99, mom=0., wd=0., decouple_wd=True):\n",
-    "    \"A `Optimizer` for RMSProp with `lr`, `sqr_mom`, `mom` and `params`\"\n",
+    "def RMSProp(\n",
+    "    params:Tensor|Iterable, # Model parameters\n",
+    "    lr:float|slice, # Default learning rate\n",
+    "    mom:float=0., # Gradient moving average (β1) coefficient\n",
+    "    sqr_mom:float=0.99, # Gradient squared moving average (β2) coefficient\n",
+    "    eps:float=1e-8, # Added for numerical stability\n",
+    "    wd:Real=0., # Optional weight decay (true or L2)\n",
+    "    decouple_wd:bool=True # Apply true weight decay or L2 regularization (RMSProp)\n",
+    ") -> Optimizer:\n",
+    "    \"A RMSProp `Optimizer`\"\n",
     "    cbs = [weight_decay] if decouple_wd else [l2_reg]\n",
     "    cbs += ([average_sqr_grad] if mom==0. else [average_grad, average_sqr_grad])\n",
     "    cbs.append(rms_prop_step)\n",
@@ -1228,8 +1255,16 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "def Adam(params, lr, mom=0.9, sqr_mom=0.99, eps=1e-5, wd=0.01, decouple_wd=True):\n",
-    "    \"A `Optimizer` for Adam with `lr`, `mom`, `sqr_mom`, `eps` and `params`\"\n",
+    "def Adam(\n",
+    "    params:Tensor|Iterable, # Model parameters\n",
+    "    lr:float|slice, # Default learning rate\n",
+    "    mom:float=0.9, # Gradient moving average (β1) coefficient\n",
+    "    sqr_mom:float=0.99, # Gradient squared moving average (β2) coefficient\n",
+    "    eps:float=1e-5, # Added for numerical stability\n",
+    "    wd:Real=0.01, # Optional weight decay (true or L2)\n",
+    "    decouple_wd:bool=True # Apply true weight decay (AdamW) or L2 regularization (Adam)\n",
+    ") -> Optimizer:\n",
+    "    \"A Adam/AdamW `Optimizer`\"\n",
     "    cbs = [weight_decay] if decouple_wd else [l2_reg]\n",
     "    cbs += [partial(average_grad, dampening=True), average_sqr_grad, step_stat, adam_step]\n",
     "    return Optimizer(params, cbs, lr=lr, mom=mom, sqr_mom=sqr_mom, eps=eps, wd=wd)"
@@ -1276,7 +1311,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "RAdam (for rectified Adam) was introduced by Zhang et al. in [On the Variance of the Adaptive Learning Rate and Beyond](https://arxiv.org/abs/1907.08610) to slightly modify the Adam optimizer to be more stable at the beginning of training (and thus not require a long warmup). They use an estimate of the variance of the moving average of the squared gradients (the term in the denominator of traditional Adam) and rescale this moving average by this term before performing the update.\n",
+    "RAdam (for rectified Adam) was introduced by Zhang et al. in [On the Variance of the Adaptive Learning Rate and Beyond](https://arxiv.org/abs/1908.03265) to slightly modify the Adam optimizer to be more stable at the beginning of training (and thus not require a long warmup). They use an estimate of the variance of the moving average of the squared gradients (the term in the denominator of traditional Adam) and rescale this moving average by this term before performing the update.\n",
     "\n",
     "This version also incorporates [SAdam](https://arxiv.org/abs/1908.00700); set `beta` to enable this (definition same as in the paper)."
    ]
@@ -1313,8 +1348,17 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "def RAdam(params, lr, mom=0.9, sqr_mom=0.99, eps=1e-5, wd=0., beta=0., decouple_wd=True):\n",
-    "    \"A `Optimizer` for Adam with `lr`, `mom`, `sqr_mom`, `eps` and `params`\"\n",
+    "def RAdam(\n",
+    "    params:Tensor|Iterable, # Model parameters\n",
+    "    lr:float|slice, # Default learning rate\n",
+    "    mom:float=0.9, # Gradient moving average (β1) coefficient\n",
+    "    sqr_mom:float=0.99, # Gradient squared moving average (β2) coefficient\n",
+    "    eps:float=1e-5, # Added for numerical stability\n",
+    "    wd:Real=0., # Optional weight decay (true or L2)\n",
+    "    beta:float=0., # Set to enable SAdam\n",
+    "    decouple_wd:bool=True # Apply true weight decay (RAdamW) or L2 regularization (RAdam)\n",
+    ") -> Optimizer:\n",
+    "    \"A RAdam/RAdamW `Optimizer`\"\n",
     "    cbs = [weight_decay] if decouple_wd else [l2_reg]\n",
     "    cbs += [partial(average_grad, dampening=True), average_sqr_grad, step_stat, radam_step]\n",
     "    return Optimizer(params, cbs, lr=lr, mom=mom, sqr_mom=sqr_mom, eps=eps, wd=wd, beta=beta)"
@@ -1390,7 +1434,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "QHAdam (for Quasi-Hyperbolic Adam) was introduced by Ma & Yarats in [Quasi-Hyperbolic Momentum and Adam for Deep Learning](https://arxiv.org/pdf/1810.06801.pdf) as a *\"computationally cheap, intuitive to interpret, and simple to implement\"* optimizer. Additional code can be found in their [qhoptim repo](https://github.com/facebookresearch/qhoptim). QHAdam is based on QH-Momentum, which introduces the immediate discount factor `nu`, encapsulating plain SGD (`nu = 0`) and momentum (`nu = 1`). QH-Momentum is defined below, where g_t+1 is the update of the moment. An interpretation of QHM is as a nu-weighted average of the momentum update step and the plain SGD update step.\n",
+    "QHAdam (for Quasi-Hyperbolic Adam) was introduced by Ma & Yarats in [Quasi-Hyperbolic Momentum and Adam for Deep Learning](https://arxiv.org/abs/1810.06801) as a *\"computationally cheap, intuitive to interpret, and simple to implement\"* optimizer. Additional code can be found in their [qhoptim repo](https://github.com/facebookresearch/qhoptim). QHAdam is based on QH-Momentum, which introduces the immediate discount factor `nu`, encapsulating plain SGD (`nu = 0`) and momentum (`nu = 1`). QH-Momentum is defined below, where g_t+1 is the update of the moment. An interpretation of QHM is as a nu-weighted average of the momentum update step and the plain SGD update step.\n",
     "\n",
     "> θ_t+1 ← θ_t − lr * [(1 − nu) · ∇L_t(θ_t) + nu · g_t+1]\n",
     "\n",
@@ -1426,8 +1470,18 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "def QHAdam(params, lr, mom=0.999, sqr_mom=0.999, nu_1=0.7, nu_2 = 1.0, eps=1e-8, wd=0., decouple_wd=True):\n",
-    "    \"An `Optimizer` for Adam with `lr`, `mom`, `sqr_mom`, `nus`, eps` and `params`\"\n",
+    "def QHAdam(\n",
+    "    params:Tensor|Iterable, # Model parameters\n",
+    "    lr:float|slice, # Default learning rate\n",
+    "    mom:float=0.999, # Gradient moving average (β1) coefficient\n",
+    "    sqr_mom:float=0.999, # Gradient squared moving average (β2) coefficient\n",
+    "    nu_1:float=0.7, # QH immediate discount factor\n",
+    "    nu_2:float=1.0, # QH momentum discount factor\n",
+    "    eps:float=1e-8, # Added for numerical stability\n",
+    "    wd:Real=0., # Optional weight decay (true or L2)\n",
+    "    decouple_wd:bool=True, # Apply true weight decay (QHAdamW) or L2 regularization (QHAdam)\n",
+    ") -> Optimizer:\n",
+    "    \"A QHAdam/QHAdamW `Optimizer`\"\n",
     "    cbs = [weight_decay] if decouple_wd else [l2_reg]\n",
     "    cbs += [partial(average_grad, dampening=True), partial(average_sqr_grad, dampening=True), step_stat, qhadam_step]\n",
     "    return Optimizer(params, cbs, lr=lr, nu_1=nu_1, nu_2=nu_2 ,\n",
@@ -1492,8 +1546,17 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "def Larc(params, lr, mom=0.9, clip=True, trust_coeff=0.02, eps=1e-8, wd=0., decouple_wd=True):\n",
-    "    \"A `Optimizer` for Adam with `lr`, `mom`, `sqr_mom`, `eps` and `params`\"\n",
+    "def Larc(\n",
+    "    params:Tensor|Iterable, # Model parameters\n",
+    "    lr:float|slice, # Default learning rate\n",
+    "    mom:float=0.9, # Gradient moving average (β1) coefficient\n",
+    "    clip:bool=True, # LARC if clip=True, LARS if clip=False\n",
+    "    trust_coeff:float=0.02, # Trust coeffiecnet for calculating layerwise LR\n",
+    "    eps:float=1e-8, # Added for numerical stability\n",
+    "    wd:Real=0., # Optional weight decay (true or L2)\n",
+    "    decouple_wd:bool=True # Apply true weight decay or L2 regularization\n",
+    ") -> Optimizer:\n",
+    "    \"A LARC/LARS `Optimizer`\"\n",
     "    cbs = [weight_decay] if decouple_wd else [l2_reg]\n",
     "    if mom!=0.: cbs.append(average_grad)\n",
     "    cbs += [partial(larc_layer_lr, clip=clip), larc_step]\n",
@@ -1576,8 +1639,16 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "def Lamb(params, lr, mom=0.9, sqr_mom=0.99, eps=1e-5, wd=0., decouple_wd=True):\n",
-    "    \"A `Optimizer` for Adam with `lr`, `mom`, `sqr_mom`, `eps` and `params`\"\n",
+    "def Lamb(\n",
+    "    params:Tensor|Iterable, # Model parameters\n",
+    "    lr:float|slice, # Default learning rate\n",
+    "    mom:float=0.9, # Gradient moving average (β1) coefficient\n",
+    "    sqr_mom:float=0.99, # Gradient squared moving average (β2) coefficient\n",
+    "    eps:float=1e-5, # Added for numerical stability\n",
+    "    wd:Real=0., # Optional weight decay (true or L2)\n",
+    "    decouple_wd:bool=True # Apply true weight decay or L2 regularization\n",
+    ") -> Optimizer:\n",
+    "    \"A LAMB `Optimizer`\"\n",
     "    cbs = [weight_decay] if decouple_wd else [l2_reg]\n",
     "    cbs += [partial(average_grad, dampening=True), average_sqr_grad, step_stat, lamb_step]\n",
     "    return Optimizer(params, cbs, lr=lr, mom=mom, sqr_mom=sqr_mom, eps=eps, wd=wd)"
@@ -1628,7 +1699,11 @@
     "class Lookahead(Optimizer, GetAttr):\n",
     "    \"Wrap `opt` in a lookahead optimizer\"\n",
     "    _default='opt'\n",
-    "    def __init__(self, opt, k=6, alpha=0.5):\n",
+    "    def __init__(self, \n",
+    "        opt:Optimizer, # `Optimizer` to wrap with Lookahead\n",
+    "        k:int=6, # How often to conduct Lookahead step\n",
+    "        alpha:float=0.5, # Slow weight moving average coefficient\n",
+    "    ):\n",
     "        store_attr('opt,k,alpha')\n",
     "        self._init_state()\n",
     "\n",
@@ -1691,9 +1766,18 @@
    "source": [
     "#|export\n",
     "@delegates(RAdam)\n",
-    "def ranger(p, lr, mom=0.95, wd=0.01, eps=1e-6, **kwargs):\n",
+    "def ranger(\n",
+    "    params:Tensor|Iterable, # Model parameters\n",
+    "    lr:float|slice, # Default learning rate\n",
+    "    mom:float=0.95, # Gradient moving average (β1) coefficient\n",
+    "    wd:Real=0.01, # Optional weight decay (true or L2)\n",
+    "    eps:float=1e-6, # Added for numerical stability\n",
+    "    k:int=6, # How often to conduct Lookahead step\n",
+    "    alpha:float=0.5, # Slow weight moving average coefficient \n",
+    "    **kwargs\n",
+    ") -> Lookahead:\n",
     "    \"Convenience method for `Lookahead` with `RAdam`\"\n",
-    "    return Lookahead(RAdam(p, lr=lr, mom=mom, wd=wd, eps=eps, **kwargs))"
+    "    return Lookahead(RAdam(params, lr=lr, mom=mom, wd=wd, eps=eps, **kwargs), k=k, alpha=alpha)"
    ]
   },
   {
@@ -1732,6 +1816,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#|hide\n",
     "tst = {'lr': 1e-2, 'mom': 0.9, 'params':[0,1,2]}\n",
     "test_eq(detuplify_pg(tst), {'lr': 1e-2, 'mom': 0.9})\n",
     "tst = {'lr': 1e-2, 'betas': (0.9,0.999), 'params':[0,1,2]}\n",
@@ -1759,6 +1844,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#|hide\n",
     "tst = {'lr': 1e-2, 'mom': 0.9, 'params':[0,1,2]}\n",
     "test_eq(set_item_pg(tst, 'lr', 1e-3), {'lr': 1e-3, 'mom': 0.9, 'params':[0,1,2]})\n",
     "tst = {'lr': 1e-2, 'betas': (0.9,0.999), 'params':[0,1,2]}\n",
@@ -1803,9 +1889,9 @@
     "    _xtra=['zero_grad', 'step', 'state_dict', 'load_state_dict']\n",
     "    _default='opt'\n",
     "    def __init__(self, \n",
-    "         params:MutableSequence|dict=None, # Model parameters to pass to `opt`. If using an already built `opt`\n",
+    "         params:Tensor|Iterable=None, # Model parameters. Don't set if using a built optimizer\n",
     "         opt:callable|torch.optim.Optimizer=None, # A torch optimizer constructor, or an already built optimizer \n",
-    "         hp_map:dict=None, # A dictionary converting the keys of a built `opt` to the keys of fastai's Optimizer\n",
+    "         hp_map:dict=None, # A dictionary converting PyTorch optimizer keys to fastai's `Optimizer` keys. Defaults to `pytorch_hp_map`\n",
     "         convert_groups:bool=True, # Convert parameter groups from splitter or pass unaltered to `opt`\n",
     "         **kwargs\n",
     "    ):\n",
@@ -1841,6 +1927,55 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To use an existing PyTorch optimizer, you can define an optimizer function like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "opt_func = partial(OptimWrapper, opt=torch.optim.SGD)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or if you already have a built optimizer, pass in only `opt`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "opt = torch.optim.SGD([tensor([1,2,3])], lr=1e-2)\n",
+    "opt_func = OptimWrapper(opt=opt)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When passing a built optimizer to `Learner`, instead of resetting the optimizer `Learner.fit` will clear the optimizer state if `reset_opt=True` or when calling `Learner.fit` for the first time.\n",
+    "\n",
+    "To prevent `Learner` from clearing the optimizer state when calling `Learner.fit` for the first time, assign the optimizer directly to `Learner.opt`:\n",
+    "\n",
+    "```python\n",
+    "opt = torch.optim.SGD([tensor([1,2,3])], lr=1e-2)\n",
+    "learn = Learner(..., opt_func=None)\n",
+    "learn.opt = OptimWrapper(opt=opt)\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -1863,6 +1998,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#|hide\n",
     "sgd = SGD([tensor([1,2,3])], lr=1e-3, mom=0.9, wd=1e-2)\n",
     "tst_sgd = OptimWrapper([tensor([1,2,3])], torch.optim.SGD, lr=1e-3, momentum=0.9, weight_decay=1e-2)\n",
     "#Access to param_groups\n",
@@ -1883,6 +2019,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#|hide\n",
     "tst_sgd = OptimWrapper([{'params': [tensor([1,2,3])], 'lr': 1e-3}, \n",
     "                                        {'params': [tensor([4,5,6])], 'lr': 1e-2}], torch.optim.SGD, momentum=0.9, weight_decay=1e-2)\n",
     "sgd = SGD([[tensor([1,2,3])], [tensor([4,5,6])]], lr=[1e-3, 1e-2], mom=0.9, wd=1e-2)\n",
@@ -1907,6 +2044,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#|hide\n",
     "# Ensure we can use an already made optimizer\n",
     "tst_sgd = torch.optim.SGD([{'params': [tensor([1,2,3])], 'lr': 1e-3}, \n",
     "                                        {'params': [tensor([4,5,6])], 'lr': 1e-2}])\n",
@@ -1961,6 +2099,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#|hide\n",
     "def _mock_train(m, x, y, opt):\n",
     "    m.train()\n",
     "    for i in range(0, 100, 25):\n",
@@ -1977,6 +2116,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#|hide\n",
     "m = nn.Linear(4,5)\n",
     "x = torch.randn(100, 3, 4)\n",
     "y = torch.randn(100, 3, 5)\n",
@@ -2035,6 +2175,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#|hide\n",
     "m = nn.Linear(4,5)\n",
     "x = torch.randn(100, 3, 4)\n",
     "y = torch.randn(100, 3, 5)\n",
@@ -2085,39 +2226,6 @@
     "    test_close(wgt1,wgt2,eps=1e-3)\n",
     "    test_close(bias1,bias2,eps=1e-3)\n",
     "finally: os.remove('tmp.pth')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To use an existing PyTorch optimizer, you can define an optimizer function like this:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "opt_func = partial(OptimWrapper, opt=torch.optim.SGD)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Or if you already have an existing one, pass in only `opt`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "opt = torch.optim.SGD([tensor([1,2,3])], lr=1e-2)\n",
-    "opt_func = OptimWrapper(opt=opt)"
    ]
   },
   {
@@ -2238,7 +2346,7 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3.9.13 ('fastaidev')",
+   "display_name": "fastaidev",
    "language": "python",
    "name": "python3"
   }


### PR DESCRIPTION
This PR upstreams `Optimizer` documentation improvements I made for [fastxtend](https://fastxtend.benjaminwarner.dev/optimizer.fused.html) to fastai.

- New `Optimizer` docments & type hints for all optimizers
- Improved and corrected existing `Optimizer` docments & type hints
- Corrected a few Arxiv paper links

I also removed the unused `train_bn` arg from `Optimizer.__init__` and added a warning if it's passed. And I added additional documentation for using the #3843 `OptimWrapper` changes.