### PR TITLE
Support TorchVision's Multi-Weight API

### DIFF
--- a/nbs/21_vision.learner.ipynb
+++ b/nbs/21_vision.learner.ipynb
@@ -17,14 +17,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#|export \n",
+    "#|export\n",
     "from __future__ import annotations\n",
+    "from packaging.version import parse\n",
+    "\n",
     "from fastai.basics import *\n",
     "from fastai.vision.core import *\n",
     "from fastai.vision.data import *\n",
     "from fastai.vision.augment import *\n",
     "from fastai.vision import models\n",
     "\n",
+    "import torchvision\n",
     "try: import timm\n",
     "except ModuleNotFoundError: pass"
    ]
@@ -302,7 +305,7 @@
        "    (ap): AdaptiveAvgPool2d(output_size=1)\n",
        "    (mp): AdaptiveMaxPool2d(output_size=1)\n",
        "  )\n",
-       "  (1): Flatten(full=False)\n",
+       "  (1): fastai.layers.Flatten(full=False)\n",
        "  (2): BatchNorm1d(10, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
        "  (3): Dropout(p=0.25, inplace=False)\n",
        "  (4): Linear(in_features=10, out_features=512, bias=False)\n",
@@ -412,11 +415,11 @@
     "\n",
     "_default_meta    = {'cut':None, 'split':default_split}\n",
     "_xresnet_meta    = {'cut':-4, 'split':_xresnet_split, 'stats':imagenet_stats}\n",
-    "_resnet_meta     = {'cut':-2, 'split':_resnet_split, 'stats':imagenet_stats}\n",
-    "_squeezenet_meta = {'cut':-1, 'split': _squeezenet_split, 'stats':imagenet_stats}\n",
-    "_densenet_meta   = {'cut':-1, 'split':_densenet_split, 'stats':imagenet_stats}\n",
-    "_vgg_meta        = {'cut':-2, 'split':_vgg_split, 'stats':imagenet_stats}\n",
-    "_alexnet_meta    = {'cut':-2, 'split':_alexnet_split, 'stats':imagenet_stats}"
+    "_resnet_meta     = {'cut':-2, 'split':_resnet_split, 'stats':imagenet_stats, 'weights':'DEFAULT'}\n",
+    "_squeezenet_meta = {'cut':-1, 'split': _squeezenet_split, 'stats':imagenet_stats, 'weights':'DEFAULT'}\n",
+    "_densenet_meta   = {'cut':-1, 'split':_densenet_split, 'stats':imagenet_stats, 'weights':'DEFAULT'}\n",
+    "_vgg_meta        = {'cut':-2, 'split':_vgg_split, 'stats':imagenet_stats, 'weights':'DEFAULT'}\n",
+    "_alexnet_meta    = {'cut':-2, 'split':_alexnet_split, 'stats':imagenet_stats, 'weights':'DEFAULT'}"
    ]
   },
   {
@@ -469,11 +472,16 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "def create_vision_model(arch, n_out, pretrained=True, cut=None, n_in=3, init=nn.init.kaiming_normal_, custom_head=None,\n",
+    "def create_vision_model(arch, n_out, pretrained=True, weights=None, cut=None, n_in=3, init=nn.init.kaiming_normal_, custom_head=None,\n",
     "                        concat_pool=True, pool=True, lin_ftrs=None, ps=0.5, first_bn=True, bn_final=False, lin_first=False, y_range=None):\n",
     "    \"Create custom vision architecture\"\n",
     "    meta = model_meta.get(arch, _default_meta)\n",
-    "    model = arch(pretrained=pretrained)\n",
+    "    if parse(torchvision.__version__) >= parse('0.13') and 'weights' in meta:\n",
+    "        if weights is not None and not pretrained:\n",
+    "            warn(f'{pretrained=} but `weights` are set {weights=}. To randomly initialize set `pretrained=False` & `weights=None`')\n",
+    "        model = arch(weights=meta['weights'] if (weights is None and pretrained) else weights)\n",
+    "    else:\n",
+    "        model = arch(pretrained=pretrained)\n",
     "    body = create_body(model, n_in, pretrained, ifnone(cut, meta['cut']))\n",
     "    nf = num_features_model(nn.Sequential(*body.children())) if custom_head is None else None\n",
     "    return add_head(body, nf, n_out, init=init, head=custom_head, concat_pool=concat_pool, pool=pool,\n",
@@ -490,10 +498,12 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "#### create_vision_model\n",
+       "[source](https://github.com/fastai/fastai/blob/master/fastai/vision/learner.py#L165){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
-       ">      create_vision_model (arch, n_out, pretrained=True, cut=None, n_in=3,\n",
-       ">                           init=<functionkaiming_normal_at0x10aac2f70>,\n",
+       "### create_vision_model\n",
+       "\n",
+       ">      create_vision_model (arch, n_out, pretrained=True, weights=None,\n",
+       ">                           cut=None, n_in=3, init=<function kaiming_normal_>,\n",
        ">                           custom_head=None, concat_pool=True, pool=True,\n",
        ">                           lin_ftrs=None, ps=0.5, first_bn=True,\n",
        ">                           bn_final=False, lin_first=False, y_range=None)\n",
@@ -501,7 +511,19 @@
        "Create custom vision architecture"
       ],
       "text/plain": [
-       "<nbdev.showdoc.BasicMarkdownRenderer>"
+       "---\n",
+       "\n",
+       "[source](https://github.com/fastai/fastai/blob/master/fastai/vision/learner.py#L165){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### create_vision_model\n",
+       "\n",
+       ">      create_vision_model (arch, n_out, pretrained=True, weights=None,\n",
+       ">                           cut=None, n_in=3, init=<function kaiming_normal_>,\n",
+       ">                           custom_head=None, concat_pool=True, pool=True,\n",
+       ">                           lin_ftrs=None, ps=0.5, first_bn=True,\n",
+       ">                           bn_final=False, lin_first=False, y_range=None)\n",
+       "\n",
+       "Create custom vision architecture"
       ]
      },
      "execution_count": null,
