### PR TITLE
TypeError: new_empty(): argument 'layout' must be torch.layout, not NoneType

### DIFF
--- a/fastai/torch_core.py
+++ b/fastai/torch_core.py
@@ -397,11 +397,11 @@ class TensorBase(Tensor):
         cls = type(self)
         return self.as_subclass(Tensor).clone(memory_format=memory_format).as_subclass(cls)
 
-    def new_empty(self, size, *, dtype=None, layout=None, device=None, pin_memory=False, requires_grad=False):
+    def new_empty(self, size, *, dtype=None, layout=torch.strided, device=None, pin_memory=False, requires_grad=False):
         cls = type(self)
         return self.as_subclass(Tensor).new_empty(size, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory, requires_grad=requires_grad).as_subclass(cls)
 
-    def new_empty(self, *size, dtype=None, layout=None, device=None, pin_memory=False, requires_grad=False):
+    def new_empty(self, *size, dtype=None, layout=torch.strided, device=None, pin_memory=False, requires_grad=False):
         cls = type(self)
         return self.as_subclass(Tensor).new_empty(*size, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory, requires_grad=requires_grad).as_subclass(cls)
 

--- a/nbs/00_torch_core.ipynb
+++ b/nbs/00_torch_core.ipynb
@@ -1288,11 +1288,11 @@
     "        cls = type(self)\n",
     "        return self.as_subclass(Tensor).clone(memory_format=memory_format).as_subclass(cls)\n",
     "\n",
-    "    def new_empty(self, size, *, dtype=None, layout=None, device=None, pin_memory=False, requires_grad=False):\n",
+    "    def new_empty(self, size, *, dtype=None, layout=torch.strided, device=None, pin_memory=False, requires_grad=False):\n",
     "        cls = type(self)\n",
     "        return self.as_subclass(Tensor).new_empty(size, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory, requires_grad=requires_grad).as_subclass(cls)\n",
     "\n",
-    "    def new_empty(self, *size, dtype=None, layout=None, device=None, pin_memory=False, requires_grad=False):\n",
+    "    def new_empty(self, *size, dtype=None, layout=torch.strided, device=None, pin_memory=False, requires_grad=False):\n",
     "        cls = type(self)\n",
     "        return self.as_subclass(Tensor).new_empty(*size, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory, requires_grad=requires_grad).as_subclass(cls)"
    ]


### PR DESCRIPTION
This resolves an issue where calling `TensorBase.new_empty` with the default parameters results in an exception.

[Tensor.new_empty](https://pytorch.org/docs/stable/generated/torch.Tensor.new_empty.html) uses `layout=torch.strided` by default, so I replicated those arguments here.

```python
│ /home/jovyan/fastai/fastai/vision/augment.py:573 in _draw_mask                                   │
│                                                                                                  │
│    570 │   │   assert len(draw)>=x.size(0)                                                       │
│    571 │   │   res = tensor(draw[:x.size(0)], dtype=x.dtype, device=x.device)                    │
│    572 │   else: res = x.new_zeros(x.size(0)) + draw                                             │
│ ❱  573 │   return TensorBase(mask_tensor(res, p=p, neutral=neutral, batch=batch))                │
│    574                                                                                           │
│    575 # %% ../../nbs/09_vision.augment.ipynb 126                                                │
│    576 def affine_mat(*ms):                                                                      │
│                                                                                                  │
│ /home/jovyan/fastai/fastai/vision/augment.py:560 in mask_tensor                                  │
│                                                                                                  │
│    557 │   if p==1.: return x                                                                    │
│    558 │   if batch: return x if random.random() < p else x.new_zeros(*x.size()) + neutral       │
│    559 │   if neutral != 0: x.add_(-neutral)                                                     │
│ ❱  560 │   mask = x.new_empty(*x.size()).bernoulli_(p)                                           │
│    561 │   x.mul_(mask)                                                                          │
│    562 │   return x.add_(neutral) if neutral != 0 else x                                         │
│    563                                                                                           │
│                                                                                                  │
│ /home/jovyan/fastai/fastai/torch_core.py:406 in new_empty                                        │
│                                                                                                  │
│   403 │                                                                                          │
│   404 │   def new_empty(self, *size, dtype=None, layout=None, device=None, pin_memory=False, r   │
│   405 │   │   cls = type(self)                                                                   │
│ ❱ 406 │   │   return self.as_subclass(Tensor).new_empty(*size, dtype=dtype, layout=layout, dev   │
│   407                                                                                            │
│   408 # %% ../nbs/00_torch_core.ipynb 105                                                        │
│   409 class TensorImageBase(TensorBase):                                                         │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
TypeError: new_empty(): argument 'layout' must be torch.layout, not NoneType
```