### PR TITLE
Fix `RandTransform` repr recursion, and document vision.augment

### DIFF
--- a/fastai/vision/augment.py
+++ b/fastai/vision/augment.py
@@ -20,7 +20,6 @@ from .data import *
 
 # %% ../../nbs/09_vision.augment.ipynb #4f678d91
 from torch import stack, zeros_like as t0, ones_like as t1
-from torch.distributions.bernoulli import Bernoulli
 
 # %% ../../nbs/09_vision.augment.ipynb #d5a5551d
 class RandTransform(DisplayedTransform):
@@ -34,7 +33,7 @@ class RandTransform(DisplayedTransform):
     ):
         store_attr('p')
         super().__init__(**kwargs)
-        self.before_call = ifnone(before_call,self.before_call)
+        if before_call is not None: self.before_call = before_call
 
     def before_call(self, 
         b, 
@@ -66,7 +65,7 @@ def flip_lr(x:TensorImageBase): return x.flip(-1)
 @patch
 def flip_lr(x:TensorPoint): return TensorPoint(_neg_axis(x.clone(), 0))
 @patch
-def flip_lr(x:TensorBBox):  return TensorBBox(TensorPoint(x.view(-1,2)).flip_lr().view(-1,4))
+def flip_lr(x:TensorBBox):  return TensorBBox(TensorPoint(x.view(-1,2)).flip_lr().view(-1,4))  # chkstyle: ignore
 
 # %% ../../nbs/09_vision.augment.ipynb #b7bd957b
 class FlipItem(RandTransform):
@@ -97,7 +96,7 @@ def dihedral(x:TensorPoint,
     if k in [3,5,6,7]: x = x.flip(1)
     return x
 @patch
-def dihedral(x:TensorBBox, 
+def dihedral(x:TensorBBox,  # chkstyle: ignore
     k:int, #Dihedral transformation to apply
 ):
     pnts = TensorPoint(x.view(-1,2)).dihedral(k).view(-1,2,2)
@@ -113,22 +112,18 @@ class DihedralItem(RandTransform):
 
     def encodes(self, x:(Image.Image,*TensorTypes)): return x.dihedral(self.k)
 
-# %% ../../nbs/09_vision.augment.ipynb #b55a5ac8
-from torchvision.transforms.functional import pad as tvpad
-
 # %% ../../nbs/09_vision.augment.ipynb #01a824b0
 mk_class('PadMode', **{o:o.lower() for o in ['Zeros', 'Border', 'Reflection']},
-         doc="All possible padding mode as attributes to get tab-completion and typo-proofing")
+    doc="All possible padding mode as attributes to get tab-completion and typo-proofing")
 
 # %% ../../nbs/09_vision.augment.ipynb #80f293fe
 _all_ = ['PadMode']
 
 # %% ../../nbs/09_vision.augment.ipynb #1c2876b7
-_pad_modes = {'zeros': 'constant', 'border': 'edge', 'reflection': 'reflect'}
+_pad_modes = dict(zeros='constant', border='edge', reflection='reflect')
 
 @patch
-def _do_crop_pad(x:Image.Image, sz, tl, orig_sz,
-                 pad_mode=PadMode.Zeros, resize_mode=BILINEAR, resize_to=None):
+def _do_crop_pad(x:Image.Image, sz, tl, orig_sz, pad_mode=PadMode.Zeros, resize_mode=BILINEAR, resize_to=None):
     if any(tl.ge(0)) or any(tl.add(sz).le(orig_sz)):
         # At least one dim is inside the image, so needs to be cropped
         c = tl.max(0)
@@ -153,7 +148,7 @@ def _do_crop_pad(x:TensorBBox, sz, tl, orig_sz, pad_mode=PadMode.Zeros, resize_t
     return TensorBBox(bbox, img_size=x.img_size)
 
 @patch
-def crop_pad(x:TensorBBox|TensorPoint|Image.Image,
+def crop_pad(x:TensorBBox|TensorPoint|Image.Image,  # chkstyle: ignore
     sz:int|tuple, # Crop/pad size of input, duplicated if one value is specified
     tl:tuple=None, # Optional top-left coordinate of the crop/pad, if `None` center crop
     orig_sz:tuple=None, # Original size of input
@@ -222,8 +217,7 @@ class RandomCrop(RandTransform):
             h_rand = (hd, -1) if hd < 0 else (0, hd)
             self.tl = fastuple(random.randint(*w_rand), random.randint(*h_rand))
 
-    def encodes(self, x:Image.Image|TensorBBox|TensorPoint):
-        return x.crop_pad(self.size, self.tl, orig_sz=self.orig_sz)
+    def encodes(self, x:Image.Image|TensorBBox|TensorPoint): return x.crop_pad(self.size, self.tl, orig_sz=self.orig_sz)
 
 # %% ../../nbs/09_vision.augment.ipynb #f0b73973
 class OldRandomCrop(CropPad):
@@ -235,7 +229,7 @@ class OldRandomCrop(CropPad):
 
 # %% ../../nbs/09_vision.augment.ipynb #00527c2c
 mk_class('ResizeMethod', **{o:o.lower() for o in ['Squish', 'Crop', 'Pad']},
-         doc="All possible resize method as attributes to get tab-completion and typo-proofing")
+    doc="All possible resize method as attributes to get tab-completion and typo-proofing")
 
 # %% ../../nbs/09_vision.augment.ipynb #d93b6880
 _all_ = ['ResizeMethod']
@@ -268,7 +262,7 @@ class Resize(RandTransform):
         orig_sz = _get_sz(x)
         if self.method==ResizeMethod.Squish:
             return x.crop_pad(orig_sz, fastuple(0,0), orig_sz=orig_sz, pad_mode=self.pad_mode,
-                   resize_mode=self.mode_mask if isinstance(x,PILMask) else self.mode, resize_to=self.size)
+                resize_mode=self.mode_mask if isinstance(x,PILMask) else self.mode, resize_to=self.size)
 
         w,h = orig_sz
         op = (operator.lt,operator.gt)[self.method==ResizeMethod.Pad]
@@ -276,7 +270,7 @@ class Resize(RandTransform):
         cp_sz = (int(m*self.size[0]),int(m*self.size[1]))
         tl = fastuple(int(self.pcts[0]*(w-cp_sz[0])), int(self.pcts[1]*(h-cp_sz[1])))
         return x.crop_pad(cp_sz, tl, orig_sz=orig_sz, pad_mode=self.pad_mode,
-                   resize_mode=self.mode_mask if isinstance(x,PILMask) else self.mode, resize_to=self.size)
+            resize_mode=self.mode_mask if isinstance(x,PILMask) else self.mode, resize_to=self.size)
 
 # %% ../../nbs/09_vision.augment.ipynb #c85221db
 @delegates()
@@ -284,13 +278,13 @@ class RandomResizedCrop(RandTransform):
     "Picks a random scaled crop of an image and resize it to `size`"
     split_idx,order = None,1
     def __init__(self, 
-         size:int|tuple, # Final size, duplicated if one value is specified,, 
-         min_scale:float=0.08, # Minimum scale of the crop, in relation to image area
-         ratio=(3/4, 4/3), # Range of width over height of the output
-         resamples=(BILINEAR, NEAREST), # Pillow `Image` resample mode, resamples[1] for mask
-         val_xtra:float=0.14, # The ratio of size at the edge cropped out in the validation set
-         max_scale:float=1., # Maximum scale of the crop, in relation to image area
-         **kwargs
+        size:int|tuple, # Final size, duplicated if one value is specified
+        min_scale:float=0.08, # Minimum scale of the crop, in relation to image area
+        ratio=(3/4, 4/3), # Range of width over height of the output
+        resamples=(BILINEAR, NEAREST), # Pillow `Image` resample mode, resamples[1] for mask
+        val_xtra:float=0.14, # The ratio of size at the edge cropped out in the validation set
+        max_scale:float=1., # Maximum scale of the crop, in relation to image area
+        **kwargs
     ):
         size = _process_sz(size)
         store_attr()
@@ -362,8 +356,7 @@ def _grid_sample(x, coords, mode='bilinear', padding_mode='reflection', align_co
         # amount we're resizing by, with 100% extra margin
         d = min(x.shape[-2]/coords.shape[-2], x.shape[-1]/coords.shape[-1])/2
         # If we're resizing up by >200%, and we're zooming less than that, interpolate first
-        if d>1 and d>z:
-            x = F.interpolate(x, scale_factor=1/d, mode='area', recompute_scale_factor=True)
+        if d>1 and d>z: x = F.interpolate(x, scale_factor=1/d, mode='area', recompute_scale_factor=True)
     return F.grid_sample(x, coords, mode=mode, padding_mode=padding_mode, align_corners=align_corners)
 
 # %% ../../nbs/09_vision.augment.ipynb #fca3bdd6
@@ -378,12 +371,12 @@ def affine_grid(
 # %% ../../nbs/09_vision.augment.ipynb #10b0ca25
 @patch
 def affine_coord(x: TensorImage, 
-     mat:Tensor=None, # Batch of affine transformation matrices
-     coord_tfm:Callable=None, # Partial function of composable coordinate transforms
-     sz:int|tuple=None, # Output size, duplicated if one value is specified
-     mode:str='bilinear', # PyTorch `F.grid_sample` interpolation applied to `TensorImage`
-     pad_mode=PadMode.Reflection, # Padding applied to `TensorImage`
-     align_corners=True # PyTorch `F.grid_sample` align_corners
+    mat:Tensor=None, # Batch of affine transformation matrices
+    coord_tfm:Callable=None, # Partial function of composable coordinate transforms
+    sz:int|tuple=None, # Output size, duplicated if one value is specified
+    mode:str='bilinear', # PyTorch `F.grid_sample` interpolation applied to `TensorImage`
+    pad_mode=PadMode.Reflection, # Padding applied to `TensorImage`
+    align_corners=True # PyTorch `F.grid_sample` align_corners
 ):
     "Apply affine and coordinate transforms to `TensorImage`"
     if mat is None and coord_tfm is None and sz is None: return x
@@ -428,7 +421,7 @@ def affine_coord(x: TensorPoint,
     return TensorPoint(x, sz=sz)
 
 @patch
-def affine_coord(x: TensorBBox, 
+def affine_coord(x: TensorBBox,  # chkstyle: ignore
     mat=None, # Batch of affine transformation matrices
     coord_tfm=None, # Partial function of composable coordinate transforms
     sz=None, # Output size, duplicated if one value is specified
@@ -440,8 +433,7 @@ def affine_coord(x: TensorBBox,
     if mat is None and coord_tfm is None: return x
     if sz is None: sz = getattr(x, "img_size", None)
     bs,n = x.shape[:2]
-    pnts = stack([x[...,:2], stack([x[...,0],x[...,3]],dim=2),
-                  stack([x[...,2],x[...,1]],dim=2), x[...,2:]], dim=2)
+    pnts = stack([x[...,:2], stack([x[...,0], x[...,3]], dim=2), stack([x[...,2], x[...,1]], dim=2), x[...,2:]], dim=2)
     pnts = TensorPoint(pnts.view(bs, 4*n, 2), img_size=sz).affine_coord(mat, coord_tfm, sz, mode, pad_mode)
     pnts = pnts.view(bs, n, 4, 2)
     tl,dr = pnts.min(dim=2)[0],pnts.max(dim=2)[0]
@@ -579,9 +571,9 @@ def _draw_mask(x, def_draw, draw=None, p=0.5, neutral=0., batch=False):
 # %% ../../nbs/09_vision.augment.ipynb #4cc16090
 def affine_mat(*ms):
     "Restructure length-6 vector `ms` into an affine matrix with 0,0,1 in the last line"
-    return stack([stack([ms[0], ms[1], ms[2]], dim=1),
-                  stack([ms[3], ms[4], ms[5]], dim=1),
-                  stack([t0(ms[0]), t0(ms[0]), t1(ms[0])], dim=1)], dim=1)
+    return stack([stack([ms[0], ms[1], ms[2]], dim=1),  # chkstyle: ignore-node
+        stack([ms[3], ms[4], ms[5]], dim=1),
+        stack([t0(ms[0]), t0(ms[0]), t1(ms[0])], dim=1)], dim=1)
 
 # %% ../../nbs/09_vision.augment.ipynb #0b648343
 def flip_mat(
@@ -593,7 +585,7 @@ def flip_mat(
     "Return a random flip matrix"
     def _def_draw(x): return x.new_ones(x.size(0))
     mask = x.new_ones(x.size(0)) - 2*_draw_mask(x, _def_draw, draw=draw, p=p, batch=batch)
-    return affine_mat(mask,     t0(mask), t0(mask),
+    return affine_mat(mask,     t0(mask), t0(mask),  # chkstyle: ignore-node
                       t0(mask), t1(mask), t0(mask))
 
 # %% ../../nbs/09_vision.augment.ipynb #ca49f33a
@@ -668,7 +660,7 @@ def dihedral_mat(
     ys = tensor([1,1,-1,1,-1,-1,1,-1], device=x.device).gather(0, idx)
     m0 = tensor([1,1,1,0,1,0,0,0], device=x.device).gather(0, idx)
     m1 = tensor([0,0,0,1,0,1,1,1], device=x.device).gather(0, idx)
-    return affine_mat(xs*m0,  xs*m1,  t0(xs),
+    return affine_mat(xs*m0,  xs*m1,  t0(xs),  # chkstyle: ignore-node
                       ys*m1,  ys*m0,  t0(xs)).float()
 
 # %% ../../nbs/09_vision.augment.ipynb #3402ff49
@@ -724,7 +716,7 @@ def rotate_mat(
     def _def_draw(x):   return x.new_empty(x.size(0)).uniform_(-max_deg, max_deg)
     def _def_draw_b(x): return x.new_zeros(x.size(0)) + random.uniform(-max_deg, max_deg)
     thetas = _draw_mask(x, _def_draw_b if batch else _def_draw, draw=draw, p=p, batch=batch) * math.pi/180
-    return affine_mat(thetas.cos(), thetas.sin(), t0(thetas),
+    return affine_mat(thetas.cos(), thetas.sin(), t0(thetas),  # chkstyle: ignore-node
                      -thetas.sin(), thetas.cos(), t0(thetas))
 
 # %% ../../nbs/09_vision.augment.ipynb #813ae11c
@@ -780,7 +772,7 @@ def zoom_mat(
     row_pct = _draw_mask(x, def_draw_c, draw=draw_y, p=1., batch=batch)
     col_c = (1-s) * (2*col_pct - 1)
     row_c = (1-s) * (2*row_pct - 1)
-    return affine_mat(s,     t0(s), col_c,
+    return affine_mat(s,     t0(s), col_c,  # chkstyle: ignore-node
                       t0(s), s,     row_c)
 
 # %% ../../nbs/09_vision.augment.ipynb #76ecc04c
@@ -816,8 +808,7 @@ class Zoom(AffineCoordTfm):
         super().__init__(aff_fs, size=size, mode=mode, pad_mode=pad_mode, align_corners=align_corners)
 
 # %% ../../nbs/09_vision.augment.ipynb #f59ebe09
-def solve(A,B):
-    return torch.linalg.solve(A,B)
+def solve(A,B): return torch.linalg.solve(A,B)
 
 # %% ../../nbs/09_vision.augment.ipynb #dad4e52a
 def find_coeffs(
@@ -865,7 +856,7 @@ class _WarpCoord():
         y_t = _draw_mask(x, self._def_draw, self.draw_y, p=self.p, batch=self.batch)
         orig_pts = torch.tensor([[-1,-1], [-1,1], [1,-1], [1,1]], dtype=x.dtype, device=x.device)
         self.orig_pts = orig_pts.unsqueeze(0).expand(x.size(0),4,2)
-        targ_pts = stack([stack([-1-y_t, -1-x_t]), stack([-1+y_t, 1+x_t]),
+        targ_pts = stack([stack([-1-y_t, -1-x_t]), stack([-1+y_t, 1+x_t]),  # chkstyle: ignore-node
                           stack([ 1+y_t, -1+x_t]), stack([ 1-y_t, 1-x_t])])
         self.targ_pts = targ_pts.permute(2,0,1)
 
@@ -957,8 +948,7 @@ class _BrightnessLogit():
         if not self.batch: return x.new_empty(x.size(0)).uniform_(0.5*(1-self.max_lighting), 0.5*(1+self.max_lighting))
         return x.new_zeros(x.size(0)) + random.uniform(0.5*(1-self.max_lighting), 0.5*(1+self.max_lighting))
 
-    def before_call(self, x):
-        self.change = _draw_mask(x, self._def_draw, draw=self.draw, p=self.p, neutral=0.5, batch=self.batch)
+    def before_call(self, x): self.change = _draw_mask(x, self._def_draw, draw=self.draw, p=self.p, neutral=0.5, batch=self.batch)
 
     def __call__(self, x): return x.add_(logit(self.change[:,None,None,None]))
 
@@ -991,8 +981,7 @@ class _ContrastLogit():
         else: res = x.new_zeros(x.size(0)) + random.uniform(math.log(1-self.max_lighting), -math.log(1-self.max_lighting))
         return torch.exp(res)
 
-    def before_call(self, x):
-        self.change = _draw_mask(x, self._def_draw, draw=self.draw, p=self.p, neutral=1., batch=self.batch)
+    def before_call(self, x): self.change = _draw_mask(x, self._def_draw, draw=self.draw, p=self.p, neutral=1., batch=self.batch)
 
     def __call__(self, x): return x.mul_(self.change[:,None,None,None])
 
@@ -1030,8 +1019,7 @@ class _SaturationLogit():
         else: res = x.new_zeros(x.size(0)) + random.uniform(math.log(1-self.max_lighting), -math.log(1-self.max_lighting))
         return torch.exp(res)
 
-    def before_call(self, x):
-        self.change = _draw_mask(x, self._def_draw, draw=self.draw, p=self.p, neutral=1., batch=self.batch)
+    def before_call(self, x): self.change = _draw_mask(x, self._def_draw, draw=self.draw, p=self.p, neutral=1., batch=self.batch)
 
     def __call__(self, x):
         #interpolate between grayscale and original in-place
@@ -1120,8 +1108,7 @@ def hsv(x: TensorImage, func): return TensorImage(hsv2rgb(func(rgb2hsv(x))))
 # %% ../../nbs/09_vision.augment.ipynb #8c609dc6
 class HSVTfm(SpaceTfm):
     "Apply `fs` to the images in HSV space"
-    def __init__(self, fs, **kwargs):
-        super().__init__(fs, TensorImage.hsv, **kwargs)
+    def __init__(self, fs, **kwargs): super().__init__(fs, TensorImage.hsv, **kwargs)
 
 # %% ../../nbs/09_vision.augment.ipynb #21afea61
 class _Hue():
@@ -1132,8 +1119,7 @@ class _Hue():
         else: res = x.new_zeros(x.size(0)) + random.uniform(math.log(1-self.max_hue), -math.log(1-self.max_hue))
         return torch.exp(res)
 
-    def before_call(self, x):
-        self.change = _draw_mask(x, self._def_draw, draw=self.draw, p=self.p, neutral=0., batch=self.batch)
+    def before_call(self, x): self.change = _draw_mask(x, self._def_draw, draw=self.draw, p=self.p, neutral=0., batch=self.batch)
 
     def __call__(self, x):
         h,s,v = x.unbind(1)

--- a/nbs/09_vision.augment.ipynb
+++ b/nbs/09_vision.augment.ipynb
@@ -54,7 +54,8 @@
    "outputs": [],
    "source": [
     "#| hide\n",
-    "from nbdev.showdoc import *"
+    "from nbdev.showdoc import *\n",
+    "from torchvision.transforms.functional import pad as tvpad"
    ]
   },
   {
@@ -65,8 +66,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "from torch import stack, zeros_like as t0, ones_like as t1\n",
-    "from torch.distributions.bernoulli import Bernoulli"
+    "from torch import stack, zeros_like as t0, ones_like as t1"
    ]
   },
   {
@@ -106,7 +106,7 @@
     "    ):\n",
     "        store_attr('p')\n",
     "        super().__init__(**kwargs)\n",
-    "        self.before_call = ifnone(before_call,self.before_call)\n",
+    "        if before_call is not None: self.before_call = before_call\n",
     "\n",
     "    def before_call(self, \n",
     "        b, \n",
@@ -232,12 +232,12 @@
    "source": [
     "def _add1(x): return x+1\n",
     "dumb_tfm = RandTransform(enc=_add1, p=0.5)\n",
-    "start,d1,d2 = 2,False,False\n",
+    "start,dos = 2,set()\n",
     "for _ in range(40):\n",
     "    t = dumb_tfm(start, split_idx=0)\n",
-    "    if dumb_tfm.do: test_eq(t, start+1); d1=True\n",
-    "    else:           test_eq(t, start)  ; d2=True\n",
-    "assert d1 and d2\n",
+    "    test_eq(t, start+1 if dumb_tfm.do else start)\n",
+    "    dos.add(dumb_tfm.do)\n",
+    "test_eq(dos, {True, False})\n",
     "dumb_tfm"
    ]
   },
@@ -265,6 +265,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "fd5e3951",
+   "metadata": {},
+   "source": [
+    "`_neg_axis` negates one coordinate axis in place, which is how flips and dihedral transforms act on points and boxes. `TensorTypes` lists the tensor classes the item transforms below are patched for."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "a833f80e",
@@ -279,7 +287,7 @@
     "@patch\n",
     "def flip_lr(x:TensorPoint): return TensorPoint(_neg_axis(x.clone(), 0))\n",
     "@patch\n",
-    "def flip_lr(x:TensorBBox):  return TensorBBox(TensorPoint(x.view(-1,2)).flip_lr().view(-1,4))"
+    "def flip_lr(x:TensorBBox):  return TensorBBox(TensorPoint(x.view(-1,2)).flip_lr().view(-1,4))  # chkstyle: ignore"
    ]
   },
   {
@@ -411,7 +419,7 @@
     "    if k in [3,5,6,7]: x = x.flip(1)\n",
     "    return x\n",
     "@patch\n",
-    "def dihedral(x:TensorBBox, \n",
+    "def dihedral(x:TensorBBox,  # chkstyle: ignore\n",
     "    k:int, #Dihedral transformation to apply\n",
     "):\n",
     "    pnts = TensorPoint(x.view(-1,2)).dihedral(k).view(-1,2,2)\n",
@@ -465,8 +473,7 @@
    ],
    "source": [
     "_,axs = subplots(2, 4)\n",
-    "for ax in axs.flatten():\n",
-    "    show_image(DihedralItem(p=1.)(img, split_idx=0), ctx=ax)"
+    "for ax in axs.flatten(): show_image(DihedralItem(p=1.)(img, split_idx=0), ctx=ax)"
    ]
   },
   {
@@ -498,24 +505,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b55a5ac8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#| export\n",
-    "from torchvision.transforms.functional import pad as tvpad"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "01a824b0",
    "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
     "mk_class('PadMode', **{o:o.lower() for o in ['Zeros', 'Border', 'Reflection']},\n",
-    "         doc=\"All possible padding mode as attributes to get tab-completion and typo-proofing\")"
+    "    doc=\"All possible padding mode as attributes to get tab-completion and typo-proofing\")"
    ]
   },
   {
@@ -573,11 +569,10 @@
    "outputs": [],
    "source": [
     "#| exporti\n",
-    "_pad_modes = {'zeros': 'constant', 'border': 'edge', 'reflection': 'reflect'}\n",
+    "_pad_modes = dict(zeros='constant', border='edge', reflection='reflect')\n",
     "\n",
     "@patch\n",
-    "def _do_crop_pad(x:Image.Image, sz, tl, orig_sz,\n",
-    "                 pad_mode=PadMode.Zeros, resize_mode=BILINEAR, resize_to=None):\n",
+    "def _do_crop_pad(x:Image.Image, sz, tl, orig_sz, pad_mode=PadMode.Zeros, resize_mode=BILINEAR, resize_to=None):\n",
     "    if any(tl.ge(0)) or any(tl.add(sz).le(orig_sz)):\n",
     "        # At least one dim is inside the image, so needs to be cropped\n",
     "        c = tl.max(0)\n",
@@ -602,7 +597,7 @@
     "    return TensorBBox(bbox, img_size=x.img_size)\n",
     "\n",
     "@patch\n",
-    "def crop_pad(x:TensorBBox|TensorPoint|Image.Image,\n",
+    "def crop_pad(x:TensorBBox|TensorPoint|Image.Image,  # chkstyle: ignore\n",
     "    sz:int|tuple, # Crop/pad size of input, duplicated if one value is specified\n",
     "    tl:tuple=None, # Optional top-left coordinate of the crop/pad, if `None` center crop\n",
     "    orig_sz:tuple=None, # Original size of input\n",
@@ -632,6 +627,14 @@
     "    if isinstance(x, tuple): x = x[0]\n",
     "    if not isinstance(x, Tensor): return fastuple(x.size)\n",
     "    return fastuple(getattr(x, 'img_size', getattr(x, 'sz', (x.shape[-1], x.shape[-2]))))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fdecbd92",
+   "metadata": {},
+   "source": [
+    "`_process_sz` turns an `int` or `(h,w)` size into the `(w,h)` order PIL uses, and `_get_sz` reads an item's size whether it is a PIL image or a tensor carrying `img_size`."
    ]
   },
   {
@@ -850,8 +853,7 @@
     "            h_rand = (hd, -1) if hd < 0 else (0, hd)\n",
     "            self.tl = fastuple(random.randint(*w_rand), random.randint(*h_rand))\n",
     "\n",
-    "    def encodes(self, x:Image.Image|TensorBBox|TensorPoint):\n",
-    "        return x.crop_pad(self.size, self.tl, orig_sz=self.orig_sz)"
+    "    def encodes(self, x:Image.Image|TensorBBox|TensorPoint): return x.crop_pad(self.size, self.tl, orig_sz=self.orig_sz)"
    ]
   },
   {
@@ -908,6 +910,14 @@
     "        super().before_call(b, split_idx)\n",
     "        w,h = self.orig_sz\n",
     "        if not split_idx: self.tl = (random.randint(0,w-self.cp_size[0]), random.randint(0,h-self.cp_size[1]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d89048f",
+   "metadata": {},
+   "source": [
+    "`OldRandomCrop` is the earlier `CropPad`-based implementation of `RandomCrop`: a random top-left corner on the training set, and the centre crop `CropPad` gives on validation."
    ]
   },
   {
@@ -1014,7 +1024,7 @@
    "source": [
     "#| export\n",
     "mk_class('ResizeMethod', **{o:o.lower() for o in ['Squish', 'Crop', 'Pad']},\n",
-    "         doc=\"All possible resize method as attributes to get tab-completion and typo-proofing\")"
+    "    doc=\"All possible resize method as attributes to get tab-completion and typo-proofing\")"
    ]
   },
   {
@@ -1117,7 +1127,7 @@
     "        orig_sz = _get_sz(x)\n",
     "        if self.method==ResizeMethod.Squish:\n",
     "            return x.crop_pad(orig_sz, fastuple(0,0), orig_sz=orig_sz, pad_mode=self.pad_mode,\n",
-    "                   resize_mode=self.mode_mask if isinstance(x,PILMask) else self.mode, resize_to=self.size)\n",
+    "                resize_mode=self.mode_mask if isinstance(x,PILMask) else self.mode, resize_to=self.size)\n",
     "\n",
     "        w,h = orig_sz\n",
     "        op = (operator.lt,operator.gt)[self.method==ResizeMethod.Pad]\n",
@@ -1125,7 +1135,7 @@
     "        cp_sz = (int(m*self.size[0]),int(m*self.size[1]))\n",
     "        tl = fastuple(int(self.pcts[0]*(w-cp_sz[0])), int(self.pcts[1]*(h-cp_sz[1])))\n",
     "        return x.crop_pad(cp_sz, tl, orig_sz=orig_sz, pad_mode=self.pad_mode,\n",
-    "                   resize_mode=self.mode_mask if isinstance(x,PILMask) else self.mode, resize_to=self.size)"
+    "            resize_mode=self.mode_mask if isinstance(x,PILMask) else self.mode, resize_to=self.size)"
    ]
   },
   {
@@ -1236,13 +1246,13 @@
     "    \"Picks a random scaled crop of an image and resize it to `size`\"\n",
     "    split_idx,order = None,1\n",
     "    def __init__(self, \n",
-    "         size:int|tuple, # Final size, duplicated if one value is specified,, \n",
-    "         min_scale:float=0.08, # Minimum scale of the crop, in relation to image area\n",
-    "         ratio=(3/4, 4/3), # Range of width over height of the output\n",
-    "         resamples=(BILINEAR, NEAREST), # Pillow `Image` resample mode, resamples[1] for mask\n",
-    "         val_xtra:float=0.14, # The ratio of size at the edge cropped out in the validation set\n",
-    "         max_scale:float=1., # Maximum scale of the crop, in relation to image area\n",
-    "         **kwargs\n",
+    "        size:int|tuple, # Final size, duplicated if one value is specified\n",
+    "        min_scale:float=0.08, # Minimum scale of the crop, in relation to image area\n",
+    "        ratio=(3/4, 4/3), # Range of width over height of the output\n",
+    "        resamples=(BILINEAR, NEAREST), # Pillow `Image` resample mode, resamples[1] for mask\n",
+    "        val_xtra:float=0.14, # The ratio of size at the edge cropped out in the validation set\n",
+    "        max_scale:float=1., # Maximum scale of the crop, in relation to image area\n",
+    "        **kwargs\n",
     "    ):\n",
     "        size = _process_sz(size)\n",
     "        store_attr()\n",
@@ -1532,8 +1542,7 @@
     "        # amount we're resizing by, with 100% extra margin\n",
     "        d = min(x.shape[-2]/coords.shape[-2], x.shape[-1]/coords.shape[-1])/2\n",
     "        # If we're resizing up by >200%, and we're zooming less than that, interpolate first\n",
-    "        if d>1 and d>z:\n",
-    "            x = F.interpolate(x, scale_factor=1/d, mode='area', recompute_scale_factor=True)\n",
+    "        if d>1 and d>z: x = F.interpolate(x, scale_factor=1/d, mode='area', recompute_scale_factor=True)\n",
     "    return F.grid_sample(x, coords, mode=mode, padding_mode=padding_mode, align_corners=align_corners)"
    ]
   },
@@ -1563,7 +1572,7 @@
     }
    ],
    "source": [
-    "img=torch.tensor([[[0,0,0],[1,0,0],[2,0,0]],\n",
+    "img=torch.tensor([[[0,0,0],[1,0,0],[2,0,0]],  # chkstyle: ignore-node\n",
     "               [[0,1,0],[1,1,0],[2,1,0]],\n",
     "               [[0,2,0],[1,2,0],[2,2,0]]]).permute(2,0,1)[None]/2.\n",
     "show_images(img)"
@@ -1595,7 +1604,7 @@
     }
    ],
    "source": [
-    "grid=torch.tensor([[[[-1,-1],[0,-1],[1,-1]],\n",
+    "grid=torch.tensor([[[[-1,-1],[0,-1],[1,-1]],  # chkstyle: ignore-node\n",
     "               [[-1,0],[0,0],[1,0]],\n",
     "               [[-1,1],[0,1],[1,1.]]]])\n",
     "img=_grid_sample(img, grid,align_corners=True)\n",
@@ -1628,7 +1637,7 @@
     }
    ],
    "source": [
-    "grid=torch.tensor([[[1.,-1],[0,-1],[-1,-1]],\n",
+    "grid=torch.tensor([[[1.,-1],[0,-1],[-1,-1]],  # chkstyle: ignore-node\n",
     "               [[1,0],[0,0],[-1,0]],\n",
     "               [[1,1],[0,1],[-1,1]]])\n",
     "img=_grid_sample(img, grid[None],align_corners=True)\n",
@@ -1661,9 +1670,9 @@
     }
    ],
    "source": [
-    "grid=torch.tensor([[[[-1,0],[0,0],[1,0]],\n",
+    "grid=torch.tensor([[[[-1,0],[0,0],[1,0]],  # chkstyle: ignore-node\n",
     "               [[-1,1],[0,1],[1,1]],\n",
-    "               [[-1,2],[0,2],[1,2.]]]]) \n",
+    "               [[-1,2],[0,2],[1,2.]]]])\n",
     "img=_grid_sample(img, grid,align_corners=True)\n",
     "show_images(img)"
    ]
@@ -1694,6 +1703,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "82e3822a",
+   "metadata": {},
+   "source": [
+    "`affine_grid` wraps `F.affine_grid`, returning the sampling grid as a `TensorFlowField`."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "10b0ca25",
@@ -1703,12 +1720,12 @@
     "#| exporti\n",
     "@patch\n",
     "def affine_coord(x: TensorImage, \n",
-    "     mat:Tensor=None, # Batch of affine transformation matrices\n",
-    "     coord_tfm:Callable=None, # Partial function of composable coordinate transforms\n",
-    "     sz:int|tuple=None, # Output size, duplicated if one value is specified\n",
-    "     mode:str='bilinear', # PyTorch `F.grid_sample` interpolation applied to `TensorImage`\n",
-    "     pad_mode=PadMode.Reflection, # Padding applied to `TensorImage`\n",
-    "     align_corners=True # PyTorch `F.grid_sample` align_corners\n",
+    "    mat:Tensor=None, # Batch of affine transformation matrices\n",
+    "    coord_tfm:Callable=None, # Partial function of composable coordinate transforms\n",
+    "    sz:int|tuple=None, # Output size, duplicated if one value is specified\n",
+    "    mode:str='bilinear', # PyTorch `F.grid_sample` interpolation applied to `TensorImage`\n",
+    "    pad_mode=PadMode.Reflection, # Padding applied to `TensorImage`\n",
+    "    align_corners=True # PyTorch `F.grid_sample` align_corners\n",
     "):\n",
     "    \"Apply affine and coordinate transforms to `TensorImage`\"\n",
     "    if mat is None and coord_tfm is None and sz is None: return x\n",
@@ -1753,7 +1770,7 @@
     "    return TensorPoint(x, sz=sz)\n",
     "\n",
     "@patch\n",
-    "def affine_coord(x: TensorBBox, \n",
+    "def affine_coord(x: TensorBBox,  # chkstyle: ignore\n",
     "    mat=None, # Batch of affine transformation matrices\n",
     "    coord_tfm=None, # Partial function of composable coordinate transforms\n",
     "    sz=None, # Output size, duplicated if one value is specified\n",
@@ -1765,8 +1782,7 @@
     "    if mat is None and coord_tfm is None: return x\n",
     "    if sz is None: sz = getattr(x, \"img_size\", None)\n",
     "    bs,n = x.shape[:2]\n",
-    "    pnts = stack([x[...,:2], stack([x[...,0],x[...,3]],dim=2),\n",
-    "                  stack([x[...,2],x[...,1]],dim=2), x[...,2:]], dim=2)\n",
+    "    pnts = stack([x[...,:2], stack([x[...,0], x[...,3]], dim=2), stack([x[...,2], x[...,1]], dim=2), x[...,2:]], dim=2)\n",
     "    pnts = TensorPoint(pnts.view(bs, 4*n, 2), img_size=sz).affine_coord(mat, coord_tfm, sz, mode, pad_mode)\n",
     "    pnts = pnts.view(bs, n, 4, 2)\n",
     "    tl,dr = pnts.min(dim=2)[0],pnts.max(dim=2)[0]\n",
@@ -1786,6 +1802,14 @@
     "    mat[:,0,1] *= h/w\n",
     "    mat[:,1,0] *= w/h\n",
     "    return mat[:,:2]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "afc2ca03",
+   "metadata": {},
+   "source": [
+    "`_prepare_mat` rescales the off-diagonal terms by the aspect ratio, so a rotation stays a rotation on a non-square image, and drops the constant last row."
    ]
   },
   {
@@ -1862,7 +1886,7 @@
    "id": "503584e2",
    "metadata": {},
    "source": [
-    "Here are examples of how to use `affine_coord` on images. Including the identity or original image, a flip, and moving the image to the left. "
+    "Here are examples of how to use `affine_coord` on images. Including the identity or original image, a flip, and moving the image to the left. Zero padding makes the shift easiest to see."
    ]
   },
   {
@@ -1888,7 +1912,7 @@
     "flip=torch.tensor([[-1,0,0],[0,1,0.]])\n",
     "translation=torch.tensor([[1,0,1.],[0,1,0]])\n",
     "mats=torch.stack((identity,flip,translation))\n",
-    "show_images(imgs.affine_coord(mats,pad_mode=PadMode.Zeros)) #Zeros easiest to see"
+    "show_images(imgs.affine_coord(mats,pad_mode=PadMode.Zeros))"
    ]
   },
   {
@@ -1932,7 +1956,7 @@
    "id": "b7e5aa68",
    "metadata": {},
    "source": [
-    "Notice the tensor 'eye' is an identity matrix. If we multiply this by a single coordinate in our original image x,y we will simply the same values returned for x and y. bi is added after this multiplication. For example, lets flip the image so the left top corner is in the right top corner: "
+    "Notice the tensor 'eye' is an identity matrix. If we multiply this by a single coordinate in our original image x,y we will simply the same values returned for x and y. bi is added after this multiplication. For example, a horizontal flip sends the upper-left corner, at (-1,-1), to the upper-right:"
    ]
   },
   {
@@ -1956,8 +1980,8 @@
     "t=torch.tensor([[-1,0,0],[0,1,0.]])\n",
     "eye=t[:,0:2]\n",
     "bi=t[:,2:3]\n",
-    "xy=torch.tensor([-1.,-1]) #upper left corner\n",
-    "torch.sum(xy*eye,dim=1)+bi[0] #now the upper right corner"
+    "xy=torch.tensor([-1.,-1])\n",
+    "torch.sum(xy*eye,dim=1)+bi[0]"
    ]
   },
   {
@@ -2098,8 +2122,7 @@
     "rrc = RandomResizedCropGPU(224, p=1.)\n",
     "y = rrc(t)\n",
     "_,axs = plt.subplots(2,4, figsize=(12,6))\n",
-    "for ax in axs.flatten():\n",
-    "    show_image(y[i], ctx=ax)"
+    "for ax in axs.flatten(): show_image(y[i], ctx=ax)"
    ]
   },
   {
@@ -2125,8 +2148,7 @@
     "rrc = RandomResizedCropGPU(224, p=1., min_scale=0.05, max_scale=0.1)\n",
     "y = rrc(t)\n",
     "_,axs = plt.subplots(2,4, figsize=(12,6))\n",
-    "for ax in axs.flatten():\n",
-    "    show_image(y[i], ctx=ax)"
+    "for ax in axs.flatten(): show_image(y[i], ctx=ax)"
    ]
   },
   {
@@ -2342,10 +2364,8 @@
     "    print('list : ', _draw_mask(x, def_draw, draw=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))\n",
     "    print('list : ',_draw_mask(x[0:2], def_draw, draw=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]))\n",
     "    print('funct: ',_draw_mask(x, def_draw, draw=lambda x: torch.arange(1,x.size(0)+1)))\n",
-    "    try:\n",
-    "        _draw_mask(x, def_draw, draw=[1,2])\n",
-    "    except AssertionError as e:\n",
-    "        print(type(e),'\\n',e)"
+    "    try: _draw_mask(x, def_draw, draw=[1,2])\n",
+    "    except AssertionError as e: print(type(e),'\\n',e)"
    ]
   },
   {
@@ -2354,6 +2374,14 @@
    "metadata": {},
    "source": [
     "Note, when using a list it can be larger than the batch size, but it cannot be smaller than the batch size. Otherwise there would not be enough augmentations for elements of the batch.  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d16d21b",
+   "metadata": {},
+   "source": [
+    "With `p` below 1, each element gets either its draw or the neutral value, so the default draw stays within `def_draw`'s range and a constant draw of 1 gives only 0s and 1s:"
    ]
   },
   {
@@ -2368,10 +2396,44 @@
     "t = _draw_mask(x, def_draw)\n",
     "assert (0. <= t).all() and (t <= 7).all() \n",
     "t = _draw_mask(x, def_draw, 1)\n",
-    "assert (0. <= t).all() and (t <= 1).all() \n",
+    "assert (0. <= t).all() and (t <= 1).all() "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22320fbc",
+   "metadata": {},
+   "source": [
+    "With `p=1` every element gets its draw, and a list longer than the batch is cut to the batch size:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "603d7e99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "test_eq(_draw_mask(x, def_draw, 1, p=1), tensor([1.,1,1,1,1]))\n",
     "test_eq(_draw_mask(x, def_draw, [0,1,2,3,4], p=1), tensor([0.,1,2,3,4]))\n",
-    "test_eq(_draw_mask(x[0:3], def_draw, [0,1,2,3,4], p=1), tensor([0.,1,2]))\n",
+    "test_eq(_draw_mask(x[0:3], def_draw, [0,1,2,3,4], p=1), tensor([0.,1,2]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5aa19cb6",
+   "metadata": {},
+   "source": [
+    "`batch=True` makes one draw and applies it to the whole batch, so every element is transformed or none is:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc897019",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "for i in range(5):\n",
     "    t = _draw_mask(x, def_draw, 1,batch=True)\n",
     "    assert (t==torch.zeros(5)).all() or (t==torch.ones(5)).all()"
@@ -2403,9 +2465,9 @@
     "#| export\n",
     "def affine_mat(*ms):\n",
     "    \"Restructure length-6 vector `ms` into an affine matrix with 0,0,1 in the last line\"\n",
-    "    return stack([stack([ms[0], ms[1], ms[2]], dim=1),\n",
-    "                  stack([ms[3], ms[4], ms[5]], dim=1),\n",
-    "                  stack([t0(ms[0]), t0(ms[0]), t1(ms[0])], dim=1)], dim=1)"
+    "    return stack([stack([ms[0], ms[1], ms[2]], dim=1),  # chkstyle: ignore-node\n",
+    "        stack([ms[3], ms[4], ms[5]], dim=1),\n",
+    "        stack([t0(ms[0]), t0(ms[0]), t1(ms[0])], dim=1)], dim=1)"
    ]
   },
   {
@@ -2512,7 +2574,7 @@
     "    \"Return a random flip matrix\"\n",
     "    def _def_draw(x): return x.new_ones(x.size(0))\n",
     "    mask = x.new_ones(x.size(0)) - 2*_draw_mask(x, _def_draw, draw=draw, p=p, batch=batch)\n",
-    "    return affine_mat(mask,     t0(mask), t0(mask),\n",
+    "    return affine_mat(mask,     t0(mask), t0(mask),  # chkstyle: ignore-node\n",
     "                      t0(mask), t1(mask), t0(mask))"
    ]
   },
@@ -2576,6 +2638,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "c3ed3a19",
+   "metadata": {},
+   "source": [
+    "Over 100 random draws both signs appear, short of a 2 in 2^100 chance:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "a78d5ff3",
@@ -2583,7 +2653,7 @@
    "outputs": [],
    "source": [
     "x = flip_mat(torch.randn(100,4,3))\n",
-    "test_eq(set(x[:,0,0].numpy()), {-1,1}) #might fail with probability 2*2**(-100) (picked only 1s or -1s)"
+    "test_eq(set(x[:,0,0].numpy()), {-1,1})"
    ]
   },
   {
@@ -2749,14 +2819,14 @@
     "with no_random(32):\n",
     "    imgs = _batch_ex(5)\n",
     "    deflt = Flip()\n",
-    "    const = Flip(p=1.,draw=1) #same as default\n",
-    "    listy = Flip(p=1.,draw=[1,0,1,0,1]) #completely manual!!!\n",
-    "    funct = Flip(draw=lambda x: torch.ones(x.size(0))) #same as default\n",
+    "    const = Flip(p=1.,draw=1)\n",
+    "    listy = Flip(p=1.,draw=[1,0,1,0,1])\n",
+    "    funct = Flip(draw=lambda x: torch.ones(x.size(0)))\n",
     "\n",
     "    show_images( deflt(imgs) ,suptitle='Default Flip')\n",
-    "    show_images( const(imgs) ,suptitle='Constant Flip',titles=[f'Flipped' for i in['','','','','']]) #same above\n",
+    "    show_images( const(imgs) ,suptitle='Constant Flip',titles=[f'Flipped' for i in['','','','','']])\n",
     "    show_images( listy(imgs) ,suptitle='Listy Flip',titles=[f'{i}Flipped' for i in ['','Not ','','Not ','']])\n",
-    "    show_images( funct(imgs) ,suptitle='Flip By Function') #same as default"
+    "    show_images( funct(imgs) ,suptitle='Flip By Function')"
    ]
   },
   {
@@ -2793,6 +2863,14 @@
     "    def __call__(self, x):\n",
     "        self.count += 1\n",
     "        return x.new_zeros(x.size(0)) + self.vals[self.count%len(self.vals)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0e703b6",
+   "metadata": {},
+   "source": [
+    "`DeterministicDraw` cycles through `vals`, one value per call, so a transform's `draw` argument can step through a known sequence. `DeterministicFlip` and `DeterministicDihedral` below use it to produce every variant in order."
    ]
   },
   {
@@ -2885,8 +2963,7 @@
    "source": [
     "b = _batch_ex(2)\n",
     "dih = DeterministicFlip()\n",
-    "for i,flipped in enumerate(['Not Flipped','Flipped']*2):\n",
-    "    show_images(dih(b),suptitle=f'Batch {i}',titles=[flipped]*2)"
+    "for i,flipped in enumerate(['Not Flipped','Flipped']*2): show_images(dih(b),suptitle=f'Batch {i}',titles=[flipped]*2)"
    ]
   },
   {
@@ -2927,8 +3004,16 @@
     "    ys = tensor([1,1,-1,1,-1,-1,1,-1], device=x.device).gather(0, idx)\n",
     "    m0 = tensor([1,1,1,0,1,0,0,0], device=x.device).gather(0, idx)\n",
     "    m1 = tensor([0,0,0,1,0,1,1,1], device=x.device).gather(0, idx)\n",
-    "    return affine_mat(xs*m0,  xs*m1,  t0(xs),\n",
+    "    return affine_mat(xs*m0,  xs*m1,  t0(xs),  # chkstyle: ignore-node\n",
     "                      ys*m1,  ys*m0,  t0(xs)).float()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8e67eaf",
+   "metadata": {},
+   "source": [
+    "The eight dihedral transformations are the four rotations by multiples of 90° and their reflections. For the drawn index, `xs` and `ys` give the signs and `m0` and `m1` choose whether the axes are swapped."
    ]
   },
   {
@@ -3044,14 +3129,14 @@
     "with no_random():\n",
     "    imgs = _batch_ex(5)\n",
     "    deflt = Dihedral()\n",
-    "    const = Dihedral(p=1.,draw=1) #same as flip_batch\n",
-    "    listy = Dihedral(p=1.,draw=[0,1,2,3,4]) #completely manual!!!\n",
-    "    funct = Dihedral(draw=lambda x: torch.randint(0,8,(x.size(0),))) #same as default\n",
+    "    const = Dihedral(p=1.,draw=1)\n",
+    "    listy = Dihedral(p=1.,draw=[0,1,2,3,4])\n",
+    "    funct = Dihedral(draw=lambda x: torch.randint(0,8,(x.size(0),)))\n",
     "\n",
     "    show_images( deflt(imgs) ,suptitle='Default Flips',titles=[i for i in range(imgs.size(0))])\n",
     "    show_images( const(imgs) ,suptitle='Constant Horizontal Flip',titles=[f'Flip 1' for i in [0,1,1,1,1]])\n",
-    "    show_images( listy(imgs) ,suptitle='Manual Listy Flips',titles=[f'Flip {i}' for i in [0,1,2,3,4]]) #manually specified, not random! \n",
-    "    show_images( funct(imgs) ,suptitle='Default Functional Flips',titles=[i for i in range(imgs.size(0))]) #same as default"
+    "    show_images( listy(imgs) ,suptitle='Manual Listy Flips',titles=[f'Flip {i}' for i in [0,1,2,3,4]])\n",
+    "    show_images( funct(imgs) ,suptitle='Default Functional Flips',titles=[i for i in range(imgs.size(0))])"
    ]
   },
   {
@@ -3162,8 +3247,16 @@
     "    def _def_draw(x):   return x.new_empty(x.size(0)).uniform_(-max_deg, max_deg)\n",
     "    def _def_draw_b(x): return x.new_zeros(x.size(0)) + random.uniform(-max_deg, max_deg)\n",
     "    thetas = _draw_mask(x, _def_draw_b if batch else _def_draw, draw=draw, p=p, batch=batch) * math.pi/180\n",
-    "    return affine_mat(thetas.cos(), thetas.sin(), t0(thetas),\n",
+    "    return affine_mat(thetas.cos(), thetas.sin(), t0(thetas),  # chkstyle: ignore-node\n",
     "                     -thetas.sin(), thetas.cos(), t0(thetas))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f01dd0a",
+   "metadata": {},
+   "source": [
+    "The angle is drawn uniformly within `max_deg` degrees of zero, and `p` is the chance that a given image is rotated at all. Rotation is about the image centre, since coordinates run from -1 to 1."
    ]
   },
   {
@@ -3279,18 +3372,15 @@
    ],
    "source": [
     "with no_random():\n",
-    "    thetas = [-30,-15,0,15,30]\n",
     "    imgs = _batch_ex(5)\n",
     "    deflt = Rotate()\n",
-    "    const = Rotate(p=1.,draw=180) #same as a vertical flip\n",
-    "    listy = Rotate(p=1.,draw=[-30,-15,0,15,30]) #completely manual!!!\n",
-    "    funct = Rotate(draw=lambda x: x.new_empty(x.size(0)).uniform_(-10, 10)) #same as default\n",
+    "    const = Rotate(p=1.,draw=180)\n",
+    "    listy = Rotate(p=1.,draw=[-30,-15,0,15,30])\n",
+    "    funct = Rotate(draw=lambda x: x.new_empty(x.size(0)).uniform_(-10, 10))\n",
     "\n",
     "    show_images( deflt(imgs) ,suptitle='Default Rotate, notice the small rotation',titles=[i for i in range(imgs.size(0))])\n",
     "    show_images( const(imgs) ,suptitle='Constant 180 Rotate',titles=[f'180 Degrees' for i in range(imgs.size(0))])\n",
-    "    #manually specified, not random! \n",
     "    show_images( listy(imgs) ,suptitle='Manual List Rotate',titles=[f'{i} Degrees' for i in [-30,-15,0,15,30]])\n",
-    "    #same as default\n",
     "    show_images( funct(imgs) ,suptitle='Default Functional Rotate',titles=[i for i in range(imgs.size(0))])"
    ]
   },
@@ -3332,8 +3422,16 @@
     "    row_pct = _draw_mask(x, def_draw_c, draw=draw_y, p=1., batch=batch)\n",
     "    col_c = (1-s) * (2*col_pct - 1)\n",
     "    row_c = (1-s) * (2*row_pct - 1)\n",
-    "    return affine_mat(s,     t0(s), col_c,\n",
+    "    return affine_mat(s,     t0(s), col_c,  # chkstyle: ignore-node\n",
     "                      t0(s), s,     row_c)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "581defba",
+   "metadata": {},
+   "source": [
+    "Scaling coordinates by `1/s` zooms in by `s`. `col_c` and `row_c` shift the centre so the zoom can focus anywhere from one corner to the other, with `draw_x` and `draw_y` giving that centre as a fraction of the image."
    ]
   },
   {
@@ -3452,18 +3550,18 @@
     }
    ],
    "source": [
-    "with no_random():\n",
+    "with no_random():  # chkstyle: ignore\n",
     "    scales = [0.8, 1., 1.1, 1.25, 1.5]\n",
     "    imgs = _batch_ex(5)\n",
     "    deflt = Zoom()\n",
-    "    const = Zoom(p=1., draw=1.5) #'Constant scale and different random centers'\n",
-    "    listy = Zoom(p=1.,draw=scales,draw_x=0.5, draw_y=0.5) #completely manual scales, constant center\n",
-    "    funct = Zoom(draw=lambda x: x.new_empty(x.size(0)).uniform_(1., 1.1)) #same as default\n",
+    "    const = Zoom(p=1., draw=1.5)\n",
+    "    listy = Zoom(p=1.,draw=scales,draw_x=0.5, draw_y=0.5)\n",
+    "    funct = Zoom(draw=lambda x: x.new_empty(x.size(0)).uniform_(1., 1.1))\n",
     "\n",
     "    show_images( deflt(imgs) ,suptitle='Default Zoom, note the small zooming', titles=[i for i in range(imgs.size(0))])\n",
     "    show_images( const(imgs) ,suptitle='Constant Scale, Valiable Position', titles=[f'Scale 1.5x' for i in range(imgs.size(0))])\n",
     "    show_images( listy(imgs) ,suptitle='Manual Listy Scale, Centered', titles=[f'Scale {i}x' for i in scales])\n",
-    "    show_images( funct(imgs) ,suptitle='Default Functional Zoom', titles=[i for i in range(imgs.size(0))]) #same as default"
+    "    show_images( funct(imgs) ,suptitle='Default Functional Zoom', titles=[i for i in range(imgs.size(0))])"
    ]
   },
   {
@@ -3482,8 +3580,7 @@
    "outputs": [],
    "source": [
     "#| exporti\n",
-    "def solve(A,B):\n",
-    "    return torch.linalg.solve(A,B)"
+    "def solve(A,B): return torch.linalg.solve(A,B)"
    ]
   },
   {
@@ -3512,6 +3609,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "0e7161ea",
+   "metadata": {},
+   "source": [
+    "A perspective warp is fixed by where it sends four points. `find_coeffs` sets up the eight linear equations relating the corners `p1` and `p2` and solves them for each item in the batch, giving the eight coefficients of the projective transform between them."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "17d093aa",
@@ -3531,6 +3636,14 @@
     "    if (coords1[...,2]==0.).any(): return coords[...,:2].view(*sz)\n",
     "    coords = coords1/coords1[...,2].unsqueeze(-1)\n",
     "    return coords[...,:2].view(*sz)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "570b0320",
+   "metadata": {},
+   "source": [
+    "`apply_perspective` appends the implied ninth coefficient of 1, applies the resulting 3×3 matrix to the coordinates in homogeneous form, and divides by the projective scale. If any point's scale would be zero, the coordinates are returned unchanged."
    ]
   },
   {
@@ -3555,13 +3668,21 @@
     "        y_t = _draw_mask(x, self._def_draw, self.draw_y, p=self.p, batch=self.batch)\n",
     "        orig_pts = torch.tensor([[-1,-1], [-1,1], [1,-1], [1,1]], dtype=x.dtype, device=x.device)\n",
     "        self.orig_pts = orig_pts.unsqueeze(0).expand(x.size(0),4,2)\n",
-    "        targ_pts = stack([stack([-1-y_t, -1-x_t]), stack([-1+y_t, 1+x_t]),\n",
+    "        targ_pts = stack([stack([-1-y_t, -1-x_t]), stack([-1+y_t, 1+x_t]),  # chkstyle: ignore-node\n",
     "                          stack([ 1+y_t, -1+x_t]), stack([ 1-y_t, 1-x_t])])\n",
     "        self.targ_pts = targ_pts.permute(2,0,1)\n",
     "\n",
     "    def __call__(self, x, invert=False):\n",
     "        coeffs = find_coeffs(self.targ_pts, self.orig_pts) if invert else find_coeffs(self.orig_pts, self.targ_pts)\n",
     "        return apply_perspective(x, coeffs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48f07940",
+   "metadata": {},
+   "source": [
+    "`_WarpCoord` draws a horizontal and a vertical displacement per image, moves the four corners by them, and turns the original and displaced corners into perspective coefficients with `find_coeffs`. `invert=True` maps the other way."
    ]
   },
   {
@@ -3779,7 +3900,7 @@
    "id": "4bc72c55",
    "metadata": {},
    "source": [
-    "Most lighting transforms work better in \"logit space\", as we do not want to blowout the image by going over maximum or minimum brightness. Taking the sigmoid of the logit allows us to get back to \"linear space.\" "
+    "Most lighting transforms work better in \"logit space\", as we do not want to blowout the image by going over maximum or minimum brightness. Taking the sigmoid of the logit allows us to get back to \"linear space.\" Below, the blue line is a contrast change applied directly and clamped at the edges, and the red line is the same change applied in logit space."
    ]
   },
   {
@@ -3801,8 +3922,8 @@
    ],
    "source": [
     "x=TensorImage(torch.tensor([.01* i for i in range(0,101)]))\n",
-    "f_lin= lambda x:(2*(x-0.5)+0.5).clamp(0,1) #blue line\n",
-    "f_log= lambda x:2*x #red line\n",
+    "f_lin= lambda x:(2*(x-0.5)+0.5).clamp(0,1)\n",
+    "f_log= lambda x:2*x\n",
     "plt.plot(x,f_lin(x),'b',x,x.lighting(f_log),'r');"
    ]
   },
