### PR TITLE
Update Requirements for PyTorch 2.2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,16 +4,16 @@ channels:
 - pytorch
 - defaults
 dependencies:
-- fastcore>=1.3.8
-- torchvision>=0.8
+- fastcore>=1.5.29
+- torchvision>=0.11
 - matplotlib
 - pandas>=1.0.0
 - requests
 - pyyaml
 - fastprogress>=0.2.4
-- pillow>=6.0.0
+- pillow>=9.0.0
 - scikit-learn
 - scipy
 - spacy
-- pytorch>=1.7.0
+- pytorch>=1.10.0
 - fastdownload

--- a/settings.ini
+++ b/settings.ini
@@ -15,8 +15,8 @@ min_python = 3.8
 audience = Developers
 language = English
 requirements = fastdownload>=0.0.5,<2 fastcore>=1.5.29,<1.6 torchvision>=0.11 matplotlib pandas requests pyyaml fastprogress>=0.2.4 pillow>=9.0.0 scikit-learn scipy spacy<4 packaging
-pip_requirements = torch>=1.10,<2.2
-conda_requirements = pytorch>=1.10,<2.2
+pip_requirements = torch>=1.10,<2.3
+conda_requirements = pytorch>=1.10,<2.3
 conda_user = fastai
 dev_requirements = ipywidgets lightning pytorch-ignite transformers sentencepiece tensorboard pydicom catalyst flask_compress captum>=0.4.1 flask wandb kornia scikit-image comet_ml albumentations opencv-python pyarrow ninja timm>=0.9 accelerate>=0.21 ipykernel
 console_scripts = configure_accelerate=fastai.distributed:configure_accelerate


### PR DESCRIPTION
All fastai cuda tests pass locally with PyTorch 2.2.  A five epoch Imagenette training run appears to be within the expected range.

I also updated the conda environment to match the settings.ini requirements.