### PR TITLE
Fix callback errors with empty exception messages

### DIFF
--- a/fastai/callback/core.py
+++ b/fastai/callback/core.py
@@ -62,7 +62,9 @@ class Callback(Stateful,GetAttr):
         if self.run and _run: 
             try: res = getcallable(self, event_name)()
             except (CancelBatchException, CancelBackwardException, CancelEpochException, CancelFitException, CancelStepException, CancelTrainException, CancelValidException): raise
-            except Exception as e: raise modify_exception(e, f'Exception occured in `{self.__class__.__name__}` when calling event `{event_name}`:\n\t{e.args[0]}', replace=True)
+            except Exception as e:
+                msg = e.args[0] if e.args else e.__class__.__name__
+                raise modify_exception(e, f'Exception occured in `{self.__class__.__name__}` when calling event `{event_name}`:\n\t{msg}', replace=True)
         if event_name=='after_fit': self.run=True #Reset self.run to True at each end of fit
         return res
 

--- a/nbs/13_callback.core.ipynb
+++ b/nbs/13_callback.core.ipynb
@@ -220,7 +220,9 @@
     "        if self.run and _run: \n",
     "            try: res = getcallable(self, event_name)()\n",
     "            except (CancelBatchException, CancelBackwardException, CancelEpochException, CancelFitException, CancelStepException, CancelTrainException, CancelValidException): raise\n",
-    "            except Exception as e: raise modify_exception(e, f'Exception occured in `{self.__class__.__name__}` when calling event `{event_name}`:\\n\\t{e.args[0]}', replace=True)\n",
+    "            except Exception as e:\n",
+    "                msg = e.args[0] if e.args else e.__class__.__name__\n",
+    "                raise modify_exception(e, f'Exception occured in `{self.__class__.__name__}` when calling event `{event_name}`:\\n\\t{msg}', replace=True)\n",
     "        if event_name=='after_fit': self.run=True #Reset self.run to True at each end of fit\n",
     "        return res\n",
     "\n",
@@ -454,7 +456,12 @@
     "learn,cb = TstLearner(1),TstCallback()\n",
     "cb.learn = learn\n",
     "with ExceptionExpected(TypeError, regex=\" in `TstCallback` when calling event `batch_begin`\"):\n",
-    "    cb('batch_begin')"
+    "    cb('batch_begin')\n",
+    "\n",
+    "class EmptyAssertionCallback(Callback):\n",
+    "    def before_fit(self): raise AssertionError\n",
+    "with ExceptionExpected(AssertionError, regex=\"AssertionError\"):\n",
+    "    EmptyAssertionCallback()('before_fit')"
    ]
   },
   {


### PR DESCRIPTION
## Summary

- prevent callback exception handling from indexing an empty `Exception.args` tuple
- retain the original first-argument behavior for normal exceptions and use the exception class name only as an empty-message fallback
- add a regression test for a callback that raises a bare `AssertionError`

Fixes #4019.

## Test plan

- `nbdev-test --path nbs/13_callback.core.ipynb --flags '' --n_workers 1`
- `python -m compileall -q fastai`
- `python -m build`