### PR TITLE
Add quoting parameter to from_csv() for Text and Vision DataLoaders

### DIFF
--- a/fastai/text/data.py
+++ b/fastai/text/data.py
@@ -278,9 +278,9 @@ class TextDataLoaders(DataLoaders):
         return cls.from_dblock(dblock, df, path=path, seq_len=seq_len, **kwargs)
 
     @classmethod
-    def from_csv(cls, path, csv_fname='labels.csv', header='infer', delimiter=None, **kwargs):
+    def from_csv(cls, path, csv_fname='labels.csv', header='infer', delimiter=None, quoting=csv.QUOTE_MINIMAL, **kwargs):
         "Create from `csv` file in `path/csv_fname`"
-        df = pd.read_csv(Path(path)/csv_fname, header=header, delimiter=delimiter)
+        df = pd.read_csv(Path(path)/csv_fname, header=header, delimiter=delimiter, quoting=quoting)
         return cls.from_df(df, path=path, **kwargs)
 
 TextDataLoaders.from_csv = delegates(to=TextDataLoaders.from_df)(TextDataLoaders.from_csv)

--- a/fastai/vision/data.py
+++ b/fastai/vision/data.py
@@ -178,9 +178,9 @@ class ImageDataLoaders(DataLoaders):
         return cls.from_dblock(dblock, df, path=path, **kwargs)
 
     @classmethod
-    def from_csv(cls, path, csv_fname='labels.csv', header='infer', delimiter=None, **kwargs):
+    def from_csv(cls, path, csv_fname='labels.csv', header='infer', delimiter=None, quoting=csv.QUOTE_MINIMAL, **kwargs):
         "Create from `path/csv_fname` using `fn_col` and `label_col`"
-        df = pd.read_csv(Path(path)/csv_fname, header=header, delimiter=delimiter)
+        df = pd.read_csv(Path(path)/csv_fname, header=header, delimiter=delimiter, quoting=quoting)
         return cls.from_df(df, path=path, **kwargs)
 
     @classmethod

--- a/nbs/08_vision.data.ipynb
+++ b/nbs/08_vision.data.ipynb
@@ -464,7 +464,7 @@
     "        return cls.from_dblock(dblock, df, path=path, **kwargs)\n",
     "\n",
     "    @classmethod\n",
-    "    def from_csv(cls, path, csv_fname='labels.csv', header='infer', delimiter=None, **kwargs):\n",
+    "    def from_csv(cls, path, csv_fname='labels.csv', header='infer', delimiter=None, quoting=csv.QUOTE_MINIMAL, **kwargs):\n",
     "        \"Create from `path/csv_fname` using `fn_col` and `label_col`\"\n",
     "        df = pd.read_csv(Path(path)/csv_fname, header=header, delimiter=delimiter)\n",
     "        return cls.from_df(df, path=path, **kwargs)\n",

--- a/nbs/31_text.data.ipynb
+++ b/nbs/31_text.data.ipynb
@@ -1174,7 +1174,7 @@
     "        return cls.from_dblock(dblock, df, path=path, seq_len=seq_len, **kwargs)\n",
     "\n",
     "    @classmethod\n",
-    "    def from_csv(cls, path, csv_fname='labels.csv', header='infer', delimiter=None, **kwargs):\n",
+    "    def from_csv(cls, path, csv_fname='labels.csv', header='infer', delimiter=None, quoting=csv.QUOTE_MINIMAL, **kwargs):\n",
     "        \"Create from `csv` file in `path/csv_fname`\"\n",
     "        df = pd.read_csv(Path(path)/csv_fname, header=header, delimiter=delimiter)\n",
     "        return cls.from_df(df, path=path, **kwargs)\n",


### PR DESCRIPTION
I was running into errors trying to import a dataset, and the cause ended up being that it was inferring quoting in a dataset that did not use quoting. I have added a parameter to the from_csv() methods for TextDataLoaders and VisionDataLoaders in order to accommodate this situation.