### PR TITLE
Update 38_tutorial.text.ipynb

### DIFF
--- a/nbs/38_tutorial.text.ipynb
+++ b/nbs/38_tutorial.text.ipynb
@@ -606,7 +606,7 @@
     "\n",
     "A datablock is built by giving the fastai library a bunch of information:\n",
     "\n",
-    "- the types used, through an argument called `blocks`: here we have images and categories, so we pass `TextBlock` and `CategoryBlock`. To inform the library our texts are files in a folder, we use the `from_folder` class method.\n",
+    "- the types used, through an argument called `blocks`: here we have texts and categories, so we pass `TextBlock` and `CategoryBlock`. To inform the library our texts are files in a folder, we use the `from_folder` class method.\n",
     "- how to get the raw items, here our function `get_text_files`.\n",
     "- how to label those items, here with the parent folder.\n",
     "- how to split those items, here with the grandparent folder."


### PR DESCRIPTION
Replaced the word "images" with "texts" in 38_tutorial.text.ipynb as shown: 



![Screenshot (109)](https://github.com/fastai/fastai/assets/54275083/0db35a35-17c6-4afb-ac58-2e01b9ad19c6)
