### PR TITLE
Fix fasttransform/plum-dispatch adoption errors

### DIFF
--- a/nbs/13a_learner.ipynb
+++ b/nbs/13a_learner.ipynb
@@ -32,7 +32,7 @@
     "from fastai.optimizer import *\n",
     "from fastai.callback.core import *\n",
     "from contextlib import nullcontext\n",
-    "import pickle,threading\n",
+    "import cloudpickle,pickle,threading\n",
     "from collections.abc import MutableSequence"
    ]
   },
@@ -2143,7 +2143,7 @@
    "source": [
     "#|export\n",
     "@patch\n",
-    "def export(self:Learner, fname='export.pkl', pickle_module=pickle, pickle_protocol=2):\n",
+    "def export(self:Learner, fname='export.pkl', pickle_module=cloudpickle, pickle_protocol=2):\n",
     "    \"Export the content of `self` without the items and the optimizer state for inference\"\n",
     "    if rank_distrib(): return # don't export if child proc\n",
     "    self._end_cleanup()\n",
@@ -2182,6 +2182,9 @@
     "        warn(\"load_learner` uses Python's insecure pickle module, which can execute malicious arbitrary code when loading. Only load files you trust.\\nIf you only need to load model weights and optimizer state, use the safe `Learner.load` instead.\")\n",
     "        load_kwargs = {\"weights_only\": False} if ismin_torch(\"2.6\") else {}\n",
     "        res = torch.load(fname, map_location=map_loc, pickle_module=pickle_module, **load_kwargs)\n",
+    "    except ImportError as e:\n",
+    "        if any(o in str(e) for o in (\"fastcore.transform\",\"fastcore.dispatch\")): \n",
+    "            raise RuntimeError(f\"Loading model {fname=}, attempted to import from `fastcore.dispatch` and/or `fastcore.transform` which are deprecated in `fastai>=2.8.0`.\\nDowngrade to `fastai<2.8.0` if you want to load this model.\")\n",
     "    except AttributeError as e:\n",
     "        e.args = [f\"Custom classes or functions exported with your `Learner` not available in namespace. Re-declare/import before loading:\\n\\t{e.args[0]}\"]\n",
     "        raise\n",

--- a/nbs/98_test_model_export.ipynb
+++ b/nbs/98_test_model_export.ipynb
@@ -1,0 +1,62 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "330ad5b0",
+   "metadata": {},
+   "source": [
+    "# test model export\n",
+    "\n",
+    "> Test the Learner.export feature"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b176eb92",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tempfile import TemporaryDirectory\n",
+    "from fastai.vision.all import *\n",
+    "from fastcore.test import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37601436",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#|cuda\n",
+    "def label_func(f): return f[0].isupper()\n",
+    "path = untar_data(URLs.PETS)\n",
+    "files = get_image_files(path/\"images\")\n",
+    "dls = ImageDataLoaders.from_name_func(path, files, label_func, item_tfms=Resize(32))\n",
+    "\n",
+    "with TemporaryDirectory() as td:\n",
+    "    learn = vision_learner(dls, resnet18, metrics=error_rate, path=td)\n",
+    "    learn.fine_tune(1,base_lr=0.00001)\n",
+    "    learn.export(\"model.pkl\")\n",
+    "    \n",
+    "    learn2 = load_learner(Path(td) / \"model.pkl\")\n",
+    "\n",
+    "o1 = learn.predict(files[0])\n",
+    "o2 = learn2.predict(files[0])\n",
+    "\n",
+    "test_eq(o1[:2],o2[:2])\n",
+    "test_close(o1[-1], o2[-1])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/settings.ini
+++ b/settings.ini
@@ -14,7 +14,7 @@ status = 4
 min_python = 3.10
 audience = Developers
 language = English
-requirements = fastdownload>=0.0.5,<2 fastcore>=1.8.0,<1.9 fasttransform torchvision>=0.11 matplotlib pandas requests pyyaml fastprogress>=0.2.4 pillow>=9.0.0 scikit-learn scipy spacy<4 packaging plum-dispatch
+requirements = fastdownload>=0.0.5,<2 fastcore>=1.8.0,<1.9 fasttransform torchvision>=0.11 matplotlib pandas requests pyyaml fastprogress>=0.2.4 pillow>=9.0.0 scikit-learn scipy spacy<4 packaging plum-dispatch cloudpickle
 pip_requirements = torch>=1.10,<2.7
 conda_requirements = pytorch>=1.10,<2.7
 conda_user = fastai

--- a/settings.ini
+++ b/settings.ini
@@ -11,10 +11,10 @@ author_email = info@fast.ai
 license = apache2
 copyright = fast.ai
 status = 4
-min_python = 3.9
+min_python = 3.10
 audience = Developers
 language = English
-requirements = fastdownload>=0.0.5,<2 fastcore>=1.8.0,<1.9 fasttransform torchvision>=0.11 matplotlib pandas requests pyyaml fastprogress>=0.2.4 pillow>=9.0.0 scikit-learn scipy spacy<4 packaging
+requirements = fastdownload>=0.0.5,<2 fastcore>=1.8.0,<1.9 fasttransform torchvision>=0.11 matplotlib pandas requests pyyaml fastprogress>=0.2.4 pillow>=9.0.0 scikit-learn scipy spacy<4 packaging plum-dispatch
 pip_requirements = torch>=1.10,<2.7
 conda_requirements = pytorch>=1.10,<2.7
 conda_user = fastai


### PR DESCRIPTION
This PR addresses three things related to the adoption of `fasttransform` and `plum-dispatch`:
1. Set python minimum version to 3.10 because under py<3.9 the | type hint syntax is not compatible with plum
2. Learner.export broke because stdlib `pickle` is not compatible. 
3. Loading models exported under `fastai<2.8` failed with an unhelpful error

**Re 1:**
Python 3.9 is going end of life in [October 2025](https://devguide.python.org/versions/#supported-versions), and is currently only receiving security updates.
Python 3.9 was already removed from fastai's testing matrix.
from __future__ import annotations (related to [PEP 563](https://peps.python.org/pep-0563/)) remains necessary as there's no definitive timeline for mandatory implementation ([source](https://docs.python.org/3/library/__future__.html#id2)).

**Re 2:**
This PR switches to `cloudpickle`. Together with `dill` they are the two popular alternative pickle libraries. We chose cloudpickle over dill because the former is compatible with pickle during loadtime. While dill is also required during loadtime.

We also add a separate test notebook to tests model exports to avoid errors like these slipping through in the future. The tests are not included in the Learner notebook itself to avoid circular imports.

**Re 3:**
We added a more descriptive error message when users load a model trained under `fastai<2.8`. This was manually tested by training a model under `fastai==2.7.19` and attempting to load it. See code snippets at the end of this PR.

**Out of scope:**
While working on this PR we noticed the docs are out of date (e.g. source refs to master branch, and the Learner class does have a docment table in the notebook while it doesnt have one in the docs). We will raise a separate issue for it.

**Code snippets:**

Train code:
```python
# /// script
# requires-python = ">=3.12"
# dependencies = [
#     "fastai==2.7.19",
#     "fastcore==1.7.29",
# ]
# ///

import fastai, fastcore
assert fastai.__version__ == "2.7.19"
assert fastcore.__version__ == "1.7.29"

from fastai.vision.all import *
def label_func(f): return f[0].isupper()
path = untar_data(URLs.PETS)
files = get_image_files(path/"images")
dls = ImageDataLoaders.from_name_func(path, files, label_func, item_tfms=Resize(224))
learn = vision_learner(dls, resnet34, metrics=error_rate, path=".")
learn.fine_tune(1)
learn.export("model_27.pkl")
```

Load code:
```python
from fastai.learner import load_learner
m = load_learner("model_27.pkl")
```

```
/Users/rensdimmendaal/git/repos/fastai/fastai/learner.py:455: UserWarning: load_learner` uses Python's insecure pickle module, which can execute malicious arbitrary code when loading. Only load files you trust.
If you only need to load model weights and optimizer state, use the safe `Learner.load` instead.
  warn("load_learner` uses Python's insecure pickle module, which can execute malicious arbitrary code when loading. Only load files you trust.\nIf you only need to load model weights and optimizer state, use the safe `Learner.load` instead.")
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
File ~/git/repos/fastai/fastai/learner.py:457, in load_learner(fname, cpu, pickle_module)
    456     load_kwargs = {"weights_only": False} if ismin_torch("2.6") else {}
--> 457     res = torch.load(fname, map_location=map_loc, pickle_module=pickle_module, **load_kwargs)
    458 except ImportError as e:

File ~/git/.venv/lib/python3.12/site-packages/torch/serialization.py:1360, in load(f, map_location, pickle_module, weights_only, mmap, **pickle_load_args)
   1359                 raise pickle.UnpicklingError(_get_wo_message(str(e))) from None
-> 1360         return _load(
   1361             opened_zipfile,
   1362             map_location,
   1363             pickle_module,
   1364             overall_storage=overall_storage,
   1365             **pickle_load_args,
   1366         )
   1367 if mmap:

File ~/git/.venv/lib/python3.12/site-packages/torch/serialization.py:1848, in _load(zip_file, map_location, pickle_module, pickle_file, overall_storage, **pickle_load_args)
   1847 _serialization_tls.map_location = map_location
-> 1848 result = unpickler.load()
   1849 _serialization_tls.map_location = None

File ~/git/.venv/lib/python3.12/site-packages/torch/serialization.py:1837, in _load.<locals>.UnpicklerWrapper.find_class(self, mod_name, name)
   1836 mod_name = load_module_mapping.get(mod_name, mod_name)
-> 1837 return super().find_class(mod_name, name)

File ~/git/repos/fastcore/fastcore/transform.py:2, in __getattr__(name)
      1 def __getattr__(name):
----> 2      raise ImportError(
      3          f"Could not import '{name}' from fastcore.transform - this module has been moved to the fasttransform package.\n"
      4          "To migrate your code, please see the migration guide at: https://answerdotai.github.io/fasttransform/fastcore_migration_guide.html"
      5      )

ImportError: Could not import 'Pipeline' from fastcore.transform - this module has been moved to the fasttransform package.
To migrate your code, please see the migration guide at: https://answerdotai.github.io/fasttransform/fastcore_migration_guide.html

During handling of the above exception, another exception occurred:

RuntimeError                              Traceback (most recent call last)
Cell In[2], line 1
----> 1 m = load_learner("model_27.pkl")

File ~/git/repos/fastai/fastai/learner.py:460, in load_learner(fname, cpu, pickle_module)
    458 except ImportError as e:
    459     if any(o in str(e) for o in ("fastcore.transform","fastcore.dispatch")):
--> 460         raise RuntimeError(f"Loading model {fname=}, attempted to import from `fastcore.dispatch` and/or `fastcore.transform` which are deprecated in `fastai>=2.8.0`.\nDowngrade to `fastai<2.8.0` if you want to load this model.")
    461 except AttributeError as e:
    462     e.args = [f"Custom classes or functions exported with your `Learner` not available in namespace. Re-declare/import before loading:\n\t{e.args[0]}"]

RuntimeError: Loading model fname='model_27.pkl', attempted to import from `fastcore.dispatch` and/or `fastcore.transform` which are deprecated in `fastai>=2.8.0`.
Downgrade to `fastai<2.8.0` if you want to load this model.
```

