### PR TITLE
Pytorch 2.0 compiler

### DIFF
--- a/fastai/layers.py
+++ b/fastai/layers.py
@@ -68,7 +68,7 @@ class PartialLambda(Lambda):
 @module(full=False)
 def Flatten(self, x):
     "Flatten `x` to a single dimension, e.g. at end of a model. `full` for rank-1 tensor"
-    return TensorBase(x.view(-1) if self.full else x.view(x.size(0), -1))
+    return x.view(-1) if self.full else x.view(x.size(0), -1)
 
 # %% ../nbs/01_layers.ipynb 15
 @module(tensor_cls=TensorBase)

--- a/fastai/layers.py
+++ b/fastai/layers.py
@@ -68,7 +68,7 @@ class PartialLambda(Lambda):
 @module(full=False)
 def Flatten(self, x):
     "Flatten `x` to a single dimension, e.g. at end of a model. `full` for rank-1 tensor"
-    return x.view(-1) if self.full else x.view(x.size(0), -1)
+    return x.view(-1) if self.full else x.view(x.size(0), -1)  # Removed cast to Tensorbase
 
 # %% ../nbs/01_layers.ipynb 15
 @module(tensor_cls=TensorBase)

--- a/nbs/01_layers.ipynb
+++ b/nbs/01_layers.ipynb
@@ -190,7 +190,7 @@
     "@module(full=False)\n",
     "def Flatten(self, x):\n",
     "    \"Flatten `x` to a single dimension, e.g. at end of a model. `full` for rank-1 tensor\"\n",
-    "    return TensorBase(x.view(-1) if self.full else x.view(x.size(0), -1))"
+    "    return x.view(-1) if self.full else x.view(x.size(0), -1)  # Removed cast to Tensorbase"
    ]
   },
   {


### PR DESCRIPTION
Pytorch 2.0 compiled models fail when used with fastai.  Two fixes are necessary to run a basic Convnext model.
fastcore L.__eq__ requires a chack for a function being passed in, and the Flatten layer has to have the Tensorbase type cast removed.  
After this a simple model=torch.compile(model) increases training throughput (it/s) by 50%+.
The compiled models can't have layers frozen/unfrozen, so the train head / train all strategy is not useable, but didn't make much difference in my limited tests.