### PR TITLE
Adding clarity on config.ini's directory in a docstring. 

### DIFF
--- a/nbs/04_data.external.ipynb
+++ b/nbs/04_data.external.ipynb
@@ -271,7 +271,7 @@
    "metadata": {},
    "source": [
     "This is a basic `Config` file that consists of `data`, `model`, `storage` and `archive`. \n",
-    "All future downloads occur at the paths defined in the config file based on the type of download. For example, all future fastai datasets are downloaded to the `data` while all pretrained model weights are download to `model` unless the default download location is updated. The parent directory is defined by enviromental variable `FASTAI_HOME` if it exists, otherwise it is set to `~/.fastai`."
+    "All future downloads occur at the paths defined in the config file based on the type of download. For example, all future fastai datasets are downloaded to the `data` while all pretrained model weights are download to `model` unless the default download location is updated. The config file directory is defined by enviromental variable `FASTAI_HOME` if it exists, otherwise it is set to `~/.fastai`."
    ]
   },
   {
@@ -524,7 +524,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`untar_data` is a thin wrapper for `FastDownload.get`. It downloads and extracts `url`, by default to subdirectories of `~/.fastai`, and returns the path to the extracted data. Setting the `force_download` flag to 'True' will overwrite any existing copy of the data already present. For an explanation of the `c_key` parameter, see `URLs`."
+    "`untar_data` is a thin wrapper for `FastDownload.get`. It downloads and extracts `url`, by default to subdirectories of `~/.fastai` (see `fastai_cfg` for details), and returns the path to the extracted data. Setting the `force_download` flag to 'True' will overwrite any existing copy of the data already present. For an explanation of the `c_key` parameter, see `URLs`."
    ]
   },
   {

--- a/nbs/04_data.external.ipynb
+++ b/nbs/04_data.external.ipynb
@@ -266,11 +266,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "This is a basic `Config` file that consists of `data`, `model`, `storage` and `archive`. \n",
-    "All future downloads occur at the paths defined in the config file based on the type of download. For example, all future fastai datasets are downloaded to the `data` while all pretrained model weights are download to `model` unless the default download location is updated."
+    "All future downloads occur at the paths defined in the config file based on the type of download. For example, all future fastai datasets are downloaded to the `data` while all pretrained model weights are download to `model` unless the default download location is updated. The parent directory is defined by enviromental variable `FASTAI_HOME` if it exists, otherwise it is set to `~/.fastai`."
    ]
   },
   {


### PR DESCRIPTION
I wanted to change the folder where datasets are being downloaded using `untar_data`, this can be done by changing env. variable FASTAI_HOME (`~/.fastai` by default). This is useful to know since on remote machines `~/.fastai` gets deleted with every restart, hence the need to download data repeatedly. So I'm adding clarity to docstrings. No code changes.