### PR TITLE
Better version support for `TensorBase.new_empty`

### DIFF
--- a/fastai/torch_core.py
+++ b/fastai/torch_core.py
@@ -307,6 +307,12 @@ def to_concat(xs, dim=0):
                           for i in range_of(o_)) for o_ in xs], L())
 
 # %% ../nbs/00_torch_core.ipynb 84
+# Parsed PyTorch versions for faster version checking
+_torch_version = parse(torch.__version__)
+_torch_113 = parse('1.13')
+_torch_112 = parse('1.12')
+
+# %% ../nbs/00_torch_core.ipynb 85
 @patch
 def set_meta(self:Tensor, x, as_copy=False):
     "Set all metadata in `__dict__`"
@@ -314,34 +320,34 @@ def set_meta(self:Tensor, x, as_copy=False):
     # XXX: change to `deepcopy` once PyTorch 1.7.1 is out, and check nb 23 segmentation fit works
     self.__dict__ = copy(x.__dict__) if as_copy else x.__dict__
 
-# %% ../nbs/00_torch_core.ipynb 85
+# %% ../nbs/00_torch_core.ipynb 86
 if not hasattr(torch,'as_subclass'): torch.as_subclass = torch.Tensor.as_subclass
 
-# %% ../nbs/00_torch_core.ipynb 86
+# %% ../nbs/00_torch_core.ipynb 87
 @patch
 def as_subclass(self:Tensor, typ):
     "Cast to `typ` and include `__dict__` and meta"
     return retain_meta(self, torch.as_subclass(self, typ))
 
-# %% ../nbs/00_torch_core.ipynb 89
+# %% ../nbs/00_torch_core.ipynb 90
 def _torch_handled(args, opt, func):
     if func not in opt: return False
     for oks in opt[func]:
         if all(isinstance(arg,ok) for arg,ok in zip(args,oks) if ok): return True
 
-# %% ../nbs/00_torch_core.ipynb 90
+# %% ../nbs/00_torch_core.ipynb 91
 # from https://github.com/pytorch/pytorch/blob/13c975684a220ec096216ec6468ccd0dc90ff50a/torch/_tensor.py#L34
 def _rebuild_from_type(func, type, args, dict):
     ret = func(*args).as_subclass(type)
     ret.__dict__ = dict
     return ret
 
-# %% ../nbs/00_torch_core.ipynb 91
+# %% ../nbs/00_torch_core.ipynb 92
 def _find_args(x):
     x0 = x[0] if is_listy(x[0]) and x[0] else x
     return [a for a in x0 if hasattr(a,'__dict__')]
 
-# %% ../nbs/00_torch_core.ipynb 92
+# %% ../nbs/00_torch_core.ipynb 93
 class TensorBase(Tensor):
     "A `Tensor` which support subclass pickling, and maintains metadata when casting or after methods"
     debug,_opt = False,defaultdict(list)
@@ -399,25 +405,33 @@ class TensorBase(Tensor):
 
     def new_empty(self, size, *, dtype=None, layout=None, device=None, pin_memory=False, requires_grad=False):
         cls = type(self)
+        if _torch_version < _torch_113 and layout is None:
+            layout = torch.strided
+        if _torch_version < _torch_112:
+            return super().new_empty(size, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory, requires_grad=requires_grad)
         return self.as_subclass(Tensor).new_empty(size, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory, requires_grad=requires_grad).as_subclass(cls)
 
     def new_empty(self, *size, dtype=None, layout=None, device=None, pin_memory=False, requires_grad=False):
         cls = type(self)
+        if _torch_version < _torch_113 and layout is None:
+            layout = torch.strided
+        if _torch_version < _torch_112:
+            return super().new_empty(*size, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory, requires_grad=requires_grad)
         return self.as_subclass(Tensor).new_empty(*size, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory, requires_grad=requires_grad).as_subclass(cls)
 
-# %% ../nbs/00_torch_core.ipynb 105
+# %% ../nbs/00_torch_core.ipynb 106
 class TensorImageBase(TensorBase):
     _show_args = ArrayImageBase._show_args
     def show(self, ctx=None, **kwargs):
         return show_image(self, ctx=ctx, **{**self._show_args, **kwargs})
 