@@ -3909,10 +4030,17 @@
     "        if not self.batch: return x.new_empty(x.size(0)).uniform_(0.5*(1-self.max_lighting), 0.5*(1+self.max_lighting))\n",
     "        return x.new_zeros(x.size(0)) + random.uniform(0.5*(1-self.max_lighting), 0.5*(1+self.max_lighting))\n",
     "\n",
-    "    def before_call(self, x):\n",
-    "        self.change = _draw_mask(x, self._def_draw, draw=self.draw, p=self.p, neutral=0.5, batch=self.batch)\n",
+    "    def before_call(self, x): self.change = _draw_mask(x, self._def_draw, draw=self.draw, p=self.p, neutral=0.5, batch=self.batch)\n",
     "\n",
     "    def __call__(self, x): return x.add_(logit(self.change[:,None,None,None]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0938bb10",
+   "metadata": {},
+   "source": [
+    "Brightness adds a constant in logit space, drawn around 0.5 within `max_lighting`. 0.5 is the neutral value, since its logit is 0."
    ]
   },
   {
@@ -3988,8 +4116,7 @@
     "scales = [0.1, 0.3, 0.5, 0.7, 0.9]\n",
     "y = _batch_ex(5).brightness(draw=scales, p=1.)\n",
     "fig,axs = plt.subplots(1,5, figsize=(15,3))\n",
-    "for i,ax in enumerate(axs.flatten()):\n",
-    "    show_image(y[i], ctx=ax, title=f'scale {scales[i]}')"
+    "for i,ax in enumerate(axs.flatten()): show_image(y[i], ctx=ax, title=f'scale {scales[i]}')"
    ]
   },
   {
@@ -4044,10 +4171,17 @@
     "        else: res = x.new_zeros(x.size(0)) + random.uniform(math.log(1-self.max_lighting), -math.log(1-self.max_lighting))\n",
     "        return torch.exp(res)\n",
     "\n",
-    "    def before_call(self, x):\n",
-    "        self.change = _draw_mask(x, self._def_draw, draw=self.draw, p=self.p, neutral=1., batch=self.batch)\n",
+    "    def before_call(self, x): self.change = _draw_mask(x, self._def_draw, draw=self.draw, p=self.p, neutral=1., batch=self.batch)\n",
     "\n",
     "    def __call__(self, x): return x.mul_(self.change[:,None,None,None])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5cc2686",
+   "metadata": {},
+   "source": [
+    "Contrast multiplies in logit space by a factor drawn log-uniformly between `1-max_lighting` and its inverse, so 1 is neutral and stretches and squeezes are equally likely."
    ]
   },
   {
@@ -4203,8 +4337,7 @@
     "        else: res = x.new_zeros(x.size(0)) + random.uniform(math.log(1-self.max_lighting), -math.log(1-self.max_lighting))\n",
     "        return torch.exp(res)\n",
     "\n",
-    "    def before_call(self, x):\n",
-    "        self.change = _draw_mask(x, self._def_draw, draw=self.draw, p=self.p, neutral=1., batch=self.batch)\n",
+    "    def before_call(self, x): self.change = _draw_mask(x, self._def_draw, draw=self.draw, p=self.p, neutral=1., batch=self.batch)\n",
     "\n",
     "    def __call__(self, x):\n",
     "        #interpolate between grayscale and original in-place\n",
@@ -4212,6 +4345,14 @@
     "        gs.mul_(1-self.change[:,None,None,None])\n",
     "        x.mul_(self.change[:,None,None,None])\n",
     "        return x.add_(gs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a8f5715",
+   "metadata": {},
+   "source": [
+    "Saturation mixes the image with its greyscale version, using the same log-uniform factor as contrast. A factor above 1 pushes colours away from grey, and one below 1 pulls them towards it."
    ]
   },
   {
@@ -4380,6 +4521,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "8aaa9a11",
+   "metadata": {},
+   "source": [
+    "Hue comes from whichever channel is largest, saturation from the spread between the largest and smallest channels, and value is the largest channel itself. Grey pixels, where all three channels match, get hue and saturation 0."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "42b94e0c",
@@ -4441,8 +4590,7 @@
     "#| export\n",
     "class HSVTfm(SpaceTfm):\n",
     "    \"Apply `fs` to the images in HSV space\"\n",
-    "    def __init__(self, fs, **kwargs):\n",
-    "        super().__init__(fs, TensorImage.hsv, **kwargs)"
+    "    def __init__(self, fs, **kwargs): super().__init__(fs, TensorImage.hsv, **kwargs)"
    ]
   },
   {
@@ -4471,14 +4619,14 @@
     }
    ],
    "source": [
-    "fig,axs=plt.subplots(figsize=(20, 4),ncols=5)\n",
+    "fig,axs=plt.subplots(figsize=(20, 4),ncols=5)  # chkstyle: ignore\n",
     "axs[0].set_ylabel('Hue')\n",
     "for ax in axs:\n",
     "    ax.set_xlabel('Saturation')\n",
     "    ax.set_yticklabels([])\n",
     "    ax.set_xticklabels([])\n",
     "\n",
-    "hsvs=torch.stack([torch.arange(0,2.1,0.01)[:,None].repeat(1,210),\n",
+    "hsvs=torch.stack([torch.arange(0,2.1,0.01)[:,None].repeat(1,210),  # chkstyle: ignore-node\n",
     "                 torch.arange(0,1.05,0.005)[None].repeat(210,1),\n",
     "                 torch.ones([210,210])])[None]\n",
     "for ax,i in zip(axs,range(0,5)):\n",
@@ -4513,14 +4661,21 @@
     "        else: res = x.new_zeros(x.size(0)) + random.uniform(math.log(1-self.max_hue), -math.log(1-self.max_hue))\n",
     "        return torch.exp(res)\n",
     "\n",
-    "    def before_call(self, x):\n",
-    "        self.change = _draw_mask(x, self._def_draw, draw=self.draw, p=self.p, neutral=0., batch=self.batch)\n",
+    "    def before_call(self, x): self.change = _draw_mask(x, self._def_draw, draw=self.draw, p=self.p, neutral=0., batch=self.batch)\n",
     "\n",
     "    def __call__(self, x):\n",
     "        h,s,v = x.unbind(1)\n",
     "        h += self.change[:,None,None]\n",
     "        h = h % 1.0\n",
     "        return x.set_(torch.stack((h, s, v),dim=1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b569acdb",
+   "metadata": {},
+   "source": [
+    "Hue is an angle, so the drawn factor is added to the hue channel and wrapped modulo 1. The factor uses the same log-uniform draw as contrast, so a value near 1 is a small shift either way."
    ]
   },
   {
@@ -4752,6 +4907,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "97cd1e4c",
+   "metadata": {},
+   "source": [
+    "Each image gets between one and `max_count` rectangles, sharing the image area between them. A rectangle's area is a random fraction between `sl` and `sh` of its share, and its aspect ratio is drawn log-uniformly between `min_aspect` and its inverse. The erased pixels are filled with Gaussian noise by `cutout_gaussian`, which is why the transform runs after `Normalize`:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "38c94d29",
@@ -4871,19 +5034,33 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "eab38088",
+   "metadata": {},
+   "source": [
+    "Affine transforms compose into a single `AffineCoordTfm`, so the batch is resampled once, and lighting transforms into a single `LightingTfm`. Anything else is left as it is. The result is the affine transform, then the lighting one, then the rest. With affine transforms only, the composed matrix is the product of the parts. The outputs themselves are not compared, since composing resamples once where applying the parts separately resamples twice:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "7055fd26",
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Affine only\n",
     "tfms = [Rotate(draw=10., p=1), Zoom(draw=1.1, draw_x=0.5, draw_y=0.5, p=1.)]\n",
     "comp = setup_aug_tfms([Rotate(draw=10., p=1), Zoom(draw=1.1, draw_x=0.5, draw_y=0.5, p=1.)])\n",
     "test_eq(len(comp), 1)\n",
     "x = torch.randn(4,3,5,5)\n",
-    "test_close(comp[0]._get_affine_mat(x)[...,:2],tfms[0]._get_affine_mat(x)[...,:2] @ tfms[1]._get_affine_mat(x)[...,:2])\n",
-    "#We can't test that the ouput of comp or the composition of tfms on x is the same cause it's not (1 interpol vs 2 sp)"
+    "test_close(comp[0]._get_affine_mat(x)[...,:2],tfms[0]._get_affine_mat(x)[...,:2] @ tfms[1]._get_affine_mat(x)[...,:2])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40b13e66",
+   "metadata": {},
+   "source": [
+    "With affine and lighting transforms mixed together, each group is combined and the result has one of each:"
    ]
   },
   {
@@ -4893,7 +5070,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Affine + lighting\n",
     "tfms = [Rotate(), Zoom(), Warp(), Brightness(), Flip(), Contrast()]\n",
     "comp = setup_aug_tfms(tfms)"
    ]
@@ -5060,8 +5236,7 @@
    ],
    "source": [
     "cam_dsrc = Datasets([cam_fn]*10, [PILImage.create, [_cam_lbl, PILMask.create]])\n",
-    "cam_tdl = TfmdDL(cam_dsrc.train, after_item=ToTensor(),\n",
-    "                 after_batch=[IntToFloatTensor(), *aug_transforms()], bs=9)\n",
+    "cam_tdl = TfmdDL(cam_dsrc.train, after_item=ToTensor(), after_batch=[IntToFloatTensor(), *aug_transforms()], bs=9)\n",
     "cam_tdl.show_batch(max_n=9, vmin=1, vmax=30)"
    ]
   },