@@ -524,18 +546,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/jhoward/mambaforge/lib/python3.9/site-packages/torchvision/models/_utils.py:208: UserWarning: The parameter 'pretrained' is deprecated since 0.13 and will be removed in 0.15, please use 'weights' instead.\n",
-      "  warnings.warn(\n",
-      "/Users/jhoward/mambaforge/lib/python3.9/site-packages/torchvision/models/_utils.py:223: UserWarning: Arguments other than a weight enum or `None` for 'weights' are deprecated since 0.13 and will be removed in 0.15. The current behavior is equivalent to passing `weights=ResNet18_Weights.IMAGENET1K_V1`. You can also use `weights=ResNet18_Weights.DEFAULT` to get the most up-to-date weights.\n",
-      "  warnings.warn(msg)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "tst = create_vision_model(models.resnet18, 10, True)\n",
     "tst = create_vision_model(models.resnet18, 10, True, n_in=1)"
@@ -634,7 +645,7 @@
    "source": [
     "#|export\n",
     "@delegates(create_vision_model)\n",
-    "def vision_learner(dls, arch, normalize=True, n_out=None, pretrained=True, \n",
+    "def vision_learner(dls, arch, normalize=True, n_out=None, pretrained=True, weights=None,\n",
     "        # learner args\n",
     "        loss_func=None, opt_func=Adam, lr=defaults.lr, splitter=None, cbs=None, metrics=None, path=None,\n",
     "        model_dir='models', wd=None, wd_bn_bias=False, train_bn=True, moms=(0.95,0.85,0.95),\n",
@@ -653,8 +664,8 @@
     "        if normalize: _timm_norm(dls, cfg, pretrained, n_in)\n",
     "    else:\n",
     "        if normalize: _add_norm(dls, meta, pretrained, n_in)\n",
-    "        model = create_vision_model(arch, n_out, pretrained=pretrained, **model_args)\n",
-    "    \n",
+    "        model = create_vision_model(arch, n_out, pretrained=pretrained, weights=weights, **model_args)\n",
+    "\n",
     "    splitter = ifnone(splitter, meta['split'])\n",
     "    learn = Learner(dls=dls, model=model, loss_func=loss_func, opt_func=opt_func, lr=lr, splitter=splitter, cbs=cbs,\n",
     "                   metrics=metrics, path=path, model_dir=model_dir, wd=wd, wd_bn_bias=wd_bn_bias, train_bn=train_bn, moms=moms)\n",
@@ -668,11 +679,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The model is built from `arch` using the number of final activations inferred from `dls` if possible (otherwise pass a value to `n_out`). It might be `pretrained` and the architecture is cut and split using the default metadata of the model architecture (this can be customized by passing a `cut` or a `splitter`). \n",
+    "The model is built from `arch` using the number of final activations inferred from `dls` if possible (otherwise pass a value to `n_out`). It might be `pretrained` and the architecture is cut and split using the default metadata of the model architecture (this can be customized by passing a `cut` or a `splitter`).\n",
     "\n",
     "If `normalize` and `pretrained` are `True`, this function adds a `Normalization` transform to the `dls` (if there is not already one) using the statistics of the pretrained model. That way, you won't ever forget to normalize your data in transfer learning.\n",
     "\n",
-    "All other arguments are passed to `Learner`."
+    "All other arguments are passed to `Learner`.\n",
+    "\n",
+    "Starting with version 0.13, TorchVision supports [multiple pretrained weights](https://pytorch.org/vision/stable/models.html#initializing-pre-trained-models) for the same model architecture. The <code>vision_learner</code> default of `pretrained=True, weights=None` will use the architecture's default weights, which are currently IMAGENET1K_V2. If you are using an older version of TorchVision or creating a [timm](https://huggingface.co/docs/timm/index) model, setting `weights` will have no effect.\n",
+    "\n",
+    "```python\n",
+    "from torchvision.models import ResNet50_Weights\n",
+    "\n",
+    "# Legacy weights with accuracy 76.130%\n",
+    "vision_learner(models.resnet50, pretrained=True, weights=ResNet50_Weights.IMAGENET1K_V1, ...)\n",
+    "\n",
+    "# New weights with accuracy 80.858%. Strings are also supported.\n",
+    "vision_learner(models.resnet50, pretrained=True, weights='IMAGENET1K_V2', ...)\n",
+    "\n",
+    "# Best available weights (currently an alias for IMAGENET1K_V2).\n",
+    "# Default weights if vision_learner weights isn't set.\n",
+    "vision_learner(models.resnet50, pretrained=True, weights=ResNet50_Weights.DEFAULT, ...)\n",
+    "\n",
+    "# No weights - random initialization\n",
+    "vision_learner(models.resnet50, pretrained=False, weights=None, ...)\n",
+    "```\n",
+    "\n",
+    "The example above shows how to use the new TorchVision 0.13 multi-weight api with <code>vision_learner</code>."
    ]
   },
   {
@@ -700,19 +732,24 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/jhoward/mambaforge/lib/python3.9/site-packages/torchvision/models/_utils.py:223: UserWarning: Arguments other than a weight enum or `None` for 'weights' are deprecated since 0.13 and will be removed in 0.15. The current behavior is equivalent to passing `weights=ResNet34_Weights.IMAGENET1K_V1`. You can also use `weights=ResNet34_Weights.DEFAULT` to get the most up-to-date weights.\n",
-      "  warnings.warn(msg)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#|hide\n",
-    "learn = vision_learner(dls, models.resnet34, loss_func=CrossEntropyLossFlat(), ps=0.25, concat_pool=False)\n",
+    "if parse(torchvision.__version__) >= parse('0.13'):\n",
+    "    from torchvision.models import ResNet34_Weights\n",
+    "    weights = ResNet34_Weights.IMAGENET1K_V1\n",
+    "else:\n",
+    "    weights = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#|hide\n",
+    "learn = vision_learner(dls, models.resnet34, weights=weights, loss_func=CrossEntropyLossFlat(), ps=0.25, concat_pool=False)\n",
     "test_ne(learn.cbs, None)"
    ]
   },
