### PR TITLE
Support PyTorch 2.3

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -15,8 +15,8 @@ min_python = 3.8
 audience = Developers
 language = English
 requirements = fastdownload>=0.0.5,<2 fastcore>=1.5.29,<1.6 torchvision>=0.11 matplotlib pandas requests pyyaml fastprogress>=0.2.4 pillow>=9.0.0 scikit-learn scipy spacy<4 packaging
-pip_requirements = torch>=1.10,<2.3
-conda_requirements = pytorch>=1.10,<2.3
+pip_requirements = torch>=1.10,<2.4
+conda_requirements = pytorch>=1.10,<2.4
 conda_user = fastai
 dev_requirements = ipywidgets lightning pytorch-ignite transformers sentencepiece tensorboard pydicom catalyst flask_compress captum>=0.4.1 flask wandb kornia scikit-image comet_ml albumentations opencv-python pyarrow ninja timm>=0.9 accelerate>=0.21 ipykernel
 console_scripts = configure_accelerate=fastai.distributed:configure_accelerate


### PR DESCRIPTION
It appears that no changes are needed for PyTorch 2.3, all tests pass as does an imagenette spot training run.