### PR TITLE
#3901 - Added Guards for Pickling Losses

### DIFF
--- a/nbs/01a_losses.ipynb
+++ b/nbs/01a_losses.ipynb
@@ -832,6 +832,38 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Tests to catch future changes to pickle which cause some loss functions to be 'unpicklable'.\n",
+    "# This causes problems with `Learner.export` as the model can't be pickled with these particular loss funcitons.\n",
+    "\n",
+    "losses_picklable = [\n",
+    " (BCELossFlat(), True),\n",
+    " (BCEWithLogitsLossFlat(), True),\n",
+    " (CombinedLoss(), False),\n",
+    " (CrossEntropyLossFlat(), True),\n",
+    " (DiceLoss(), False),\n",
+    " (FocalLoss(), True),\n",
+    " (FocalLossFlat(), False),\n",
+    " (L1LossFlat(), True),\n",
+    " (LabelSmoothingCrossEntropyFlat(), False),\n",
+    " (LabelSmoothingCrossEntropy(), True),\n",
+    " (MSELossFlat(), True),\n",
+    "]\n",
+    "\n",
+    "for loss, picklable in losses_picklable:\n",
+    "    try:\n",
+    "        pickle.dumps(loss, protocol=2)\n",
+    "    except (pickle.PicklingError, TypeError) as e:\n",
+    "        if picklable:\n",
+    "            # Loss was previously picklable but isn't currently\n",
+    "            raise e"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
Started with guards for current loss functions & python 3.10.8. Will investigate why these losses can't be pickled in further commits