### PR TITLE
PR: automatically resumable learner

### DIFF
--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -9,7 +9,7 @@ import pickle,threading
 from collections.abc import MutableSequence
 
 # %% auto 0
-__all__ = ['replacing_yield', 'mk_metric', 'save_model', 'load_model', 'SkipToEpoch', 'Learner', 'before_batch_cb',
+__all__ = ['replacing_yield', 'mk_metric', 'save_model', 'load_model', 'SkipToIter', 'Learner', 'before_batch_cb',
            'load_learner', 'Metric', 'AvgMetric', 'AvgLoss', 'AvgSmoothLoss', 'ValueMetric', 'Recorder', 'CastToTensor',
            'CancelBackwardException', 'CancelStepException', 'CancelFitException', 'CancelEpochException',
            'CancelTrainException', 'CancelValidException', 'CancelBatchException']
@@ -35,21 +35,25 @@ def mk_metric(m):
     return m if isinstance(m, Metric) else AvgMetric(m)
 
 # %% ../nbs/13a_learner.ipynb 15
-def save_model(file, model, opt, with_opt=True, pickle_protocol=2, **torch_save_kwargs):
-    "Save `model` to `file` along with `opt` (if available, and if `with_opt`)"
+def save_model(file, model, opt, iteration, with_opt = True, with_iter = True, pickle_protocol = 2, **torch_save_kwargs):
+    "Save `model` to `file` along with `opt` (if available, and if `with_opt`), and iteration information (epoch and iteration) (if available, and if `with_epoch_iter`. This allows automatically resumable training)"
+    if with_iter: assert with_opt, f'Optimizer state must be saved for epoch/iteration resumable training. Set with_opt= True  if with_epoch_iter=True. '
+    
     if rank_distrib(): return # don't save if child proc
     if opt is None: with_opt=False
     state = get_model(model).state_dict()
     if with_opt: state = {'model': state, 'opt':opt.state_dict()}
+    if with_iter: state['iter'] = iteration
     torch.save(state, file, pickle_protocol=pickle_protocol, **torch_save_kwargs)
-
+        
 # %% ../nbs/13a_learner.ipynb 17
-def load_model(file, model, opt, with_opt=True, device=None, strict=True, **torch_load_kwargs):
-    "Load `model` from `file` along with `opt` (if available, and if `with_opt`)"
+def load_model(file, model, opt, with_opt=True, with_iter = True, device=None, strict=True, **torch_load_kwargs):
+    "Load `model` from `file` along with `opt` (if available, and if `with_opt`), and iteration information (epoch and iteration, saved as a dictionary in self.resumeIter) (if available, and if `with_epoch_iter`. This allows automatically resumable training. "
     if isinstance(device, int): device = torch.device('cuda', device)
     elif device is None: device = 'cpu'
     state = torch.load(file, map_location=device, **torch_load_kwargs)
-    hasopt = set(state)=={'model', 'opt'}
+    hasopt = 'opt' in state
+    hasiter = 'iter' in state
     model_state = state['model'] if hasopt else state
     get_model(model).load_state_dict(model_state, strict=strict)
     if hasopt and with_opt:
@@ -57,6 +61,13 @@ def load_model(file, model, opt, with_opt=True, device=None, strict=True, **torc
         except:
             if with_opt: warn("Could not load the optimizer state.")
     elif with_opt: warn("Saved file doesn't contain an optimizer state.")
+    if hasiter and with_iter:
+        try: 
+            return state['iter'] 
+            if with_iter: warn("Could not load the iteration state.")
+    elif with_iter: warn("Saved file doesn't contain iteration state.")
+    
+    
 
 # %% ../nbs/13a_learner.ipynb 19
 def _try_concat(o):
@@ -73,17 +84,21 @@ class _ConstantFunc():
     def __init__(self, o): self.o = o
     def __call__(self, *args, **kwargs): return self.o
 
-# %% ../nbs/13a_learner.ipynb 22
-class SkipToEpoch(Callback):
-    "Skip training up to `epoch`"
+class SkipToIter(Callback):
+    "Skip training up to   `iter`th iteration in `epoch`th epoch"
     order = 70
     
-    def __init__(self, epoch:int):
-        self._skip_to = epoch
+    def __init__(self, epoch:int, iter: int = 0):
+        self._skip_to_epoch = epoch
+        self._skip_to_iter = iter
 
     def before_epoch(self):
-        if self.epoch < self._skip_to:
+        if self.epoch < self._skip_to_epoch:
             raise CancelEpochException
+        
+    def before_batch(self):
+        if self.iter < self._skip_to_iter:
+            raise CancelBatchException
 
 # %% ../nbs/13a_learner.ipynb 24
 _loop = ['Start Fit', 'before_fit', 'Start Epoch Loop', 'before_epoch', 'Start Train', 'before_train',
@@ -252,9 +267,15 @@ class Learner(GetAttr):
             self.epoch=epoch
             self._with_events(self._do_epoch, 'epoch', CancelEpochException)
 
-    def fit(self, n_epoch, lr=None, wd=None, cbs=None, reset_opt=False, start_epoch=0):
-        if start_epoch != 0:
-            cbs = L(cbs) + SkipToEpoch(start_epoch)
+    def fit(self, n_epoch, lr=None, wd=None, cbs=None, reset_opt=False, start_epoch=0, start_iter = 0):
+        
+        if hasattr(self, 'resumeIter'): #resumeIter only exists if a checkpoint has been loaded with iteration info
+            start_epoch = start_epoch or self.resumeIter['epoch']
+            start_iter = start_iter or self.resumeIter['iter']
+            
+        if start_epoch != 0 or start_iter != 0:
+            cbs = L(cbs) + SkipToIter(start_epoch, start_iter)
+        
         with self.added_cbs(cbs):
             if reset_opt or not self.opt: self.create_opt()
             if wd is None: wd = self.wd
@@ -262,6 +283,9 @@ class Learner(GetAttr):
             self.opt.set_hypers(lr=self.lr if lr is None else lr)
             self.n_epoch = n_epoch
             self._with_events(self._do_fit, 'fit', CancelFitException, self._end_cleanup)
+            
+            
+    
 
     def _end_cleanup(self): self.dl,self.xb,self.yb,self.pred,self.loss = None,(None,),(None,),None,None
     def __enter__(self): self(_before_epoch); return self
@@ -405,8 +429,12 @@ def before_batch_cb(f):
 def save(self:Learner, file, **kwargs):
     "Save model and optimizer state (if `with_opt`) to `self.path/self.model_dir/file`"
     file = join_path_file(file, self.path/self.model_dir, ext='.pth')
-    save_model(file, self.model, getattr(self,'opt',None), **kwargs)
+    
+    iteration = {'epoch':getattr(self,'epoch',0), 'iter': getattr(self,'iter',0) }
+    
+    save_model(file, self.model, getattr(self,'opt',None), iteration, **kwargs)
     return file
+
 
 # %% ../nbs/13a_learner.ipynb 98
 @patch
@@ -417,7 +445,8 @@ def load(self:Learner, file, device=None, **kwargs):
     if self.opt is None: self.create_opt()
     file = join_path_file(file, self.path/self.model_dir, ext='.pth')
     distrib_barrier()
-    load_model(file, self.model, self.opt, device=device, **kwargs)
+    iteration = load_model(file, self.model, self.opt, device=device, **kwargs)
+    if iteration: self.resumeIter = iteration
     return self
 
 # %% ../nbs/13a_learner.ipynb 102


### PR DESCRIPTION
# TLDR
This PR introduces granular resumable training in `Learner` class. Specifically, the Learner can resume training from the exact epoch and iteration that a checkpoint was saved at. The Checkpoint file saves this info (along with model and optimizer states). This way, when a user invokes `Learner.load`, the Learner automatically resumes training from the last "saved" `n_epoch` and `n_iter`.  

In Summary

1. `Learner.save` saves the iteration info along with `model` and `opt` states. Specifically, the epoch (`Learner.epoch`) and the iteration (`Learner.iter`) in the epoch.  Similarly, `Learner.load` checks for saved `epoch` and `iter`. 
2. If `Learner.load` is invoked, `Learner.fit` retrieves info on which `epoch` and `iter` to resume training on. 
3. `SkipToEpoch` has been modified to `SkipToIter`, and skips training to the `iter`th iteration in the `epoch`th epoch.  

 # Problem Statement
 I think that the Learner class is designed for mini-scale training on a local GPU, and does not support large-scale training without having to write a lot of custom code for housekeeping. 

(FYI, I am currently training an LLM using fastai)

1. One big problem I faced was that I could not resume the training if my hardware suddenly failed. Sure, there's the `start_epoch` argument in `Learner.fit`. But most likely for large-scale training (eg for LLMs), an epoch itself is EXTREMELY large, and it makes more sense to be able to resume from a specific iteration in a specific epoch. 

2. Ideally, the learner should automatically resume training from the last saved epoch and iteration. Therefore the checkpoint file should save the current epoch and iter info along with model and opt states. Learn.fit should automatically resume from this iteration, UNLESS the user specifically specifies `start_epoch` (and by extension, `start_iter`) in `Learner.fit`. 

# Code
### Note: Please suggest improvement in the code structure to make the code cleaner and style-compliant. I'm writing obvious issues that MAY be problematic. Also, let me know what all unit tests, jupyter notebook experiments and documentations need to be written. I'll be happy to spend more time on it. 

1. Learner `save` patch function passes an additional dictionary containing current `epoch` and `iter`, to the save_model function, IF `with_iter` is True. If `with_iter` is True, `with_opt` must also be True. 
2. `save_model` saves a dictionary (using torch.save) containing `model`, `opt` and `iter` (where iter is the dictionary containing epoch and iter info)
3. Learner `load` patch function saves iter info (dictionary) in a new Learner variable `Learner.resumeIter`.
4. `load_model` function not only loads model and opt states, but also returns iter info to the above load function. 
NOTE: not sure how to modify Learner.epoch and Learner.iter by reference. So I had to introduce return function. Please suggest a better way. 
5. `Learner.load` checks for self.resumeIter variable, and initializes `SkiptoIter` (modified `SkipToEpoch`) Callback. However, `start_epoch` and a new argument `start_iter` override the loaded epoch and iter values. 
6. `SkipToIter` essentially adds a `before_batch` methods apart from the  `before_epoch` method, which ensures that Training is skipped until the desired iteration. 
