### PR TITLE
Issue #3880 Possible Fix

### DIFF
--- a/nbs/07_vision.core.ipynb
+++ b/nbs/07_vision.core.ipynb
@@ -478,7 +478,7 @@
     "        if isinstance(fn,Tensor): fn = fn.numpy()\n",
     "        if isinstance(fn,ndarray): return cls(Image.fromarray(fn))\n",
     "        if isinstance(fn,bytes): fn = io.BytesIO(fn)\n",
-    "        if isinstance(fn,Image.Image) and not isinstance(fn,cls): return cls(fn)\n",
+    "        if isinstance(fn,Image.Image): return cls(fn)\n",
     "        return cls(load_image(fn, **merge(cls._open_args, kwargs)))\n",
     "\n",
     "    def show(self, ctx=None, **kwargs):\n",
@@ -498,7 +498,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -548,6 +547,18 @@
     "test_eq(type(im), PILImage)\n",
     "test_eq(im.mode, 'RGB')\n",
     "test_eq(str(im), 'PILImage mode=RGB size=1200x803')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "im2 = PILImage.create(im)\n",
+    "test_eq(type(im2), PILImage)\n",
+    "test_eq(im2.mode, 'RGB')\n",
+    "test_eq(str(im2), 'PILImage mode=RGB size=1200x803')"
    ]
   },
   {


### PR DESCRIPTION
The `self.types` loop in [`infer_idx`](https://github.com/fastai/fastai/blob/4d1834cb0b6ac20b068de55cf57f40a0c2296cd4/fastai/data/core.py#L400-L409) hits the break on line [404](https://github.com/fastai/fastai/blob/4d1834cb0b6ac20b068de55cf57f40a0c2296cd4/fastai/data/core.py#L404) one element earlier than the commit prior to https://github.com/fastai/fastai/pull/3872 and the idx gets set to one value lower. This means that the [rm_tfms](https://github.com/fastai/fastai/blob/4d1834cb0b6ac20b068de55cf57f40a0c2296cd4/fastai/data/core.py#L514) variable within https://github.com/fastai/fastai/blob/4d1834cb0b6ac20b068de55cf57f40a0c2296cd4/fastai/data/core.py#L504-L523 contains the [create method](https://github.com/fastai/fastai/blob/4d1834cb0b6ac20b068de55cf57f40a0c2296cd4/fastai/vision/core.py#L117-L125) of [PILBase](https://github.com/fastai/fastai/blob/4d1834cb0b6ac20b068de55cf57f40a0c2296cd4/fastai/vision/core.py#L111) when it previously didn't.

Making the [create method](https://github.com/fastai/fastai/blob/4d1834cb0b6ac20b068de55cf57f40a0c2296cd4/fastai/vision/core.py#L117-L125) of [PILBase](https://github.com/fastai/fastai/blob/4d1834cb0b6ac20b068de55cf57f40a0c2296cd4/fastai/vision/core.py#L111) method safely accept a PILImage means this `rm_tfms` variable that gets set to the `test_tl.tfms.fs` attribute is executed successfully when [compose_tfms ](https://github.com/fastai/fastcore/blob/f7fea257626106e2016d4a55d280f8b876f6dcb4/fastcore/transform.py#L153-L159) is called.

Whilst I think its good that a `PILImage` can be created from another PILImage, this fix doesn't preserve the original behavior of how [`infer_idx`](https://github.com/fastai/fastai/blob/4d1834cb0b6ac20b068de55cf57f40a0c2296cd4/fastai/data/core.py#L400-L409) previously functioned. **_Not sure if this is a bigger problem or if change this is sufficient_**