### PR TITLE
Fix: Fixed the missing exception handling

### DIFF
--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -458,6 +458,7 @@ def load_learner(fname, cpu=True, pickle_module=pickle):
     except ImportError as e:
         if any(o in str(e) for o in ("fastcore.transform","fastcore.dispatch")): 
             raise RuntimeError(f"Loading model {fname=}, attempted to import from `fastcore.dispatch` and/or `fastcore.transform` which are deprecated in `fastai>=2.8.0`.\nDowngrade to `fastai<2.8.0` if you want to load this model.")
+        raise e
     except AttributeError as e:
         e.args = [f"Custom classes or functions exported with your `Learner` not available in namespace. Re-declare/import before loading:\n\t{e.args[0]}"]
         raise


### PR DESCRIPTION
We installed fastai and tried to load a model. In our training environment we had the module 'timm' installed while it was missing in our inference environment. fastai reported a semantic error: "UnboundLocalError: cannot access local variable 'res' where it is not associated with a value" instead of the correct error which was an Import error due to a missing module.