-# %% ../nbs/00_torch_core.ipynb 106
+# %% ../nbs/00_torch_core.ipynb 107
 class TensorImage(TensorImageBase): pass
 
-# %% ../nbs/00_torch_core.ipynb 107
+# %% ../nbs/00_torch_core.ipynb 108
 class TensorImageBW(TensorImage): _show_args = ArrayImageBW._show_args
 
-# %% ../nbs/00_torch_core.ipynb 108
+# %% ../nbs/00_torch_core.ipynb 109
 class TensorMask(TensorImageBase):
     _show_args = ArrayMask._show_args
 
@@ -426,7 +440,7 @@ class TensorMask(TensorImageBase):
         if codes is not None: kwargs = merge({'vmin': 0, 'vmax': len(codes)}, kwargs)
         return super().show(ctx=ctx, **kwargs)
 
-# %% ../nbs/00_torch_core.ipynb 109
+# %% ../nbs/00_torch_core.ipynb 110
 for o in Tensor.__getitem__, Tensor.__ne__,Tensor.__eq__,Tensor.add,Tensor.sub,Tensor.mul,Tensor.div,Tensor.__rsub__,Tensor.__radd__,Tensor.matmul,Tensor.bmm:
     TensorBase.register_func(o, TensorMask, TensorImageBase)
     TensorBase.register_func(o, TensorImageBase, TensorMask)
@@ -434,24 +448,24 @@ for o in Tensor.__getitem__, Tensor.__ne__,Tensor.__eq__,Tensor.add,Tensor.sub,T
 TensorMask.register_func(torch.einsum, str, TensorImageBase, TensorMask)
 TensorMask.register_func(torch.einsum, str, TensorMask, TensorImageBase)
 
-# %% ../nbs/00_torch_core.ipynb 116
+# %% ../nbs/00_torch_core.ipynb 117
 class TensorFlowField(TensorBase): pass
 TensorImage.register_func(F.grid_sample, TensorImageBase, TensorFlowField)
 
-# %% ../nbs/00_torch_core.ipynb 118
+# %% ../nbs/00_torch_core.ipynb 119
 class TensorCategory(TensorBase): pass
 
 TensorBase.register_func(Tensor.__getitem__, TensorImageBase, TensorCategory)
 
-# %% ../nbs/00_torch_core.ipynb 120
+# %% ../nbs/00_torch_core.ipynb 121
 class TensorMultiCategory(TensorCategory): pass
 
-# %% ../nbs/00_torch_core.ipynb 121
+# %% ../nbs/00_torch_core.ipynb 122
 class TitledTensorScalar(TensorBase):
     "A tensor containing a scalar that has a `show` method"
     def show(self, **kwargs): show_title(self.item(), **kwargs)
 
-# %% ../nbs/00_torch_core.ipynb 123
+# %% ../nbs/00_torch_core.ipynb 124
 @patch
 def tensored(self:L):
     "`mapped(tensor)`"
@@ -465,7 +479,7 @@ def cat  (self:L, dim=0):
     "Same as `torch.cat`"
     return torch.cat  (list(self.tensored()), dim=dim)
 
-# %% ../nbs/00_torch_core.ipynb 132
+# %% ../nbs/00_torch_core.ipynb 133
 def concat(*ls):
     "Concatenate tensors, arrays, lists, or tuples"
     if not len(ls): return []
@@ -478,7 +492,7 @@ def concat(*ls):
         else: res = L(res)
     return retain_type(res, it)
 
-# %% ../nbs/00_torch_core.ipynb 134
+# %% ../nbs/00_torch_core.ipynb 135
 class Chunks:
     "Slice and int indexing into a list of lists"
     def __init__(self, chunks, lens=None):
@@ -506,7 +520,7 @@ class Chunks:
         cl = self.cumlens[docidx]
         return docidx,i-cl
 
-# %% ../nbs/00_torch_core.ipynb 139
+# %% ../nbs/00_torch_core.ipynb 140
 def show_title(o, ax=None, ctx=None, label=None, color='black', **kwargs):
     "Set title of `ax` to `o`, or print `o` if `ax` is `None`"
     ax = ifnone(ax,ctx)
@@ -520,7 +534,7 @@ def show_title(o, ax=None, ctx=None, label=None, color='black', **kwargs):
         ax = pd.concat([ax,pd.Series({label: o})])
     return ax
 
