### PR TITLE
Fix `set_categories` call for pandas 1.3+

### DIFF
--- a/nbs/40_tabular.core.ipynb
+++ b/nbs/40_tabular.core.ipynb
@@ -660,7 +660,7 @@
     "                    'd1_date': ['2021-02-09', None, '2020-05-12', '2020-08-14'],\n",
     "                    })\n",
     "df = add_datepart(df, 'd1_date', drop=False)\n",
-    "df['cat1'].cat.set_categories(['xl','l','m','s','xs'], ordered=True, inplace=True)\n",
+    "df['cat1'] = df['cat1'].cat.set_categories(['xl','l','m','s','xs'], ordered=True)\n",
     "cont_names, cat_names = cont_cat_split(df, max_card=0)"
    ]
   },


### PR DESCRIPTION
Pandas 1.3+ removed `inplace=True` for `set_categories`.