### PR TITLE
Fixed format string, Closes #3920

### DIFF
--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -354,6 +354,6 @@ def plot_top_losses(x:TensorImage, y:TensorMask, samples, outs, raws, losses, nr
     for axs,s,o,l in zip(axes, samples, outs, losses):
         imgs = (s[0], s[1], o[0])
         for ax,im,title in zip(axs, imgs, titles):
-            if title=="pred": title += f"; loss = {l:.4f}"
+            if title=="pred": title += f"; loss = {l.item():.4f}"
             im.show(ctx=ax, **kwargs)
             ax.set_title(title)

--- a/nbs/21_vision.learner.ipynb
+++ b/nbs/21_vision.learner.ipynb
@@ -1051,7 +1051,7 @@
     "    for axs,s,o,l in zip(axes, samples, outs, losses):\n",
     "        imgs = (s[0], s[1], o[0])\n",
     "        for ax,im,title in zip(axs, imgs, titles):\n",
-    "            if title==\"pred\": title += f\"; loss = {l:.4f}\"\n",
+    "            if title==\"pred\": title += f\"; loss = {l.item():.4f}\"\n",
     "            im.show(ctx=ax, **kwargs)\n",
     "            ax.set_title(title)"
    ]


### PR DESCRIPTION
Closes https://github.com/fastai/fastai/issues/3920

Had this error today and went ahead to create a PR with the fix suggested by @shrdluk 

```python
interp = SegmentationInterpretation.from_learner(learn)
interp.plot_top_losses(k=2)
```

## After the fix

![image-segmentation](https://github.com/fastai/fastai/assets/2899501/3002b69d-e727-4f62-a478-06e2babc5d90)




---

