### PR TITLE
Added support for model containers other than nn.Sequential in vision_learner

### DIFF
--- a/fastai/vision/learner.py
+++ b/fastai/vision/learner.py
@@ -149,18 +149,18 @@ model_meta = {
     models.alexnet:{**_alexnet_meta}}
 
 # %% ../../nbs/21_vision.learner.ipynb 30
-def add_head(body, nf, n_out, init=nn.init.kaiming_normal_, head=None, concat_pool=True, pool=True,
+def add_head(body, nf, n_out, init=nn.init.kaiming_normal_, model_container=nn.Sequential, head=None, concat_pool=True, pool=True,
                 lin_ftrs=None, ps=0.5, first_bn=True, bn_final=False, lin_first=False, y_range=None):
     "Add a head to a vision body"
     if head is None:
         head = create_head(nf, n_out, concat_pool=concat_pool, pool=pool,
                            lin_ftrs=lin_ftrs, ps=ps, first_bn=first_bn, bn_final=bn_final, lin_first=lin_first, y_range=y_range)
-    model = nn.Sequential(body, head)
+    model = model_container(body, head)
     if init is not None: apply_init(model[1], init)
     return model
 
 # %% ../../nbs/21_vision.learner.ipynb 31
-def create_vision_model(arch, n_out, pretrained=True, weights=None, cut=None, n_in=3, init=nn.init.kaiming_normal_, custom_head=None,
+def create_vision_model(arch, n_out, pretrained=True, weights=None, cut=None, n_in=3, init=nn.init.kaiming_normal_, model_container=nn.Sequential, custom_head=None,
                         concat_pool=True, pool=True, lin_ftrs=None, ps=0.5, first_bn=True, bn_final=False, lin_first=False, y_range=None):
     "Create custom vision architecture"
     meta = model_meta.get(arch, _default_meta)
@@ -172,7 +172,7 @@ def create_vision_model(arch, n_out, pretrained=True, weights=None, cut=None, n_
         model = arch(pretrained=pretrained)
     body = create_body(model, n_in, pretrained, ifnone(cut, meta['cut']))
     nf = num_features_model(nn.Sequential(*body.children())) if custom_head is None else None
-    return add_head(body, nf, n_out, init=init, head=custom_head, concat_pool=concat_pool, pool=pool,
+    return add_head(body, nf, n_out, init=init, model_container=model_container, head=custom_head, concat_pool=concat_pool, pool=pool,
                     lin_ftrs=lin_ftrs, ps=ps, first_bn=first_bn, bn_final=bn_final, lin_first=lin_first, y_range=y_range)
 
 # %% ../../nbs/21_vision.learner.ipynb 35
@@ -185,13 +185,13 @@ class TimmBody(nn.Module):
     def forward(self,x): return self.model.forward_features(x) if self.needs_pool else self.model(x)
 
 # %% ../../nbs/21_vision.learner.ipynb 36
-def create_timm_model(arch, n_out, cut=None, pretrained=True, n_in=3, init=nn.init.kaiming_normal_, custom_head=None,
+def create_timm_model(arch, n_out, cut=None, pretrained=True, n_in=3, init=nn.init.kaiming_normal_, model_container=nn.Sequential, custom_head=None,
                      concat_pool=True, pool=True, lin_ftrs=None, ps=0.5, first_bn=True, bn_final=False, lin_first=False, y_range=None, **kwargs):
     "Create custom architecture using `arch`, `n_in` and `n_out` from the `timm` library"
     model = timm.create_model(arch, pretrained=pretrained, num_classes=0, in_chans=n_in, **kwargs)
     body = TimmBody(model, pretrained, None, n_in)
     nf = body.model.num_features
-    res = add_head(body, nf, n_out, init=init, head=custom_head, concat_pool=concat_pool, pool=body.needs_pool,
+    res = add_head(body, nf, n_out, init=init, model_container=model_container, head=custom_head, concat_pool=concat_pool, pool=body.needs_pool,
                    lin_ftrs=lin_ftrs, ps=ps, first_bn=first_bn, bn_final=bn_final, lin_first=lin_first, y_range=y_range)
     return res,model.default_cfg
 
@@ -219,13 +219,13 @@ def vision_learner(dls, arch, normalize=True, n_out=None, pretrained=True, weigh
         loss_func=None, opt_func=Adam, lr=defaults.lr, splitter=None, cbs=None, metrics=None, path=None,
         model_dir='models', wd=None, wd_bn_bias=False, train_bn=True, moms=(0.95,0.85,0.95),
         # model & head args
-        cut=None, init=nn.init.kaiming_normal_, custom_head=None, concat_pool=True, pool=True,
+        cut=None, init=nn.init.kaiming_normal_, model_container=nn.Sequential, custom_head=None, concat_pool=True, pool=True,
         lin_ftrs=None, ps=0.5, first_bn=True, bn_final=False, lin_first=False, y_range=None, **kwargs):
     "Build a vision learner from `dls` and `arch`"
     if n_out is None: n_out = get_c(dls)
     assert n_out, "`n_out` is not defined, and could not be inferred from data, set `dls.c` or pass `n_out`"
     meta = model_meta.get(arch, _default_meta)
-    model_args = dict(init=init, custom_head=custom_head, concat_pool=concat_pool, pool=pool, lin_ftrs=lin_ftrs, ps=ps,
+    model_args = dict(init=init, model_container=model_container, custom_head=custom_head, concat_pool=concat_pool, pool=pool, lin_ftrs=lin_ftrs, ps=ps,
                       first_bn=first_bn, bn_final=bn_final, lin_first=lin_first, y_range=y_range, **kwargs)
     n_in = kwargs['n_in'] if 'n_in' in kwargs else 3
     if isinstance(arch, str):


### PR DESCRIPTION
Previously, when calling vision_learner, the only possible option was to create a nn.Sequential container with 'body' and 'head'. Now I have added the argument 'model_container' to support the use of custom containers, like the 'SiameseModel' in the ([tutorials](https://docs.fast.ai/tutorial.siamese.html#the-model)). The default option it's still nn.Sequential.