### PR TITLE
Fix for #4104 : Tutorial image_sequence has no rename_extracted function

### DIFF
--- a/nbs/24_tutorial.image_sequence.ipynb
+++ b/nbs/24_tutorial.image_sequence.ipynb
@@ -129,7 +129,6 @@
     "                myrar.extractall(dest.parent)\n",
     "        else: \n",
     "            raise Exception(f'Unrecognized archive: {fname}')\n",
-    "        rename_extracted(dest)\n",
     "    return dest"
    ]
   },
@@ -154,6 +153,36 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "This function is to normalize the extracted archive structure ensuring all its content end up in `dest`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import shutil\n",
+    "\n",
+    "def move_extracted(dest):\n",
+    "    extracted_folders = list(dest.parent.iterdir())\n",
+    "    extracted_folders = [f for f in extracted_folders if f != dest and not f.name.startswith('.')]\n",
+    "    if len(extracted_folders) == 1 and extracted_folders[0].is_dir():\n",
+    "        extracted_folder = extracted_folders[0]\n",
+    "        dest.mkdir(parents=True, exist_ok=True)\n",
+    "        for item in extracted_folder.iterdir():\n",
+    "            shutil.move(str(item), str(dest))\n",
+    "        shutil.rmtree(extracted_folder)\n",
+    "    else:\n",
+    "        dest.mkdir(parents=True, exist_ok=True)\n",
+    "        for item in extracted_folders:\n",
+    "            shutil.move(str(item), str(dest))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "> unraring a large file like this one is very slow."
    ]
   },
@@ -172,7 +201,8 @@
    ],
    "source": [
     "#|slow\n",
-    "path = unrar(ucf_fname, dest)"
+    "path = unrar(ucf_fname, dest)\n",
+    "move_extracted(dest)"
    ]
   },
   {


### PR DESCRIPTION
Changes in the PR -
1. `rename_extracted` function was never defined and its function call was removed.
2. Replaced it with the function **`move_extracted`** to normalize extracted archive structure of UCF dataset ensuring all its content end up in path defined under `dest`.
3. Added required markdown for the function description.


**`move_extracted`** function :

If the archive extracts a single top-level folder (e.g., 'UCF-101/'), this function moves the contents of that folder directly into the target `dest` directory and deletes the original extracted folder.
> (Safe-check) If multiple folders / files are extracted, then they are all moved directly into `dest`. This ensures a consistent layout regardless of the internal archive structure of the rar file.