### PR TITLE
Pin plum-dispatch below 2.10, which breaks import on compiled wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = {text = "Apache-2.0"}
 authors = [{name = "Jeremy Howard, Sylvain Gugger, and contributors", email = "info@fast.ai"}]
 keywords = ['fastai,', 'deep', 'learning,', 'machine', 'learning']
 classifiers = ["Natural Language :: English", "Intended Audience :: Developers", "Development Status :: 4 - Beta", "Programming Language :: Python :: 3", "Programming Language :: Python :: 3 :: Only"]
-dependencies = ['fastdownload>=0.0.5,<2', 'fastcore>=2.2.21', 'fasttransform>=0.0.2', 'torchvision>=0.11', 'matplotlib', 'pandas', 'requests', 'pyyaml', 'fastprogress>=0.2.4', 'pillow>=9.0.0', 'scikit-learn', 'scipy', 'spacy<4', 'packaging', 'plum-dispatch', 'cloudpickle', 'torch>=1.10,<3']
+dependencies = ['fastdownload>=0.0.5,<2', 'fastcore>=2.2.21', 'fasttransform>=0.0.2', 'torchvision>=0.11', 'matplotlib', 'pandas', 'requests', 'pyyaml', 'fastprogress>=0.2.4', 'pillow>=9.0.0', 'scikit-learn', 'scipy', 'spacy<4', 'packaging', 'plum-dispatch<2.10', 'cloudpickle', 'torch>=1.10,<3']
 
 [project.urls]
 Repository = "https://github.com/fastai/fastai"


### PR DESCRIPTION
plum-dispatch 2.10.0 makes `Function.__doc__` read-only on its mypyc-compiled wheels, so fastcore's `add_docs` fails while importing `fastai.data.transforms` on Linux, macOS Intel and Windows. Pinning to `<2.10` restores the import until the upstream fix lands. Reported at beartype/plum#317.