### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ To run the tests in parallel, launch:
 For all the tests to pass, you’ll need to install the dependencies
 specified as part of dev_requirements in settings.ini
 
-`pip install -e .[dev]`
+`pip install -e '.[dev]'`
 
 Tests are written using `nbdev`, for example see the documentation for
 `test_eq`.


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `README.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`