-# %% ../nbs/00_torch_core.ipynb 141
+# %% ../nbs/00_torch_core.ipynb 142
 class ShowTitle:
     "Base class that adds a simple `show`"
     _show_args = {'label': 'text'}
@@ -555,46 +569,46 @@ class TitledTuple(fastuple, ShowTitle):
 add_docs(TitledInt, "An `int` with `show`"); add_docs(TitledStr, "An `str` with `show`");
 add_docs(TitledFloat, "A `float` with `show`"); add_docs(TitledTuple, "A `fastuple` with `show`")
 
-# %% ../nbs/00_torch_core.ipynb 148
+# %% ../nbs/00_torch_core.ipynb 149
 @patch
 def truncate(self:TitledStr, n):
     "Truncate self to `n`"
     words = self.split(' ')[:n]
     return TitledStr(' '.join(words))
 
-# %% ../nbs/00_torch_core.ipynb 150
+# %% ../nbs/00_torch_core.ipynb 151
 if not hasattr(pd.DataFrame,'_old_init'): pd.DataFrame._old_init = pd.DataFrame.__init__
 
-# %% ../nbs/00_torch_core.ipynb 151
+# %% ../nbs/00_torch_core.ipynb 152
 @patch
 def __init__(self:pd.DataFrame, data=None, index=None, columns=None, dtype=None, copy=None):
     if data is not None and isinstance(data, Tensor): data = to_np(data)
     self._old_init(data, index=index, columns=columns, dtype=dtype, copy=copy)
 
-# %% ../nbs/00_torch_core.ipynb 152
+# %% ../nbs/00_torch_core.ipynb 153
 def get_empty_df(n):
     "Return `n` empty rows of a dataframe"
     df = pd.DataFrame(index = range(n))
     return [df.iloc[i] for i in range(n)]
 
-# %% ../nbs/00_torch_core.ipynb 153
+# %% ../nbs/00_torch_core.ipynb 154
 def display_df(df):
     "Display `df` in a notebook or defaults to print"
     try: from IPython.display import display, HTML
     except: return print(df)
     display(HTML(df.to_html()))
 
-# %% ../nbs/00_torch_core.ipynb 154
+# %% ../nbs/00_torch_core.ipynb 155
 def get_first(c):
     "Get the first element of c, even if c is a dataframe"
     return getattr(c, 'iloc', c)[0]
 
-# %% ../nbs/00_torch_core.ipynb 155
+# %% ../nbs/00_torch_core.ipynb 156
 def one_param(m):
     "First parameter in `m`"
     return first(m.parameters())
 
-# %% ../nbs/00_torch_core.ipynb 156
+# %% ../nbs/00_torch_core.ipynb 157
 def item_find(x, idx=0):
     "Recursively takes the `idx`-th element of `x`"
     if is_listy(x): return item_find(x[idx])
@@ -603,19 +617,19 @@ def item_find(x, idx=0):
         return item_find(x[key])
     return x
 
-# %% ../nbs/00_torch_core.ipynb 157
+# %% ../nbs/00_torch_core.ipynb 158
 def find_device(b):
     "Recursively search the device of `b`."
     return item_find(b).device
 
-# %% ../nbs/00_torch_core.ipynb 159
+# %% ../nbs/00_torch_core.ipynb 160
 def find_bs(b):
     "Recursively search the batch size of `b`."
     res = item_find(b)
     if not hasattr(res, "shape"): return len(b)
     return res.shape[0]
 
-# %% ../nbs/00_torch_core.ipynb 161
+# %% ../nbs/00_torch_core.ipynb 162
 def np_func(f):
     "Convert a function taking and returning numpy arrays to one taking and returning tensors"
     def _inner(*args, **kwargs):
@@ -624,21 +638,21 @@ def np_func(f):
     functools.update_wrapper(_inner, f)
     return _inner
 
-# %% ../nbs/00_torch_core.ipynb 165
+# %% ../nbs/00_torch_core.ipynb 166
 class Module(nn.Module, metaclass=PrePostInitMeta):
     "Same as `nn.Module`, but no need for subclasses to call `super().__init__`"
     def __pre_init__(self, *args, **kwargs): super().__init__()
     def __init__(self): pass
 
