### PR TITLE
Fixed SaveModelCallback

### DIFF
--- a/fastai/callback/tracker.py
+++ b/fastai/callback/tracker.py
@@ -108,7 +108,7 @@ class SaveModelCallback(TrackerCallback):
     def after_fit(self, **kwargs):
         "Load the best model."
         if self.at_end: self._save(f'{self.fname}')
-        elif not self.every_epoch: self.learn.load(f'{self.fname}', with_opt=self.with_opt)
+        elif not self.every_epoch: self.learn.load(f'{self.fname}', with_opt=self.with_opt, weights_only=False)
 
 # %% ../../nbs/17_callback.tracker.ipynb 30
 class ReduceLROnPlateau(TrackerCallback):

--- a/nbs/17_callback.tracker.ipynb
+++ b/nbs/17_callback.tracker.ipynb
@@ -795,7 +795,7 @@
     "    def after_fit(self, **kwargs):\n",
     "        \"Load the best model.\"\n",
     "        if self.at_end: self._save(f'{self.fname}')\n",
-    "        elif not self.every_epoch: self.learn.load(f'{self.fname}', with_opt=self.with_opt)"
+    "        elif not self.every_epoch: self.learn.load(f'{self.fname}', with_opt=self.with_opt, weights_only=False)"
    ]
   },
   {


### PR DESCRIPTION
Since `torch` got upgraded to version 2.6, the `weights_only` argument of `torch.load` now defaults to `True`. This breaks `SaveModelCallback` when using `with_opt=True`.

# Changes
* Added `weights_only=False` when loading a model in the `after_fit` method of `SaveModelCallback`.

# Testing
* I've been using this fix for some time in my personal projects, so I can confirm it works.