### PR TITLE
fixes fastai/fastai#3981 to stop deprecated warning messages

### DIFF
--- a/fastai/torch_core.py
+++ b/fastai/torch_core.py
@@ -260,7 +260,7 @@ defaults.use_cuda = None
 # %% ../nbs/00_torch_core.ipynb 71
 def _has_mps():
     if nested_attr(torch, 'backends.mps.is_available', noop)(): return True
-    return getattr(torch, 'has_mps', False)
+    return nested_attr(torch, 'backends.mps.is_built', False)
 
 def default_device(use=-1):
     "Return or set default device; `use_cuda`: -1 - CUDA/mps if available; True - error if not available; False - CPU"

--- a/nbs/00_torch_core.ipynb
+++ b/nbs/00_torch_core.ipynb
@@ -960,7 +960,7 @@
     "#|export\n",
     "def _has_mps():\n",
     "    if nested_attr(torch, 'backends.mps.is_available', noop)(): return True\n",
-    "    return getattr(torch, 'has_mps', False)\n",
+    "    return nested_attr(torch, 'backends.mps.is_built', False)\n",
     "\n",
     "def default_device(use=-1):\n",
     "    \"Return or set default device; `use_cuda`: -1 - CUDA/mps if available; True - error if not available; False - CPU\"\n",


### PR DESCRIPTION
I have used the current torch.backends.mps.is_built attribute to replace the older has_mps has been deprecated about 6 months ago on this [pytorch commit](https://github.com/pytorch/pytorch/commit/4cfa06f706811e2c3b70289b222461822537bd93)

I have tested on an M1 machine for the positive case should the mps.is_available (line above) return false.  I have also tested this on a x86/nvidia machine and it remove the warning signs.

I have attached here a screenshot on how it can look like on google collab when its not fixed.
<img width="1011" alt="Screenshot 2023-12-15 at 15 22 35" src="https://github.com/fastai/fastai/assets/751589/63769c9b-4cf4-42e3-9800-f3ecc788f7b7">
