### PR TITLE
Add support for PyTorch 2.6

### DIFF
--- a/fastai/data/load.py
+++ b/fastai/data/load.py
@@ -22,11 +22,11 @@ def _wif(worker_id):
 
 class _FakeLoader:
     def _fn_noops(self, x=None, *args, **kwargs): return x
-    
-    _IterableDataset_len_called,_auto_collation,collate_fn,drop_last = None,False,_fn_noops,False
+
+    _IterableDataset_len_called,_auto_collation,collate_fn,drop_last,in_order = None,False,_fn_noops,False,True
     _index_sampler,generator,prefetch_factor,_get_shared_seed  = Inf.count,None,2,noop
     dataset_kind = _dataset_kind = _DatasetKind.Iterable
-    
+
     def __init__(self, d, pin_memory, num_workers, timeout, persistent_workers,pin_memory_device):
         self.dataset,self.default,self.worker_init_fn,self.pin_memory_device = self,d,_wif,pin_memory_device
         store_attr('d,pin_memory,num_workers,timeout,persistent_workers,pin_memory_device')

--- a/nbs/02_data.load.ipynb
+++ b/nbs/02_data.load.ipynb
@@ -92,11 +92,11 @@
     "\n",
     "class _FakeLoader:\n",
     "    def _fn_noops(self, x=None, *args, **kwargs): return x\n",
-    "    \n",
-    "    _IterableDataset_len_called,_auto_collation,collate_fn,drop_last = None,False,_fn_noops,False\n",
+    "\n",
+    "    _IterableDataset_len_called,_auto_collation,collate_fn,drop_last,in_order = None,False,_fn_noops,False,True\n",
     "    _index_sampler,generator,prefetch_factor,_get_shared_seed  = Inf.count,None,2,noop\n",
     "    dataset_kind = _dataset_kind = _DatasetKind.Iterable\n",
-    "    \n",
+    "\n",
     "    def __init__(self, d, pin_memory, num_workers, timeout, persistent_workers,pin_memory_device):\n",
     "        self.dataset,self.default,self.worker_init_fn,self.pin_memory_device = self,d,_wif,pin_memory_device\n",
     "        store_attr('d,pin_memory,num_workers,timeout,persistent_workers,pin_memory_device')\n",
