### PR TITLE
Updated install instructions for conda in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ miniforge). First install PyTorch using the conda line shown
 [here](https://pytorch.org/get-started/locally/), and then run:
 
 ``` bash
-conda install -c fastai fastai
+conda install fastai::fastai
 ```
 
 To install with pip, use: `pip install fastai`.


### PR DESCRIPTION
The old instructions (`conda install -c fastai fastai`) installs version 2.1.10 of fast.ai instead of the latest one. To install the latest version, `conda install fastai::fastai `should be used.

Adding the PR, because this has been an issue for me on a couple of VM installs already and I was recently reminded of it. The old version will lead to issues with torch imports in xresnet.py and the pin_memory_device issue mentioned here: https://github.com/fastai/fastai/issues/3996 which could be closed after this is merged.