@@ -731,7 +768,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you pass a `str` to `arch`, then a [TIMM](https://fastai.github.io/timmdocs/models) model will be created:"
+    "If you pass a `str` to `arch`, then a [timm](https://huggingface.co/docs/timm/index) model will be created:"
    ]
   },
   {
@@ -752,11 +789,16 @@
    "source": [
     "#|export\n",
     "@delegates(models.unet.DynamicUnet.__init__)\n",
-    "def create_unet_model(arch, n_out, img_size, pretrained=True, cut=None, n_in=3, **kwargs):\n",
+    "def create_unet_model(arch, n_out, img_size, pretrained=True, weights=None, cut=None, n_in=3, **kwargs):\n",
     "    \"Create custom unet architecture\"\n",
     "    meta = model_meta.get(arch, _default_meta)\n",
-    "    model = arch(pretrained=pretrained)\n",
-    "    body = create_body(model, n_in, pretrained, ifnone(cut, meta['cut']))    \n",
+    "    if parse(torchvision.__version__) >= parse('0.13') and 'weights' in meta:\n",
+    "        if weights is not None and not pretrained:\n",
+    "            warn(f'{pretrained=} but `weights` are set {weights=}. To randomly initialize set `pretrained=False` & `weights=None`')\n",
+    "        model = arch(weights=meta['weights'] if (weights is None and pretrained) else weights)\n",
+    "    else:\n",
+    "        model = arch(pretrained=pretrained)\n",
+    "    body = create_body(model, n_in, pretrained, ifnone(cut, meta['cut']))\n",
     "    model = models.unet.DynamicUnet(body, n_out, img_size, **kwargs)\n",
     "    return model"
    ]
@@ -771,38 +813,34 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "#### create_unet_model\n",
+       "[source](https://github.com/fastai/fastai/blob/master/fastai/vision/learner.py#L250){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
-       ">      create_unet_model (arch, n_out, img_size, pretrained=True, cut=None,\n",
-       ">                         n_in=3, blur=False, blur_final=True,\n",
+       "### create_unet_model\n",
+       "\n",
+       ">      create_unet_model (arch, n_out, img_size, pretrained=True, weights=None,\n",
+       ">                         cut=None, n_in=3, blur=False, blur_final=True,\n",
        ">                         self_attention=False, y_range=None, last_cross=True,\n",
-       ">                         bottle=False,\n",
-       ">                         act_cls=<class'torch.nn.modules.activation.ReLU'>,\n",
-       ">                         init=<functionkaiming_normal_at0x10aac2f70>,\n",
-       ">                         norm_type=None)\n",
+       ">                         bottle=False, act_cls=<class\n",
+       ">                         'torch.nn.modules.activation.ReLU'>, init=<function\n",
+       ">                         kaiming_normal_>, norm_type=None)\n",
        "\n",
-       "Create custom unet architecture\n",
-       "\n",
-       "|    | **Type** | **Default** | **Details** |\n",
-       "| -- | -------- | ----------- | ----------- |\n",
-       "| arch |  |  |  |\n",
-       "| n_out |  |  | Argument passed to `DynamicUnet.__init__` |\n",
-       "| img_size |  |  | Argument passed to `DynamicUnet.__init__` |\n",
-       "| pretrained | bool | True |  |\n",
-       "| cut | NoneType | None |  |\n",
-       "| n_in | int | 3 |  |\n",
-       "| blur | bool | False | Argument passed to `DynamicUnet.__init__` |\n",
-       "| blur_final | bool | True | Argument passed to `DynamicUnet.__init__` |\n",
-       "| self_attention | bool | False | Argument passed to `DynamicUnet.__init__` |\n",
-       "| y_range | NoneType | None | Argument passed to `DynamicUnet.__init__` |\n",
-       "| last_cross | bool | True | Argument passed to `DynamicUnet.__init__` |\n",
-       "| bottle | bool | False | Argument passed to `DynamicUnet.__init__` |\n",
-       "| act_cls | type | ReLU | Argument passed to `DynamicUnet.__init__` |\n",
-       "| init | function | kaiming_normal_ | Argument passed to `DynamicUnet.__init__` |\n",
-       "| norm_type | NoneType | None | Argument passed to `DynamicUnet.__init__` |"
+       "Create custom unet architecture"
       ],
       "text/plain": [
-       "<nbdev.showdoc.BasicMarkdownRenderer>"
+       "---\n",
+       "\n",
+       "[source](https://github.com/fastai/fastai/blob/master/fastai/vision/learner.py#L250){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### create_unet_model\n",
+       "\n",
+       ">      create_unet_model (arch, n_out, img_size, pretrained=True, weights=None,\n",
+       ">                         cut=None, n_in=3, blur=False, blur_final=True,\n",
+       ">                         self_attention=False, y_range=None, last_cross=True,\n",
+       ">                         bottle=False, act_cls=<class\n",
+       ">                         'torch.nn.modules.activation.ReLU'>, init=<function\n",
+       ">                         kaiming_normal_>, norm_type=None)\n",
+       "\n",
+       "Create custom unet architecture"
       ]
      },
      "execution_count": null,
