### PR TITLE
Fix max_n for tabular data show_batch function

### DIFF
--- a/fastai/tabular/core.py
+++ b/fastai/tabular/core.py
@@ -341,7 +341,7 @@ class ReadTabBatch(ItemTransform):
 # %% ../../nbs/40_tabular.core.ipynb 93
 @typedispatch
 def show_batch(x: Tabular, y, its, max_n=10, ctxs=None):
-    x.show()
+    x.show(max_n=max_n)
 
 # %% ../../nbs/40_tabular.core.ipynb 94
 @delegates()

--- a/nbs/40_tabular.core.ipynb
+++ b/nbs/40_tabular.core.ipynb
@@ -1922,7 +1922,7 @@
     "#|export\n",
     "@typedispatch\n",
     "def show_batch(x: Tabular, y, its, max_n=10, ctxs=None):\n",
-    "    x.show()"
+    "    x.show(max_n=max_n)"
    ]
   },
   {


### PR DESCRIPTION
## Why

`show_batch` for tabular data doesn't respect the `max_n` parameter.

## Reproduce the error:

```python
import numpy as np
import pandas as pd
from fastai.tabular.all import TabularPandas

df = pd.DataFrame({"A": [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20], "ys": np.ones(20)})
tp = TabularPandas(df, cat_names=[], cont_names=["A"], y_names="ys")
dls = tp.dataloaders(bs=5)
dls.show_batch(max_n=3)
 # 5 rows are shown
```