### PR TITLE
PyTorch 2.1 and Sync Lib

### DIFF
--- a/fastai/metrics.py
+++ b/fastai/metrics.py
@@ -428,7 +428,7 @@ class CorpusBLEUMetric(Metric):
                     c,t = self.get_correct_ngrams(pred, targ, i+1, max_n=self.vocab_sz)
                     if c == 0:
                         smooth_mteval *= 2
-                        c = 1 / smooth_mteval    # exp smoothing, method 3 from https://aclanthology.org/W14-3346/
+                        c = 1 / smooth_mteval    # exp smoothing, method 3 from http://acl2014.org/acl2014/W14-33/pdf/W14-3346.pdf
                     self.corrects[i] += c
                     self.counts[i]   += t
 

--- a/settings.ini
+++ b/settings.ini
@@ -15,8 +15,8 @@ min_python = 3.8
 audience = Developers
 language = English
 requirements = fastdownload>=0.0.5,<2 fastcore>=1.5.29,<1.6 torchvision>=0.11 matplotlib pandas requests pyyaml fastprogress>=0.2.4 pillow>=9.0.0 scikit-learn scipy spacy<4 packaging
-pip_requirements = torch>=1.10,<2.1
-conda_requirements = pytorch>=1.10,<2.1
+pip_requirements = torch>=1.10,<2.2
+conda_requirements = pytorch>=1.10,<2.2
 conda_user = fastai
 dev_requirements = ipywidgets lightning pytorch-ignite transformers sentencepiece tensorboard pydicom catalyst flask_compress captum>=0.4.1 flask wandb kornia scikit-image comet_ml albumentations opencv-python pyarrow ninja timm>=0.9 accelerate>=0.21 ipykernel
 console_scripts = configure_accelerate=fastai.distributed:configure_accelerate


### PR DESCRIPTION
This PR bumps the fastai install requirements to support PyTorch 2.1. It also resyncs the library from c3157c1.

My local testing using the fastai cuda tests and my fastxtend cuda tests showed no errors with PyTorch 2.1. There doesn't seem to be any compatibility changes required. A couple from scratch imagenette test shows training accuracy in the expected range.