### PR TITLE
Inference example quick_start.ipynb should use image that exists

### DIFF
--- a/nbs/quick_start.ipynb
+++ b/nbs/quick_start.ipynb
@@ -188,7 +188,7 @@
     }
    ],
    "source": [
-    "img = PILImage.create('images/cat.jpg')\n",
+    "img = PILImage.create('/root/.fastai/data/oxford-iiit-pet/images/Abyssinian_100.jpg')\n",
     "img"
    ]
   },


### PR DESCRIPTION
As it currently exists, quick_start.ipnyb has an example inference step using the image

> img = PILImage.create('images/cat.jpg')

This image does not exist, and this line throws the error

> FileNotFoundError: [Errno 2] No such file or directory: 'images/cat.jpg'

This change is a minimal fix, replacing the non-existent image with one in the dataset used in this tutorial.