### PR TITLE
Make DataLoader.__init__() respect num_workers

### DIFF
--- a/fastai/data/load.py
+++ b/fastai/data/load.py
@@ -100,9 +100,9 @@ class DataLoader(GetAttr):
             try: n = len(dataset)
             except TypeError: pass
         store_attr('dataset,bs,shuffle,drop_last,indexed,n,pin_memory,timeout,device')
-        self.rng,self.num_workers,self.offs = random.Random(random.randint(0,2**32-1)),1,0
         if sys.platform == "win32" and IN_NOTEBOOK and num_workers > 0: num_workers = 0       
         if sys.platform == "darwin" and num_workers > 0: num_workers = 0       
+        self.rng,self.num_workers,self.offs = random.Random(random.randint(0,2**32-1)),num_workers,0
         self.fake_l = _FakeLoader(self, pin_memory, num_workers, timeout, persistent_workers=persistent_workers,
                                   pin_memory_device=pin_memory_device)
 


### PR DESCRIPTION
fixes #3954 
furthermore, I moved the win32/darwin check earlier, where I think it should be to have any effect.