### PR TITLE
Fix #4072 untar_data() ignores provided base

### DIFF
--- a/fastai/data/external.py
+++ b/fastai/data/external.py
@@ -131,8 +131,14 @@ def untar_data(
     data:Path=None, # Optional override for `Config`'s `data` key
     c_key:str='data', # Key in `Config` where to extract file
     force_download:bool=False, # Setting to `True` will overwrite any existing copy of data
-    base:str='~/.fastai' # Directory containing config file and base of relative paths
+    base:str=None # Directory containing config file and base of relative paths
 ) -> Path: # Path to extracted file(s)
     "Download `url` using `FastDownload.get`"
-    d = FastDownload(fastai_cfg(), module=fastai.data, archive=archive, data=data, base=base)
+    cfg = None
+    if base is None:
+        cfg = fastai_cfg()
+        # A base must be provided as FastDownload initializes a Path with it even
+        # though the config provided is ultimately used instead.
+        base = '~/.fastai'
+    d = FastDownload(cfg, module=fastai.data, archive=archive, data=data, base=base)
     return d.get(url, force=force_download, extract_key=c_key)

--- a/nbs/04_data.external.ipynb
+++ b/nbs/04_data.external.ipynb
@@ -513,10 +513,16 @@
     "    data:Path=None, # Optional override for `Config`'s `data` key\n",
     "    c_key:str='data', # Key in `Config` where to extract file\n",
     "    force_download:bool=False, # Setting to `True` will overwrite any existing copy of data\n",
-    "    base:str='~/.fastai' # Directory containing config file and base of relative paths\n",
+    "    base:str=None # Directory containing config file and base of relative paths\n",
     ") -> Path: # Path to extracted file(s)\n",
     "    \"Download `url` using `FastDownload.get`\"\n",
-    "    d = FastDownload(fastai_cfg(), module=fastai.data, archive=archive, data=data, base=base)\n",
+    "    cfg = None\n",
+    "    if base is None:\n",
+    "        cfg = fastai_cfg()\n",
+    "        # A base must be provided as FastDownload initializes a Path with it even\n",
+    "        # though the config provided is ultimately used instead.\n",
+    "        base = '~/.fastai'\n",
+    "    d = FastDownload(cfg, module=fastai.data, archive=archive, data=data, base=base)\n",
     "    return d.get(url, force=force_download, extract_key=c_key)"
    ]
   },


### PR DESCRIPTION
Updated untar_data() to pass a None config to FastDownload when an overridden base is provided. FastDownload _always_ uses a provided config object and ignores base if both are given.