### PR TITLE
Set DataLoaders device if not None and to exists

### DIFF
--- a/fastai/data/core.py
+++ b/fastai/data/core.py
@@ -203,7 +203,7 @@ class DataLoaders(GetAttr):
         device=None # Device to put `DataLoaders`
     ):
         self.loaders,self.path = list(loaders),Path(path)
-        if device is not None or hasattr(loaders[0],'to'): self.device = device
+        if device is not None and hasattr(loaders[0],'to'): self.device = device
 
     def __getitem__(self, i): return self.loaders[i]
     def __len__(self): return len(self.loaders)

--- a/nbs/03_data.core.ipynb
+++ b/nbs/03_data.core.ipynb
@@ -609,7 +609,7 @@
     "        device=None # Device to put `DataLoaders`\n",
     "    ):\n",
     "        self.loaders,self.path = list(loaders),Path(path)\n",
-    "        if device is not None or hasattr(loaders[0],'to'): self.device = device\n",
+    "        if device is not None and hasattr(loaders[0],'to'): self.device = device\n",
     "\n",
     "    def __getitem__(self, i): return self.loaders[i]\n",
     "    def __len__(self): return len(self.loaders)\n",


### PR DESCRIPTION
This PR changes `DataLoaders.__init__` to set device only if `to` exists and a device is passed on init. Currently if `to` exists and no device is passed, init will overwrite any existing DataLoader device with None.

I left the device.setter alone but could change check if `to` exists in the DataLoader and warn if there isn't one. Which could lead to multiple warnings, one per DataLoader. Currently setting DataLoaders device will error out if a DataLoader doesn't have a `to` method.