### PR TITLE
Honor custom output directories when tokenizing folders

### DIFF
--- a/fastai/text/core.py
+++ b/fastai/text/core.py
@@ -212,7 +212,7 @@ def tokenize_folder(path, extensions=None, folders=None, output_dir=None, skip_i
     path,extensions = Path(path),ifnone(extensions, ['.txt'])
     files = get_files(path, extensions=extensions, recurse=True, folders=folders)
     def _f(i,output_dir): return output_dir/files[i].relative_to(path)
-    return _tokenize_files(_f, files, path, skip_if_exists=skip_if_exists, **kwargs)
+    return _tokenize_files(_f, files, path, output_dir=output_dir, skip_if_exists=skip_if_exists, **kwargs)
 
 # %% ../../nbs/30_text.core.ipynb #429353d7
 @delegates(_tokenize_files)

--- a/nbs/30_text.core.ipynb
+++ b/nbs/30_text.core.ipynb
@@ -840,7 +840,7 @@
     "    path,extensions = Path(path),ifnone(extensions, ['.txt'])\n",
     "    files = get_files(path, extensions=extensions, recurse=True, folders=folders)\n",
     "    def _f(i,output_dir): return output_dir/files[i].relative_to(path)\n",
-    "    return _tokenize_files(_f, files, path, skip_if_exists=skip_if_exists, **kwargs)"
+    "    return _tokenize_files(_f, files, path, output_dir=output_dir, skip_if_exists=skip_if_exists, **kwargs)"
    ]
   },
   {
@@ -1400,7 +1400,11 @@
     "    path,df,csv_fname = _prepare_texts(Path(tmp_d))\n",
     "    items = get_text_files(path)\n",
     "    splits = RandomSplitter()(items)\n",
-    "    dsets = Datasets(items, [Tokenizer.from_folder(path)], splits=splits)\n",
+    "    outp = Path(tmp_d)/'custom_tok'\n",
+    "    tok = Tokenizer.from_folder(path, output_dir=outp)\n",
+    "    test_eq(tok.output_dir, outp)\n",
+    "    test_eq(tok(items[0]), (outp/items[0].relative_to(path)).read_text().split())\n",
+    "    dsets = Datasets(items, [tok], splits=splits)\n",
     "    print(dsets.train[0])\n",
     "    \n",
     "    dsets = Datasets(df, [Tokenizer.from_df('text')], splits=splits)\n",


### PR DESCRIPTION
`tokenize_folder` accepts `output_dir` but drops it when calling `_tokenize_files`, so `Tokenizer.from_folder` and `TextBlock.from_folder` also write to the default sibling directory instead of the requested location.

Forward `output_dir` to the existing helper and extend the notebook's `Tokenizer.from_folder` test to check the custom directory and read its cached tokens. Default-directory selection and cache handling remain with `_tokenize_files`.

Fixes #4033.

Validation on macOS arm64, Python 3.11.15 / PyTorch 2.6.0:

- The new notebook assertion failed before the fix: the returned directory was `tmp_tok` instead of `custom_tok`.
- `nbdev-test nbs/30_text.core.ipynb --n-workers 0 --do-print --timing`: passed the complete notebook with the default test flags, including existing default-directory, partial-cache, spaCy, and SentencePiece tests.
- 12 additional offline scenarios exercised `tokenize_folder`, `Tokenizer.from_folder`, and `TextBlock.from_folder` with string/Path output directories and 0/2 workers. Checked nested token files, counters, lengths, cache reuse, forced refresh, and absence of unintended default-directory writes.
- Exported the notebook with `nbdev-export`, cleaned it with `nbdev-clean`, and passed `git diff --check`.

The full repository suite and GPU tests were not run; no model or dataset downloads were needed. OpenAI Codex implemented and tested the change, with a separate agent performing an independent review.
