### PR TITLE
Fixed bug in MultiCategorize to support encoding empty inputs

### DIFF
--- a/fastai/data/transforms.py
+++ b/fastai/data/transforms.py
@@ -286,7 +286,7 @@ class MultiCategorize(Categorize):
             diff = [elem for elem in o if elem not in self.vocab.o2i.keys()]
             diff_str = "', '".join(diff)
             raise KeyError(f"Labels '{diff_str}' were not included in the training dataset")
-        return TensorMultiCategory([self.vocab.o2i[o_] for o_ in o])
+        return TensorMultiCategory([self.vocab.o2i[o_] for o_ in o]).type(torch.int64)
     def decodes(self, o): return MultiCategory      ([self.vocab    [o_] for o_ in o])
 
 # %% ../../nbs/05_data.transforms.ipynb 85

--- a/nbs/05_data.transforms.ipynb
+++ b/nbs/05_data.transforms.ipynb
@@ -1218,7 +1218,7 @@
     "            diff = [elem for elem in o if elem not in self.vocab.o2i.keys()]\n",
     "            diff_str = \"', '\".join(diff)\n",
     "            raise KeyError(f\"Labels '{diff_str}' were not included in the training dataset\")\n",
-    "        return TensorMultiCategory([self.vocab.o2i[o_] for o_ in o])\n",
+    "        return TensorMultiCategory([self.vocab.o2i[o_] for o_ in o]).type(torch.int64)\n",
     "    def decodes(self, o): return MultiCategory      ([self.vocab    [o_] for o_ in o])"
    ]
   },
@@ -1248,6 +1248,7 @@
     "test_eq(cat([]), tensor([]))\n",
     "test_eq(cat.decode([1]), ['b'])\n",
     "test_eq(cat.decode([0,2]), ['a', 'c'])\n",
+    "test_eq(cat.encodes([]).dtype, torch.int64)\n",
     "test_stdout(lambda: show_at(tds,2), 'a;c')\n",
     "\n",
     "# if vocab supplied, ensure it maintains its order (i.e., it doesn't sort)\n",


### PR DESCRIPTION
I found this issue running an object detection model where for some images I have no bounding boxes. The decode pipeline for my dataloader broke because the `TensorBBoxLabel` was of type `float32` instead of `int64`, which can be used to index into arrays.

I figure out that the root of the bug is in `MultiCategorize`, here there is a small reproducible example

```python
from fastai.vision.all import *
print("empty:", MultiCategorize(["foo"]).encodes([]).dtype) # gets torch.float32
print("with elements:", MultiCategorize(["foo"]).encodes(["foo"]).dtype) # gets torch.int64
``` 
The issue is than in pytorch when creating an empty tensor it defaults to `float32` as a dtype. To fix this I added a cast to `int64` after the object is created.
I also added a test for this case.
