### PR TITLE
Fix rank0_first problems after merging #3873

### DIFF
--- a/fastai/data/core.py
+++ b/fastai/data/core.py
@@ -206,7 +206,7 @@ class DataLoaders(GetAttr):
         device=None # Device to put `DataLoaders`
     ):
         self.loaders,self.path = list(loaders),Path(path)
-        if device is not None and hasattr(loaders[0],'to'): self.device = device
+        if device is not None and (loaders!=() and hasattr(loaders[0],'to')): self.device = device
 
     def __getitem__(self, i): return self.loaders[i]
     def __len__(self): return len(self.loaders)

--- a/nbs/03_data.core.ipynb
+++ b/nbs/03_data.core.ipynb
@@ -612,7 +612,7 @@
     "        device=None # Device to put `DataLoaders`\n",
     "    ):\n",
     "        self.loaders,self.path = list(loaders),Path(path)\n",
-    "        if device is not None and hasattr(loaders[0],'to'): self.device = device\n",
+    "        if device is not None and (loaders!=() and hasattr(loaders[0],'to')): self.device = device\n",
     "\n",
     "    def __getitem__(self, i): return self.loaders[i]\n",
     "    def __len__(self): return len(self.loaders)\n",


### PR DESCRIPTION
Code snippet which fails on the newest fastai version - 2.7.11 caused by #3873:
```python 
from torchvision.models import vgg16, vgg19
from fastai.distributed import rank0_first


vgg16_rank0_first= rank0_first(lambda: vgg16(pretrained=True).features.eval().requires_grad_(False))
```
`rank0_first` creates `DataLoaders` with argument loaders=() therefore `hasattr(loaders[0],'to')` causes `IndexError: tuple index of out range`. I've added extra check which asserts if `loaders!=()`
```python
def rank0_first(func, *args, **kwargs):
    "Execute `func` in the Rank-0 process first, then in other ranks in parallel."
    if args or kwargs: func = partial(func, *args, **kwargs)
    dummy_l = Learner(DataLoaders(device='cpu'), nn.Linear(1,1), loss_func=lambda: 0)
    with dummy_l.distrib_ctx():
        if not rank_distrib(): res = func()
        distrib_barrier()
        if rank_distrib(): res = func()
    return res
   ```
