### PR TITLE
weblink not working #4053

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Colab](https://colab.research.google.com/). In fact, every page of this
 documentation is also available as an interactive notebook - click “Open
 in colab” at the top of any page to open it (be sure to change the Colab
 runtime to “GPU” to have it run fast!) See the fast.ai documentation on
-[Using Colab](https://course.fast.ai/start_colab) for more information.
+[Using Colab](https://course.fast.ai/Resources/book.html#colab) for more information.
 
 You can install fastai on your own machines with conda (highly
 recommended), as long as you’re running Linux or Windows (NB: Mac is not


### PR DESCRIPTION
1. changed the colab link from (https://course.fast.ai/start_colab) -> (https://course.fast.ai/Resources/book.html#colab)