### PR TITLE
Update plot lr find

### DIFF
--- a/fastai/callback/schedule.py
+++ b/fastai/callback/schedule.py
@@ -281,7 +281,6 @@ def plot_lr_find(self:Recorder, skip_end=5, return_fig=True, suggestions=None, n
         for (val, idx), nm, color in zip(suggestions, nms, colors):
             ax.plot(val, idx, 'o', label=nm, c=color)
         ax.legend(loc='best')
-    if return_fig: return fig
 
 # %% ../../nbs/14_callback.schedule.ipynb 89
 mk_class("SuggestionMethod", **{o.__name__.capitalize():o for o in [valley,slide,minimum,steep]},

--- a/fastai/callback/schedule.py
+++ b/fastai/callback/schedule.py
@@ -281,6 +281,7 @@ def plot_lr_find(self:Recorder, skip_end=5, return_fig=True, suggestions=None, n
         for (val, idx), nm, color in zip(suggestions, nms, colors):
             ax.plot(val, idx, 'o', label=nm, c=color)
         ax.legend(loc='best')
+    if return_fig: fig
 
 # %% ../../nbs/14_callback.schedule.ipynb 89
 mk_class("SuggestionMethod", **{o.__name__.capitalize():o for o in [valley,slide,minimum,steep]},

--- a/fastai/callback/schedule.py
+++ b/fastai/callback/schedule.py
@@ -281,8 +281,7 @@ def plot_lr_find(self:Recorder, skip_end=5, return_fig=True, suggestions=None, n
         for (val, idx), nm, color in zip(suggestions, nms, colors):
             ax.plot(val, idx, 'o', label=nm, c=color)
         ax.legend(loc='best')
-    if return_fig:
-        return fig
+    if return_fig: return fig
 
 # %% ../../nbs/14_callback.schedule.ipynb 89
 mk_class("SuggestionMethod", **{o.__name__.capitalize():o for o in [valley,slide,minimum,steep]},

--- a/fastai/callback/schedule.py
+++ b/fastai/callback/schedule.py
@@ -281,6 +281,8 @@ def plot_lr_find(self:Recorder, skip_end=5, return_fig=True, suggestions=None, n
         for (val, idx), nm, color in zip(suggestions, nms, colors):
             ax.plot(val, idx, 'o', label=nm, c=color)
         ax.legend(loc='best')
+    if return_fig:
+        return fig
 
 # %% ../../nbs/14_callback.schedule.ipynb 89
 mk_class("SuggestionMethod", **{o.__name__.capitalize():o for o in [valley,slide,minimum,steep]},

--- a/nbs/14_callback.schedule.ipynb
+++ b/nbs/14_callback.schedule.ipynb
@@ -2309,7 +2309,8 @@
     "        colors = plt.rcParams['axes.prop_cycle'].by_key()['color'][1:]\n",
     "        for (val, idx), nm, color in zip(suggestions, nms, colors):\n",
     "            ax.plot(val, idx, 'o', label=nm, c=color)\n",
-    "        ax.legend(loc='best')"
+    "        ax.legend(loc='best')\n",
+    "    if return_fig: fig"
    ]
   },
   {


### PR DESCRIPTION
This PR addresses a long-standing oversight in the `plot_lr_find` method of the `Recorder` class. Specifically, the method accepts a `return_fig` parameter, but the `fig` object was never actually returned—making the parameter redundant in practice.

I discovered and initially suggested a fix for this issue in the [fast.ai forums](https://forums.fast.ai/t/using-plot-lr-find-with-suggestions-param/108472/2) over 18 months ago. However, it appears the update was never incorporated into the codebase.

**What’s Changed:**

At the end of the `plot_lr_find` function, I’ve added:

```python
if return_fig: return fig
```

**Why This Matters:**

This change ensures the `fig` object is returned when `return_fig=True`, enabling users to further manipulate or save the figure outside the method. This is particularly useful when plotting with `suggestions` and needing to customize or export the plot.

Without this fix, users might assume that setting `return_fig=True` returns the figure, but it does not—leading to confusion and unnecessary debugging.

**Fix Summary:**

* Respects the intent of the `return_fig` flag
* Enables access to the `matplotlib` figure object
* Aligns function behavior with user expectations and documentation

Let me know if further tests or documentation updates are needed.