### PR TITLE
Add support for a batch transforms `to` method

### DIFF
--- a/fastai/data/core.py
+++ b/fastai/data/core.py
@@ -179,7 +179,8 @@ class TfmdDL(DataLoader):
     ):
         self.device = device
         for tfm in self.after_batch.fs:
-            if hasattr(tfm, 'to'): tfm.to(device)
+            # Check that tfm.to is callable as TabularPandas & transforms set tfm.to as an object
+            if hasattr(tfm, 'to') and callable(tfm.to): tfm.to(device)
             else:
                 for a in L(getattr(tfm, 'parameters', None)): setattr(tfm, a, getattr(tfm, a).to(device))
         return self

--- a/fastai/data/core.py
+++ b/fastai/data/core.py
@@ -179,7 +179,9 @@ class TfmdDL(DataLoader):
     ):
         self.device = device
         for tfm in self.after_batch.fs:
-            for a in L(getattr(tfm, 'parameters', None)): setattr(tfm, a, getattr(tfm, a).to(device))
+            if hasattr(tfm, 'to'): tfm.to(device)
+            else:
+                for a in L(getattr(tfm, 'parameters', None)): setattr(tfm, a, getattr(tfm, a).to(device))
         return self
 
 # %% ../../nbs/03_data.core.ipynb 16

--- a/nbs/03_data.core.ipynb
+++ b/nbs/03_data.core.ipynb
@@ -292,7 +292,8 @@
     "    ):\n",
     "        self.device = device\n",
     "        for tfm in self.after_batch.fs:\n",
-    "            if hasattr(tfm, 'to'): tfm.to(device)\n",
+    "            # Check that tfm.to is callable as TabularPandas & transforms set tfm.to as an object\n",
+    "            if hasattr(tfm, 'to') and callable(tfm.to): tfm.to(device)\n",
     "            else:\n",
     "                for a in L(getattr(tfm, 'parameters', None)): setattr(tfm, a, getattr(tfm, a).to(device))\n",
     "        return self"

--- a/nbs/03_data.core.ipynb
+++ b/nbs/03_data.core.ipynb
@@ -292,7 +292,9 @@
     "    ):\n",
     "        self.device = device\n",
     "        for tfm in self.after_batch.fs:\n",
-    "            for a in L(getattr(tfm, 'parameters', None)): setattr(tfm, a, getattr(tfm, a).to(device))\n",
+    "            if hasattr(tfm, 'to'): tfm.to(device)\n",
+    "            else:\n",
+    "                for a in L(getattr(tfm, 'parameters', None)): setattr(tfm, a, getattr(tfm, a).to(device))\n",
     "        return self"
    ]
   },


### PR DESCRIPTION
This PR modifies `TfmdDL.to` to support calling a `to` method on batch transforms as an alternate means of moving the transform to a device. The current approach of looking for PyTorch Parameters and calling `to` doesn't work for moving `nn.Module` based transforms such as Torchaudio's [AmplitudeToDB](https://pytorch.org/audio/stable/generated/torchaudio.transforms.AmplitudeToDB.html).