### PR TITLE
Fix FillMissing processor by removing inplace=True

### DIFF
--- a/fastai/tabular/core.py
+++ b/fastai/tabular/core.py
@@ -311,7 +311,7 @@ class FillMissing(TabularProc):
         for n in missing.any()[missing.any()].keys():
             assert n in self.na_dict, f"nan values in `{n}` but not in setup training set"
         for n in self.na_dict.keys():
-            to[n].fillna(self.na_dict[n], inplace=True)
+            to[n] = to[n].fillna(self.na_dict[n])
             if self.add_col:
                 to.loc[:,n+'_na'] = missing[n]
                 if n+'_na' not in to.cat_names: to.cat_names.append(n+'_na')

--- a/tests/test_tabular_core.py
+++ b/tests/test_tabular_core.py
@@ -1,0 +1,27 @@
+import pandas as pd
+from fastai.tabular.core import FillMissing, TabularPandas
+
+def test_fillna():
+    # Mock data
+    df = pd.DataFrame({"a": [1, None, 3], "b": [4, 5, None]})
+    na_dict = {"a": 0, "b": -1}
+    
+    # Initialize TabularPandas with appropriate columns
+    tab_pandas = TabularPandas(
+        df, 
+        procs=[],  # No preprocessing steps required
+        cont_names=["a", "b"], 
+        cat_names=[],
+        y_names=[]
+    )
+    
+    # Initialize FillMissing
+    fill_missing = FillMissing(add_col=False)
+    fill_missing.na_dict = na_dict  # Manually set the na_dict for testing
+    
+    # Apply the transformation
+    fill_missing.encodes(tab_pandas)
+
+    # Check results
+    assert (tab_pandas["a"] == [1, 0, 3]).all()
+    assert (tab_pandas["b"] == [4, 5, -1]).all()


### PR DESCRIPTION
### Issue:
- The `FillMissing` processor in `tabular.core` raised a warning due to the deprecated `inplace=True` in Pandas.
- This caused compatibility issues with recent Pandas versions.

### Fix:
- Replaced `inplace=True` with reassignment in the `FillMissing` processor.
- Updated `FillMissing` to work with TabularPandas objects and tested the behavior.

### Test:
- Added a new test in `tests/test_tabular_core.py` to validate the `FillMissing` functionality.
- Verified that missing values are filled correctly in continuous columns.