### PR TITLE
PyTorch 2.6 safe loading support for fastai optimizers

### DIFF
--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -52,7 +52,7 @@ def load_model(file, model, opt, with_opt=True, device=None, strict=True, **torc
     if isinstance(device, int): device = torch.device('cuda', device)
     elif device is None: device = 'cpu'
     if ismin_torch("2.5"):
-        context = torch.serialization.safe_globals([L])
+        context = torch.serialization.safe_globals([L, np.core.multiarray.scalar, np.dtype, *[getattr(np.dtypes, dt) for dt in np.dtypes.__all__]])
         torch_load_kwargs.setdefault("weights_only", True)
     else: context = nullcontext()
     with context:

--- a/nbs/13a_learner.ipynb
+++ b/nbs/13a_learner.ipynb
@@ -217,7 +217,7 @@
     "    if isinstance(device, int): device = torch.device('cuda', device)\n",
     "    elif device is None: device = 'cpu'\n",
     "    if ismin_torch(\"2.5\"):\n",
-    "        context = torch.serialization.safe_globals([L])\n",
+    "        context = torch.serialization.safe_globals([L, np.core.multiarray.scalar, np.dtype, *[getattr(np.dtypes, dt) for dt in np.dtypes.__all__]])\n",
     "        torch_load_kwargs.setdefault(\"weights_only\", True)\n",
     "    else: context = nullcontext()\n",
     "    with context:\n",


### PR DESCRIPTION
This PR follows up on #4078 and resolves #4068 by adding numpy dtypes to `safe_globals` so optimizer hyperparameters can be loaded.