### PR TITLE
Allow Pillow Image to be passed to PILBase.create

### DIFF
--- a/nbs/07_vision.core.ipynb
+++ b/nbs/07_vision.core.ipynb
@@ -466,17 +466,19 @@
    "source": [
     "#|export\n",
     "class PILBase(Image.Image, metaclass=BypassNewMeta):\n",
+    "    \"Base class for a Pillow `Image` that can show itself and convert to a Tensor\"\n",
     "    _bypass_type=Image.Image\n",
     "    _show_args = {'cmap':'viridis'}\n",
     "    _open_args = {'mode': 'RGB'}\n",
     "    @classmethod\n",
-    "    def create(cls, fn:Path|str|Tensor|ndarray|bytes, **kwargs)->None:\n",
-    "        \"Open an `Image` from path `fn`\"\n",
+    "    def create(cls, fn:Path|str|Tensor|ndarray|bytes|Image.Image, **kwargs):\n",
+    "        \"Return an Image from `fn`\"\n",
     "        if isinstance(fn,TensorImage): fn = fn.permute(1,2,0).type(torch.uint8)\n",
-    "        if isinstance(fn, TensorMask): fn = fn.type(torch.uint8)\n",
+    "        if isinstance(fn,TensorMask): fn = fn.type(torch.uint8)\n",
     "        if isinstance(fn,Tensor): fn = fn.numpy()\n",
     "        if isinstance(fn,ndarray): return cls(Image.fromarray(fn))\n",
     "        if isinstance(fn,bytes): fn = io.BytesIO(fn)\n",
+    "        if isinstance(fn,Image.Image) and not isinstance(fn,cls): return cls(fn)\n",
     "        return cls(load_image(fn, **merge(cls._open_args, kwargs)))\n",
     "\n",
     "    def show(self, ctx=None, **kwargs):\n",
@@ -492,8 +494,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#|export\n",
-    "class PILImage(PILBase): pass"
+    "show_doc(PILBase.create)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Images passed to `PILBase` or inherited classes' `create` as a PyTorch `Tensor`, NumPy `ndarray`, or Pillow `Image` must already be in the correct Pillow image format. For example, `uint8`, and RGB or BW for `PILImage` or `PILImageBW`, respectively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_doc(PILBase.show)"
    ]
   },
   {
@@ -503,7 +521,21 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "class PILImageBW(PILImage): _show_args,_open_args = {'cmap':'Greys'},{'mode': 'L'}"
+    "class PILImage(PILBase): \n",
+    "    \"A RGB Pillow `Image` that can show itself and converts to `TensorImage`\"\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#|export\n",
+    "class PILImageBW(PILImage):\n",
+    "    \"A BW Pillow `Image` that can show itself and converts to `TensorImageBW`\"\n",
+    "    _show_args,_open_args = {'cmap':'Greys'},{'mode': 'L'}"
    ]
   },
   {
@@ -618,7 +650,9 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "class PILMask(PILBase): _open_args,_show_args = {'mode':'L'},{'alpha':0.5, 'cmap':'tab20'}"
+    "class PILMask(PILBase):\n",
+    "    \"A Pillow `Image` Mask that can show itself and converts to `TensorMask`\"\n",
+    "    _open_args,_show_args = {'mode':'L'},{'alpha':0.5, 'cmap':'tab20'}"
    ]
   },
   {
@@ -1561,13 +1595,6 @@
     "from nbdev import nbdev_export\n",
     "nbdev_export()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR modifies `PILBase` to accept a Pillow `Image` in `create`, which makes using `ImageBlock` more intuitive at both training and inference.

I also added more doc strings to PILBase derived classes.