### PR TITLE
fix: correct typos 'occured' and 'recieved'

### DIFF
--- a/fastai/callback/core.py
+++ b/fastai/callback/core.py
@@ -61,7 +61,7 @@ class Callback(Stateful,GetAttr):
         if self.run and _run: 
             try: res = getcallable(self, event_name)()
             except (CancelBatchException, CancelBackwardException, CancelEpochException, CancelFitException, CancelStepException, CancelTrainException, CancelValidException): raise
-            except Exception as e: raise modify_exception(e, f'Exception occured in `{self.__class__.__name__}` when calling event `{event_name}`:\n\t{e.args[0]}', replace=True)
+            except Exception as e: raise modify_exception(e, f'Exception occurred in `{self.__class__.__name__}` when calling event `{event_name}`:\n\t{e.args[0]}', replace=True)
         if event_name=='after_fit': self.run=True #Reset self.run to True at each end of fit
         return res
 

--- a/fastai/fp16_utils.py
+++ b/fastai/fp16_utils.py
@@ -86,7 +86,7 @@ class FP16Model(nn.Module):
 
 
 def backwards_debug_hook(grad):
-    raise RuntimeError("master_params recieved a gradient in the backward pass!")
+    raise RuntimeError("master_params received a gradient in the backward pass!")
 
 def prep_param_lists(model, flat_master=False):
     """


### PR DESCRIPTION
Corrects spelling:
- `occured` → `occurred` in callback/core.py
- `recieved` → `received` in fp16_utils.py