### PR TITLE
docs: Link ImageBlock and other task-specific blocks to TransformBlock

### DIFF
--- a/nbs/06_data.block.ipynb
+++ b/nbs/06_data.block.ipynb
@@ -62,6 +62,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 📘 **Note**: Several domain-specific blocks such as `ImageBlock`, `BBoxBlock`, `PointBlock`, and `CategoryBlock` are implemented on top of `TransformBlock`. These blocks are designed to handle common tasks in computer vision, classification, and regression. See the [Vision Blocks](https://docs.fast.ai/data.block.html#Vision-blocks) section for more details.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -860,9 +867,21 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR improves the `06_data.block.ipynb` documentation by clarifying that task-specific blocks such as `ImageBlock`, `BBoxBlock`, `CategoryBlock`, and others are built on top of `TransformBlock`.

It also adds a direct link to the Vision Blocks section to improve discoverability and user understanding.

This change addresses the issue raised in [#4099](https://github.com/fastai/fastai/issues/4099).

Let me know if any adjustments are needed. Happy to iterate!