-# %% ../nbs/00_torch_core.ipynb 168
+# %% ../nbs/00_torch_core.ipynb 169
 from torch.nn.parallel import DistributedDataParallel
 
-# %% ../nbs/00_torch_core.ipynb 169
+# %% ../nbs/00_torch_core.ipynb 170
 def get_model(model):
     "Return the model maybe wrapped inside `model`."
     return model.module if isinstance(model, (DistributedDataParallel, nn.DataParallel)) else model
 
-# %% ../nbs/00_torch_core.ipynb 170
+# %% ../nbs/00_torch_core.ipynb 171
 def one_hot(x, c):
     "One-hot encode `x` with `c` classes."
     res = torch.zeros(c, dtype=torch.uint8)
@@ -646,24 +660,24 @@ def one_hot(x, c):
     else: res[list(L(x, use_list=None))] = 1.
     return res
 
-# %% ../nbs/00_torch_core.ipynb 172
+# %% ../nbs/00_torch_core.ipynb 173
 def one_hot_decode(x, vocab=None):
     return L(vocab[i] if vocab else i for i,x_ in enumerate(x) if x_==1)
 
-# %% ../nbs/00_torch_core.ipynb 174
+# %% ../nbs/00_torch_core.ipynb 175
 def params(m):
     "Return all parameters of `m`"
     return [p for p in m.parameters()]
 
-# %% ../nbs/00_torch_core.ipynb 175
+# %% ../nbs/00_torch_core.ipynb 176
 def trainable_params(m):
     "Return all trainable parameters of `m`"
     return [p for p in m.parameters() if p.requires_grad]
 
-# %% ../nbs/00_torch_core.ipynb 177
+# %% ../nbs/00_torch_core.ipynb 178
 norm_types = (nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d, nn.InstanceNorm1d, nn.InstanceNorm2d, nn.InstanceNorm3d, nn.LayerNorm)
 
-# %% ../nbs/00_torch_core.ipynb 178
+# %% ../nbs/00_torch_core.ipynb 179
 def norm_bias_params(m, with_bias=True):
     "Return all bias and BatchNorm parameters"
     if isinstance(m, norm_types): return L(m.parameters())
@@ -671,7 +685,7 @@ def norm_bias_params(m, with_bias=True):
     if with_bias and getattr(m, 'bias', None) is not None: res.append(m.bias)
     return res
 
-# %% ../nbs/00_torch_core.ipynb 180
+# %% ../nbs/00_torch_core.ipynb 181
 def batch_to_samples(b, max_n=10):
     "'Transposes' a batch to (at most `max_n`) samples"
     if isinstance(b, Tensor): return retain_types(list(b[:max_n]), [b])
@@ -679,7 +693,7 @@ def batch_to_samples(b, max_n=10):
         res = L(b).map(partial(batch_to_samples,max_n=max_n))
         return retain_types(res.zip(), [b])
 
-# %% ../nbs/00_torch_core.ipynb 182
+# %% ../nbs/00_torch_core.ipynb 183
 @patch
 def interp_1d(x:Tensor, xp, fp):
     "Same as `np.interp`"
@@ -689,7 +703,7 @@ def interp_1d(x:Tensor, xp, fp):
     locs = locs.clamp(0,len(slopes)-1)
     return slopes[locs]*x + incx[locs]
 
-# %% ../nbs/00_torch_core.ipynb 184
+# %% ../nbs/00_torch_core.ipynb 185
 @patch
 def pca(x:Tensor, k=2):
     "Compute PCA of `x` with `k` dimensions."
@@ -697,56 +711,56 @@ def pca(x:Tensor, k=2):
     U,S,V = torch.svd(x.t())
     return torch.mm(x,U[:,:k])
 
-# %% ../nbs/00_torch_core.ipynb 185
+# %% ../nbs/00_torch_core.ipynb 186
 def logit(x):
     "Logit of `x`, clamped to avoid inf."
     x = x.clamp(1e-7, 1-1e-7)
     return -(1/x-1).log()
 
-# %% ../nbs/00_torch_core.ipynb 186
+# %% ../nbs/00_torch_core.ipynb 187
 def num_distrib():
     "Return the number of processes in distributed training (if applicable)."
     return int(os.environ.get('WORLD_SIZE', 0))
 