@@ -703,18 +703,9 @@
    "metadata": {},
    "outputs": [
     {
-     "ename": "AssertionError",
-     "evalue": "!=:\n[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]\n[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "File \u001b[0;32m<timed eval>:1\u001b[0m\n",
-      "File \u001b[0;32m~/git/fastcore/fastcore/test.py:73\u001b[0m, in \u001b[0;36mtest_shuffled\u001b[0;34m(a, b)\u001b[0m\n\u001b[1;32m     71\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mtest_shuffled\u001b[39m(a,b):\n\u001b[1;32m     72\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m`test` that `a` and `b` are shuffled versions of the same sequence of items\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m---> 73\u001b[0m     \u001b[43mtest_ne\u001b[49m\u001b[43m(\u001b[49m\u001b[43ma\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mb\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     74\u001b[0m     test_eq(Counter(a), Counter(b))\n",
-      "File \u001b[0;32m~/git/fastcore/fastcore/test.py:49\u001b[0m, in \u001b[0;36mtest_ne\u001b[0;34m(a, b)\u001b[0m\n\u001b[1;32m     47\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mtest_ne\u001b[39m(a,b):\n\u001b[1;32m     48\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m`test` that `a!=b`\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m---> 49\u001b[0m     \u001b[43mtest\u001b[49m\u001b[43m(\u001b[49m\u001b[43ma\u001b[49m\u001b[43m,\u001b[49m\u001b[43mb\u001b[49m\u001b[43m,\u001b[49m\u001b[43mnequals\u001b[49m\u001b[43m,\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43m!=\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/git/fastcore/fastcore/test.py:27\u001b[0m, in \u001b[0;36mtest\u001b[0;34m(a, b, cmp, cname)\u001b[0m\n\u001b[1;32m     25\u001b[0m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m`assert` that `cmp(a,b)`; display inputs and `cname or cmp.__name__` if it fails\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     26\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m cname \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m: cname\u001b[38;5;241m=\u001b[39mcmp\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\n\u001b[0;32m---> 27\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m cmp(a,b),\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mcname\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m:\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00ma\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00mb\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n",
-      "\u001b[0;31mAssertionError\u001b[0m: !=:\n[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]\n[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]"
-     ]
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
     }
    ],
    "source": [

--- a/nbs/13a_learner.ipynb
+++ b/nbs/13a_learner.ipynb
@@ -31,6 +31,7 @@
     "from fastai.data.all import *\n",
     "from fastai.optimizer import *\n",
     "from fastai.callback.core import *\n",
+    "from contextlib import nullcontext\n",
     "import pickle,threading\n",
     "from collections.abc import MutableSequence"
    ]
@@ -215,7 +216,12 @@
     "    \"Load `model` from `file` along with `opt` (if available, and if `with_opt`)\"\n",
     "    if isinstance(device, int): device = torch.device('cuda', device)\n",
     "    elif device is None: device = 'cpu'\n",
-    "    state = torch.load(file, map_location=device, **torch_load_kwargs)\n",
+    "    if ismin_torch(\"2.5\"):\n",
+    "        context = torch.serialization.safe_globals([L])\n",
+    "        torch_load_kwargs.setdefault(\"weights_only\", True)\n",
+    "    else: context = nullcontext()\n",
+    "    with context:\n",
+    "        state = torch.load(file, map_location=device, **torch_load_kwargs)\n",
     "    hasopt = set(state)=={'model', 'opt'}\n",
     "    model_state = state['model'] if hasopt else state\n",
     "    get_model(model).load_state_dict(model_state, strict=strict)\n",
@@ -230,11 +236,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`file` can be a `Path` object, a string or an opened file object. If a `device` is passed, the model is loaded on it, otherwise it's loaded on the CPU. \n",
+    "`file` can be a `Path` object, a string or an opened file object. If a `device` is passed, the model is loaded on it, otherwise it's loaded on the CPU.\n",
     "\n",
     "If `strict` is `True`, the file must exactly contain weights for every parameter key in `model`, if `strict` is `False`, only the keys that are in the saved model are loaded in `model`.\n",
     "\n",
-    "You can pass in other kwargs to `torch.load` through `torch_load_kwargs`."
+    "You can pass in other kwargs to `torch.load` through `torch_load_kwargs`.\n",
+    "\n",
+    "As of PyTorch 2.5 and fastai 2.7.19, `load_model` uses PyTorch's safe serialization for model loading."
    ]
   },
   {
@@ -2081,7 +2089,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`file` can be a `Path`, a `string` or a buffer. Use `device` to load the model/optimizer state on a device different from the one it was saved."
+    "`file` can be a `Path`, a `string` or a buffer. Use `device` to load the model/optimizer state on a device different from the one it was saved.\n",
+    "\n",
+    "As of PyTorch 2.5 and fastai 2.7.19, `Learner.load` uses PyTorch's safe serialization for model loading."
    ]
   },
   {
@@ -2168,11 +2178,14 @@
     "    \"Load a `Learner` object in `fname`, by default putting it on the `cpu`\"\n",
     "    distrib_barrier()\n",
     "    map_loc = 'cpu' if cpu else default_device()\n",
-    "    try: res = torch.load(fname, map_location=map_loc, pickle_module=pickle_module)\n",
-    "    except AttributeError as e: \n",
+    "    try:\n",
+    "        warn(\"load_learner` uses Python's insecure pickle module, which can execute malicious arbitrary code when loading. Only load files you trust.\\nIf you only need to load model weights and optimizer state, use the safe `Learner.load` instead.\")\n",
+    "        load_kwargs = {\"weights_only\": False} if ismin_torch(\"2.6\") else {}\n",
+    "        res = torch.load(fname, map_location=map_loc, pickle_module=pickle_module, **load_kwargs)\n",
+    "    except AttributeError as e:\n",
     "        e.args = [f\"Custom classes or functions exported with your `Learner` not available in namespace. Re-declare/import before loading:\\n\\t{e.args[0]}\"]\n",
     "        raise\n",
-    "    if cpu: \n",
+    "    if cpu:\n",
     "        res.dls.cpu()\n",
     "        if hasattr(res, 'channels_last'): res = res.to_contiguous(to_fp32=True)\n",
     "        elif hasattr(res, 'mixed_precision'): res = res.to_fp32()\n",
@@ -2184,6 +2197,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    ":::{.callout-important}\n",
+    "\n",
+    "`load_learner` uses Python's insecure `pickle` module. Maliciously crafted pickle data can execute arbitrary code when loading. Never use `load_learner` on untrusted or potentially compromised sources. **Only load files you fully trust**.\"\n",
+    "\n",
+    "If you only need to load model weights and optimizer state, use the safe `Learner.load` instead.\n",
+    "\n",
+    ":::\n",
+    "\n",
     ":::{.callout-warning}\n",
     "\n",
     "`load_learner` requires all your custom code be in the exact same place as when exporting your `Learner` (the main script, or the module you imported it from).\n",

--- a/settings.ini
+++ b/settings.ini
@@ -15,7 +15,7 @@ min_python = 3.9
 audience = Developers
 language = English
 requirements = fastdownload>=0.0.5,<2 fastcore>=1.5.29,<1.8 torchvision>=0.11 matplotlib pandas requests pyyaml fastprogress>=0.2.4 pillow>=9.0.0 scikit-learn scipy spacy<4 packaging
-pip_requirements = torch>=1.10,<2.6
+pip_requirements = torch>=1.10,<2.7
 conda_requirements = pytorch>=1.10,<2.6
 conda_user = fastai
 dev_requirements = ipywidgets lightning pytorch-ignite transformers sentencepiece tensorboard pydicom catalyst flask_compress captum>=0.4.1 flask wandb kornia scikit-image comet_ml albumentations opencv-python pyarrow ninja timm>=0.9 accelerate>=0.21 ipykernel


### PR DESCRIPTION
This PR adds support for PyTorch 2.6.

It also enables PyTorch's safe serialization methods for `Learner.load` and `load_model` for PyTorch 2.5 and 2.6.

Since `load_learner` is supposed to be able to reference arbitrary Python objects, it won't be able to use PyTorch's safe serialization methods, so I updated the documentation and added a warning to the method about the potential to run malicious code.

cc @jph00 