### PR TITLE
Address deprecation warnings in fp16 Callback

### DIFF
--- a/fastai/callback/fp16.py
+++ b/fastai/callback/fp16.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 from ..basics import *
 from .progress import *
 
-from torch.cuda.amp import GradScaler,autocast
-from torch.cuda.amp.grad_scaler import OptState
+from torch.amp import GradScaler,autocast
+from torch.amp.grad_scaler import OptState
 
 # %% auto 0
 __all__ = ['AMPMode', 'MixedPrecision', 'get_master', 'to_master_grads', 'to_model_params', 'test_overflow', 'grad_overflow',
@@ -44,7 +44,7 @@ class MixedPrecision(Callback):
             raise ValueError(f"Unrecognized precision: {self.amp_mode}")
         # `GradScaler` is not needed for bfloat16 as fp32 and bf16 have the same range
         self.kwargs['enabled'] = dtype == torch.float16
-        self.autocast,self.learn.scaler,self.scales = autocast(dtype=dtype),GradScaler(**self.kwargs),L()
+        self.autocast,self.learn.scaler,self.scales = autocast('cuda', dtype=dtype),GradScaler('cuda', **self.kwargs),L()
 
     def before_batch(self): self.autocast.__enter__()
     def after_pred(self):

--- a/nbs/18_callback.fp16.ipynb
+++ b/nbs/18_callback.fp16.ipynb
@@ -31,8 +31,8 @@
     "from fastai.basics import *\n",
     "from fastai.callback.progress import *\n",
     "\n",
-    "from torch.cuda.amp import GradScaler,autocast\n",
-    "from torch.cuda.amp.grad_scaler import OptState"
+    "from torch.amp import GradScaler,autocast\n",
+    "from torch.amp.grad_scaler import OptState"
    ]
   },
   {
@@ -251,7 +251,7 @@
     "            raise ValueError(f\"Unrecognized precision: {self.amp_mode}\")\n",
     "        # `GradScaler` is not needed for bfloat16 as fp32 and bf16 have the same range\n",
     "        self.kwargs['enabled'] = dtype == torch.float16\n",
-    "        self.autocast,self.learn.scaler,self.scales = autocast(dtype=dtype),GradScaler(**self.kwargs),L()\n",
+    "        self.autocast,self.learn.scaler,self.scales = autocast('cuda', dtype=dtype),GradScaler('cuda', **self.kwargs),L()\n",
     "\n",
     "    def before_batch(self): self.autocast.__enter__()\n",
     "    def after_pred(self):\n",


### PR DESCRIPTION
Updates the `fp16` Callback to use the modern `torch.amp` API instead of the deprecated `torch.cuda.amp` functions. This resolves the following `FutureWarning` messages:

```
FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
FutureWarning: `torch.cuda.amp.GradScaler(args...)` is deprecated. Please use `torch.amp.GradScaler('cuda', args...)` instead.
```

The deprecated `torch.cuda.amp.autocast` and `torch.cuda.amp.GradScaler` are replaced with `torch.amp.autocast('cuda', ...)` and `torch.amp.GradScaler('cuda', ...)` respectively.