### PR TITLE
Fix layered API image

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ composable building blocks. This way, a user wanting to rewrite part of
 the high-level API or add particular behavior to suit their needs does
 not have to learn how to use the lowest level.
 
-<img alt="Layered API" src="images/layered.png" width="345">
+<img alt="Layered API" src="https://docs.fast.ai/images/layered.png" width="345">
 
 ## Migrating from other libraries
 


### PR DESCRIPTION
fixed image source for layered API image in README.md, so the image is now visible.

Image source could also be `nbs/images/...`