### PR TITLE
Fix broken link to paper in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ navigation sidebar to look through the fastai documentation. Every
 class, function, and method is documented here.
 
 To learn about the design and motivation of the library, read the [peer
-reviewed paper](https://arxiv.org/pdf/2002.04688).
+reviewed paper](https://www.mdpi.com/2078-2489/11/2/108).
 
 ## About fastai
 


### PR DESCRIPTION
The link to the fastai paper in the README is broken. I couldn't find a replacement on MDPI but there is a copy on arxiv.