### PR TITLE
Read callback and transform arguments with `init_args`

### DIFF
--- a/fastai/callback/wandb.py
+++ b/fastai/callback/wandb.py
@@ -165,7 +165,7 @@ class WandbCallback(Callback):
 def gather_args(self:Learner):
     "Gather config parameters accessible to the learner"
     # args stored by `store_attr`
-    cb_args = {f'{cb}':getattr(cb,'__stored_args__',True) for cb in self.cbs}
+    cb_args = {f'{cb}':init_args(cb) or True for cb in self.cbs}
     args = {'Learner':self, **cb_args}
     # input dimensions
     try:
@@ -205,8 +205,7 @@ def _make_plt(img):
 def _format_config_value(v):
     if isinstance(v, list):
         return [_format_config_value(item) for item in v]
-    elif hasattr(v, '__stored_args__'):
-        return {**_format_config(v.__stored_args__), '_name': v}
+    elif (args := init_args(v)): return {**_format_config(args), '_name': v}
     return v
 
 # %% ../../nbs/70_callback.wandb.ipynb #5b490d6b

--- a/fastai/tabular/core.py
+++ b/fastai/tabular/core.py
@@ -229,7 +229,7 @@ class TabularProc(InplaceTransform):
         return self(items.items if isinstance(items,Datasets) else items)
 
     @property
-    def name(self): return f"{super().name} -- {getattr(self,'__stored_args__',{})}"
+    def name(self): return f"{super().name} -- {init_args(self)}"
 
 # %% ../../nbs/40_tabular.core.ipynb #87389d74
 def _apply_cats (voc, add, c):

--- a/nbs/40_tabular.core.ipynb
+++ b/nbs/40_tabular.core.ipynb
@@ -1373,7 +1373,7 @@
     "        return self(items.items if isinstance(items,Datasets) else items)\n",
     "\n",
     "    @property\n",
-    "    def name(self): return f\"{super().name} -- {getattr(self,'__stored_args__',{})}\""
+    "    def name(self): return f\"{super().name} -- {init_args(self)}\""
    ]
   },
   {

--- a/nbs/70_callback.wandb.ipynb
+++ b/nbs/70_callback.wandb.ipynb
@@ -326,7 +326,7 @@
     "def gather_args(self:Learner):\n",
     "    \"Gather config parameters accessible to the learner\"\n",
     "    # args stored by `store_attr`\n",
-    "    cb_args = {f'{cb}':getattr(cb,'__stored_args__',True) for cb in self.cbs}\n",
+    "    cb_args = {f'{cb}':init_args(cb) or True for cb in self.cbs}\n",
     "    args = {'Learner':self, **cb_args}\n",
     "    # input dimensions\n",
     "    try:\n",
@@ -412,8 +412,7 @@
     "def _format_config_value(v):\n",
     "    if isinstance(v, list):\n",
     "        return [_format_config_value(item) for item in v]\n",
-    "    elif hasattr(v, '__stored_args__'):\n",
-    "        return {**_format_config(v.__stored_args__), '_name': v}\n",
+    "    elif (args := init_args(v)): return {**_format_config(args), '_name': v}\n",
     "    return v"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = {text = "Apache-2.0"}
 authors = [{name = "Jeremy Howard, Sylvain Gugger, and contributors", email = "info@fast.ai"}]
 keywords = ['fastai,', 'deep', 'learning,', 'machine', 'learning']
 classifiers = ["Natural Language :: English", "Intended Audience :: Developers", "Development Status :: 4 - Beta", "Programming Language :: Python :: 3", "Programming Language :: Python :: 3 :: Only"]
-dependencies = ['fastdownload>=0.0.5,<2', 'fastcore>=1.14.6', 'fasttransform>=0.0.2', 'torchvision>=0.11', 'matplotlib', 'pandas', 'requests', 'pyyaml', 'fastprogress>=0.2.4', 'pillow>=9.0.0', 'scikit-learn', 'scipy', 'spacy<4', 'packaging', 'plum-dispatch', 'cloudpickle', 'torch>=1.10,<3']
+dependencies = ['fastdownload>=0.0.5,<2', 'fastcore>=2.2.21', 'fasttransform>=0.0.2', 'torchvision>=0.11', 'matplotlib', 'pandas', 'requests', 'pyyaml', 'fastprogress>=0.2.4', 'pillow>=9.0.0', 'scikit-learn', 'scipy', 'spacy<4', 'packaging', 'plum-dispatch', 'cloudpickle', 'torch>=1.10,<3']
 
 [project.urls]
 Repository = "https://github.com/fastai/fastai"


### PR DESCRIPTION
The wandb callback logs each callback's constructor arguments through fastcore's `init_args`, and `TabularProc.name` shows them the same way, replacing the `__stored_args__` record that fastcore no longer keeps. Pins `fastcore>=2.2.21`.