### PR TITLE
learner: re-raise non-special ImportErrors in load_learner to avoid U…

### DIFF
--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -458,6 +458,7 @@ def load_learner(fname, cpu=True, pickle_module=pickle):
     except ImportError as e:
         if any(o in str(e) for o in ("fastcore.transform","fastcore.dispatch")): 
             raise RuntimeError(f"Loading model {fname=}, attempted to import from `fastcore.dispatch` and/or `fastcore.transform` which are deprecated in `fastai>=2.8.0`.\nDowngrade to `fastai<2.8.0` if you want to load this model.")
+        raise 
     except AttributeError as e:
         e.args = [f"Custom classes or functions exported with your `Learner` not available in namespace. Re-declare/import before loading:\n\t{e.args[0]}"]
         raise


### PR DESCRIPTION
---

# learner.load\_learner: re-raise non-special `ImportError`s to avoid `UnboundLocalError`

**Fixes:** Resolves #4115

## Summary

`load_learner` could raise an unrelated `UnboundLocalError: local variable 'res' referenced before assignment` when `torch.load(...)` throws an `ImportError` that **doesn’t** mention `fastcore.dispatch`/`fastcore.transform`.
The `except ImportError` block only raised for that specific deprecation message and otherwise silently continued, leaving `res` undefined and later accessed at `res.dls.cpu()`.

This PR re-raises all other `ImportError`s so users see the *real* failure (e.g., missing module, version mismatch, bad path), and we never fall through with an uninitialized `res`.

## Reproduction

### Minimal repro (before this PR)

```python
from fastai.vision.all import load_learner
load_learner("definitely_missing.pkl")   # or trigger an ImportError from a custom class not importable
```

**Actual (before):**

```
UnboundLocalError: local variable 'res' referenced before assignment
```

**Expected:**

* A clear exception that reflects the real cause, e.g.:

  * `FileNotFoundError` (missing file)
  * `ImportError` (custom type/function not importable)

## Root cause

`load_learner`:

* Handles a very specific `ImportError` case (the `fastcore.dispatch/transform` move) by raising a helpful `RuntimeError`.
* For **all other `ImportError`s**, it didn’t re-raise, so execution fell through to `res.dls.cpu()` while `res` was never assigned.

## The change

* Keep the special message for `fastcore.dispatch`/`fastcore.transform`.
* For any other `ImportError`, `raise` so the original error surfaces.
* No behavior changes on the successful path.

## Tests

```python
import pytest
from fastai.learner import load_learner

def test_load_learner_missing_file_raises_file_not_found(tmp_path):
    missing = tmp_path / "nope.pkl"
    with pytest.raises(FileNotFoundError):
        load_learner(missing)

def test_load_learner_non_special_import_error_bubbles_up(monkeypatch, tmp_path):
    # Force torch.load to raise ImportError that does not contain the special strings
    import fastai.learner as L
    def bad_load(*args, **kwargs):
        raise ImportError("Some other import problem")
    monkeypatch.setattr(L.torch, "load", bad_load)
    with pytest.raises(ImportError):
        L.load_learner(tmp_path / "anything.pkl")
```

## Backwards compatibility

* No changes to the success path or the public API.
* Users now get clearer errors that reflect the true load failure.
* The existing deprecation guidance for `fastcore.dispatch/transform` remains intact.

