### PR TITLE
fix: resolve TensorText show_results dispatch

### DIFF
--- a/fastai/text/learner.py
+++ b/fastai/text/learner.py
@@ -291,7 +291,7 @@ def show_results(x: LMTensorText, y, samples, outs, ctxs=None, max_n=10, **kwarg
 def show_results(x: TensorText, y, samples, outs, ctxs=None, max_n=10, trunc_at=150, **kwargs):
     if ctxs is None: ctxs = get_empty_df(min(len(samples), max_n))
     samples = L((s[0].truncate(trunc_at),*s[1:]) for s in samples)
-    ctxs = show_results[object](x, y, samples, outs, ctxs=ctxs, max_n=max_n, **kwargs)
+    ctxs = show_results._resolve_method_with_cache((object, object, object, object))[0](x, y, samples, outs, ctxs=ctxs, max_n=max_n, **kwargs)
     display_df(pd.DataFrame(ctxs))
     return ctxs
 

--- a/nbs/37_text.learner.ipynb
+++ b/nbs/37_text.learner.ipynb
@@ -1162,9 +1162,23 @@
     "def show_results(x: TensorText, y, samples, outs, ctxs=None, max_n=10, trunc_at=150, **kwargs):\n",
     "    if ctxs is None: ctxs = get_empty_df(min(len(samples), max_n))\n",
     "    samples = L((s[0].truncate(trunc_at),*s[1:]) for s in samples)\n",
-    "    ctxs = show_results[object](x, y, samples, outs, ctxs=ctxs, max_n=max_n, **kwargs)\n",
+    "    ctxs = show_results._resolve_method_with_cache((object, object, object, object))[0](x, y, samples, outs, ctxs=ctxs, max_n=max_n, **kwargs)\n",
     "    display_df(pd.DataFrame(ctxs))\n",
     "    return ctxs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f6a0b2c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| hide\n",
+    "samples = L([(TitledStr('input text'), TitledStr('target text'))])\n",
+    "outs = L([(TitledStr('prediction text'),)])\n",
+    "ctxs = show_results(TensorText([1]), TensorText([1]), samples, outs)\n",
+    "test_eq(ctxs[0].to_dict(), {'text': 'input text', 'text_': 'target text', 'text__': 'prediction text'})"
    ]
   },
   {


### PR DESCRIPTION
Closes #4092

## Summary

- Resolve the generic `show_results` fallback through Plum's dispatcher instead of subscripting the dispatched function.
- Add a notebook regression for displaying `TensorText` results.

## Validation

- `nbdev-test --path nbs/37_text.learner.ipynb --n-workers 1 --cell-timeout 120 --do-print`