-# %% ../nbs/00_torch_core.ipynb 187
+# %% ../nbs/00_torch_core.ipynb 188
 def rank_distrib():
     "Return the distributed rank of this process (if applicable)."
     return int(os.environ.get('RANK', 0))
 
-# %% ../nbs/00_torch_core.ipynb 188
+# %% ../nbs/00_torch_core.ipynb 189
 def distrib_barrier():
     "Place a synchronization barrier in distributed training"
     if num_distrib() > 1 and torch.distributed.is_initialized(): torch.distributed.barrier()
 
-# %% ../nbs/00_torch_core.ipynb 190
+# %% ../nbs/00_torch_core.ipynb 191
 # Saving arrays requires pytables - optional dependency
 try: import tables
 except: pass
 
-# %% ../nbs/00_torch_core.ipynb 191
+# %% ../nbs/00_torch_core.ipynb 192
 def _comp_filter(lib='lz4',lvl=3): return tables.Filters(complib=f'blosc:{lib}', complevel=lvl)
 
-# %% ../nbs/00_torch_core.ipynb 192
+# %% ../nbs/00_torch_core.ipynb 193
 @patch
 def save_array(p:Path, o, complib='lz4', lvl=3):
     "Save numpy array to a compressed `pytables` file, using compression level `lvl`"
     if isinstance(o,Tensor): o = to_np(o)
     with tables.open_file(p, mode='w', filters=_comp_filter(lib=complib,lvl=lvl)) as f: f.create_carray('/', 'data', obj=o)
 
-# %% ../nbs/00_torch_core.ipynb 194
+# %% ../nbs/00_torch_core.ipynb 195
 @patch
 def load_array(p:Path):
     "Save numpy array to a `pytables` file"
     with tables.open_file(p, 'r') as f: return f.root.data.read()
 
-# %% ../nbs/00_torch_core.ipynb 195
+# %% ../nbs/00_torch_core.ipynb 196
 def base_doc(elt):
     "Print a base documentation of `elt`"
     name = getattr(elt, '__qualname__', getattr(elt, '__name__', ''))
     print(f'{name}{inspect.signature(elt)}\n{inspect.getdoc(elt)}\n')
     print('To get a prettier result with hyperlinks to source code and documentation, install nbdev: pip install nbdev')
 
-# %% ../nbs/00_torch_core.ipynb 196
+# %% ../nbs/00_torch_core.ipynb 197
 def doc(elt):
     "Try to use doc form nbdev and fall back to `base_doc`"
     try:
@@ -754,7 +768,7 @@ def doc(elt):
         doc(elt)
     except: base_doc(elt)
 
-# %% ../nbs/00_torch_core.ipynb 197
+# %% ../nbs/00_torch_core.ipynb 198
 def nested_reorder(t, idxs):
     "Reorder all tensors in `t` using `idxs`"
     if isinstance(t, (Tensor,L)): return t[idxs]
@@ -762,14 +776,14 @@ def nested_reorder(t, idxs):
     if t is None: return t
     raise TypeError(f"Expected tensor, tuple, list or L but got {type(t)}")
 
-# %% ../nbs/00_torch_core.ipynb 199
+# %% ../nbs/00_torch_core.ipynb 200
 def flatten_check(inp, targ):
     "Check that `inp` and `targ` have the same number of elements and flatten them."
     inp,targ = TensorBase(inp.contiguous()).view(-1),TensorBase(targ.contiguous()).view(-1)
     test_eq(len(inp), len(targ))
     return inp,targ
 
-# %% ../nbs/00_torch_core.ipynb 202
+# %% ../nbs/00_torch_core.ipynb 203
 def make_cross_image(bw=True):
     "Create a tensor containing a cross image, either `bw` (True) or color"
     if bw:
@@ -782,7 +796,7 @@ def make_cross_image(bw=True):
         im[1,:,2] = 1.
     return im
 
-# %% ../nbs/00_torch_core.ipynb 205
+# %% ../nbs/00_torch_core.ipynb 206
 def show_image_batch(b, show=show_titled_image, items=9, cols=3, figsize=None, **kwargs):
     "Display batch `b` in a grid of size `items` with `cols` width"
     if items<cols: cols=items
