### PR TITLE
add plum-dispatch as requirement and set minimum python version to 3.10

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -11,10 +11,10 @@ author_email = info@fast.ai
 license = apache2
 copyright = fast.ai
 status = 4
-min_python = 3.9
+min_python = 3.10
 audience = Developers
 language = English
-requirements = fastdownload>=0.0.5,<2 fastcore>=1.8.0,<1.9 fasttransform torchvision>=0.11 matplotlib pandas requests pyyaml fastprogress>=0.2.4 pillow>=9.0.0 scikit-learn scipy spacy<4 packaging
+requirements = fastdownload>=0.0.5,<2 fastcore>=1.8.0,<1.9 fasttransform torchvision>=0.11 matplotlib pandas requests pyyaml fastprogress>=0.2.4 pillow>=9.0.0 scikit-learn scipy spacy<4 packaging plum-dispatch
 pip_requirements = torch>=1.10,<2.7
 conda_requirements = pytorch>=1.10,<2.7
 conda_user = fastai


### PR DESCRIPTION
Addresses two things:
- It adds plum-dispatch as a dependency. It was already used as a dependency of fasttransform. Because it's directly imported by fastai, it should be added to the requirements. This PR fixes the previous oversight.
- It sets the minimum python version to 3.10. Because python 3.9 is not compatible with plum-dispatch and | syntax for type hints.

**Additional background context:**
- Python 3.9 is going end of life in [October 2025](https://devguide.python.org/versions/#supported-versions), and is currently only receiving security updates.
- Python 3.9 was already removed from fastai's testing matrix.
- `from __future__ import annotations` (related to [PEP 563](https://peps.python.org/pep-0563/)) remains necessary as there's no definitive timeline for mandatory implementation ([source](https://docs.python.org/3/library/__future__.html#id2)).