### PR TITLE
Fix ReduceLROnPlateau with wrapped PyTorch optimizers

### DIFF
--- a/fastai/callback/tracker.py
+++ b/fastai/callback/tracker.py
@@ -136,7 +136,7 @@ class ReduceLROnPlateau(TrackerCallback):
             self.wait += 1
             if self.wait >= self.patience:
                 old_lr = self.opt.hypers[-1]['lr']
-                for h in self.opt.hypers: h['lr'] = max(h['lr'] / self.factor, self.min_lr)
+                self.opt.set_hyper('lr', [max(h['lr'] / self.factor, self.min_lr) for h in self.opt.hypers])
                 self.wait = 0
                 if self.opt.hypers[-1]["lr"] < old_lr:
                     print(f'Epoch {self.epoch}: reducing lr to {self.opt.hypers[-1]["lr"]}')

--- a/nbs/17_callback.tracker.ipynb
+++ b/nbs/17_callback.tracker.ipynb
@@ -1064,7 +1064,7 @@
     "            self.wait += 1\n",
     "            if self.wait >= self.patience:\n",
     "                old_lr = self.opt.hypers[-1]['lr']\n",
-    "                for h in self.opt.hypers: h['lr'] = max(h['lr'] / self.factor, self.min_lr)\n",
+    "                self.opt.set_hyper('lr', [max(h['lr'] / self.factor, self.min_lr) for h in self.opt.hypers])\n",
     "                self.wait = 0\n",
     "                if self.opt.hypers[-1][\"lr\"] < old_lr:\n",
     "                    print(f'Epoch {self.epoch}: reducing lr to {self.opt.hypers[-1][\"lr\"]}')"
@@ -1234,6 +1234,22 @@
    "source": [
     "#| hide\n",
     "test_eq(learn.opt.hypers[-1]['lr'], 1e-8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3ec42b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| hide\n",
+    "for opt_func in [SGD, partial(OptimWrapper, opt=torch.optim.SGD)]:\n",
+    "    learn = synth_learner(n_trn=2, splitter=lambda m: [[m.a], [m.b]])\n",
+    "    learn.opt_func = opt_func\n",
+    "    with learn.no_bar(), learn.no_logging():\n",
+    "        learn.fit(6, lr=[1e-6, 1e-4], cbs=ReduceLROnPlateau(min_delta=1e10, patience=2, min_lr=5e-7))\n",
+    "    test_close([h['lr'] for h in learn.opt.hypers], [5e-7, 1e-6], eps=1e-12)"
    ]
   },
   {


### PR DESCRIPTION
`ReduceLROnPlateau` writes directly to `opt.hypers`, but `OptimWrapper.hypers` returns copies of the underlying PyTorch parameter groups. As a result, the callback leaves the optimizer's learning rates unchanged.

Use the existing `set_hyper` interface to update all groups, preserving their separate learning rates and the `min_lr` floor. The notebook regression trains a synthetic learner with both fastai SGD and wrapped PyTorch SGD, using two parameter groups, repeated reductions, and a minimum learning rate.

Fixes #4046.

Validation (Python 3.11.15, PyTorch 2.6.0, CPU):

- The new regression fails before the fix: wrapped optimizer rates remain `[1e-6, 1e-4]` instead of `[5e-7, 1e-6]`.
- `nbdev-test` passed for `17_callback.tracker.ipynb`, `12_optimizer.ipynb`, and `14_callback.schedule.ipynb` with the repository's default slow/GPU exclusions.
- Exported the notebook with `nbdev-export`; `git diff --check` passed. The full notebook suite and GPU tests were not run.

AI disclosure: Codex investigated the issue, implemented the change, and ran the checks. A separate agent independently reviewed the diff and call paths; this does not represent a human maintainer review.
