### PR TITLE
update torch version to 2.7

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -15,8 +15,8 @@ min_python = 3.10
 audience = Developers
 language = English
 requirements = fastdownload>=0.0.5,<2 fastcore>=1.8.0,<1.9 fasttransform>=0.0.2 torchvision>=0.11 matplotlib pandas requests pyyaml fastprogress>=0.2.4 pillow>=9.0.0 scikit-learn scipy spacy<4 packaging plum-dispatch cloudpickle
-pip_requirements = torch>=1.10,<2.7
-conda_requirements = pytorch>=1.10,<2.7
+pip_requirements = torch>=1.10,<2.8
+conda_requirements = pytorch>=1.10,<2.8
 conda_user = fastai
 dev_requirements = ipywidgets lightning pytorch-ignite transformers sentencepiece tensorboard pydicom catalyst flask_compress captum>=0.4.1 flask wandb kornia scikit-image comet_ml albumentations opencv-python pyarrow ninja timm>=0.9 accelerate>=0.21 ipykernel
 console_scripts = configure_accelerate=fastai.distributed:configure_accelerate


### PR DESCRIPTION
This PR updates the PyTorch version constraint in settings.ini to allow compatibility with PyTorch 2.7.

## Changes
- Updated `pip_requirements` from `torch>=1.10,<2.7` to `torch>=1.10,<2.8`
- Updated `conda_requirements` from `pytorch>=1.10,<2.7` to `pytorch>=1.10,<2.8`

## Testing
I've tested this change locally with PyTorch 2.7.0 and confirmed basic functionality works:
- Model training with vision_learner
- DataLoaders functionality
- Basic operations with tensors

## Motivation
This change is needed to allow projects that depend on fastai (such as [AutoGluon](https://github.com/autogluon/autogluon)) to use the latest PyTorch versions without version conflicts.