@@ -5106,7 +5281,7 @@
    "source": [
     "pnt_dsrc = Datasets([mnist_fn]*10, [[PILImage.create, Resize((35,28))], _pnt_lbl])\n",
     "pnt_tdl = TfmdDL(pnt_dsrc.train, after_item=[PointScaler(), ToTensor()],\n",
-    "                 after_batch=[IntToFloatTensor(), *aug_transforms(max_warp=0)], bs=9)\n",
+    "    after_batch=[IntToFloatTensor(), *aug_transforms(max_warp=0)], bs=9)\n",
     "pnt_tdl.show_batch(max_n=9)"
    ]
   },
@@ -5154,7 +5329,7 @@
    "source": [
     "coco_dsrc = Datasets([coco_fn]*10, [PILImage.create, [_coco_bb], [_coco_lbl, MultiCategorize(add_na=True)]], n_inp=1)\n",
     "coco_tdl = TfmdDL(coco_dsrc, bs=9, after_item=[BBoxLabeler(), PointScaler(), ToTensor(), Resize(256)],\n",
-    "                  after_batch=[IntToFloatTensor(), *aug_transforms()])\n",
+    "    after_batch=[IntToFloatTensor(), *aug_transforms()])\n",
     "\n",
     "coco_tdl.show_batch(max_n=9)"
    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = {text = "Apache-2.0"}
 authors = [{name = "Jeremy Howard, Sylvain Gugger, and contributors", email = "info@fast.ai"}]
 keywords = ['fastai,', 'deep', 'learning,', 'machine', 'learning']
 classifiers = ["Natural Language :: English", "Intended Audience :: Developers", "Development Status :: 4 - Beta", "Programming Language :: Python :: 3", "Programming Language :: Python :: 3 :: Only"]
-dependencies = ['fastdownload>=0.0.5,<2', 'fastcore>=2.2.21', 'fasttransform>=0.0.2', 'torchvision>=0.11', 'matplotlib', 'pandas', 'requests', 'pyyaml', 'fastprogress>=0.2.4', 'pillow>=9.0.0', 'scikit-learn', 'scipy', 'spacy<4', 'packaging', 'plum-dispatch<2.10', 'cloudpickle', 'torch>=1.10,<3']
+dependencies = ['fastdownload>=0.0.8,<2', 'fastcore>=2.2.22', 'fasttransform>=0.0.3', 'torchvision>=0.11', 'matplotlib', 'pandas', 'requests', 'pyyaml', 'fastprogress>=0.2.4', 'pillow>=9.0.0', 'scikit-learn', 'scipy', 'spacy<4', 'packaging', 'plum-dispatch<2.10', 'cloudpickle', 'torch>=1.10,<3']
 
 [project.urls]
 Repository = "https://github.com/fastai/fastai"


### PR DESCRIPTION
`RandTransform.__init__` stored its own bound `before_call` method on the instance, so `init_args` picked it up and the method's repr recursed back into the transform's repr until `RecursionError`. It now only stores `before_call` when one is passed, and the class method serves the default. `DihedralItem` and every subclass that inherits that `__init__` are fixed with it.

`09_vision.augment.ipynb` is also brought to a clean chkstyle run: prose after every exported definition that had none, comments folded into the surrounding notes, the `_draw_mask` check split into three lessons, the unused `Bernoulli` import dropped, and `tvpad` moved out of the module. The matrix and grid layouts in the affine code keep their aligned form under `chkstyle: ignore-node`.

Dependency floors move with the changes that need them: `fastcore>=2.2.22` for `init_args`, `fasttransform>=0.0.3` for the plum pin, and `fastdownload>=0.0.8` for the download lock.