@@ -791,13 +805,13 @@ def show_image_batch(b, show=show_titled_image, items=9, cols=3, figsize=None, *
     fig,axs = plt.subplots(rows, cols, figsize=figsize)
     for *o,ax in zip(*to_cpu(b), axs.flatten()): show(o, ax=ax, **kwargs)
 
-# %% ../nbs/00_torch_core.ipynb 208
+# %% ../nbs/00_torch_core.ipynb 209
 def requires_grad(m):
     "Check if the first parameter of `m` requires grad or not"
     ps = list(m.parameters())
     return ps[0].requires_grad if len(ps)>0 else False
 
-# %% ../nbs/00_torch_core.ipynb 210
+# %% ../nbs/00_torch_core.ipynb 211
 def init_default(m, func=nn.init.kaiming_normal_):
     "Initialize `m` weights with `func` and set `bias` to 0."
     if func:
@@ -805,31 +819,31 @@ def init_default(m, func=nn.init.kaiming_normal_):
         if hasattr(m, 'bias') and hasattr(m.bias, 'data'): m.bias.data.fill_(0.)
     return m
 
-# %% ../nbs/00_torch_core.ipynb 212
+# %% ../nbs/00_torch_core.ipynb 213
 def cond_init(m, func):
     "Apply `init_default` to `m` unless it's a batchnorm module"
     if (not isinstance(m, norm_types)) and requires_grad(m): init_default(m, func)
 
-# %% ../nbs/00_torch_core.ipynb 214
+# %% ../nbs/00_torch_core.ipynb 215
 def apply_leaf(m, f):
     "Apply `f` to children of `m`."
     c = m.children()
     if isinstance(m, nn.Module): f(m)
     for l in c: apply_leaf(l,f)
 
-# %% ../nbs/00_torch_core.ipynb 216
+# %% ../nbs/00_torch_core.ipynb 217
 def apply_init(m, func=nn.init.kaiming_normal_):
     "Initialize all non-batchnorm layers of `m` with `func`."
     apply_leaf(m, partial(cond_init, func=func))
 
-# %% ../nbs/00_torch_core.ipynb 219
+# %% ../nbs/00_torch_core.ipynb 220
 def script_use_ctx(f):
     "Decorator: create jit script and pass everything in `ctx.saved_variables to `f`, after `*args`"
     sf = torch.jit.script(f)
     def _f(ctx, *args, **kwargs): return sf(*args, *ctx.saved_variables, **kwargs)
     return update_wrapper(_f,f)
 
-# %% ../nbs/00_torch_core.ipynb 220
+# %% ../nbs/00_torch_core.ipynb 221
 def script_save_ctx(static, *argidx):
     "Decorator: create jit script and save args with indices `argidx` using `ctx.save_for_backward`"
     def _dec(f):
@@ -844,34 +858,34 @@ def script_save_ctx(static, *argidx):
         return update_wrapper(_f,f)
     return _dec
 
-# %% ../nbs/00_torch_core.ipynb 221
+# %% ../nbs/00_torch_core.ipynb 222
 def script_fwd(*argidx):
     "Decorator: create static jit script and save args with indices `argidx` using `ctx.save_for_backward`"
     return script_save_ctx(True, *argidx)
 
-# %% ../nbs/00_torch_core.ipynb 222
+# %% ../nbs/00_torch_core.ipynb 223
 def script_bwd(f):
     "Decorator: create static jit script and pass everything in `ctx.saved_variables to `f`, after `*args`"
     return staticmethod(script_use_ctx(f))
 
-# %% ../nbs/00_torch_core.ipynb 223
+# %% ../nbs/00_torch_core.ipynb 224
 def grad_module(cls):
     "Decorator: convert `cls` into an autograd function"
     class _c(nn.Module):
         def forward(self, *args, **kwargs): return cls.apply(*args, **kwargs)
     return _c
 
-# %% ../nbs/00_torch_core.ipynb 225
+# %% ../nbs/00_torch_core.ipynb 226
 def ismin_torch(min_version):
     "Check if `torch.__version__` >= `min_version` using packaging.version"
-    return parse(torch.__version__) >= parse(min_version)
+    return _torch_version >= parse(min_version)
 
-# %% ../nbs/00_torch_core.ipynb 226
+# %% ../nbs/00_torch_core.ipynb 227
 def notmax_torch(max_version):
     "Check if `torch.__version__` < `max_version` using packaging.version"
-    return parse(torch.__version__) < parse(max_version)
+    return _torch_version < parse(max_version)
 
-# %% ../nbs/00_torch_core.ipynb 228
+# %% ../nbs/00_torch_core.ipynb 229
 # PyTorch 1.13 introduced a Tensor Subclass string formatting bug
 # Workaround from pending PyTorch PR: https://github.com/pytorch/pytorch/pull/82766
 if ismin_torch('1.13') and notmax_torch('1.14'):

--- a/nbs/00_torch_core.ipynb
+++ b/nbs/00_torch_core.ipynb
@@ -1133,6 +1133,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#|exporti\n",
+    "# Parsed PyTorch versions for faster version checking\n",
+    "_torch_version = parse(torch.__version__)\n",
+    "_torch_113 = parse('1.13')\n",
+    "_torch_112 = parse('1.12')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "#|export\n",
     "@patch\n",
     "def set_meta(self:Tensor, x, as_copy=False):\n",
@@ -1290,10 +1303,18 @@
     "\n",
     "    def new_empty(self, size, *, dtype=None, layout=None, device=None, pin_memory=False, requires_grad=False):\n",
     "        cls = type(self)\n",
+    "        if _torch_version < _torch_113 and layout is None:\n",
+    "            layout = torch.strided\n",
+    "        if _torch_version < _torch_112:\n",
+    "            return super().new_empty(size, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory, requires_grad=requires_grad)\n",
     "        return self.as_subclass(Tensor).new_empty(size, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory, requires_grad=requires_grad).as_subclass(cls)\n",
     "\n",
     "    def new_empty(self, *size, dtype=None, layout=None, device=None, pin_memory=False, requires_grad=False):\n",
     "        cls = type(self)\n",
+    "        if _torch_version < _torch_113 and layout is None:\n",
+    "            layout = torch.strided\n",
+    "        if _torch_version < _torch_112:\n",
+    "            return super().new_empty(*size, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory, requires_grad=requires_grad)\n",
     "        return self.as_subclass(Tensor).new_empty(*size, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory, requires_grad=requires_grad).as_subclass(cls)"
    ]
   },
