### PR TITLE
get rid of inplace operation and warning

### DIFF
--- a/fastai/tabular/core.py
+++ b/fastai/tabular/core.py
@@ -311,7 +311,6 @@ class FillMissing(TabularProc):
         for n in missing.any()[missing.any()].keys():
             assert n in self.na_dict, f"nan values in `{n}` but not in setup training set"
         for n in self.na_dict.keys():
-            #to[n].fillna(self.na_dict[n], inplace=True)
             to[n] = to[n].fillna(self.na_dict[n])
             if self.add_col:
                 to.loc[:,n+'_na'] = missing[n]


### PR DESCRIPTION
Fixes #4043

I tried to make the change in the notebook but ran into a Module Not Found error (get_embeddings) . I couldn't figure out how to fix that so here's the change directly in the py file.