### PR TITLE
Resolve pickling error with lambda functions during export

### DIFF
--- a/fastai/learner.py
+++ b/fastai/learner.py
@@ -8,7 +8,7 @@ from .data.all import *
 from .optimizer import *
 from .callback.core import *
 from contextlib import nullcontext
-import cloudpickle,pickle,threading
+import dill,pickle,threading
 from collections.abc import MutableSequence
 
 # %% auto 0
@@ -430,7 +430,7 @@ def load(self:Learner, file, device=None, **kwargs):
 
 # %% ../nbs/13a_learner.ipynb 102
 @patch
-def export(self:Learner, fname='export.pkl', pickle_module=cloudpickle, pickle_protocol=2):
+def export(self:Learner, fname='export.pkl', pickle_module=dill, pickle_protocol=2):
     "Export the content of `self` without the items and the optimizer state for inference"
     if rank_distrib(): return # don't export if child proc
     self._end_cleanup()
@@ -447,7 +447,7 @@ def export(self:Learner, fname='export.pkl', pickle_module=cloudpickle, pickle_p
     self.dls = old_dbunch
 
 # %% ../nbs/13a_learner.ipynb 104
-def load_learner(fname, cpu=True, pickle_module=pickle):
+def load_learner(fname, cpu=True, pickle_module=dill):
     "Load a `Learner` object in `fname`, by default putting it on the `cpu`"
     distrib_barrier()
     map_loc = 'cpu' if cpu else default_device()

--- a/nbs/13a_learner.ipynb
+++ b/nbs/13a_learner.ipynb
@@ -32,7 +32,7 @@
     "from fastai.optimizer import *\n",
     "from fastai.callback.core import *\n",
     "from contextlib import nullcontext\n",
-    "import cloudpickle,pickle,threading\n",
+    "import dill,pickle,threading\n",
     "from collections.abc import MutableSequence"
    ]
   },
@@ -2143,7 +2143,7 @@
    "source": [
     "#|export\n",
     "@patch\n",
-    "def export(self:Learner, fname='export.pkl', pickle_module=cloudpickle, pickle_protocol=2):\n",
+    "def export(self:Learner, fname='export.pkl', pickle_module=dill, pickle_protocol=2):\n",
     "    \"Export the content of `self` without the items and the optimizer state for inference\"\n",
     "    if rank_distrib(): return # don't export if child proc\n",
     "    self._end_cleanup()\n",
@@ -2174,7 +2174,7 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "def load_learner(fname, cpu=True, pickle_module=pickle):\n",
+    "def load_learner(fname, cpu=True, pickle_module=dill):\n",
     "    \"Load a `Learner` object in `fname`, by default putting it on the `cpu`\"\n",
     "    distrib_barrier()\n",
     "    map_loc = 'cpu' if cpu else default_device()\n",

--- a/settings.ini
+++ b/settings.ini
@@ -14,7 +14,7 @@ status = 4
 min_python = 3.10
 audience = Developers
 language = English
-requirements = fastdownload>=0.0.5,<2 fastcore>=1.8.0,<1.9 fasttransform>=0.0.2 torchvision>=0.11 matplotlib pandas requests pyyaml fastprogress>=0.2.4 pillow>=9.0.0 scikit-learn scipy spacy<4 packaging plum-dispatch cloudpickle
+requirements = fastdownload>=0.0.5,<2 fastcore>=1.8.0,<1.9 fasttransform>=0.0.2 torchvision>=0.11 matplotlib pandas requests pyyaml fastprogress>=0.2.4 pillow>=9.0.0 scikit-learn scipy spacy<4 packaging plum-dispatch dill
 pip_requirements = torch>=1.10,<2.9
 conda_requirements = pytorch>=1.10,<2.9
 conda_user = fastai


### PR DESCRIPTION
The `Learner.export()` method fails with a `PicklingError: Can't pickle <function <lambda>` when using lambda functions. This is a long standing issue, as discussed on the [forums](https://forums.fast.ai/t/problems-using-learn-export-picklingerror-cant-pickle-function-lambda/78472). This PR resolves the issue by replacing `cloudpickle` with `dill`, as originally suggested by the user **_asoellinger_**.

# Changes
* In `export` and `load_learner`, the `pickle_module` is now `dill` by default.
* The project dependency has been switched from `cloudpickle` to `dill`.

# Testing
* This change has been tested locally and is confirmed to fix the pickling error for lambda functions. Is there a specific reason or performance consideration for originally choosing `cloudpickle` that I should be aware of?