@@ -3259,7 +3280,7 @@
     "#|export\n",
     "def ismin_torch(min_version):\n",
     "    \"Check if `torch.__version__` >= `min_version` using packaging.version\"\n",
-    "    return parse(torch.__version__) >= parse(min_version)"
+    "    return _torch_version >= parse(min_version)"
    ]
   },
   {
@@ -3271,7 +3292,7 @@
     "#|export\n",
     "def notmax_torch(max_version):\n",
     "    \"Check if `torch.__version__` < `max_version` using packaging.version\"\n",
-    "    return parse(torch.__version__) < parse(max_version)"
+    "    return _torch_version < parse(max_version)"
    ]
   },
   {


### PR DESCRIPTION
This PR updates #3882 to support PyTorch 1.12, as @csaroff pointed out it failed in #3885.

The pre-parsed PyTorch versions decrease the speed hit of `TensorBase.new_empty` from ~18.75x slower than `Tensor.new_empty` when parsing in `new_empty` to ~4.4x slower.

I tested this PR on PyTorch 1.13, 1.12, 1.11. 1.10, and 1.9 using the following script:

```python
from fastai.vision.all import *
from copy import deepcopy

t = TensorBase([1,2,3,4])
x = deepcopy(t)

imagenette = untar_data(URLs.IMAGENETTE_160)

block = DataBlock(
    blocks=(ImageBlock, CategoryBlock),
    splitter=GrandparentSplitter(valid_name='val'),
    get_items=get_image_files, get_y=parent_label,
    item_tfms=Resize(128),
    batch_tfms=[*aug_transforms(flip_vert=True, max_rotate=45, max_warp=0.3, xtra_tfms=[Hue(), Saturation()]),
                Normalize.from_stats(*imagenet_stats)],
)
dls = block.dataloaders(imagenette, bs=128, num_workers=num_cpus(), pin_memory=True)

learn = Learner(dls, xresnext18(n_out=dls.c)).to_channelslast()
learn.fit_one_cycle(1, 3e-4)
```