### PR TITLE
bump torch to <2.10 and add nbdev to dev requirements

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -15,10 +15,10 @@ min_python = 3.10
 audience = Developers
 language = English
 requirements = fastdownload>=0.0.5,<2 fastcore>=1.8.0,<1.9 fasttransform>=0.0.2 torchvision>=0.11 matplotlib pandas requests pyyaml fastprogress>=0.2.4 pillow>=9.0.0 scikit-learn scipy spacy<4 packaging plum-dispatch cloudpickle
-pip_requirements = torch>=1.10,<2.9
-conda_requirements = pytorch>=1.10,<2.9
+pip_requirements = torch>=1.10,<2.10
+conda_requirements = pytorch>=1.10,<2.10
 conda_user = fastai
-dev_requirements = ipywidgets lightning pytorch-ignite transformers sentencepiece tensorboard pydicom catalyst flask_compress captum>=0.4.1 flask wandb kornia scikit-image comet_ml albumentations opencv-python pyarrow ninja timm>=0.9 accelerate>=0.21 ipykernel
+dev_requirements = nbdev ipywidgets lightning pytorch-ignite transformers sentencepiece tensorboard pydicom catalyst flask_compress captum>=0.4.1 flask wandb kornia scikit-image comet_ml albumentations opencv-python pyarrow ninja timm>=0.9 accelerate>=0.21 ipykernel
 console_scripts = configure_accelerate=fastai.distributed:configure_accelerate
 nbs_path = nbs
 doc_path = _docs


### PR DESCRIPTION
Fixes #4129 . Tested w torch 2.9 on the following settings:

* nvidia rtx 4090
* fastai latest main
* `torch.__version__=='2.9.0+cu128'`
* `torchvision.__version__=='0.24.00.24.0+cu128`
* `nbdev_test --flags cuda`

I've also added `nbdev` to the `dev_requirements` as it's needed to run the tests.
