### PR TITLE
Update GitHub Actions workflow to install libraries from main branch of answerdotai repositories

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,8 +46,8 @@ jobs:
 
     - name: Install libraries
       run: |
-        pip install git+https://github.com/fastai/fastcore.git@master
-        pip install git+https://github.com/fastai/nbdev.git@master
+        pip install git+https://github.com/answerdotai/fastcore.git@main
+        pip install git+https://github.com/answerdotai/nbdev.git@main
         pip install -Uq fastprogress
         pip install -Uqe .[dev] --extra-index-url https://download.pytorch.org/whl/cpu
 


### PR DESCRIPTION
CI is currently failing, as shown [here](https://github.com/fastai/fastai/actions/runs/13916336471/job/38940020659). The root cause appears to be that nbdev and fastcore are being installed from outdated master branches. This PR updates the GitHub workflow to use the latest versions from the answerdotai organization and the main branch.