@@ -831,25 +869,25 @@
    "source": [
     "#|export\n",
     "@delegates(create_unet_model)\n",
-    "def unet_learner(dls, arch, normalize=True, n_out=None, pretrained=True, config=None,\n",
+    "def unet_learner(dls, arch, normalize=True, n_out=None, pretrained=True, weights=None, config=None,\n",
     "                 # learner args\n",
     "                 loss_func=None, opt_func=Adam, lr=defaults.lr, splitter=None, cbs=None, metrics=None, path=None,\n",
-    "                 model_dir='models', wd=None, wd_bn_bias=False, train_bn=True, moms=(0.95,0.85,0.95), **kwargs):    \n",
+    "                 model_dir='models', wd=None, wd_bn_bias=False, train_bn=True, moms=(0.95,0.85,0.95), **kwargs):\n",
     "    \"Build a unet learner from `dls` and `arch`\"\n",
-    "    \n",
+    "\n",
     "    if config:\n",
     "        warnings.warn('config param is deprecated. Pass your args directly to unet_learner.')\n",
     "        kwargs = {**config, **kwargs}\n",
-    "    \n",
+    "\n",
     "    meta = model_meta.get(arch, _default_meta)\n",
     "    n_in = kwargs['n_in'] if 'n_in' in kwargs else 3\n",
     "    if normalize: _add_norm(dls, meta, pretrained, n_in)\n",
-    "    \n",
+    "\n",
     "    n_out = ifnone(n_out, get_c(dls))\n",
     "    assert n_out, \"`n_out` is not defined, and could not be inferred from data, set `dls.c` or pass `n_out`\"\n",
     "    img_size = dls.one_batch()[0].shape[-2:]\n",
     "    assert img_size, \"image size could not be inferred from data\"\n",
-    "    model = create_unet_model(arch, n_out, img_size, pretrained=pretrained, **kwargs)\n",
+    "    model = create_unet_model(arch, n_out, img_size, pretrained=pretrained, weights=weights, **kwargs)\n",
     "\n",
     "    splitter = ifnone(splitter, meta['split'])\n",
     "    learn = Learner(dls=dls, model=model, loss_func=loss_func, opt_func=opt_func, lr=lr, splitter=splitter, cbs=cbs,\n",
@@ -865,11 +903,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The model is built from `arch` using the number of final filters inferred from `dls` if possible (otherwise pass a value to `n_out`). It might be `pretrained` and the architecture is cut and split using the default metadata of the model architecture (this can be customized by passing a `cut` or a `splitter`). \n",
+    "The model is built from `arch` using the number of final filters inferred from `dls` if possible (otherwise pass a value to `n_out`). It might be `pretrained` and the architecture is cut and split using the default metadata of the model architecture (this can be customized by passing a `cut` or a `splitter`).\n",
     "\n",
     "If `normalize` and `pretrained` are `True`, this function adds a `Normalization` transform to the `dls` (if there is not already one) using the statistics of the pretrained model. That way, you won't ever forget to normalize your data in transfer learning.\n",
     "\n",
-    "All other arguments are passed to `Learner`."
+    "All other arguments are passed to `Learner`.\n",
+    "\n",
+    "<code>unet_learner</code> also supports TorchVision's new multi-weight API via `weights`. See `vision_learner` for more details."
    ]
   },
   {
@@ -1073,13 +1113,6 @@
     "from nbdev import nbdev_export\n",
     "nbdev_export()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR updates `vision_learner` and `unet_learner` to support TorchVision's multi-weight API using the new `weights` argument. The default of `pretrained=True, weights=None` will download the DEFAULT weights from TorchVision, which at the time of this PR are IMAGENET1K_V2.

To randomly initialize a model's weights, users will need to set both `pretrained=False, weights=None`.

If using pre TorchVision 0.13 or timm models setting `weights` will have no effect.