### PR TITLE
Improve documentation for Learner.fit

### DIFF
--- a/nbs/13a_learner.ipynb
+++ b/nbs/13a_learner.ipynb
@@ -826,7 +826,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Uses `lr` and `wd` if they are provided, otherwise use the defaults values given by the `lr` and `wd` attributes of `Learner`."
+       "If `lr` or `wd` are provided, those values override the learner defaults. ",
+       "If `reset_opt=True`, a new optimizer is created before training."
    ]
   },
   {


### PR DESCRIPTION
This PR improves the clarity of the documentation for `Learner.fit`.

- Clarifies that provided `lr` and `wd` override the Learner defaults.
- Notes that `reset_opt=True` creates a new optimizer before training.
- Documentation-only change.

These additions help beginners understand the behavior of `fit` without reading the source code.
