### PR TITLE
Add option to (optionally) save confusion matrix plot

### DIFF
--- a/nbs/20_interpret.ipynb
+++ b/nbs/20_interpret.ipynb
@@ -685,7 +685,7 @@
     "        plt.ylabel('Actual')\n",
     "        plt.xlabel('Predicted')\n",
     "        plt.grid(False)\n",
-    "        if save_plot:\n",
+    "        if save_plot and title is not None:\n",
     "            plt.savefig('_'.join(map(lambda x: x.lower(), title.split(' '))))\n",
     "\n",
     "    def most_confused(self, min_val=1):\n",

--- a/nbs/20_interpret.ipynb
+++ b/nbs/20_interpret.ipynb
@@ -657,6 +657,7 @@
     "        cmap:str=\"Blues\", # Colormap from matplotlib\n",
     "        norm_dec:int=2, # Decimal places for normalized occurrences\n",
     "        plot_txt:bool=True, # Display occurrence in matrix\n",
+    "        save_plot:bool=False, #Save the plot, off by default\n",
     "        **kwargs\n",
     "    ):\n",
     "        \"Plot the confusion matrix, with `title` and using `cmap`.\"\n",
@@ -684,6 +685,8 @@
     "        plt.ylabel('Actual')\n",
     "        plt.xlabel('Predicted')\n",
     "        plt.grid(False)\n",
+    "        if save_plot:\n",
+    "            plt.savefig('_'.join(map(lambda x: x.lower(), title.split(' '))))\n",
     "\n",
     "    def most_confused(self, min_val=1):\n",
     "        \"Sorted descending largest non-diagonal entries of confusion matrix (actual, predicted, # occurrences\"\n",
@@ -989,6 +992,18 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR adds an optional parameter `save_plot` to the `plot_confusion_matrix` function which allows offline analysis of models and their confusion matrix across several tuning or iterations.

